### PR TITLE
cppcheck: Fix reports "Prefer prefix ++/-- operators for non-primitiv…

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -310,7 +310,7 @@ void procinfo_show(PROC_MAP& pm) {
     PROCINFO pi;
     pi.clear();
     PROC_MAP::iterator i;
-    for (i=pm.begin(); i!=pm.end(); i++) {
+    for (i=pm.begin(); i!=pm.end(); ++i) {
         PROCINFO& p = i->second;
 
         msg_printf(NULL, MSG_INFO, "%d %s: boinc? %d low_pri %d (u%f k%f)",

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -690,7 +690,7 @@ void print_old_results(MIOFILE& mf) {
             ores.completed_time,
             ores.create_time
         );
-        i++;
+        ++i;
     }
     mf.printf("</old_results>\n");
 }


### PR DESCRIPTION
…e types"

[client/app.cpp:313]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[client/result.cpp:693]: (performance) Prefer prefix ++/-- operators for non-primitive types.