### PR TITLE
Drupal: bug fix-firefox word wrapping of task names

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view-field--boinc-account-tasks-all--id.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view-field--boinc-account-tasks-all--id.tpl.php
@@ -19,6 +19,7 @@
   * the view is modified.
   */
 ?>
-<span class="task-name">
+<?php // Fix wrapping issue in Firefox (see DBOINCP-244) - replaced span tag with div ?>
+<div class="task-name">
   <?php print l($row->result_name, "task/{$row->id}"); ?>
-</span>
+</div>

--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view-field--boinc-host-tasks-all--id.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view-field--boinc-host-tasks-all--id.tpl.php
@@ -19,6 +19,7 @@
   * the view is modified.
   */
 ?>
-<span class="task-name">
+<?php // Fix wrapping issue in Firefox (see DBOINCP-244) - replaced span tag with div ?>
+<div class="task-name">
   <?php print l($row->result_name, "task/{$row->id}"); ?>
-</span>
+</div>

--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view-field--boinc-workunit-tasks-all--id.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view-field--boinc-workunit-tasks-all--id.tpl.php
@@ -19,6 +19,7 @@
   * the view is modified.
   */
 ?>
-<span class="task-name">
+<?php // Fix wrapping issue in Firefox (see DBOINCP-244) - replaced span tag with div ?>
+<div class="task-name">
   <?php print l($row->result_name, "task/{$row->id}"); ?>
-</span>
+</div>


### PR DESCRIPTION
Drupal: Replaced span tags with div tags to fix firefox not word-wrapping. Fixes DBOINCP-244