### PR TITLE
bug in make_project and additional help for enduser

### DIFF
--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -247,9 +247,10 @@ def create_project_dirs(dest_dir):
         return apply(os.path.join,(dest_dir,)+d)
     def mkdir2(d):
         try:
-            os.mkdir(d);
-        except:
-            pass
+            os.makedirs(d)
+        except OSError as e:
+            if not os.path.isdir(d):
+                raise SystemExit(e)
     map(lambda d: mkdir2(dir(d)),
         [   '',
             'cgi-bin',
@@ -273,7 +274,6 @@ def create_project_dirs(dest_dir):
             'html/ops/ffmail',
             'html/ops/mass_email',
             'html/ops/remind_email',
-            'html/ops',
             'html/project',
             'html/stats',
             'html/user',

--- a/tools/make_project
+++ b/tools/make_project
@@ -456,9 +456,13 @@ print >>open(readme_filename,'w'), '''Steps to complete installation:
 
 -  Change Apache configuration (as root):
 
+   If you are using Apache 2.4, edit the %(httpd_conf_template_filename)s
+   (see file for specific instructions).
+
    cat %(httpd_conf_template_filename)s >> /etc/apache/httpd.conf
 
    (path to httpd.conf varies; try /etc/httpd/ or /etc/apache2)
+
    Then restart the web server:
 
    /usr/sbin/apache2ctl restart
@@ -478,6 +482,11 @@ print >>open(readme_filename,'w'), '''Steps to complete installation:
 
     htpasswd -c .htpasswd username
 
+-  Add the project name and copyright holder for the boinc Web site:
+
+    edit html/project/project.inc
+
+    change PROJECT and COPYRIGHT_HOLDER
 ----------------------------
 
 To start, show status, and stop the project, run:


### PR DESCRIPTION
There is a bug when creating a project, In create_project_dirs(), if a directory cannot be created due to permissions or any other reason, then the original code simply uses a try-except block with "pass". This means even if the base project directory cannot be created, the code continues. The result is that a bit later when the the program tries to [chmod 02770 some directories](https://github.com/BOINC/boinc/blob/master/py/Boinc/setup_project.py#L291), create_project_dirs() will fail in an ungraceful way. The chmod lambda-map() is not set in a try-except block.

My solution is to re-write the mkdir2 function to be smarter. Now it tries to create the directory. And then it checks if the directory already exists. Finally, it raises an SystemExit exception if both fail. This means the create_project_dirs() function can be called multiple times, as is done in setup_project.py.

Also, the directory 'html/ops' is present twice.

Finally, there are some misc changes to the text of the readme file so the end user knows to change the httpd.conf file for Apache 2.4. And knows where to file the project.inc file so s/he can change the project name and copyright holder strings for the project Web page.
