### PR TITLE
Use sh to detect applications in _autosetup

### DIFF
--- a/_autosetup
+++ b/_autosetup
@@ -1,18 +1,19 @@
-#!/usr/bin/env bash
+#!/bin/sh
 ## $Id$
 
 ## ---------- some portability checks/adjustments [stolen from configure] ----------
 ## 'echo -n' is not portable..
 case `echo "testing\c"; echo 1,2,3`,`echo -n testing; echo 1,2,3` in
   *c*,-n*) ECHO_N= ECHO_C='
-' ECHO_T='      ' ;;
+' ECHO_T='	' ;;
   *c*,*  ) ECHO_N=-n ECHO_C= ECHO_T= ;;
   *)       ECHO_N= ECHO_C='\c' ECHO_T= ;;
 esac
 ##----------
 
 ## ----------------------------------------------------------------------
-## Check that given command $1 has version >= $2.$3
+## Check that given command $1 has version >= $2
+## Full path $3 may be specified in order to skip command search.
 ## return 0 if ok, 1 too old or not found  (-> shell conventions).
 ## ----------------------------------------------------------------------
 check_version()
@@ -24,12 +25,7 @@ check_version()
     desired=`echo $2 | awk -F. '{print $1*100+$2}'`
     echo $ECHO_N "Checking version of '$1' >= $desired... $ECHO_C"
     name=$1
-    app_var_name=`echo $name | tr '[:lower:]-' '[:upper:]_'`
-    if [ ! -z ${!app_var_name+x} ]; then
-        name=${!app_var_name}
-    fi
-
-    fullpath=`type $name | awk '{ print $(NF) }'`;
+    fullpath=${3:-`command -v "$name"`};
     if [ -x "$fullpath" ]; then
         foundit=yes;
     fi
@@ -75,62 +71,37 @@ check_version()
   ## in case there's GNU drop-in tools available, set these
 
   ## some sorry systems don't have proper GNU-make...
-  if check_version make 3.79; then
-      echo >/dev/null
-  else
-      if check_version gmake 3.79; then
-          have_gmake=yes;
-      else
-        echo "Couldn't find a new-enough version of GNU 'make', please install one!";
-        echo "If you have a newer version, set the environment variable 'MAKE' to its path";
-        exit 1;
-      fi
+  if ! check_version make 3.79 "$MAKE"; then
+      echo "Couldn't find a new-enough version of GNU 'make', please install one!";
+      echo "If you have a newer version, set the environment variable 'MAKE' to its path";
+      exit 1;
   fi
 
   ## FreeBSD's m4 seems to be broken? Download a fresh one
-  if check_version m4 1.4; then
-      echo >/dev/null
-  else
-      ## solaris m4 works fine
-      if test -f /usr/ccs/bin/m4
-      then
-         echo >/dev/null
-      elif check_version gm4 1.4; then
-         have_gm4=yes;
-      else
-         echo "Couldn't find a new-enough version of 'm4', please install one!";
-         echo "If you have a newer version, set the environment variable 'M4' to its path";
-         exit 1;
-      fi
-      # build_lsc_aux "m4-1.4.1"
+  if ! check_version m4 1.4 "$M4" && [ ! -f /usr/ccs/bin/m4 ] && ! check_version gm4 1.4; then
+     echo "Couldn't find a new-enough version of 'm4', please install one!";
+     echo "If you have a newer version, set the environment variable 'M4' to its path";
+     exit 1;
   fi
 
-  if check_version pkg-config 0.15; then
-      echo >/dev/null
-  else
+  if ! check_version pkg-config 0.15; then
       echo "Couldn't find a new-enough version of 'pkg-config', please install one!";
       exit 1;
       # build_lsc_aux "pkgconfig-0.15.0"
   fi
 
-  if check_version autoreconf 2.58; then
-      echo >/dev/null
-  else
+  if ! check_version autoreconf 2.58; then
       echo "Couldn't find a new-enough version of 'autoreconf', please install one!";
       exit 1;
       # build_lsc_aux "autoconf-2.59"
   fi
-  if check_version automake 1.8; then
-      echo >/dev/null
-  else
+  if ! check_version automake 1.8 "$AUTOMAKE"; then
       echo "Couldn't find a new-enough version of 'automake', please install one!";
       echo "If you have a newer version, set the environment variable 'AUTOMAKE' and 'ACLOCAL' to its path";
       exit 1;
       # build_lsc_aux "automake-1.8.5"
   fi
-  if check_version libtoolize 1.5; then
-      echo >/dev/null
-  else
+  if ! check_version libtoolize 1.5 "$LIBTOOLIZE"; then
       echo "Couldn't find a new-enough version of 'libtoolize', please install one!";
       echo "If you have a newer version, set the environment variable 'LIBTOOLIZE' to its path";
       exit 1;
@@ -142,6 +113,7 @@ check_version()
   if [ "$1" = "-f" ]; then
     cmdline="autoreconf -i -f";
   fi
+
 echo "$cmdline"
 if eval $cmdline; then
     echo "Done, now run ./configure"


### PR DESCRIPTION
Continued from #1498 

This PR is made by applying @f8l's patch in the original PR. I also removed gmake detection as it is expected that the user should set MAKE to its path instead. The `echo >/dev/null` is also removed and replaced by inverting the if conditions instead.

From my testing, it seems that in my original PR user can specify application name in `$PATH` but this one an absolute path is required. As the error messages already specified that the variables should be set to its path I consider this behavior to be correct as well.