### PR TITLE
Use wxString where necessary

### DIFF
--- a/clientgui/BOINCBaseView.cpp
+++ b/clientgui/BOINCBaseView.cpp
@@ -913,11 +913,11 @@ void CBOINCBaseView::AppendColumn(int){
 }
 
 
-void CBOINCBaseView::append_to_status(wxString& existing, const wxChar* additional) {
+void CBOINCBaseView::append_to_status(wxString& existing, const wxString& additional) {
     if (existing.size() == 0) {
         existing = additional;
     } else {
-        existing = existing + wxT(", ") + additional;
+        existing += wxT(", ") + additional;
     }
 }
 

--- a/clientgui/BOINCBaseView.h
+++ b/clientgui/BOINCBaseView.h
@@ -193,7 +193,7 @@ protected:
     bool                    _EnsureLastItemVisible();
     virtual bool            EnsureLastItemVisible();
 
-    static  void            append_to_status(wxString& existing, const wxChar* additional);
+    static  void            append_to_status(wxString& existing, const wxString& additional);
     static  wxString        HtmlEntityEncode(wxString strRaw);
     static  wxString        HtmlEntityDecode(wxString strRaw);
 

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -632,28 +632,24 @@ void CBOINCGUIApp::SaveState() {
 ///
 void CBOINCGUIApp::OnInitCmdLine(wxCmdLineParser &parser) {
     wxApp::OnInitCmdLine(parser);
-    static const wxCmdLineEntryDesc cmdLineDesc[] = {
-        { wxCMD_LINE_SWITCH, "a", "autostart", _("BOINC Manager was started by the operating system automatically")},
+    parser.AddSwitch("a", "autostart", _("BOINC Manager was started by the operating system automatically"));
 #if defined(__WXMSW__) || defined(__WXMAC__)
-        { wxCMD_LINE_SWITCH, "s", "systray", _("Startup BOINC so only the system tray icon is visible")},
+    parser.AddSwitch("s", "systray", _("Startup BOINC so only the system tray icon is visible"));
 #else
-        { wxCMD_LINE_OPTION, "e", "clientdir", _("Directory containing the BOINC Client executable")},
-        { wxCMD_LINE_OPTION, "d", "datadir", _("BOINC data directory")},
+    parser.AddSwitch("e", "clientdir", _("Directory containing the BOINC Client executable"));
+    parser.AddSwitch("d", "datadir", _("BOINC data directory"));
 #endif
-        { wxCMD_LINE_OPTION, "n", "namehost", _("Host name or IP address")},
-        { wxCMD_LINE_OPTION, "g", "gui_rpc_port", _("GUI RPC port number")},
-        { wxCMD_LINE_OPTION, "p", "password", _("Password")},
-        { wxCMD_LINE_OPTION, "b", "boincargs", _("Startup BOINC with these optional arguments")},
-        { wxCMD_LINE_SWITCH, "i","insecure", _("disable BOINC security users and permissions")},
-        { wxCMD_LINE_SWITCH, "c", "checkskins", _("set skin debugging mode to enable skin manager error messages")},
-        { wxCMD_LINE_SWITCH, "m", "multiple", _("multiple instances of BOINC Manager allowed")},
+    parser.AddSwitch("n", "namehost", _("Host name or IP address"));
+    parser.AddSwitch("g", "gui_rpc_port", _("GUI RPC port number"));
+    parser.AddSwitch("p", "password", _("Password"));
+    parser.AddSwitch("b", "boincargs", _("Startup BOINC with these optional arguments"));
+    parser.AddSwitch("i","insecure", _("disable BOINC security users and permissions"));
+    parser.AddSwitch("c", "checkskins", _("set skin debugging mode to enable skin manager error messages"));
+    parser.AddSwitch("m", "multiple", _("multiple instances of BOINC Manager allowed"));
 #if (defined(__WXMAC__) && defined(_DEBUG))
-        { wxCMD_LINE_OPTION, "NSDocumentRevisionsDebugMode", NULL, _("Not used: workaround for bug in XCode 4.2")},
+    parser.AddLongSwitch("NSDocumentRevisionsDebugMode", _("Not used: workaround for bug in XCode 4.2"));
 #endif
-        { wxCMD_LINE_SWITCH, "nd", "no-daemon", _("Not run the daemon")},
-        { wxCMD_LINE_NONE}  //DON'T forget this line!!
-    };
-    parser.SetDesc(cmdLineDesc);
+    parser.AddSwitch("nd", "no-daemon", _("Not run the daemon"));
 }
 
 

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -274,7 +274,7 @@ bool CNetworkConnection::IsComputerNameLocal(const wxString& strMachine) {
 
 
 int CNetworkConnection::SetComputer(
-    const wxChar* szComputer, const int iPort, const wxChar* szPassword,
+    const wxString& szComputer, const int iPort, const wxString& szPassword,
     const bool bUseDefaultPassword
 ) {
     m_strNewComputerName.Empty();
@@ -642,7 +642,7 @@ int CMainDocument::ResetState() {
 }
 
 
-int CMainDocument::Connect(const wxChar* szComputer, int iPort, const wxChar* szComputerPassword, const bool bDisconnect, const bool bUseDefaultPassword) {
+int CMainDocument::Connect(const wxString& szComputer, int iPort, const wxString& szComputerPassword, const bool bDisconnect, const bool bUseDefaultPassword) {
     if (IsComputerNameLocal(szComputer)) {
         // Restart client if not already running
         m_pClientManager->AutoRestart();
@@ -688,7 +688,7 @@ int CMainDocument::GetConnectingComputerName(wxString& strMachine) {
 }
 
 
-bool CMainDocument::IsComputerNameLocal(const wxString strMachine) {
+bool CMainDocument::IsComputerNameLocal(const wxString& strMachine) {
     return m_pNetworkConnection->IsComputerNameLocal(strMachine);
 }
 

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -75,8 +75,7 @@ public:
     bool           IsComputerNameLocal(const wxString& strMachine);
     int            GetLocalPassword(wxString& strPassword);
     int SetComputer(
-        const wxChar* szComputer, const int iPort, const wxChar* szPassword,
-        const bool bUseDefaultPassword
+        const wxString& szComputer, const int iPort, const wxString& szPassword, const bool bUseDefaultPassword
     );
     void           SetStateError();
     void           SetStateErrorAuthentication();
@@ -134,9 +133,9 @@ public:
     int                         ResetState();
 
     int                         Connect(
-                                    const wxChar* szComputer,
+                                    const wxString& szComputer,
                                     const int iPort,
-                                    const wxChar* szComputerPassword = wxEmptyString,
+                                    const wxString& szComputerPassword = wxEmptyString,
                                     const bool bDisconnect = FALSE,
                                     const bool bUseDefaultPassword = FALSE
                                 );
@@ -152,7 +151,7 @@ public:
     int                         GetConnectedComputerName(wxString& strMachine);
     int                         GetConnectedComputerVersion(wxString& strVersion);
     int                         GetConnectingComputerName(wxString& strMachine);
-    bool                        IsComputerNameLocal(const wxString strMachine);
+    bool                        IsComputerNameLocal(const wxString& strMachine);
     bool                        IsConnected();
     bool                        IsReconnecting();
 


### PR DESCRIPTION
When building BOINC with `wxUSE_STL=1` there are compiler errors (#1515) because the implicit conversion to `const char*` and `const wxChar*` is deactivated. The solution was to replace `char*` or `wxChar*` by `wxString`. At some point in the stack, the `wxChar*` were implicitly converted to `wxString` again, so this seems like the obvious best way.

One advantage is that `wxString` owns the memory, so we know it always points to valid memory.