### PR TITLE
BUILD: add example apps into the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
     - BOINC_TYPE=libs
     - BOINC_TYPE=server
     - BOINC_TYPE=client
+    - BOINC_TYPE=apps
     #- BOINC_TYPE=manager
     #- BOINC_TYPE=coverity
 
@@ -47,6 +48,7 @@ script:
 - if [[ "${BOINC_TYPE}" == "libs" ]]; then ( ./configure --disable-server --disable-client --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "server" ]]; then ( ./configure --disable-client --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "client" ]]; then ( ./configure --disable-server --disable-manager && make ) fi
+- if [[ "${BOINC_TYPE}" == "apps" ]]; then ( ./configure --enable-apps --disable-server --disable-client --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" ]]; then ( ./configure --disable-server --disable-client && make ) fi
 
 addons:

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,6 +13,10 @@ if ENABLE_LIBRARIES
 if ENABLE_SERVER
     API_SUBDIRS += zip
 endif
+## boinc_zip needed for wrapper
+if ENABLE_APPS
+    API_SUBDIRS += zip
+endif
 if ENABLE_BOINCZIP
     API_SUBDIRS += zip
 endif

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,9 +34,13 @@ if BUILD_X11_SCREENSAVER
 endif
 endif
 
+if ENABLE_APPS
+   APPS_SUBDIRS = samples
+endif
+
 # ORDER MATTERS below.  One must build dependencies FIRST, then things
 # that depend on them later
-SUBDIRS = m4 $(API_SUBDIRS) $(SERVER_SUBDIRS) $(CLIENT_SUBDIRS) $(CLIENTGUI_SUBDIRS) doc
+SUBDIRS = m4 $(API_SUBDIRS) $(SERVER_SUBDIRS) $(CLIENT_SUBDIRS) $(CLIENTGUI_SUBDIRS) $(APPS_SUBDIRS) doc
 
 # Putting a directory name recursively copies the entire contents - the
 # dist-hook below gets rid of CVS directories.

--- a/configure.ac
+++ b/configure.ac
@@ -32,7 +32,7 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CONFIG_SRCDIR(lib/shmem.cpp)
 
-AC_REVISION([$Revision$]) 
+AC_REVISION([$Revision$])
 REV=`echo '$Revision$' | awk "{print $2}"`
 RDATE=`date '+%Y.%m.%d'`
 if test -d .svn ; then
@@ -72,45 +72,45 @@ AM_PROG_CC_C_O
 m4_divert_once([HELP_ENABLE],
   AS_HELP_STRING([BOINC Default enable values], [--enable-server --enable-client --enable-libraries --enable-manager: builds server, client, and libraries]))
 
-AC_ARG_ENABLE(dynamic-client-linkage, 
+AC_ARG_ENABLE(dynamic-client-linkage,
     AS_HELP_STRING([--enable-dynamic-client-linkage],
                    [dynamically link the client to the boinc libraries]),
     [dynamic_client=${enableval}],
     [dynamic_client=no])
 
-AC_ARG_ENABLE(server, 
+AC_ARG_ENABLE(server,
     AS_HELP_STRING([--disable-server],
                    [disable building the scheduling server]),
     [enable_server=${enableval}],
     [enable_server=yes])
 
-AC_ARG_ENABLE(fcgi, 
+AC_ARG_ENABLE(fcgi,
     AS_HELP_STRING([--disable-fcgi],
                    [disable building fcgi libraries or server components]),
     [enable_fcgi=${enableval}],
     [enable_fcgi=${enable_server}])
 
-AC_ARG_ENABLE(client, 
+AC_ARG_ENABLE(client,
     AS_HELP_STRING([--disable-client],
                    [disable building the client]),
     [enable_client=${enableval}],
     [enable_client=yes])
 
-AC_ARG_ENABLE(manager, 
+AC_ARG_ENABLE(manager,
     AS_HELP_STRING([--disable-manager],
                    [disable building the boinc manager gui]),
     [enable_manager=${enableval}],
     [enable_manager=yes])
 
-AC_ARG_ENABLE(libraries, 
+AC_ARG_ENABLE(libraries,
     AS_HELP_STRING([--disable-libraries],
                    [disable building the boinc client and server libraries]),
     [enable_libraries=${enableval}],
     [enable_libraries=yes])
 
-AC_ARG_ENABLE(install-headers, 
+AC_ARG_ENABLE(install-headers,
     AS_HELP_STRING([--disable-install-headers],
-                   [if building libraries do not install the boinc library 
+                   [if building libraries do not install the boinc library
                     header files]),
     [enable_install_headers=${enableval}],
     [enable_install_headers=yes])
@@ -121,7 +121,13 @@ AC_ARG_ENABLE(boinczip,
     [enable_boinczip=${enableval}],
     [enable_boinczip=no])
 
-AC_ARG_ENABLE(pkg-libs, 
+AC_ARG_ENABLE(apps,
+    AS_HELP_STRING([--enable-apps],
+                   [enable building the boinc example apps]),
+    [enable_apps=${enableval}],
+    [enable_apps=no])
+
+AC_ARG_ENABLE(pkg-libs,
     AS_HELP_STRING([--enable-pkg-libs],
                    [Builds and installs components that would be present in a
 		   boinc-libs package.  This is a synonym for --disable-server
@@ -135,10 +141,11 @@ AC_ARG_ENABLE(pkg-libs,
      enable_install_headers=no
      enable_static=no
 	 enable_boinczip=yes
+	 enable_apps=no
     ],
     [])
 
-AC_ARG_ENABLE(pkg-devel, 
+AC_ARG_ENABLE(pkg-devel,
     AS_HELP_STRING([--enable-pkg-devel],
                    [Builds and installs components that would be present in a
 		   boinc-devel package.  This is a synonym for --disable-server
@@ -151,10 +158,11 @@ AC_ARG_ENABLE(pkg-devel,
      enable_manager=no
      enable_install_headers=yes
 	 enable_boinczip=yes
+	 enable_apps=no
     ],
     [])
 
-AC_ARG_ENABLE(pkg-client, 
+AC_ARG_ENABLE(pkg-client,
     AS_HELP_STRING([--enable-pkg-client],
                    [Builds and installs components that would be present in a
 		   boinc-client package. This is a synonym for --disable-server
@@ -167,10 +175,11 @@ AC_ARG_ENABLE(pkg-client,
      enable_manager=no
      enable_install_headers=no
 	 enable_boinczip=no
+	 enable_apps=no
     ],
     [])
 
-AC_ARG_ENABLE(pkg-manager, 
+AC_ARG_ENABLE(pkg-manager,
     AS_HELP_STRING([--enable-pkg-manager],
                    [Builds and installs components that would be present in a boinc-manager package. This is a synonym for --disable-server --disable-client --disable-libraries --enable-manager
     ]),
@@ -181,6 +190,7 @@ AC_ARG_ENABLE(pkg-manager,
      enable_manager=yes
      enable_install_headers=no
 	 enable_boinczip=no
+	 enable_apps=no
     ],
     [])
 
@@ -200,6 +210,9 @@ fi
 if test x$enable_server = xyes ; then
   configured_to_build="${configured_to_build} server"
 fi
+if test x$enable_apps = xyes ; then
+  configured_to_build="${configured_to_build} apps"
+fi
 
 if test -z "${configured_to_build}" ; then
         AC_MSG_ERROR([
@@ -217,11 +230,11 @@ fi
 dnl ======================================================================
 dnl some vodoo required for building portable client-binary (client, clientgui)
 dnl ======================================================================
-AC_ARG_ENABLE([client-release], 
+AC_ARG_ENABLE([client-release],
    AS_HELP_STRING([--enable-client-release],
         [Attempt to build a portable "release-candidate": this links libstd++ and
-	other addon-libraries statically. 
-	(On GNU/Linux you might need to use gcc-3.0 for this to produce a 
+	other addon-libraries statically.
+	(On GNU/Linux you might need to use gcc-3.0 for this to produce a
 	binary that works for glibc <= 2.2 systems. => use CC=gcc-3.0 and CXX=g++-3.0)
 	(Default = no)]),
     [
@@ -239,7 +252,7 @@ WARNING:  You have requested a statically linked release build.
     also need to edit Makefiles manually in order for linking to work.
 
     It is far better to use dynamic linkage, which can resolve most
-    library interdependencies at run time.  
+    library interdependencies at run time.
 
     When the executable fails to link, and you can identify the missing
     library, you can edit the Makefile to add it, or if there is a --with
@@ -303,7 +316,7 @@ dnl AC_DEFINE_UNQUOTED([BOINC_MAJOR_VERSION], $BOINC_MAJOR_VERSION, [Major part 
 dnl AC_DEFINE_UNQUOTED([BOINC_MINOR_VERSION], $BOINC_MINOR_VERSION, [Minor part of BOINC version number])
 dnl AC_DEFINE_UNQUOTED([BOINC_RELEASE], $BOINC_RELEASE, [Release part of BOINC version number])
 
-dnl Need to duplicate these AC_SUBST because some versions of autoconf wont 
+dnl Need to duplicate these AC_SUBST because some versions of autoconf wont
 dnl find AC_SUBST in a macro unless subsequently used in a DEFINE or SUBST
 dnl outside of a macro.  Dont ask me why.
 AC_SUBST([BOINC_VERSION_STRING])
@@ -331,7 +344,7 @@ dnl If we're running under cygwin, check whether we want to use X11 or WIN32
 dnl GUI
 BOINC_CHECK_CYGWIN
 
-dnl enable objective-C 
+dnl enable objective-C
 if test x$OBJC = x ; then
   OBJC="$CC"
 fi
@@ -361,7 +374,7 @@ if ( test "${enable_client_release}" = yes ) && ( test "${enable_client}" != yes
 The switch --enable-client-release is only useful for building the client and will be ignored
 --------------------------------------------------])
 fi
-   
+
 
 
 dnl Find the extensions used on shared and static libraries on this system
@@ -373,7 +386,7 @@ dnl enable debug mode on all components using standard debug flags
 dnl if test "${enable_debug}" = yes; then
     dnl CXXFLAGS="$CXXFLAGS -DDEBUG -D_DEBUG"
     dnl CFLAGS="$CFLAGS -DDEBUG -D_DEBUG"
-dnl 
+dnl
     dnl AC_SUBST(CXXFLAGS)
     dnl AC_SUBST(CFLAGS)
 dnl fi
@@ -399,15 +412,15 @@ fi
 dnl Checks for libraries.
 
 dnl NOTE: Libraries subject to version changes, or those that might not be
-dnl installed everywhere should be linked statically when building portable 
+dnl installed everywhere should be linked statically when building portable
 dnl binaries.  Put libraries that should be linked statically on every platform
-dnl in the STATIC_LIB_LIST variable before calling SAH_CHECK_LIB.  (Note: Only 
+dnl in the STATIC_LIB_LIST variable before calling SAH_CHECK_LIB.  (Note: Only
 dnl the '*' wildcard is supported).
 STATIC_LIB_LIST="stdc++* gcc gcc_s gcc_eh atk* gtk* gdk* gmodule* gthread* gobject* glib* pango* cairo* wx* tiff* jpeg* png* Xi glut socket z expat* krb5support freetype fontconfig* resolv* idn c_nonshared gpg* gss* gnutls sasl2 sqlite3"
 
-dnl We'll store these libs in a separate variable BOINC_EXTRA_LIBS for later 
-dnl post-processing instead of the default-action, which would append 
-dnl them to LIBS (note, we also dont define HAVE_LIBXXX, because 
+dnl We'll store these libs in a separate variable BOINC_EXTRA_LIBS for later
+dnl post-processing instead of the default-action, which would append
+dnl them to LIBS (note, we also dont define HAVE_LIBXXX, because
 dnl currently they arent used)
 
 dnl Special rules for specific targets go here:  It's easier to add static libs
@@ -429,7 +442,7 @@ dnl ---------- libcurl (m4/libcurl.m4) ------------------------------
 
 if test "${enable_client}" = yes; then
    LIBCURL_CHECK_CONFIG([yes], [7.17.1], [haveCurl=yes], [haveCurl=no])
-   
+
    if test "${haveCurl}" != yes; then
       AC_MSG_ERROR([
 ================================================================================
@@ -438,8 +451,8 @@ ERROR: could not find (recent enough) development-libs for libcurl.
   This library is required to build the boinc-client.
   (If you don't want to build the client, use --disable-client with configure.
 
-  If libcurl-dev is installed on your system, make sure that the script 
-  'curl-config' is found in your PATH, and that 
+  If libcurl-dev is installed on your system, make sure that the script
+  'curl-config' is found in your PATH, and that
   'curl-config --version' gives something recent enough (see above).
 
   You can download libcurl from: http://curl.haxx.se/
@@ -460,7 +473,7 @@ ERROR: could not find (recent enough) development-libs for libcurl.
       fi
       BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${LIBCURL}"
 
-   fi	
+   fi
 
 fi
 
@@ -479,22 +492,22 @@ SAH_CHECK_LIB([cygipc], [shmget],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
 SAH_CHECK_LIB([aio], [aio_fork],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
-SAH_CHECK_LIB([dl], [dlopen], 
+SAH_CHECK_LIB([dl], [dlopen],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
-SAH_CHECK_LIB([nsl], [gethostbyname], 
+SAH_CHECK_LIB([nsl], [gethostbyname],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
-SAH_CHECK_LIB([freetype], [fopen], 
+SAH_CHECK_LIB([freetype], [fopen],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
-SAH_CHECK_LIB([socket], [bind], 
+SAH_CHECK_LIB([socket], [bind],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
-SAH_CHECK_LIB([z], [gzopen], 
+SAH_CHECK_LIB([z], [gzopen],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
 SAH_CHECK_LIB([cups], [md5_finish],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
 if test "${isWIN32}" = "yes" ; then
-   SAH_CHECK_LIB([wsock32], [fopen], 
+   SAH_CHECK_LIB([wsock32], [fopen],
        [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
-   SAH_CHECK_LIB([wsock], [fopen], 
+   SAH_CHECK_LIB([wsock], [fopen],
        [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
    SAH_CHECK_LIB([comctl32], [fopen],
        [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
@@ -528,7 +541,7 @@ if test "x${libdir}" = "xNONE" -o -z "${libdir}" ; then
 fi
 
 dnl if --sysconfdir was not specified, default ${sysconfdir} to '/etc/'.
-dnl this is done to preserve the behaviour of previous BOINC versions 
+dnl this is done to preserve the behaviour of previous BOINC versions
 dnl which always installed to /etc/ in client/scripts/. Now we install
 dnl to ${sysconfdir}/.
 dnl the default value for ${sysconfdir} set by automake is '${prefix}/etc',
@@ -542,7 +555,7 @@ AC_DEFINE_UNQUOTED(BOINC_EXECPREFIX,"`eval echo ${bindir}`",[Directory where BOI
 AC_DEFINE_UNQUOTED(BOINC_LIBDIR,"`eval echo ${libdir}`",[Directory where BOINC libraries will be installed])
 
 dnl ---------- decide wether to build the graphical boinc-api libs or not
-dnl check for X11 
+dnl check for X11
 AC_PATH_X
 AC_PATH_XTRA
 
@@ -567,7 +580,7 @@ if test "X${no_x}" != "Xyes" -a "$no_glut" = yes; then
    if test "$have_Xi" = no; then
    	AC_MSG_WARN([Test for glut-dev might have failed because of missing libXi-dev!])
    fi
-fi	
+fi
 
 if test "$no_gl" = yes -o "$no_glu" = yes -o "$no_glut" = yes; then
    have_glut=no
@@ -601,7 +614,7 @@ else
 ================================================================================
 WARNING: libjpeg.a/jpeglib.h not found.
 
-BOINC's openGL graphics-API needs libjpeg ! 
+BOINC's openGL graphics-API needs libjpeg !
 see http://www.ijg.org/
 
 ==> I will continue building the non-graphical parts of the BOINC API library.
@@ -656,7 +669,7 @@ AC_TYPE_SIGNAL
 if test "${isWIN32}" = "yes" ; then
   AC_CHECK_HEADERS(winsock2.h winsock.h windows.h ws2tcpip.h winternl.h crtdbg.h)
 fi
-AC_CHECK_HEADERS(sys/types.h sys/un.h arpa/inet.h dirent.h grp.h fcntl.h inttypes.h stdint.h memory.h netdb.h netinet/in.h netinet/tcp.h netinet/ether.h net/if.h net/if_arp.h signal.h strings.h sys/auxv.h sys/file.h sys/fcntl.h sys/ipc.h sys/ioctl.h sys/msg.h sys/param.h sys/resource.h sys/select.h sys/sem.h sys/shm.h sys/sockio.h sys/socket.h sys/stat.h sys/statvfs.h sys/statfs.h sys/systeminfo.h sys/time.h sys/types.h sys/utsname.h sys/vmmeter.h sys/wait.h unistd.h utmp.h errno.h procfs.h ieeefp.h setjmp.h float.h sal.h) 
+AC_CHECK_HEADERS(sys/types.h sys/un.h arpa/inet.h dirent.h grp.h fcntl.h inttypes.h stdint.h memory.h netdb.h netinet/in.h netinet/tcp.h netinet/ether.h net/if.h net/if_arp.h signal.h strings.h sys/auxv.h sys/file.h sys/fcntl.h sys/ipc.h sys/ioctl.h sys/msg.h sys/param.h sys/resource.h sys/select.h sys/sem.h sys/shm.h sys/sockio.h sys/socket.h sys/stat.h sys/statvfs.h sys/statfs.h sys/systeminfo.h sys/time.h sys/types.h sys/utsname.h sys/vmmeter.h sys/wait.h unistd.h utmp.h errno.h procfs.h ieeefp.h setjmp.h float.h sal.h)
 
 save_cxxflags="${CXXFLAGS}"
 save_cppflags="${CPPFLAGS}"
@@ -743,7 +756,7 @@ AC_CHECK_HEADER(nvapi.h, [
   #include "sal.h"
   #endif
   #ifndef __success
-  #define __success(x)  
+  #define __success(x)
   #endif
   #ifndef __in
   #define __in
@@ -777,10 +790,10 @@ AC_CHECK_HEADER(nvapi.h, [
   #endif
   #ifndef __inout_ecount_part_opt
   #define __inout_ecount_part_opt(x,y)
-  #endif 
+  #endif
   #ifndef __inout_ecount_full_opt
   #define __inout_ecount_full_opt(x,y)
-  #endif 
+  #endif
   #ifndef __out_ecount_full_opt
   #define __out_ecount_full_opt(x)
   #endif
@@ -914,7 +927,7 @@ AC_LANG_POP
 dnl Checks for library functions.
 AC_PROG_GCC_TRADITIONAL
 AC_FUNC_VPRINTF
-AC_CHECK_FUNCS(ether_ntoa setpriority sched_setscheduler strlcpy strlcat strcasestr strcasecmp sigaction getutent setutent getisax strdup _strdup strdupa _strdupa daemon stat64 putenv setenv unsetenv res_init strtoull localtime localtime_r gmtime gmtime_r) 
+AC_CHECK_FUNCS(ether_ntoa setpriority sched_setscheduler strlcpy strlcat strcasestr strcasecmp sigaction getutent setutent getisax strdup _strdup strdupa _strdupa daemon stat64 putenv setenv unsetenv res_init strtoull localtime localtime_r gmtime gmtime_r)
 
 AC_CHECK_DECLS([_fpreset, fpreset, _configthreadlocale],
     [],[],[[
@@ -1013,7 +1026,7 @@ dnl ---------- libNotify --------------------------------------------------
 if test "${enable_manager}" = yes ; then
   PKG_CHECK_MODULES(LIBNOTIFY, [libnotify])
 fi
- 
+
 dnl ---------- Sqlite3 ----------------------------------------------------
 if test "${enable_manager}" = yes ; then
   AM_PATH_SQLITE3
@@ -1024,7 +1037,7 @@ if test "${enable_manager}" = yes; then
     PKG_CHECK_MODULES(XCB,xcb,have_Xcb="yes",[echo "WARNING: Xcb not found, x11_screensaver will not be built"])
     PKG_CHECK_MODULES(XCBATOM,xcb-atom,have_Xcbatom="yes",[echo "WARNING: Xcb-atom not found, x11_screensaver will not be built"])
 fi
-AM_CONDITIONAL(BUILD_X11_SCREENSAVER, [ test "$have_Xcb" = yes -a "$have_Xcbatom" = yes ]) 
+AM_CONDITIONAL(BUILD_X11_SCREENSAVER, [ test "$have_Xcb" = yes -a "$have_Xcbatom" = yes ])
 dnl -----------------------------------------------------------------------
 
 dnl Heres another way to set up host-specific stuff
@@ -1035,7 +1048,7 @@ if echo $host_os | grep '^darwin' >/dev/null ; then
   fi
 fi
 
-AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep '^linux' > /dev/null]) 
+AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep '^linux' > /dev/null])
 dnl In case anyone wants to try building the windows code using mingw!
 AM_CONDITIONAL(OS_WIN32, [echo $host_os | egrep '^mingw|^winnt' > /dev/null])
 AM_CONDITIONAL(OS_WIN32_MINGW, [echo $host_os | grep '^mingw' > /dev/null])
@@ -1053,6 +1066,7 @@ AM_CONDITIONAL(ENABLE_CLIENT, [test "${enable_client}" = yes])
 AM_CONDITIONAL(ENABLE_MANAGER, [ test "x${ac_cv_have_wxwidgets}" = xyes -a "${enable_manager}" = yes ])
 AM_CONDITIONAL(ENABLE_LIBRARIES, [test "${enable_libraries}" = yes])
 AM_CONDITIONAL(ENABLE_BOINCZIP, [test "${enable_boinczip}" = yes])
+AM_CONDITIONAL(ENABLE_APPS, [test "${enable_apps}" = yes])
 AM_CONDITIONAL(ENABLE_BOINCCRYPT, [test "x${enable_server}" = xyes  || test "x${enable_client}" = xyes ])
 AM_CONDITIONAL(INSTALL_HEADERS, [test "${enable_install_headers}" = yes])
 AM_CONDITIONAL(HAVE_CUDA_LIB, [test "${enable_client}" = yes -a -f ./coprocs/CUDA/posix/${boinc_platform}/libcudart.so])
@@ -1079,7 +1093,7 @@ fi
        echo DEBUG: CLIENTLIBS=${CLIENTLIBS} >&5
 if test "$enable_release_client" = yes -a "$disable_static_linkage" = no ; then
 if test x${ac_cv_cxx_compiler_gnu} != xno ; then
-  SAH_CHECK_LIB([gcc_eh],[_Unwind_Resume],[ 
+  SAH_CHECK_LIB([gcc_eh],[_Unwind_Resume],[
     AC_DEFINE([HAVE_LIBGCC_EH],[1],[Define to 1 if you have the gcc_eh library])
     CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
    echo DEBUG: CLIENTLIBS=${CLIENTLIBS} >&5
@@ -1087,7 +1101,7 @@ if test x${ac_cv_cxx_compiler_gnu} != xno ; then
     AC_DEFINE([HAVE_LIBGCC],[1],[Define to 1 if you have the gcc library])
     CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
    echo DEBUG: CLIENTLIBS=${CLIENTLIBS} >&5
-  SAH_CHECK_LIB([c_nonshared],[fopen],[ 
+  SAH_CHECK_LIB([c_nonshared],[fopen],[
     AC_DEFINE([HAVE_LIBC_NONSHARED],[1],[Define to 1 if you have the c_nonshared library])
     CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
    echo DEBUG: CLIENTLIBS=${CLIENTLIBS} >&5
@@ -1108,14 +1122,14 @@ if test ${isWIN32} = "yes" ; then
      echo DEBUG: CLIENTLIBS=${CLIENTLIBS} >&5
      found_msvcrt=no
   SAH_CHECK_LIB([msvcr110],[fopen],[
-      found_msvcrt=yes 
+      found_msvcrt=yes
       AC_DEFINE([HAVE_LIBMSVCR110],[1],[Define to 1 if you have the msvcr110 library])
       AC_DEFINE([HAVE_MSVCRT],[1],[Define to 1 if you have a visual c runtime library])
       CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
      echo DEBUG: CLIENTLIBS=${CLIENTLIBS} >&5
   if test $found_msvcrt = no ; then
     SAH_CHECK_LIB([msvcr100],[fopen],[
-        found_msvcrt=yes 
+        found_msvcrt=yes
         AC_DEFINE([HAVE_LIBMSVCR100],[1],[Define to 1 if you have the msvcr100 library])
         AC_DEFINE([HAVE_MSVCRT],[1],[Define to 1 if you have a visual c runtime library])
         CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
@@ -1123,7 +1137,7 @@ if test ${isWIN32} = "yes" ; then
   fi
   if test $found_msvcrt = no ; then
     SAH_CHECK_LIB([msvcr90d],[fopen],[
-        found_msvcrt=yes 
+        found_msvcrt=yes
         AC_DEFINE([HAVE_LIBMSVCR90D],[1],[Define to 1 if you have the msvcr90d library])
         AC_DEFINE([HAVE_MSVCRT],[1],[Define to 1 if you have a visual c runtime library])
         CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
@@ -1131,7 +1145,7 @@ if test ${isWIN32} = "yes" ; then
   fi
   if test $found_msvcrt = no ; then
     SAH_CHECK_LIB([msvcr90],[fopen],[
-        found_msvcrt=yes 
+        found_msvcrt=yes
         AC_DEFINE([HAVE_LIBMSVCR90],[1],[Define to 1 if you have the msvcr90 library])
         AC_DEFINE([HAVE_MSVCRT],[1],[Define to 1 if you have a visual c runtime library])
         CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
@@ -1172,7 +1186,7 @@ if test ${isWIN32} = "yes" ; then
 fi
 
 svlibs=$LIBS
-if test "${ac_cv_func_res_init}" != "yes" ; then 
+if test "${ac_cv_func_res_init}" != "yes" ; then
   AC_CHECK_LIB([resolv],[res_init],[
     ac_cv_func_res_init="yes"
     AC_CHECK_FUNCS([res_init])
@@ -1233,7 +1247,7 @@ if test "${enable_client_release}" = "yes" ; then
 
 
 
-   ## NOTE: its *extremely* important to always compile with __NO_CTYPE 
+   ## NOTE: its *extremely* important to always compile with __NO_CTYPE
    ## defined, because this avoids GLIBC_2.3 symbols being pulled in via ctype.h-macros,
    CPPFLAGS="${CPPFLAGS} -D__NO_CTYPE"
 fi
@@ -1308,6 +1322,7 @@ AC_CONFIG_FILES([
                  packages/solaris/CSW/boincmanager/Makefile
                  packages/solaris/CSW/boincmanager/pkginfo
                  packages/solaris/CSW/boincmanager/prototype
+                 samples/Makefile
                  test/boinc_path_config.py:py/boinc_path_config.py.in
                  test/Makefile
                  test/version.inc

--- a/samples/Makefile.am
+++ b/samples/Makefile.am
@@ -1,0 +1,7 @@
+## -*- mode: makefile; tab-width: 4 -*-
+
+include $(top_srcdir)/Makefile.incl
+
+## list the apps that should be build
+SUBDIRS = condor example_app multi_thread sleeper vboxmonitor vboxwrapper worker wrapper
+## NOTE: nvcuda and wrappture need external libraries

--- a/samples/vboxmonitor/Makefile
+++ b/samples/vboxmonitor/Makefile
@@ -26,5 +26,5 @@ clean: distclean
 distclean:
 	/bin/rm -f $(PROGS) *.o libstdc++.a
 
-vboxwrapper: vboxmonitor.o libstdc++.a $(BOINC_LIB_DIR)/libboinc.a $(BOINC_API_DIR)/libboinc_api.a
+vboxmonitor: vboxmonitor.o libstdc++.a $(BOINC_LIB_DIR)/libboinc.a $(BOINC_API_DIR)/libboinc_api.a
 	g++ $(CXXFLAGS) -o vboxmonitor vboxmonitor.o libstdc++.a -pthread -lboinc_api -lboinc


### PR DESCRIPTION
- By default apps won't be built. In order to build the example apps use --enable-apps as option to ./configure. Not all apps are supported as some need further external libraries.
- Also fix a copy/paste error in the vboxmonitor Makefile