### PR TITLE
Update BOINC-Manager.po "Boinc anhalten" => "Boinc pausieren"

### DIFF
--- a/locale/de/BOINC-Manager.po
+++ b/locale/de/BOINC-Manager.po
@@ -915,7 +915,7 @@ msgstr "Öffne %s..."
 #: clientgui/BOINCTaskBar.cpp:533 clientgui/BOINCTaskBar.cpp:631
 #: clientgui/BOINCTaskBar.cpp:636
 msgid "Snooze"
-msgstr "BOINC anhalten"
+msgstr "BOINC pausieren"
 
 #: clientgui/BOINCTaskBar.cpp:535 clientgui/BOINCTaskBar.cpp:650
 #: clientgui/BOINCTaskBar.cpp:655


### PR DESCRIPTION
Snooze should be translated to "pausieren" like in "Snooze GPU"=="GPU pausieren".
The current translation "anhalten" means "suspend" and is currently used when open Boinc manager and suspend boinc.
Suspend means stop until user resumes != Snooze means stop for 1 hour and auto resume.