### PR TITLE
new `make_project` options which allow building and running project on different systems

### DIFF
--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -8,7 +8,7 @@
 import boinc_path_config
 from Boinc import database, db_mid, configxml, tools
 from Boinc.boinc_db import *
-import os, sys, glob, time, shutil, re, random, socket
+import os, sys, glob, time, shutil, re, random
 
 class Options:
     pass
@@ -454,6 +454,7 @@ class Project:
                  project_dir=None, key_dir=None,
                  master_url=None,
                  db_name=None,
+                 host=None,
                  web_only=False,
                  no_db=False,
                  production=False
@@ -480,8 +481,7 @@ class Project:
         config.db_host = options.db_host
         config.shmem_key = generate_shmem_key()
         config.uldl_dir_fanout = 1024
-        local_host = socket.gethostname()
-        config.host = local_host.split('.')[0]
+        config.host = host
         config.min_sendwork_interval = 0
         config.max_wus_to_send = 50
         config.daily_result_quota = 500

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -455,12 +455,14 @@ class Project:
                  master_url=None,
                  db_name=None,
                  web_only=False,
+                 no_db=False,
                  production=False
                  ):
         init()
 
         self.production     = production
         self.web_only       = web_only
+        self.no_db          = no_db
         self.short_name     = short_name
         self.long_name      = long_name or 'Project ' + self.short_name.replace('_',' ').capitalize()
 
@@ -578,12 +580,15 @@ class Project:
         print >>f, "<link rel=\"boinc_scheduler\" href=\"" + self.scheduler_url.strip()+ "\">"
         f.close()
 
-        verbose_echo(1, "Setting up database")
-        database.create_database(
-            srcdir = options.srcdir,
-            config = self.config.config,
-            drop_first = options.drop_db_first
-            )
+        if self.no_db:
+            verbose_echo(1, "Not setting up database (--no_db was specified)")
+        else:
+            verbose_echo(1, "Setting up database")
+            database.create_database(
+                srcdir = options.srcdir,
+                config = self.config.config,
+                drop_first = options.drop_db_first
+                )
 
         verbose_echo(1, "Writing config files")
 

--- a/tools/make_project
+++ b/tools/make_project
@@ -35,6 +35,7 @@ Misc options:
    --drop_db_first      drop database first (from prev installation)
    --test_app           install example application
    --web_only           install web files, no executables (for Bossa, Bolt)
+   --no_db              don't create the database
    --srcdir             where to find the source files (default: current directory)
 
 Dir-options:
@@ -76,6 +77,7 @@ try:
             'no_query',
             'test_app',
             'web_only',
+            'no_db',
             'srcdir=',
             'user_name=',
             'drop_db_first',
@@ -99,6 +101,7 @@ options.url_base = None
 options.no_query = False
 options.test_app = False
 options.web_only = False
+options.no_db = False
 options.delete_prev_inst = False
 options.srcdir = None
 
@@ -109,6 +112,7 @@ for o,a in opts:
     elif o == '--no_query':      options.no_query       = True
     elif o == '--test_app':      options.test_app       = True
     elif o == '--web_only':      options.web_only       = True
+    elif o == '--no_db':         options.no_db          = True
     elif o == '--srcdir':        options.srcdir         = a
     elif o == '--user_name':     options.user_name      = a
     elif o == '--drop_db_first': options.drop_db_first  = True
@@ -215,6 +219,7 @@ project = Project(
     key_dir = options.key_dir,
     db_name = options.db_name,
     web_only = options.web_only,
+    no_db = options.no_db,
     production = True
     )
 
@@ -288,10 +293,11 @@ t.disabled = 0
 
 project.config.write()
 
-try:
-    os.system('cd '+proot+'/html/ops; ./db_schemaversion.php > '+proot+'/db_revision')
-except:
-    print '''Couldn't set db schema version number'''
+if not options.no_db:
+    try:
+        os.system('cd '+proot+'/html/ops; ./db_schemaversion.php > '+proot+'/db_revision')
+    except:
+        print '''Couldn't set db schema version number'''
 
 try:
     os.system('cd '+proot+'/html/ops; ./update_translations.php -d 1')

--- a/tools/make_project
+++ b/tools/make_project
@@ -41,7 +41,8 @@ Misc options:
 Dir-options:
    --project_root       default: HOME/projects/PROJECT
    --key_dir            default: PROJECT_ROOT/keys
-   --url_base           default: http://$NODENAME/ (http://%(NODENAME)s/)
+   --project_host       default: $HOSTNAME (%(NODENAME)s)
+   --url_base           default: http://PROJECT_HOST/
 
    --html_user_url      default: URL_BASE/PROJECT/
    --html_ops_url       default: URL_BASE/PROJECT_ops/
