### PR TITLE
[1153] typo in file INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,6 +1,6 @@
 To build the BOINC client software:
     ./_autosetup
-    ./configure --disable_server
+    ./configure --disable-server
 
 For more information, visit:
 http://boinc.berkeley.edu/trac/wiki/CompileClient


### PR DESCRIPTION
Fixed the typo in INSTALL when using the ./configure command. This caused an
error when trying to configure BOINC.