### PR TITLE
cppcheck: fix 1 kind of reports

### DIFF
--- a/dcapi/condor/condor_utils.c
+++ b/dcapi/condor/condor_utils.c
@@ -173,7 +173,7 @@ _DC_get_file(char *fn)
 	if ((f= fopen(fn, "r")) != NULL)
 	{
 		int bs= 100, i;
-		char c;
+		int c;
 
 		buf= malloc(bs);
 		i= 0;
@@ -185,10 +185,10 @@ _DC_get_file(char *fn)
 				bs+= 100;
 				buf= realloc(buf, bs);
 			}
-			buf[i]= c;
+			buf[i]= (char)c;
 			i++;
-			buf[i]= '\0';
 		}
+		buf[i]= '\0';
 		fclose(f);
 	}
 	return(buf);
@@ -363,7 +363,7 @@ _DC_read_message(char *box, char *name, int del_msg)
 	if ((f= fopen(fn, "r")) != NULL)
 	{
 		int bs= 100, i;
-		char c;
+		int c;
 
 		buf= malloc(bs);
 		i= 0;
@@ -375,10 +375,10 @@ _DC_read_message(char *box, char *name, int del_msg)
 				bs+= 100;
 				buf= realloc(buf, bs);
 			}
-			buf[i]= c;
+			buf[i]= (char)c;
 			i++;
-			buf[i]= '\0';
 		}
+		buf[i]= '\0';
 		fclose(f);
 		if (del_msg)
 			unlink(fn);

--- a/dcapi/condor/tc.c
+++ b/dcapi/condor/tc.c
@@ -32,7 +32,7 @@ get_file(char *fn)
 	if ((f= fopen(fn, "r")) != NULL)
 	{
 		int bs= 100, i;
-		char c;
+		int c;
 
 		buf= malloc(bs);
 		i= 0;
@@ -44,10 +44,10 @@ get_file(char *fn)
 				bs+= 100;
 				buf= realloc(buf, bs);
 			}
-			buf[i]= c;
+			buf[i]= (char)c;
 			i++;
-			buf[i]= '\0';
 		}
+		buf[i]= '\0';
 		fclose(f);
 	}
 	return(buf);

--- a/dcapi/local/local_utils.c
+++ b/dcapi/local/local_utils.c
@@ -177,7 +177,7 @@ _DC_get_file(char *fn)
 	if ((f= fopen(fn, "r")) != NULL)
 	{
 		int bs= 100, i;
-		char c;
+		int c;
 
 		buf= malloc(bs);
 		i= 0;
@@ -189,10 +189,10 @@ _DC_get_file(char *fn)
 				bs+= 100;
 				buf= realloc(buf, bs);
 			}
-			buf[i]= c;
+			buf[i]= (char)c;
 			i++;
-			buf[i]= '\0';
 		}
+		buf[i]= '\0';
 		fclose(f);
 	}
 	return(buf);
@@ -367,7 +367,7 @@ _DC_read_message(char *box, char *name, int del_msg)
 	if ((f= fopen(fn, "r")) != NULL)
 	{
 		int bs= 100, i;
-		char c;
+		int c;
 
 		buf= malloc(bs);
 		i= 0;
@@ -379,10 +379,10 @@ _DC_read_message(char *box, char *name, int del_msg)
 				bs+= 100;
 				buf= realloc(buf, bs);
 			}
-			buf[i]= c;
+			buf[i]= (char)c;
 			i++;
-			buf[i]= '\0';
 		}
+		buf[i]= '\0';
 		fclose(f);
 		if (del_msg)
 			unlink(fn);


### PR DESCRIPTION
(warning) Storing fgetc() return value in char variable and then comparing with EOF
+ optimize a bit by moving the instruction "buf[i]= '\0';" inside the loop, outside from it.
(only non example files have been changed)