@@ -72,26 +73,27 @@ def usage():
 try:
     opts, args = getopt.getopt(sys.argv[1:],
         'hv', [
-            'help',
-            'verbose=',
-            'no_query',
-            'test_app',
-            'web_only',
-            'no_db',
-            'srcdir=',
-            'user_name=',
-            'drop_db_first',
-            'delete_prev_inst',
             'base=',
-            'key_dir=',
-            'project_root=',
-            'url_base=',
-            'html_user_url=',
-            'html_ops_url=',
-            'db_name=',
-            'db_user=',
-            'db_passwd=',
             'db_host=',
+            'db_name=',
+            'db_passwd=',
+            'db_user=',
+            'delete_prev_inst',
+            'drop_db_first',
+            'help',
+            'html_ops_url=',
+            'html_user_url=',
+            'key_dir=',
+            'no_db',
+            'no_query',
+            'project_host=',
+            'project_root=',
+            'srcdir=',
+            'test_app',
+            'url_base=',
+            'user_name=',
+            'verbose=',
+            'web_only',
             ]
         )
 except getopt.GetoptError, e:
@@ -107,25 +109,26 @@ options.srcdir = None
 
 for o,a in opts:
     if o == '-h' or o == '--help':        usage()
-    elif o == '-v':              options.echo_verbose   = 2
-    elif o == '--verbose':       options.echo_verbose   = int(a)
-    elif o == '--no_query':      options.no_query       = True
-    elif o == '--test_app':      options.test_app       = True
-    elif o == '--web_only':      options.web_only       = True
-    elif o == '--no_db':         options.no_db          = True
-    elif o == '--srcdir':        options.srcdir         = a
-    elif o == '--user_name':     options.user_name      = a
-    elif o == '--drop_db_first': options.drop_db_first  = True
-    elif o == '--delete_prev_inst': options.delete_prev_inst  = True
-    elif o == '--key_dir':       options.key_dir        = a
-    elif o == '--project_root':  options.project_root   = a
-    elif o == '--url_base':      options.url_base       = a
-    elif o == '--html_user_url': options.html_user_url  = a
-    elif o == '--html_ops_url':  options.html_ops_url   = a
-    elif o == '--db_name':       options.db_name        = a
-    elif o == '--db_user':       options.db_user        = a
-    elif o == '--db_passwd':     options.db_passwd      = a
     elif o == '--db_host':       options.db_host        = a
+    elif o == '--db_name':       options.db_name        = a
+    elif o == '--db_passwd':     options.db_passwd      = a
+    elif o == '--db_user':       options.db_user        = a
+    elif o == '--delete_prev_inst': options.delete_prev_inst  = True
+    elif o == '--drop_db_first': options.drop_db_first  = True
+    elif o == '--html_ops_url':  options.html_ops_url   = a
+    elif o == '--html_user_url': options.html_user_url  = a
+    elif o == '--key_dir':       options.key_dir        = a
+    elif o == '--no_db':         options.no_db          = True
+    elif o == '--no_query':      options.no_query       = True
+    elif o == '--project_host':  options.project_host   = a
+    elif o == '--project_root':  options.project_root   = a
+    elif o == '--srcdir':        options.srcdir         = a
+    elif o == '--test_app':      options.test_app       = True
+    elif o == '--url_base':      options.url_base       = a
+    elif o == '--user_name':     options.user_name      = a
+    elif o == '--verbose':       options.echo_verbose   = int(a)
+    elif o == '--web_only':      options.web_only       = True
+    elif o == '-v':              options.echo_verbose   = 2
     else:
         raise SystemExit('internal error o=%s'%o)
 
@@ -161,7 +164,8 @@ def replopt(str):
 def defopt(name, v, isdir=True):
     options.__dict__[name] = opt_repls[name.upper()] = add_slash(replopt(options.__dict__.get(name) or v), isdir)
 
-defopt('url_base'      , 'http://%s/'%NODENAME)
+defopt('project_host'  , NODENAME, isdir=False)
+defopt('url_base'      , 'http://%s/'%options.project_host)
 
 if not isurl(options.url_base):
     syntax_error('url_base needs to be an URL')
@@ -181,6 +185,7 @@ defopt('db_host'       , '', isdir=False)
 print "Creating project '%s' (short name '%s'):" %(project_longname, project_shortname)
 for k in [
     'project_root',
+    'project_host',
     'url_base',
     'html_user_url',
     'html_ops_url',
@@ -218,6 +223,7 @@ project = Project(
     master_url = options.html_user_url,
     key_dir = options.key_dir,
     db_name = options.db_name,
+    host = options.project_host,
     web_only = options.web_only,
     no_db = options.no_db,
     production = True


### PR DESCRIPTION
I added two new options to `tools/make_project`:

```
   --no_db              don't create the database
   --project_host       default: $HOSTNAME
```

These allow one to build the project on a different system than the one which will ultimately run it. In this case the build system doesn't need to be connected to the mysql database nor does it need to have the same hostname. One example use-case (mine) is to allow creating a BOINC server Docker image where the build happens in a different container than the one running the project.
