### PR TITLE
Work around invalid XML in logs

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -409,7 +409,7 @@ int ACCT_MGR_OP::parse(FILE* f) {
         }
         if (log_flags.unparsed_xml) {
             msg_printf(NULL, MSG_INFO,
-                "[unparsed_xml] ACCT_MGR_OP::parse: unrecognized tag <%s>",
+                "[unparsed_xml] ACCT_MGR_OP::parse: unrecognized tag <%s/>",
                 xp.parsed_tag
             );
         }

--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -457,7 +457,7 @@ int CC_CONFIG::parse_options_client(XML_PARSER& xp) {
 
         msg_printf_notice(NULL, false,
             "http://boinc.berkeley.edu/manager_links.php?target=notice&controlid=config",
-            "%s: <%s>",
+            "%s: <%s/>",
             _("Unrecognized tag in cc_config.xml"),
             xp.parsed_tag
         );
@@ -512,7 +512,7 @@ int CC_CONFIG::parse_client(FILE* f) {
         if (xp.match_tag("log_flags/")) continue;
         msg_printf_notice(NULL, false,
             "http://boinc.berkeley.edu/manager_links.php?target=notice&controlid=config",
-            "%s: <%s>",
+            "%s: <%s/>",
             _("Unrecognized tag in cc_config.xml"),
             xp.parsed_tag
         );

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -878,7 +878,7 @@ void XML_PARSER::skip_unexpected(
 
     if (verbose) {
         fprintf(stderr,
-            "%s: Unrecognized XML tag '<%s>' in %s; skipping\n",
+            "%s: Unrecognized XML tag '<%s/>' in %s; skipping\n",
             time_to_string(dtime()), start_tag, where
         );
     }


### PR DESCRIPTION
Ironically, should the user specify an invalid XML tag in configuration, BOINC will write a log message containing that tag unescaped and unclosed. Needless to say, it breaks XML parsing instantly. This patch auto-closes such tags in the log messages.