### PR TITLE
Cast as int instead of function

### DIFF
--- a/tools/update_versions
+++ b/tools/update_versions
@@ -372,7 +372,7 @@ function confirm($fds, $v) {
 function get_bool($xml_element, $name) {
     foreach($xml_element->xpath($name) as $x) {
         $s = trim((string) $x);
-        if ($s == "" || int($s)>0) return true;
+        if ($s == "" || ((int)$s)>0) return true;
     }
     return false;
 }


### PR DESCRIPTION
This prevents the error:

```
PHP Fatal error:  Call to undefined function int() in /tmp/boinc-project/bin/update_versions on line 375

      Fatal error: Call to undefined function int() in /tmp/boinc-project/bin/update_versions on line 375
```

As far as I can tell, `int()` is not a function. But I've seen this reported on Stackoverflow.com and some other places, so it must have been at one point?

There is an `intval()` function, which I can update this PR to use if desired.