### PR TITLE
@advanced view: added connect-to-computer shortcut

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -341,7 +341,7 @@ bool CAdvancedFrame::CreateMenu() {
 
     menuFile->Append(
         ID_SELECTCOMPUTER, 
-        _("Select computer..."),
+        _("Select computer...\tCtrl+Shift+I"),
         _("Connect to a BOINC client on another computer")
     );
     menuFile->Append(
@@ -733,11 +733,20 @@ bool CAdvancedFrame::CreateMenu() {
         delete m_pOldMenubar;
     }
     
+
+
 #ifdef __WXMAC__
     // Set HELP key as keyboard shortcut
     m_Shortcuts[0].Set(wxACCEL_NORMAL, WXK_HELP, ID_HELPBOINCMANAGER);
+    m_Shortcuts[1].Set(wxACCEL_CTRL|wxACCEL_SHIFT, (int)'I', ID_SELECTCOMPUTER);
+    m_pAccelTable = new wxAcceleratorTable(2, m_Shortcuts);
+    SetAcceleratorTable(*m_pAccelTable);
+ #else
+    //only set the connect-to-computer shortcut
+    m_Shortcuts[0].Set(wxACCEL_CTRL|wxACCEL_SHIFT, (int)'I', ID_SELECTCOMPUTER);
     m_pAccelTable = new wxAcceleratorTable(1, m_Shortcuts);
     SetAcceleratorTable(*m_pAccelTable);
+
  #endif
 
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::CreateMenu - Function End"));

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -733,21 +733,18 @@ bool CAdvancedFrame::CreateMenu() {
         delete m_pOldMenubar;
     }
     
-
-
 #ifdef __WXMAC__
     // Set HELP key as keyboard shortcut
     m_Shortcuts[0].Set(wxACCEL_NORMAL, WXK_HELP, ID_HELPBOINCMANAGER);
     m_Shortcuts[1].Set(wxACCEL_CTRL|wxACCEL_SHIFT, (int)'I', ID_SELECTCOMPUTER);
     m_pAccelTable = new wxAcceleratorTable(2, m_Shortcuts);
     SetAcceleratorTable(*m_pAccelTable);
- #else
+#else
     //only set the connect-to-computer shortcut
     m_Shortcuts[0].Set(wxACCEL_CTRL|wxACCEL_SHIFT, (int)'I', ID_SELECTCOMPUTER);
     m_pAccelTable = new wxAcceleratorTable(1, m_Shortcuts);
     SetAcceleratorTable(*m_pAccelTable);
-
- #endif
+#endif
 
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::CreateMenu - Function End"));
     return true;


### PR DESCRIPTION
Added a connect-to-computer shortcut in the advanced view of boincmanager, as well as the corresponding menu entry.

Due to readabilty, i've chosen not to go for as little lines as possible (and put as little inside the conditional), as the `#ifdef` is done by the preprocessor anyway and not during runtime.