### PR TITLE
lib: improve useless getaddrinfo message

### DIFF
--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -169,7 +169,7 @@ int resolve_hostname(const char* hostname, sockaddr_storage &ip_addr) {
     int retval = getaddrinfo(hostname, NULL, &hints, &res);
     if (retval) {
         char buf[256];
-        snprintf(buf, sizeof(buf), "%s: getaddrinfo", time_to_string(dtime()));
+        snprintf(buf, sizeof(buf), "%s: getaddrinfo: %s: %s", time_to_string(dtime()), hostname, gai_strerror(retval));
         perror(buf);
         return ERR_GETADDRINFO;
     }


### PR DESCRIPTION
Turn

	25-Apr-2016 17:10:31: getaddrinfo: No such file or directory

into

	25-Apr-2016 18:38:54: getaddrinfo: compute03:
	Name or service not known: No such file or directory

(From that, I was then able to conclude the hostname was missing
from /etc/hosts.)