### PR TITLE
virtualbox icon should be const char*

### DIFF
--- a/clientgui/res/virtualboxicon.xpm
+++ b/clientgui/res/virtualboxicon.xpm
@@ -1,5 +1,5 @@
 /* XPM */
-static char *virtualboxicon_xpm[] = {
+static const char *virtualboxicon_xpm[] = {
 /* columns rows colors chars-per-pixel */
 "16 16 107 2",
 "K  c #3A577C",


### PR DESCRIPTION
to avoid a warning when transforming into a string.

I remember to have contributed these kind of compile-time-optics patches a lot some long time ago :) The Debian build demons all publish their runs here:
https://buildd.debian.org/status/fetch.php?pkg=boinc&arch=amd64&ver=7.6.31%2Bdfsg-6&stamp=1460045578