### PR TITLE
Client: fix nvidia_driver_version dlopen()

### DIFF
--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -105,8 +105,13 @@ static int nvidia_driver_version() {
     void *handle = NULL;
     char driver_string[81];
 
-    handle  = dlopen("libnvidia-ml.so", RTLD_NOW);
-    if (!handle) goto end; 
+    handle  = dlopen("libnvidia-ml.so.1", RTLD_NOW);
+    if (!handle) {
+        handle  = dlopen("libnvidia-ml.so", RTLD_NOW);
+        if (!handle) {
+            goto end;
+        }
+    }
 
     nvml_driver = (int(*)(char *, unsigned int)) dlsym(handle,  "nvmlSystemGetDriverVersion");
     nvml_init = (int(*)(void)) dlsym(handle,  "nvmlInit");


### PR DESCRIPTION
On Debian only the versioned object can be opened. It usually is a symlink to the actual file.

Please review and merge into the 7.6 branch.