### PR TITLE
Web: use https urls everywhere

### DIFF
--- a/html/inc/email.inc
+++ b/html/inc/email.inc
@@ -73,14 +73,14 @@ function send_auth_email($user) {
     $body = "This email was sent in response to a request on the ".PROJECT." web site.
 
 To log in to your ".PROJECT." account, visit:
-".URL_BASE."login_action.php?id=$user->id&t=$now&h=$x
+".secure_url_base()."login_action.php?id=$user->id&t=$now&h=$x
 (This link is valid for 1 day).
 After logging in, you can change your account's password or email address.
 ";
 
 $body .= "
 For further information and assistance with ".PROJECT.", visit
-".URL_BASE."
+".secure_url_base()."
 ";
 
     return send_email($user, $subject, $body);
@@ -109,6 +109,6 @@ function salted_key($key) {
 }
 
 function opt_out_url($user) {
-    return URL_BASE."opt_out.php?code=".salted_key($user->authenticator)."&userid=$user->id";
+    return secure_url_base()."opt_out.php?code=".salted_key($user->authenticator)."&userid=$user->id";
 }
 ?>

--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -1300,7 +1300,7 @@ function subscribe_rss($notify, &$title, &$msg, &$url) {
     $thread = BoincThread::lookup_id($notify->opaque);
     $title = tra("New posts in subscribed thread");
     $msg = tra("There are new posts in the thread '%1'",$thread->title);
-    $url = URL_BASE."forum_thread.php?id=$thread->id";
+    $url = secure_url_base()."forum_thread.php?id=$thread->id";
 }
 
 function show_mark_as_read_button($user) {

--- a/html/inc/forum_email.inc
+++ b/html/inc/forum_email.inc
@@ -68,7 +68,7 @@ function send_moderation_email($forum, $post, $thread, $explanation, $action) {
     $subject = PROJECT." moderation notice";
 
     $body = "Your post [ID $post->id] in thread '$thread->title'
-".URL_BASE."forum_thread.php?id=$thread->id#$post->id
+".secure_url_base()."forum_thread.php?id=$thread->id#$post->id
 has been $action by moderator $moderator->name (ID $moderator->id).
 $explanation
 
@@ -82,7 +82,7 @@ For assistance with ".PROJECT." go to ".$master_url;
 
     $body = "Because of moderation by $moderator->name (ID $moderator->id),
 The following email was sent to $user->name (ID $user->id)
-".URL_BASE."forum_user_posts.php?userid=$user->id
+".secure_url_base()."forum_user_posts.php?userid=$user->id
 ------------------------------
 Subject: $subject
 
@@ -105,7 +105,7 @@ function send_thread_moderation_email(
 
     $subject = PROJECT." forum moderation notice";
     $body = "Your thread '$thread->title'
-".URL_BASE."forum_thread.php?id=$thread->id
+".secure_url_base()."forum_thread.php?id=$thread->id
 has been $action_name by moderator $moderator->name (ID $moderator->id).
 $explanation
 
@@ -123,14 +123,14 @@ For assistance with ".PROJECT." go to ".$master_url;
 //
 function send_reply_notification_email($thread, $user){
     $title = PROJECT . ": A user has posted to '". $thread->title ."'";
-    $link = URL_BASE . "forum_thread.php?id=" . $thread->id;
+    $link = secure_url_base() . "forum_thread.php?id=" . $thread->id;
     $body = "Another " . PROJECT . " user has posted to the thread
 \"" . $thread->title . "\".\n"
            ."To view the updated thread, visit:\n$link
 
 --------------------------
 To change email preferences, visit:
-".URL_BASE."edit_forum_preferences_form.php
+".secure_url_base()."edit_forum_preferences_form.php
 Do not reply to this message.
 ";
     return send_email($user, $title, $body);
@@ -150,7 +150,7 @@ A post in the ".PROJECT." forums was reported as offensive.
     Thread:         $thread->title
     Post:           $post->id by $owner->id ($owner->name)
     Reporting User: $user->id ($user->name)
-    Link:           ".URL_BASE."forum_thread.php?id=$thread->id#$post->id
+    Link:           ".secure_url_base()."forum_thread.php?id=$thread->id#$post->id
     
 Comments from reporting user:
 $message

--- a/html/inc/forum_rss.inc
+++ b/html/inc/forum_rss.inc
@@ -30,7 +30,7 @@ function contains_image_or_video($x) {
 }
 
 function show_forum_rss_item($thread, $userid, $threads_only, $no_images) {
-    $unique_url=URL_BASE."forum_thread.php?id=".$thread->id;
+    $unique_url=secure_url_base()."forum_thread.php?id=".$thread->id;
 
     $clause2 = " and hidden=0 ";
     if ($userid) $clause2 .= "and user=$userid";
@@ -102,20 +102,20 @@ function forum_rss($forumid, $userid, $threads_only, $ndays) {
     if ($userid) {
         $description .= " (posts by $user->name)";
     }
-    $channel_image = URL_BASE . "rss_image.gif";
+    $channel_image = secure_url_base() . "rss_image.gif";
     $language = "en-us";
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>
         <rss version=\"2.0\">
         <channel>
         <title>".$description."</title>
-        <link>".URL_BASE."</link>
+        <link>".secure_url_base()."</link>
         <copyright>".COPYRIGHT_HOLDER."</copyright>
         <lastBuildDate>".$create_date."</lastBuildDate>
         <language>".$language."</language>
         <image>
             <url>".$channel_image."</url>
             <title>".PROJECT."</title>
-            <link>".URL_BASE."</link>
+            <link>".secure_url_base()."</link>
         </image>
     ";
 

--- a/html/inc/friend.inc
+++ b/html/inc/friend.inc
@@ -61,11 +61,11 @@ $src_user->name says: $msg
 
     $message .= "
 Please accept or decline by visiting
-".URL_BASE."home.php
+".secure_url_base()."home.php
 
 --------------------------
 To change email preferences, visit:
-".URL_BASE."edit_forum_preferences_form.php
+".secure_url_base()."edit_forum_preferences_form.php
 Do not reply to this message.
 " ;
     send_email($dest_user, "[".PROJECT."] friend request", $message);
@@ -83,11 +83,11 @@ $dest_user->name says: $msg
 
     $message .= "
 Visit your Account page at
-".URL_BASE."home.php
+".secure_url_base()."home.php
 
 --------------------------
 To change email preferences, visit:
-".URL_BASE."edit_forum_preferences_form.php
+".secure_url_base()."edit_forum_preferences_form.php
 Do not reply to this message.
 " ;
     send_email($src_user, "[".PROJECT."] friend confirmed", $message);
@@ -101,7 +101,7 @@ function friend_req_rss($notify, &$title, &$msg, &$url) {
     }
     $title = "Friend request";
     $msg = "$src_user->name has requested friendship with you. Please accept or decline.";
-    $url = URL_BASE."friend.php?action=query&target_userid=$notify->userid&userid=$notify->opaque";
+    $url = secure_url_base()."friend.php?action=query&target_userid=$notify->userid&userid=$notify->opaque";
 }
 
 function friend_accept_rss($notify, &$title, &$msg, &$url) {
@@ -112,7 +112,7 @@ function friend_accept_rss($notify, &$title, &$msg, &$url) {
     }
     $title = "Friendship confirmation";
     $msg = "$src_user->name has confirmed you as a friend";
-    $url = URL_BASE."home.php";
+    $url = secure_url_base()."home.php";
 }
 
 ?>

--- a/html/inc/news.inc
+++ b/html/inc/news.inc
@@ -37,7 +37,7 @@ function news_item($date, $title, $post) {
     ";
     if ($forum_link && !DISABLE_FORUMS) {
         echo "
-            &middot; <a href=".URL_BASE."forum_thread.php?id=$post->thread> ".tra("Comment")."</a>
+            &middot; <a href=".url_base()."forum_thread.php?id=$post->thread> ".tra("Comment")."</a>
         ";
     }
     echo "</span>
@@ -103,7 +103,7 @@ function show_news($start, $count) {
     }
 
     if ($count) {
-        echo "<a href=".URL_BASE."old_news.php>... more</a>";
+        echo "<a href=".url_base()."old_news.php>... more</a>";
     }
     echo "
         <br><br><small>

--- a/html/inc/notify.inc
+++ b/html/inc/notify.inc
@@ -23,7 +23,7 @@ function notify_rss_auth($user) {
 }
 
 function notify_rss_url($user) {
-    return URL_BASE."notify_rss.php?userid=$user->id&auth=".notify_rss_auth($user);
+    return secure_url_base()."notify_rss.php?userid=$user->id&auth=".notify_rss_auth($user);
 }
 
 function show_notify_rss_item($notify) {

--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -106,10 +106,10 @@ $content
 
 --------------------------
 To delete or respond to this message, visit:
-".URL_BASE."pm.php
+".secure_url_base()."pm.php
 
 To change email preferences, visit:
-".URL_BASE."edit_forum_preferences_form.php
+".secure_url_base()."edit_forum_preferences_form.php
 Do not reply to this message.
 " ;
     send_email($to_user, "[".PROJECT."] - private message", $message);
@@ -202,8 +202,8 @@ function pm_rss($notify, &$title, &$msg, &$url) {
         return;
     }
     $title = tra("Private message");
-    $msg = "You have received a <a href=".URL_BASE."pm.php>private message</a>.";
-    $url = URL_BASE."pm.php";
+    $msg = "You have received a <a href=".secure_url_base()."pm.php>private message</a>.";
+    $url = secure_url_base()."pm.php";
 }
 
 function pm_delete_user($user) {

--- a/html/inc/profile.inc
+++ b/html/inc/profile.inc
@@ -61,11 +61,11 @@ function profile_thumb_path($userid) {
 }
 
 function profile_image_url($userid) {
-    return URL_BASE.IMAGE_URL.$userid.'.jpg';
+    return url_base().IMAGE_URL.$userid.'.jpg';
 }
 
 function profile_thumb_url($userid) {
-    return URL_BASE.IMAGE_URL.$userid.'_sm.jpg';
+    return url_base().IMAGE_URL.$userid.'_sm.jpg';
 }
 
 function profile_user_thumb_url($user) {
@@ -182,7 +182,7 @@ function get_profile_summary($profile) {
 
     }
 
-    $summary = "<a href=\"".URL_BASE."view_profile.php?userid=".$profile->userid."\">".$user->name."</a> ".$description;
+    $summary = "<a href=\"".url_base()."view_profile.php?userid=".$profile->userid."\">".$user->name."</a> ".$description;
     return $summary;
 }
 

--- a/html/inc/uotd.inc
+++ b/html/inc/uotd.inc
@@ -27,7 +27,7 @@ if (!defined('UOTD_THRESHOLD')) {
 
 function uotd_thumbnail($profile, $user) {
     if ($profile->has_picture) {
-        return "<a href=\"".URL_BASE."view_profile.php?userid=$user->id\"><img border=0 vspace=4 hspace=8 align=left src=\"".profile_thumb_url($user->id)."\" alt=\"".tra("User profile")."\"></a>";
+        return "<a href=\"".url_base()."view_profile.php?userid=$user->id\"><img border=0 vspace=4 hspace=8 align=left src=\"".profile_thumb_url($user->id)."\" alt=\"".tra("User profile")."\"></a>";
     } else {
         return "";
     }

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -136,7 +136,7 @@ function show_user_stats_private($user) {
     }
     $x .= ' &middot; <a href="cert_all.php">'.tra("Cross-project").'</a>';
     row2(tra("Certificate"), $x);
-    row2(tra("Stats on your cell phone"), URL_BASE."userw.php?id=$user->id");
+    row2(tra("Stats on your cell phone"), url_base()."userw.php?id=$user->id");
 }
 
 function notify_description($notify) {
@@ -228,13 +228,13 @@ function friend_links($user) {
         if ($profile && $profile->has_picture) {
             $img_url = profile_thumb_url($user->id);
         } else {
-            $img_url = URL_BASE."img/head_20.png";
+            $img_url = url_base()."img/head_20.png";
         }
         $title = tra("View the profile of %1", $user->name);
         $alt = tra("Profile");
-        $x .= ' <a href="'.URL_BASE.'view_profile.php?userid='.$user->id.'"><img title="'.$title.'" src="'.$img_url.'" alt="'.$alt.'"></a><br>';
+        $x .= ' <a href="'.url_base().'view_profile.php?userid='.$user->id.'"><img title="'.$title.'" src="'.$img_url.'" alt="'.$alt.'"></a><br>';
     }
-    $x .= " <a href=\"".URL_BASE."show_user.php?userid=".$user->id."\">".$user->name."</a>";
+    $x .= " <a href=\"".url_base()."show_user.php?userid=".$user->id."\">".$user->name."</a>";
     if ($user->donated == 1) {
         require_once("../project/donations.inc");
         $x .= DONATION_LINK;
@@ -253,10 +253,10 @@ function user_links($user, $badge_height=0) {
     }
     $x = "";
     if ($user->has_profile) {
-        $img_url = URL_BASE."img/head_20.png";
-        $x .= ' <a href="'.URL_BASE.'view_profile.php?userid='.$user->id.'"><img title="View the profile of '.$user->name.'" src="'.$img_url.'" alt="Profile"></a>';
+        $img_url = url_base()."img/head_20.png";
+        $x .= ' <a href="'.url_base().'view_profile.php?userid='.$user->id.'"><img title="View the profile of '.$user->name.'" src="'.$img_url.'" alt="Profile"></a>';
     }
-    $x .= " <a href=\"".URL_BASE."show_user.php?userid=".$user->id."\">".$user->name."</a>";
+    $x .= " <a href=\"".url_base()."show_user.php?userid=".$user->id."\">".$user->name."</a>";
     if ($user->donated == 1) {
         require_once("../project/donations.inc");
         $x .= DONATION_LINK;
@@ -285,7 +285,7 @@ function show_community_private($user) {
     if (!DISABLE_FORUMS) {
         $tot = total_posts($user);
         if ($tot) {
-            row2(tra("Message boards"), "<a href=\"".URL_BASE."forum_user_posts.php?userid=$user->id\">".tra("%1 posts", $tot)."</a>");
+            row2(tra("Message boards"), "<a href=\"".url_base()."forum_user_posts.php?userid=$user->id\">".tra("%1 posts", $tot)."</a>");
         }
     }
     
@@ -370,7 +370,7 @@ function show_user_summary_public($user) {
         show_credit($user);
 
         if ($user->show_hosts) {
-            row2(tra("Computers"), "<a href=\"".URL_BASE."hosts_user.php?userid=$user->id\">".tra("View")."</a>");
+            row2(tra("Computers"), "<a href=\"".url_base()."hosts_user.php?userid=$user->id\">".tra("View")."</a>");
         } else {
             row2(tra("Computers"), tra("hidden"));
         }
@@ -410,14 +410,14 @@ function community_links($clo, $logged_in_user){
     
     if (!DISABLE_TEAMS) {
         if ($user->teamid && $team) {
-            row2(tra("Team"), "<a href=\"".URL_BASE."team_display.php?teamid=$team->id\">$team->name</a>");
+            row2(tra("Team"), "<a href=\"".url_base()."team_display.php?teamid=$team->id\">$team->name</a>");
         } else {
             row2(tra("Team"), tra("None"));
         }
     }
     if (!DISABLE_FORUMS) {
         if ($tot) {
-            row2(tra("Message boards"), "<a href=\"".URL_BASE."forum_user_posts.php?userid=$user->id\">".tra("%1 posts", $tot)."</a>");
+            row2(tra("Message boards"), "<a href=\"".url_base()."forum_user_posts.php?userid=$user->id\">".tra("%1 posts", $tot)."</a>");
         }
     }
     if ($logged_in_user && $logged_in_user->id != $user->id) {

--- a/html/inc/util_ops.inc
+++ b/html/inc/util_ops.inc
@@ -76,7 +76,7 @@ function c_row2($color, $x, $y) {
 function show_profile_link_ops($user) {
     if ($user->has_profile) { 
         row2("Profile",
-            "<a href=\"".URL_BASE."view_profile.php?userid=$user->id\">View</a>"
+            "<a href=\"".url_base()."view_profile.php?userid=$user->id\">View</a>"
         );
     }
 }

--- a/html/ops/badge_admin.php
+++ b/html/ops/badge_admin.php
@@ -52,7 +52,7 @@ function show_form() {
             if (strstr($badge->image_url, "http") == $badge->image_url) {
                 $y = $badge->image_url;
             } else {
-                $y = URL_BASE.$badge->image_url;
+                $y = url_base().$badge->image_url;
             }
             $x = " <img align=right height=64 src=\"$y\">";
         }

--- a/html/ops/error_summary.php
+++ b/html/ops/error_summary.php
@@ -60,7 +60,7 @@ foreach ($error_codes as $code => $x) {
     $j = 0;
     foreach ($results as $r) {
         if ($j++ >= $nresults_per_code) break;
-        echo "&nbsp;<a href=".URL_BASE."result.php?resultid=$r->id>$r->id</a><br>\n";
+        echo "&nbsp;<a href=".url_base()."result.php?resultid=$r->id>$r->id</a><br>\n";
     }
 }
 page_tail();

--- a/html/ops/failure_result_summary_by_host.php
+++ b/html/ops/failure_result_summary_by_host.php
@@ -72,7 +72,7 @@ table_header(
 while ($res = _mysql_fetch_object($result)) {
     table_row(
         app_version_desc($res->app_version_id),
-        "<a href=".URL_BASE."show_host_detail.php?hostid=$res->Host_ID>$res->Host_ID</a>",
+        "<a href=".url_base()."show_host_detail.php?hostid=$res->Host_ID>$res->Host_ID</a>",
         $res->OS_Version, $res->Results_Today,
         "<a href=db_action.php?table=result&detail=low&hostid=$res->Host_ID&app_version_id=$res->app_version_id&server_state=5&outcome=3>$res->error_count</a>"
     );

--- a/html/ops/index.php
+++ b/html/ops/index.php
@@ -129,11 +129,11 @@ echo "
     </td> 
     <td><b>User management</b>
     <ul>
-        <li><a href=".URL_BASE."/forum_index.php>Post news item</a></li>
+        <li><a href=".url_base()."/forum_index.php>Post news item</a></li>
         <li><a href=\"profile_screen_form.php\">Screen user profiles </a></li>
         <li><a href=\"badge_admin.php\">Badges</a></li>
         <li><a href=\"manage_special_users.php\">User privileges</a></li>
-        <li><a href=".URL_BASE."/manage_project.php>User job submission privileges</a></li>
+        <li><a href=".url_base()."/manage_project.php>User job submission privileges</a></li>
         <li><a href=\"mass_email.php\">Send mass email to a selected set of users</a></li>
         <li><form action=\"manage_user.php\">
             <input class=\"btn btn-default\" type=\"submit\" value=\"Manage user\">

--- a/html/ops/mass_email.php
+++ b/html/ops/mass_email.php
@@ -86,7 +86,7 @@ if ($receiver > 0) {
     while ($user = _mysql_fetch_object($result)) {
     	// TODO: might want to also replace TOTAL_CREDIT, RAC, and similar.
         $body_to_send = str_replace("USERNAME", $user->name, $body);
-        $body_to_send .= "\n\nTo opt out of future emails from ".PROJECT.", please edit your project preferences at ".URL_BASE."prefs.php?subset=project\n";
+        $body_to_send .= "\n\nTo opt out of future emails from ".PROJECT.", please edit your project preferences at ".secure_url_base()."prefs.php?subset=project\n";
         $retval = send_email($user, $subject, $body_to_send);
         if ($retval) {
             // send_email returns TRUE on success

--- a/html/ops/notify.php
+++ b/html/ops/notify.php
@@ -44,12 +44,12 @@ function send_notify_email($userid, $message) {
     $subject = "Daily notification summary from ".PROJECT;
     $body = "The following events occurred in the past day at ".PROJECT.".
 For details, visit your Account page at
-".URL_BASE."home.php
+".secure_url_base()."home.php
 
 $message
 ---------------
 To change your email preferences for ".PROJECT.", visit:
-".URL_BASE."edit_forum_preferences_form.php
+".secure_url_base()."edit_forum_preferences_form.php
 
 Do not reply to this email.
 ";

--- a/html/ops/update_profile_pages.php
+++ b/html/ops/update_profile_pages.php
@@ -79,7 +79,7 @@ function show_user_table($members, $offset, $numToDisplay, $cols) {
                     $show_picture = false;
                 }
                 if ($show_picture) {
-                    echo "<a href=\"".URL_BASE."view_profile.php?userid={$members[$count]}\"><img src=\"".URL_BASE.IMAGE_URL."{$members[$count]}_sm.jpg\"></a>";
+                    echo "<a href=\"".secure_url_base()."view_profile.php?userid={$members[$count]}\"><img src=\"".secure_url_base().IMAGE_URL."{$members[$count]}_sm.jpg\"></a>";
                 } else {
                     echo "&nbsp;";
                 }
@@ -203,7 +203,7 @@ function build_picture_pages($width, $height) {
             for ($col = 0; $col < $width; $col++) {
 	            if ($count < $numIds) {
                     echo "<td class=\"bordered\" align=\"center\">
-                        <a href=\"".URL_BASE."view_profile.php?userid=".$userIds[$count]."\"><img src=\"".URL_BASE.IMAGE_URL.$userIds[$count]."_sm.jpg\"></a>
+                        <a href=\"".secure_url_base()."view_profile.php?userid=".$userIds[$count]."\"><img src=\"".secure_url_base().IMAGE_URL.$userIds[$count]."_sm.jpg\"></a>
                     </td>";
                     $count++;
                 }
@@ -397,7 +397,7 @@ function build_alpha_summary_page($characters_used) {
 
     foreach ($alphabet as $character) {
         if (isset($characters_used[$character])) {
-            echo "<a href=\"".URL_BASE.PROFILE_URL."profile_{$character}_1.html\">$character</a>&nbsp;";
+            echo "<a href=\"".secure_url_base().PROFILE_URL."profile_{$character}_1.html\">$character</a>&nbsp;";
             unset($characters_used[$character]);
         } else {
             echo "$character ";
@@ -406,7 +406,7 @@ function build_alpha_summary_page($characters_used) {
 
     // Link to the 'Other' page if necessary.
     if (!empty($characters_used)) {
-        echo "<a href=\"".URL_BASE.PROFILE_URL."profile_other_1.html\">Other</a>&nbsp;";
+        echo "<a href=\"".secure_url_base().PROFILE_URL."profile_other_1.html\">Other</a>&nbsp;";
     }
     close_output_buffer($filename);
 }

--- a/html/user/create_account_action.php
+++ b/html/user/create_account_action.php
@@ -136,9 +136,9 @@ if(defined('INVITE_CODES')) {
 $next_url = post_str('next_url', true);
 $next_url = sanitize_local_url($next_url);
 if ($next_url) {
-    Header("Location: ".URL_BASE."$next_url");
+    Header("Location: ".url_base()."$next_url");
 } else {
-    Header("Location: ".URL_BASE."home.php");
+    Header("Location: ".url_base()."home.php");
     send_cookie('init', "1", true);
     send_cookie('via_web', "1", true);
 }

--- a/html/user/donate.php
+++ b/html/user/donate.php
@@ -43,7 +43,7 @@ $payment_id = _mysql_insert_id();
 
 $URL = "www.paypal.com/cgi-bin/webscr";
 
-$fields = ("cmd=_xclick&lc=US&business=".PAYPAL_ADDRESS."&quantity=1&item_name=Donation&item_number=".$payment_id."_".$order_time."&amount=".$amount."&no_shipping=1&return=".URL_BASE."donated.php?st=Completed&rm=2&cancel_return=".URL_BASE."/donated.php&no_note=1&currency_code=".$currency."&bn=PP-BuyNowBF");
+$fields = ("cmd=_xclick&lc=US&business=".PAYPAL_ADDRESS."&quantity=1&item_name=Donation&item_number=".$payment_id."_".$order_time."&amount=".$amount."&no_shipping=1&return=".url_base()."donated.php?st=Completed&rm=2&cancel_return=".url_base()."/donated.php&no_note=1&currency_code=".$currency."&bn=PP-BuyNowBF");
 
 header("Location: https://$URL?$fields");
 

--- a/html/user/forum_moderate_post_action.php
+++ b/html/user/forum_moderate_post_action.php
@@ -111,9 +111,9 @@ if ($action=="hide"){
     }
     $result = move_post($post, $thread, $forum, $new_thread, $new_forum);
     $explanation = "Old thread: $thread->title
-".URL_BASE."forum_thread.php?id=$thread->id
+".secure_url_base()."forum_thread.php?id=$thread->id
 New thread: $new_thread->title
-".URL_BASE."forum_thread.php?id=$new_thread->id&postid=$post->id
+".secure_url_base()."forum_thread.php?id=$new_thread->id&postid=$post->id
 ";
     $explanation .= mod_comment();
     $action_name = "moved to another thread";

--- a/html/user/forum_search_action.php
+++ b/html/user/forum_search_action.php
@@ -219,7 +219,7 @@ if (!count($threads) && !count($posts)){
     echo "<p>".tra("Sorry, couldn't find anything matching your search query. You can try to broaden your search by using less words (or less specific words).")."</p>
     <p>"
     .tra("You can also %1try the same search on Google.%2",
-         "<a href=\"http://www.google.com/search?domains=".URL_BASE."&sitesearch=".URL_BASE."forum_thread.php&q=".htmlentities($search_keywords)."\">",
+         "<a href=\"http://www.google.com/search?domains=".url_base()."&sitesearch=".url_base()."forum_thread.php&q=".htmlentities($search_keywords)."\">",
          "</a>")
     ."</p>";
 }

--- a/html/user/login_action.php
+++ b/html/user/login_action.php
@@ -54,7 +54,7 @@ function login_with_email($email_addr, $passwd, $next_url, $perm) {
         exit;
     }
     $authenticator = $user->authenticator;
-    Header("Location: ".URL_BASE."$next_url");
+    Header("Location: ".url_base()."$next_url");
     send_cookie('auth', $authenticator, $perm);
 }
 
@@ -119,7 +119,7 @@ function login_with_ldap($uid, $passwd, $next_url, $perm) {
     if (!$user) {
         error_page("Couldn't create user");
     }
-    Header("Location: ".URL_BASE."$next_url");
+    Header("Location: ".url_base()."$next_url");
     send_cookie('auth', $user->authenticator, $perm);
     return;
 }

--- a/html/user/mail_passwd.php
+++ b/html/user/mail_passwd.php
@@ -27,7 +27,7 @@ function email_sent_message($email_addr) {
     if (defined('EMAIL_FROM')) {
         $email_from = EMAIL_FROM;
     } else {
-        $email_from = URL_BASE;
+        $email_from = secure_url_base();
     }
 
     page_head("Email sent");

--- a/html/user/notices.php
+++ b/html/user/notices.php
@@ -36,7 +36,7 @@ function notices_rss_start() {
         <rss version=\"2.0\">
         <channel>
         <title>".PROJECT." notices</title>
-        <link>".URL_BASE."</link>
+        <link>".secure_url_base()."</link>
         <description>Notices</description>
         <lastBuildDate>$t</lastBuildDate>
     ";

--- a/html/user/notify_rss.php
+++ b/html/user/notify_rss.php
@@ -46,14 +46,14 @@ header("Last-Modified: ".$create_date);
 header("Content-Type: application/xml");
 
 $description = "Community notifications";
-$channel_image = URL_BASE."rss_image.gif";
+$channel_image = secure_url_base()."rss_image.gif";
 $language = "en-us";
 echo "<?xml version=\"1.0\" encoding=\"ISO-8859-1\" ?>
     <rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\">
     <channel>
     <title>".PROJECT."</title>
-    <link>".URL_BASE."</link>
-    <atom:link href=\"".URL_BASE."notify_rss.php\" rel=\"self\" type=\"application/rss+xml\" />
+    <link>".secure_url_base()."</link>
+    <atom:link href=\"".secure_url_base()."notify_rss.php\" rel=\"self\" type=\"application/rss+xml\" />
     <description>".$description."</description>
     <copyright>".COPYRIGHT_HOLDER."</copyright>
     <lastBuildDate>".$create_date."</lastBuildDate>
@@ -61,7 +61,7 @@ echo "<?xml version=\"1.0\" encoding=\"ISO-8859-1\" ?>
     <image>
         <url>".$channel_image."</url>
         <title>".PROJECT."</title>
-        <link>".URL_BASE."</link>
+        <link>".secure_url_base()."</link>
     </image>
 ";
 

--- a/html/user/openid_login.php
+++ b/html/user/openid_login.php
@@ -146,9 +146,9 @@ try {
         $next_url = post_str('next_url', true);
         $next_url = sanitize_local_url($next_url);
         if ($next_url) {
-            Header("Location: ".URL_BASE."$next_url");
+            Header("Location: ".url_base()."$next_url");
         } else {
-            Header("Location: ".URL_BASE."home.php");
+            Header("Location: ".url_base()."home.php");
             send_cookie('init', "1", true);
             send_cookie('via_web', "1", true);
         }

--- a/html/user/opt_out.php
+++ b/html/user/opt_out.php
@@ -41,7 +41,7 @@ if ($result) {
         No further emails will be sent to $user->email_addr.
         <p>
         To resume getting emails,
-        <a href=".URL_BASE."prefs_edit.php?subset=project>edit your project preferences</a>.
+        <a href=".url_base()."prefs_edit.php?subset=project>edit your project preferences</a>.
     ";
     page_tail();
 }

--- a/html/user/profile_menu.php
+++ b/html/user/profile_menu.php
@@ -59,8 +59,8 @@ echo "</td></tr>";
 row1(tra("User Profile Explorer"));
 echo "<tr><td>
     <ul>
-    <li>".tra("View the %1User Picture Gallery%2.", "<a href=\"" . URL_BASE . "user_profile/user_gallery_1.html\">", "</a>")."</li>
-    <li>".tra("Browse profiles %1by country%2.", "<a href=\"" . URL_BASE . "user_profile/profile_country.html\">", "</a>")."</li>
+    <li>".tra("View the %1User Picture Gallery%2.", "<a href=\"" . url_base() . "user_profile/user_gallery_1.html\">", "</a>")."</li>
+    <li>".tra("Browse profiles %1by country%2.", "<a href=\"" . url_base() . "user_profile/profile_country.html\">", "</a>")."</li>
     <li>".tra("Browse profiles %1at random%2, %3at random with pictures%2, or %4at random without pictures%2.", "<a href=\"?cmd=rand&amp;pic=-1\">", "</a>",
             "<a href=\"?cmd=rand&amp;pic=1\">", "<a href=\"?cmd=rand&amp;pic=0\">")."</li>
 ";
@@ -105,7 +105,7 @@ function select_profile($cmd) {
 
         shuffle($profiles);
         $userid = $profiles[0]->userid;
-        header("Location: ".URL_BASE."view_profile.php?userid=$userid");
+        header("Location: ".url_base()."view_profile.php?userid=$userid");
         exit();
     }
 }

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -139,7 +139,7 @@ function show_nav() {
 
 $stopped = web_stopped();
 $rssname = PROJECT . " RSS 2.0" ;
-$rsslink = URL_BASE . "rss_main.php";
+$rsslink = url_base() . "rss_main.php";
 
 header("Content-type: text/html; charset=utf-8");
 

--- a/html/user/team_founder_transfer_action.php
+++ b/html/user/team_founder_transfer_action.php
@@ -45,7 +45,7 @@ function send_founder_transfer_email($team, $user, $founder) {
     $subject = "Team founder transfer request";
     $body = "Team member ".$user->name." has asked that you
 transfer foundership of $team->name.
-Please go [url=".URL_BASE."team_change_founder_form.php?teamid=$team->id]here[/url] to grant or decline the request.
+Please go [url=".secure_url_base()."team_change_founder_form.php?teamid=$team->id]here[/url] to grant or decline the request.
     
 If you do not respond within 60 days, ".$user->name." will
 be allowed to become the team founder.
@@ -57,7 +57,7 @@ be allowed to become the team founder.
     $body = "Team member ".$user->name." has asked that you
 transfer foundership of $team->name in ".PROJECT.".
 Please visit
-".URL_BASE."team_change_founder_form.php?teamid=".$team->id."
+".secure_url_base()."team_change_founder_form.php?teamid=".$team->id."
 to grant or decline the request.
     
 If you do not respond within 60 days, ".$user->name." will
@@ -118,7 +118,7 @@ case "finalize_transfer":
     if ($user->id == $team->ping_user && transfer_ok($team, $now)) {
         page_head(tra("Assumed foundership of %1", $team->name));
         $team->update("userid=$user->id, ping_user=0, ping_time=0");
-        echo tra("Congratulations, you are now the founder of team %1. Go to %2Your Account page%3 to find the Team Admin options.", $team->name, "<a href=\"".URL_BASE."home.php\">", "</a>");
+        echo tra("Congratulations, you are now the founder of team %1. Go to %2Your Account page%3 to find the Team Admin options.", $team->name, "<a href=\"".secure_url_base()."home.php\">", "</a>");
     } else {
         error_page(tra("Foundership request not allowed now"));
     }

--- a/html/user/uotd_gadget.php
+++ b/html/user/uotd_gadget.php
@@ -33,7 +33,7 @@ echo "
                    computing project ".PROJECT."\"
      height=\"100\"
   /> 
-  <Content type=\"url\" href=\"".URL_BASE."user_profile/uotd_gadget.html\" /> 
+  <Content type=\"url\" href=\"".secure_url_base()."user_profile/uotd_gadget.html\" /> 
 </Module>
 ";
 


### PR DESCRIPTION
Modern Browser complain if there are non-https elements in https websites. This makes sure that if the user visits via https all elements of the page are also retrieved using SSL. Furthermore it uses https urls in emails that are send to the user, if SECURE_URL_BASE is set in project/project.inc.
The only remaining places where URL_BASE is used is when it is used as master_url where it is important that it is in sync with what the scheduler uses.