### PR TITLE
Client: fix cpu detection for ARMv8

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -484,6 +484,10 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
 #elif __arm__
     strcpy(host.p_vendor, "ARM");
     vendor_hack = vendor_found = true;
+#elif __aarch64__
+    strcpy(p_vendor, "ARM");
+    vendor_hack = vendor_found = true;
+    model_hack = true;
 #endif
 
     host.m_cache=-1;
@@ -524,6 +528,9 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
             strstr(buf, "cpu\t\t: ")
 #elif __arm__
             strstr(buf, "Processor\t: ") || strstr(buf, "model name")
+#elif __aarch64__
+            // Hardware is a fallback specifying the board this CPU is on (not ideal but better than nothing)
+            strstr(buf, "Processor\t: ") || strstr(buf, "CPU architecture: ") || strstr(buf, "Hardware\t: ")
 #else
             strstr(buf, "model name\t: ") || strstr(buf, "cpu model\t\t: ")
 #endif
@@ -548,6 +555,16 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
                 testc = strrchr(buf, ':')+2;
                 if (isdigit(*testc)) {
                     family = atoi(testc);
+                    continue;    /* skip this line */
+                }
+#endif
+#ifdef __aarch64__
+                /* depending on kernel version, CPU architecture can either be
+                 * a number or a string. If a string, we have a model name, else we don't
+                 */
+                char *testc = NULL;
+                testc = strrchr(buf, ':')+2;
+                if (isdigit(*testc)) {
                     continue;    /* skip this line */
                 }
 #endif

--- a/client/hostinfo_unix_test.cpp
+++ b/client/hostinfo_unix_test.cpp
@@ -56,6 +56,10 @@ int main(void) {
 #elif __arm__
     strcpy(p_vendor, "ARM ");
     vendor_hack = vendor_found = true;
+#elif __aarch64__
+    strcpy(p_vendor, "ARM ");
+    vendor_hack = vendor_found = true;
+    model_hack = true;
 #endif
 
     strcpy(features, "");
@@ -96,6 +100,9 @@ int main(void) {
             strstr(buf, "cpu\t\t: ")
 #elif __arm__
             strstr(buf, "Processor\t: ") || strstr(buf, "model name")
+#elif __aarch64__
+            // Hardware is a fallback available on ODROID devices
+            strstr(buf, "Processor\t: ") || strstr(buf, "CPU architecture: ") || strstr(buf, "Hardware\t: ")
 #else
             strstr(buf, "model name\t: ") || strstr(buf, "cpu model\t\t: ")
 #endif
@@ -120,6 +127,18 @@ int main(void) {
                 testc = strrchr(buf, ':')+2;
                 if (isdigit(*testc)) {
                     family = atoi(testc);
+                    continue;    /* skip this line */
+                }
+#endif
+#ifdef __aarch64__
+                /* depending on kernel version, CPU architecture can either be
+                 * a number or a string. If a string, we have a model name, else we don't
+                 * also checks "Hardware" for ODROID devices as a fallback*/
+                char *testc = NULL;
+                testc = strrchr(buf, ':')+2;
+                if (!isdigit(*testc)) {
+                    model_found = true;
+                    strlcpy(p_model, strchr(buf, ':') + 2, sizeof(p_model));
                     continue;    /* skip this line */
                 }
 #endif

--- a/client/hostinfo_unix_test.cpp
+++ b/client/hostinfo_unix_test.cpp
@@ -34,7 +34,7 @@ int main(void) {
     bool model_hack=false, vendor_hack=false;
     int n;
     int family=-1, model=-1, stepping=-1;
-    char  p_vendor[256], p_model[256];
+    char  p_vendor[256], p_model[256], product_name[256];
     char buf2[256];
     int m_cache=-1;
 
@@ -66,6 +66,7 @@ int main(void) {
 #endif
 
     strcpy(features, "");
+    strcpy(product_name, "");
     while (fgets(buf, 256, f)) {
         //strip_whitespace(buf);
         if (
@@ -96,6 +97,19 @@ int main(void) {
             }
         }
 
+#ifdef __aarch64__
+        if (
+            // Hardware is specifying the board this CPU is on, store it in product_name while we parse /proc/cpuinfo
+            strstr(buf, "Hardware\t: ")
+        ) {
+            strlcpy(buf2, strchr(buf, ':') + 2, sizeof(product_name) - strlen(product_name) - 1);
+            //strip_whitespace(buf2);
+            if (strlen(product_name)) {
+                strcat(product_name, " ");
+            }
+            strcat(product_name, buf2);
+        }
+#endif
         if (
 #ifdef __ia64__
             strstr(buf, "family     : ") || strstr(buf, "model name : ")


### PR DESCRIPTION
Tested on an ODROID C2 which now returns "ARM" as p_vendor and "ODROID-C2" as p_model. Other kernels may report something like "AArch64 Processor rev 4 (aarch64)" as p_model.
Note: The aarch64 cpu reports the neon feature as "asimd".