### PR TITLE
XSS Idle Detection Bugfix (XCloseDisplay)

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -2090,6 +2090,7 @@ bool xss_idle(long idle_threshold) {
 	  "[idle_detection] XScreenSaver extension not available for DISPLAY '%s'.",
 	  it->c_str());
       }
+      XCloseDisplay(disp);
       continue;
     }
 
@@ -2097,6 +2098,9 @@ bool xss_idle(long idle_threshold) {
     no_available_x_display = false;
     XScreenSaverQueryInfo(disp, DefaultRootWindow(disp), xssInfo);
     idle_time = xssInfo->idle;
+
+    // Close the connection to the XServer
+    XCloseDisplay(disp);
 
     // convert from milliseconds to seconds
     idle_time = idle_time / 1000;


### PR DESCRIPTION
Previous merged PR: https://github.com/BOINC/boinc/pull/1453

Apologies. My initial code didn't close the connections to the X
displays after opening them. I had thought that falling out of scope
would close the connection automatically. However, thanks to a bug
report by Dan Merillat that I was able to replicate, I now know better:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=812835

This simple adjustment closes the connection to the display (if a
connection succeeded in the first place; if XOpenDisplay() failed, it
returns NULL and there is no connection). Testing on my end shows that
this resolves the issue of the boinc client piling up new connections to
X servers.