### PR TITLE
Update filesys.cpp

### DIFF
--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -616,7 +616,8 @@ int boinc_copy(const char* orig, const char* newf) {
 
 static int boinc_rename_aux(const char* old, const char* newf) {
 #ifdef _WIN32
-    if (MoveFileExA(old, newf, MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH)) return 0;
+    // MOVEFILE_COPY_ALLOWED is needed if destination is on another volume (move is simulated by copy&delete)
+    if (MoveFileExA(old, newf, MOVEFILE_COPY_ALLOWED | MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) return 0;
     return GetLastError();
 #else
     // rename() doesn't work between filesystems.


### PR DESCRIPTION
I tried to redirect the "slots" directory to another volume and came to the conclusion that it was not possible for some projects, because they use boinc_rename to move their results back to the project directory before they send it to the server. One of them was Virtual LHC@home. I compiled my own BOINC client for this, so that I can use my very fast but volatile SSD for such projects.
Now I want to share my findings and give you this simple patch. It don't have any negative side effects. There was only a flag missing which Windows needs if you want to move files or directories over volume boundaries.