### PR TITLE
BoincAPI Windows static CRT leak

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -701,10 +701,12 @@ int boinc_finish_message(int status, const char* msg, bool is_notice) {
     finishing = true;
     boinc_sleep(2.0);   // let the timer thread send final messages
 	boinc_disable_timer_thread = true;     // then disable it
+#ifdef _WIN32
 	#if !(defined(_MT) && defined(_DLL)) // Static C-Runtime special care,
 		WaitForSingleObject( timer_thread_handle, INFINITE ); // Wait for the timer thread to exit, so we can free the handle
 		CloseHandle( timer_thread_handle );
 	#endif
+#endif
 
     if (options.main_program) {
         FILE* f = fopen(BOINC_FINISH_CALLED_FILE, "w");
@@ -1323,7 +1325,7 @@ int start_timer_thread() {
     //
 	// Dynamic or Static C-Runtime determined correct threading Api to use
 	// see documentation at 
-	#if defined(_MT) && defined (_DLL) //Dynamic linked C-Runtime, leave as is for now pending later review 
+	#if defined(_MT) && defined(_DLL) //Dynamic linked C-Runtime, leave as is for now pending later review 
 		if (!CreateThread(NULL, 0, timer_thread, 0, 0, &timer_thread_id)) {
 			fprintf(stderr,
 				"%s start_timer_thread(): CreateThread() failed, errno %d\n",

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -153,6 +153,7 @@ extern void options_defaults(BOINC_OPTIONS&);
 extern APP_CLIENT_SHM *app_client_shm;
 #ifdef _WIN32
 extern HANDLE worker_thread_handle;
+extern HANDLE timer_thread_handle;
 #endif
 extern int boinc_init_options_general(BOINC_OPTIONS& opt);
 extern int start_timer_thread();


### PR DESCRIPTION
Handle and resource leakage corrected for main application timer thread
(first cut).  This covers the ordinary boinc_finish() run to completion
situation only. Medium speed XP 32 bit host estimated at 2-6 weeks
between needing a reboot due to low kernel resources.  One actual host
under observation exhibited the 'reboot to clear'  issue after 7 weeks,

The API will need further attention to what happens to the timer thread
handle and resources under various unusual exit conditions, perhaps
moving cleanup  to boinc_exit(), however since the timer thread calls
boinc_exit(), that's problematic. Cases of client shutdown, abort and
error exits, will need investigation, along with API review for the
dynamic C Runtime  with respect to handles.;  A Test Protocol should be
devised once applicable other areas are identified.

See MSDN documentation for _beignthreadex() and CreateThread() for
Visual Studio 2008/2010/2013, for details.