### PR TITLE
Drupal: Fixed bug in boinc user import module. 

### DIFF
--- a/drupal/sites/default/boinc/modules/boincimport/boincimport.module
+++ b/drupal/sites/default/boinc/modules/boincimport/boincimport.module
@@ -482,7 +482,7 @@ function boincimport_users() {
   else {
     // Need to import any user who is currently ignored in order to keep them
     // ignored... not particularly clean (ignored users are stored in a string)
-    $ignored_user_list = array();
+    $ignored_user_list = array(0);
     $ignoring_users = db_query("
       SELECT ignorelist
       FROM forum_preferences


### PR DESCRIPTION
If no users are ignored then the dbquery for users fails. Changed array initialization to array(0), which fixes the dbquery and the bug.

BOINC user import module has a bug where if there are no ignored users, the subsequent database query will fail. To fix this, the ignored_user_list array is initialized to zero.