### PR TITLE
Fix issue #79: Optionally not start the daemon

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -154,6 +154,8 @@ bool CBOINCGUIApp::OnInit() {
     m_iDisplayExitDialog = 1;
     m_iGUISelected = BOINC_SIMPLEGUI;
     m_bSafeMessageBoxDisplayed = 0;
+    m_bRunDaemon = true;
+    m_bNeedRunDaemon = true;
 
     // Initialize local variables
     int      iErrorCode = 0;
@@ -221,8 +223,11 @@ bool CBOINCGUIApp::OnInit() {
     m_pConfig->Read(wxT("LanguageISO"), &m_strISOLanguageCode, wxT(""));
     m_pConfig->Read(wxT("GUISelection"), &m_iGUISelected, BOINC_SIMPLEGUI);
     m_pConfig->Read(wxT("EventLogOpen"), &bOpenEventLog);
+    m_pConfig->Read(wxT("RunDaemon"), &m_bRunDaemon, 1L);
 
-
+    // Detect if the daemon should be launched
+    m_bNeedRunDaemon = m_bNeedRunDaemon && m_bRunDaemon;
+    
     // Should we abort the BOINC Manager startup process?
     if (m_bBOINCMGRAutoStarted && m_iBOINCMGRDisableAutoStart) {
         return false;
@@ -646,6 +651,7 @@ void CBOINCGUIApp::SaveState() {
     m_pConfig->Write(wxT("AutomaticallyShutdownClient"), m_iShutdownCoreClient);
     m_pConfig->Write(wxT("DisplayShutdownClientDialog"), m_iDisplayExitDialog);
     m_pConfig->Write(wxT("DisableAutoStart"), m_iBOINCMGRDisableAutoStart);
+    m_pConfig->Write(wxT("RunDaemon"), m_bRunDaemon);
 }
 
 
@@ -672,6 +678,7 @@ void CBOINCGUIApp::OnInitCmdLine(wxCmdLineParser &parser) {
 #if (defined(__WXMAC__) && defined(_DEBUG))
         { wxCMD_LINE_OPTION, "NSDocumentRevisionsDebugMode", NULL, _("Not used: workaround for bug in XCode 4.2")},
 #endif
+        { wxCMD_LINE_SWITCH, "nd", "no-daemon", _("Not run the daemon")},
         { wxCMD_LINE_NONE}  //DON'T forget this line!!
     };
     parser.SetDesc(cmdLineDesc);
@@ -748,6 +755,10 @@ bool CBOINCGUIApp::OnCmdLineParsed(wxCmdLineParser &parser) {
 
     if (hostNameSpecified && passwordSpecified) {
         m_bMultipleInstancesOK = true;
+    }
+
+    if (parser.Found(wxT("no-daemon"))) {
+        m_bNeedRunDaemon = false;
     }
     return true;
 }

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -104,6 +104,8 @@ protected:
     bool                m_bMultipleInstancesOK;
     bool                m_bFilterEvents;
     bool                m_bAboutDialogIsOpen;
+    bool                m_bRunDaemon;
+    bool                m_bNeedRunDaemon;
 
 #ifdef __WXMAC__
     ProcessSerialNumber m_psnCurrentProcess;
@@ -157,6 +159,13 @@ public:
     void                SetBOINCMGRDisplayExitMessage(int iDisplayExitMessage)
                                                     { m_iDisplayExitDialog = iDisplayExitMessage; }
 
+    bool                GetRunDaemon()
+                                                    { return m_bRunDaemon; }
+    void                SetRunDaemon(bool bRunDaemon)
+                                                    { m_bRunDaemon = bRunDaemon; }
+
+    bool                GetNeedRunDaemon()
+                                                    { return m_bNeedRunDaemon; }
 
     wxArrayString&      GetSupportedLanguages()     { return m_astrLanguages; }
     wxString            GetISOLanguageCode()        { return m_strISOLanguageCode; }

--- a/clientgui/DlgOptions.cpp
+++ b/clientgui/DlgOptions.cpp
@@ -99,6 +99,7 @@ bool CDlgOptions::Create(wxWindow* parent, wxWindowID id, const wxString& captio
     m_LanguageSelectionCtrl = NULL;
     m_ReminderFrequencyCtrl = NULL;
     m_EnableBOINCManagerAutoStartCtrl = NULL;
+    m_EnableRunDaemonCtrl = NULL;
     m_EnableBOINCManagerExitMessageCtrl = NULL;
     m_DialupStaticBoxCtrl = NULL;
 #if defined(__WXMSW__)
@@ -209,8 +210,18 @@ void CDlgOptions::CreateControls() {
 #endif
 
     wxStaticText* itemStaticText11 = new wxStaticText;
-    itemStaticText11->Create( itemPanel4, wxID_STATIC, _("Enable Manager exit dialog?"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemStaticText11->Create( itemPanel4, wxID_STATIC, _("Run daemon?"), wxDefaultPosition, wxDefaultSize, 0 );
     itemFlexGridSizer6->Add(itemStaticText11, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+
+    m_EnableRunDaemonCtrl = new wxCheckBox;
+    m_EnableRunDaemonCtrl->Create( itemPanel4, ID_ENABLERUNDAEMON, wxT(""), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+    if (ShowToolTips())
+        m_EnableRunDaemonCtrl->SetToolTip(_("Run daemon when launching the Manager."));
+    itemFlexGridSizer6->Add(m_EnableRunDaemonCtrl, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+
+    wxStaticText* itemStaticText12 = new wxStaticText;
+    itemStaticText12->Create( itemPanel4, wxID_STATIC, _("Enable Manager exit dialog?"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemFlexGridSizer6->Add(itemStaticText12, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     m_EnableBOINCManagerExitMessageCtrl = new wxCheckBox;
     m_EnableBOINCManagerExitMessageCtrl->Create( itemPanel4, ID_ENABLEEXITMESSAGE, wxT(""), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
@@ -631,6 +642,7 @@ bool CDlgOptions::ReadSettings() {
         m_DialupClearDefaultCtrl->Disable();
     }
 #endif
+    m_EnableRunDaemonCtrl->SetValue(wxGetApp().GetRunDaemon());
 
     // Proxy Tabs
     m_bRetrievedProxyConfiguration = (0 == pDoc->GetProxyConfiguration());
@@ -737,6 +749,7 @@ bool CDlgOptions::SaveSettings() {
     // Connection Tab
     pFrame->SetDialupConnectionName(GetDefaultDialupConnection());
 #endif
+    wxGetApp().SetRunDaemon(m_EnableRunDaemonCtrl->GetValue());
 
     // Proxy Tabs
     if (m_bRetrievedProxyConfiguration) {

--- a/clientgui/DlgOptions.h
+++ b/clientgui/DlgOptions.h
@@ -54,6 +54,7 @@
 #define ID_REMINDERFREQUENCY 10018
 #define ID_ENABLEAUTOSTART 10031
 #define ID_ENABLEEXITMESSAGE 10032
+#define ID_ENABLERUNDAEMON 10033
 #define ID_CONNECTONS 10019
 #define ID_NETWORKAUTODETECT 10020
 #define ID_NETWORKLAN 10021
@@ -165,6 +166,7 @@ private:
     wxComboBox* m_ReminderFrequencyCtrl;
     wxCheckBox* m_EnableBOINCManagerAutoStartCtrl;
     wxCheckBox* m_EnableBOINCManagerExitMessageCtrl;
+    wxCheckBox* m_EnableRunDaemonCtrl;
     wxStaticBoxSizer* m_DialupStaticBoxCtrl;
     wxListBox* m_DialupConnectionsCtrl;
     wxButton* m_DialupSetDefaultCtrl;

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -579,19 +579,20 @@ int CMainDocument::OnPoll() {
             }
         }
         
-        if (IsComputerNameLocal(hostName)) {
-            pFrame->UpdateStatusText(_("Starting client"));
-            if (m_pClientManager->StartupBOINCCore()) {
+        if (wxGetApp().GetNeedRunDaemon()) {
+            if (IsComputerNameLocal(hostName)) {
+              pFrame->UpdateStatusText(_("Starting client"));
+              if (m_pClientManager->StartupBOINCCore()) {
                 Connect(wxT("localhost"), portNum, password, TRUE, TRUE);
-            } else {
+              } else {
                 m_pNetworkConnection->ForceDisconnect();
                 pFrame->ShowDaemonStartFailedAlert();
+              }
+            } else {
+              pFrame->UpdateStatusText(_("Connecting to client"));
+              Connect(hostName, portNum, password, TRUE, password.IsEmpty());
             }
-        } else {
-            pFrame->UpdateStatusText(_("Connecting to client"));
-            Connect(hostName, portNum, password, TRUE, password.IsEmpty());
         }
-
         pFrame->UpdateStatusText(wxEmptyString);
     }
 


### PR DESCRIPTION
- New commanline option -nd (short) and --no-daemon (long).
- New option in Preferences Dialog "Run daemon?"
So after Manager start daemon will be run only if commandline option --no-daemon is off and option "Run daemon?" is on. Otherwise daemon will not be run.