### PR TITLE
VBOX: fixed error code not being reported

### DIFF
--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -138,7 +138,7 @@ void read_completion_file_info(unsigned long& exit_code, bool& is_notice, string
     FILE* f = fopen(path, "r");
     if (f) {
         if (fgets(buf, 1024, f) != NULL) {
-            exit_code = atoi(buf) != 0;
+            exit_code = atoi(buf);
         }
         if (fgets(buf, 1024, f) != NULL) {
             is_notice = atoi(buf) != 0;


### PR DESCRIPTION
Prior to this if you dumped an error code in `completion_trigger_file` it was always reported to BOINC as exit status = 1. 

Should be straight forward but someone should double check this as I've neither compiled nor tested this fix. 