### PR TITLE
Drupal: changed link to forums, was forums (incorrect), now points to…

### DIFF
--- a/drupal/sites/default/boinc/modules/boincimport/boincimport.pages.inc
+++ b/drupal/sites/default/boinc/modules/boincimport/boincimport.pages.inc
@@ -399,7 +399,7 @@ function boincimport_post_configuration() {
       formatted in BBcode. It would be a good idea to verify that BBcode is
       being formatted correctly in the imported posts. Have a look around
       !the_forum.', array(
-        '!the_forum' =>  l(t('the forum'), 'forum')
+        '!the_forum' =>  l(t('the forum'), 'community')
       )) . '</p>';
   }
 


### PR DESCRIPTION
Drupal: fixed broken link to forum page, was forum (incorrect) now community (correct)

(DBOINC-151)