### PR TITLE
Prevent memory leak on reallocation failure

### DIFF
--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -154,10 +154,11 @@ int copy_stream(FILE* in, FILE* out) {
 // append to a malloc'd string
 //
 int strcatdup(char*& p, char* buf) {
-    p = (char*)realloc(p, strlen(p) + strlen(buf)+1);
-    if (!p) {
+    char* new_p = (char*)realloc(p, strlen(p) + strlen(buf)+1);
+    if (!new_p) {
         return ERR_MALLOC;
     }
+    p = new_p;
     strcat(p, buf);
     return 0;
 }
@@ -210,12 +211,18 @@ int dup_element(FILE* in, const char* tag_name, char** pp) {
         if (strstr(buf, end_tag)) {
             snprintf(buf, sizeof(buf), "</%s>\n", tag_name);
             retval = strcatdup(p, buf);
-            if (retval) return retval;
+            if (retval) {
+                free(p);
+                return retval;
+            }
             *pp = p;
             return 0;
         }
         retval = strcatdup(p, buf);
-        if (retval) return retval;
+        if (retval) {
+            free(p);
+            return retval;
+        }
     }
     free(p);
     return ERR_XML_PARSE;

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -152,6 +152,8 @@ int copy_stream(FILE* in, FILE* out) {
 }
 
 // append to a malloc'd string
+// If reallocation fails, the pointer p remains unchanged, and the data will
+// not be freed. (strong exception safety)
 //
 int strcatdup(char*& p, char* buf) {
     char* new_p = (char*)realloc(p, strlen(p) + strlen(buf)+1);


### PR DESCRIPTION
If `realloc` fails, the old pointer is not freed. We should not overwrite the old pointer in this case, otherwise we have a memory leak.

We also have to free previously allocated memory in the case of reallocation failure.