### PR TITLE
Don't add example_app to project.xml unless requested

### DIFF
--- a/py/Boinc/boincxml.py
+++ b/py/Boinc/boincxml.py
@@ -144,7 +144,7 @@ class XMLConfig:
         self._set_elements()
         if not output:
             output = open(self.filename,'w')
-        self.xml.writexml(output, "", "  ", "\n")
+        self.xml.writexml(output, "", " "*4, "\n")
         print >>output
         return self
     def _set_elements(self):

--- a/tools/make_project
+++ b/tools/make_project
@@ -5,7 +5,7 @@
 
 import boinc_path_config
 from Boinc.setup_project import *
-from Boinc import database, db_mid, configxml, tools
+from Boinc import database, db_mid, configxml, tools, projectxml
 import sys, os, getopt, re, socket
 
 def getfqdn():
@@ -320,6 +320,14 @@ if options.test_app:
     shutil.copy('example_app_in', proot+'/templates/')
     shutil.copy('example_app_out', proot+'/templates/')
     shutil.copy('../tools/create_work_example', proot+'/bin/')
+
+    #add app to project.xml
+    pf = projectxml.ProjectFile(os.path.join(proot,'project.xml')).read()
+    a = pf.elements.make_node_and_append('app')
+    a.name = 'example_app'
+    a.user_friendly_name = 'Example Application'
+    pf.write()
+
 
 httpd_conf_template_filename = os.path.join(
     options.project_root,

--- a/tools/project.xml
+++ b/tools/project.xml
@@ -51,8 +51,4 @@
         <name>anonymous</name>
         <user_friendly_name>anonymous</user_friendly_name>
     </platform>
-    <app>
-        <name>example_app</name>
-        <user_friendly_name>Example Application</user_friendly_name>
-    </app>
 </boinc>


### PR DESCRIPTION
Currently even if you don't give the `--test_app` option to `make_project`, you still get `example_app` in your `project.xml`, which means it goes in the database and is displayed under "Applications" on the website. This makes it so it only goes in `project.xml` if you actually requested it. 