### PR TITLE
vboxwrapper ncpus -> nthreads bug

### DIFF
--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -504,7 +504,7 @@ int main(int argc, char** argv) {
         if (!strcmp(argv[i], "--trickle")) {
             trickle_period = atof(argv[++i]);
         }
-        if (!strcmp(argv[i], "--ncpus")) {
+        if (!strcmp(argv[i], "--nthreads")) {
             ncpus = atof(argv[++i]);
         }
         if (!strcmp(argv[i], "--memory_size_mb")) {


### PR DESCRIPTION
Typo where vboxwrapper was accepting `--ncpus` instead of `--nthreads` like it should. 