### PR TITLE
Web: rename recaptcha_get_html() because of a conflict with Drupal

### DIFF
--- a/html/inc/account.inc
+++ b/html/inc/account.inc
@@ -78,7 +78,7 @@ function create_account_form($teamid, $next_url) {
     if ($publickey) {
         row2(
             "",
-            recaptcha_get_html($publickey)
+            boinc_recaptcha_get_html($publickey)
         );
     }
 

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -1002,7 +1002,7 @@ function recaptcha_get_head_extra() {
     }
 }
 
-function recaptcha_get_html($publickey) {
+function boinc_recaptcha_get_html($publickey) {
     if ($publickey) {
         return '<div class="g-recaptcha" data-sitekey="' . $publickey . '"></div>';
     } else {

--- a/html/user/create_profile.php
+++ b/html/user/create_profile.php
@@ -107,7 +107,7 @@ function show_submit() {
     $config = get_config();
     $publickey = parse_config($config, "<recaptcha_public_key>");
     if ($publickey) {
-        table_row(recaptcha_get_html($publickey));
+        table_row(boinc_recaptcha_get_html($publickey));
     }
     table_row("<p><input class=\"btn btn-primary\" type=\"submit\" value=\"".tra("Create/edit profile") ."\" name=\"submit\">");
 }


### PR DESCRIPTION
When also including an older recaptchalib.php this function gets redefined. Since it is only a wrapper function and only used within BOINC, renaming it is safe.