### PR TITLE
file upload handler: add logging and error checking

### DIFF
--- a/lib/sched_msgs.cpp
+++ b/lib/sched_msgs.cpp
@@ -24,6 +24,7 @@ SCHED_MSG_LOG log_messages;
 const char* SCHED_MSG_LOG::v_format_kind(int kind) const {
     switch(kind) {
     case MSG_CRITICAL: return "[CRITICAL]";
+    case MSG_WARNING:  return "[warning]";
     case MSG_NORMAL:   return "";
     case MSG_DEBUG:    return "[debug]";
     default:       return "*** internal error: invalid MessageKind ***";

--- a/lib/sched_msgs.h
+++ b/lib/sched_msgs.h
@@ -24,14 +24,14 @@
 #include "boinc_fcgi.h"
 #endif
 
-enum { MSG_CRITICAL=1, MSG_NORMAL, MSG_DEBUG };
+enum { MSG_CRITICAL=1, MSG_WARNING, MSG_NORMAL, MSG_DEBUG };
 
 class SCHED_MSG_LOG : public MSG_LOG {
     const char* v_format_kind(int kind) const;
     bool v_message_wanted(int kind) const;
 public:
     int debug_level;
-    enum { MSG_CRITICAL=1, MSG_NORMAL, MSG_DEBUG };
+    enum { MSG_CRITICAL=1, MSG_WARNING, MSG_NORMAL, MSG_DEBUG };
     SCHED_MSG_LOG(): MSG_LOG(stderr) { debug_level = MSG_NORMAL; }
     void set_debug_level(int new_level) { debug_level = new_level; }
     void set_indent_level(const int new_indent_level);

--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -164,6 +164,10 @@ int copy_socket_to_file(FILE* in, char* path, double offset, double nbytes) {
                     // and made read-only;
                     // return success to the client won't keep trying
                     //
+                    log_messages.printf(MSG_CRITICAL,
+                      "client tried to reupload the read-only file %s\n",
+                      path
+                    );
                     return return_success(0);
                 }
                 return return_error(ERR_TRANSIENT,
@@ -262,7 +266,9 @@ int copy_socket_to_file(FILE* in, char* path, double offset, double nbytes) {
     }
     // upload complete; make the file read-only so we won't try to upload it again.
     //
-    fchmod(fd, S_IRUSR|S_IRGRP|S_IROTH);
+    if (fchmod(fd, S_IRUSR|S_IRGRP|S_IROTH)) {
+        log_messages.printf(MSG_CRITICAL, "can't make file %s read only: %s\n", path, strerror(errno));
+    }
     close(fd);
     return return_success(0);
 }
@@ -726,6 +732,12 @@ int main(int argc, char *argv[]) {
             return_error(ERR_TRANSIENT, "can't read key file");
             exit(1);
         }
+    }
+
+    if (access(config.upload_dir, W_OK)) {
+        log_messages.printf(MSG_CRITICAL, "can't write to upload_dir\n");
+        return_error(ERR_TRANSIENT, "can't write to upload_dir");
+        exit(1);
     }
 
 #ifdef _USING_FCGI_

--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -164,7 +164,7 @@ int copy_socket_to_file(FILE* in, char* path, double offset, double nbytes) {
                     // and made read-only;
                     // return success to the client won't keep trying
                     //
-                    log_messages.printf(MSG_CRITICAL,
+                    log_messages.printf(MSG_WARNING,
                       "client tried to reupload the read-only file %s\n",
                       path
                     );


### PR DESCRIPTION
Add logging to the code introduced in ce00365 to eventually get to know the frequency and cause of reuploads. Also check if the file upload handler can write into the upload_dir at startup. This should more clearly detect permission issues.