### PR TITLE
Openssl api change

### DIFF
--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -464,14 +464,14 @@ void openssl_to_keys(
 ) {
     pub.bits = nbits;
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-    BIGNUM *n;
-    BIGNUM *e;
-    BIGNUM *d;
-    BIGNUM *p;
-    BIGNUM *q;
-    BIGNUM *dmp1;
-    BIGNUM *dmq1;
-    BIGNUM *iqmp;
+    const BIGNUM *n;
+    const BIGNUM *e;
+    const BIGNUM *d;
+    const BIGNUM *p;
+    const BIGNUM *q;
+    const BIGNUM *dmp1;
+    const BIGNUM *dmq1;
+    const BIGNUM *iqmp;
     RSA_get0_key(rp, &n, &e, &d);
     RSA_get0_factors(rp, &p, &q);
     RSA_get0_crt_params(rp, &dmp1, &dmq1, &iqmp);
@@ -544,18 +544,16 @@ void public_to_openssl(R_RSA_PUBLIC_KEY& pub, RSA* rp) {
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
     BIGNUM *n;
     BIGNUM *e;
-    BIGNUM *d;
     n = BN_bin2bn(pub.modulus, sizeof(pub.modulus), 0);
     e = BN_bin2bn(pub.exponent, sizeof(pub.exponent), 0);
-    // d??? FIXME
-    RSA_set0_key(rp, n, e, d);
+    RSA_set0_key(rp, n, e, NULL);
 #else
     rp->n = BN_bin2bn(pub.modulus, sizeof(pub.modulus), 0);
     rp->e = BN_bin2bn(pub.exponent, sizeof(pub.exponent), 0);
 #endif
 }
 
-static int _bn2bin(BIGNUM *from, unsigned char *to, int max) {
+static int _bn2bin(const BIGNUM *from, unsigned char *to, int max) {
 	int i;
 	i=BN_num_bytes(from);
 	if (i > max) {
@@ -569,14 +567,14 @@ static int _bn2bin(BIGNUM *from, unsigned char *to, int max) {
 
 int openssl_to_private(RSA *from, R_RSA_PRIVATE_KEY *to) {
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-    BIGNUM *n;
-    BIGNUM *e;
-    BIGNUM *d;
-    BIGNUM *p;
-    BIGNUM *q;
-    BIGNUM *dmp1;
-    BIGNUM *dmq1;
-    BIGNUM *iqmp;
+    const BIGNUM *n;
+    const BIGNUM *e;
+    const BIGNUM *d;
+    const BIGNUM *p;
+    const BIGNUM *q;
+    const BIGNUM *dmp1;
+    const BIGNUM *dmq1;
+    const BIGNUM *iqmp;
 
     RSA_get0_key(from, &n, &e, &d);
     RSA_get0_factors(from, &p, &q);

--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -554,15 +554,15 @@ void public_to_openssl(R_RSA_PUBLIC_KEY& pub, RSA* rp) {
 }
 
 static int _bn2bin(const BIGNUM *from, unsigned char *to, int max) {
-	int i;
-	i=BN_num_bytes(from);
-	if (i > max) {
-		return(0);
-	}
-	memset(to,0,(unsigned int)max);
-	if (!BN_bn2bin(from,&(to[max-i])))
-		return(0);
-	return(1);
+    int i;
+    i=BN_num_bytes(from);
+    if (i > max) {
+        return(0);
+    }
+    memset(to,0,(unsigned int)max);
+    if (!BN_bn2bin(from,&(to[max-i])))
+        return(0);
+    return(1);
 }
 
 int openssl_to_private(RSA *from, R_RSA_PRIVATE_KEY *to) {
@@ -598,23 +598,23 @@ int openssl_to_private(RSA *from, R_RSA_PRIVATE_KEY *to) {
     if (!_bn2bin(iqmp,to->coefficient,MAX_RSA_PRIME_LEN))
         return(0);
 #else
-	to->bits = BN_num_bits(from->n);
-	if (!_bn2bin(from->n,to->modulus,MAX_RSA_MODULUS_LEN)) 
-	    return(0);
-	if (!_bn2bin(from->e,to->publicExponent,MAX_RSA_MODULUS_LEN)) 
-	    return(0);
-	if (!_bn2bin(from->d,to->exponent,MAX_RSA_MODULUS_LEN)) 
-	    return(0);
-	if (!_bn2bin(from->p,to->prime[0],MAX_RSA_PRIME_LEN)) 
-	    return(0);
-	if (!_bn2bin(from->q,to->prime[1],MAX_RSA_PRIME_LEN)) 
-	    return(0);
-	if (!_bn2bin(from->dmp1,to->primeExponent[0],MAX_RSA_PRIME_LEN)) 
-	    return(0);
-	if (!_bn2bin(from->dmq1,to->primeExponent[1],MAX_RSA_PRIME_LEN)) 
-	    return(0);
-	if (!_bn2bin(from->iqmp,to->coefficient,MAX_RSA_PRIME_LEN)) 
-	    return(0);
+    to->bits = BN_num_bits(from->n);
+    if (!_bn2bin(from->n,to->modulus,MAX_RSA_MODULUS_LEN))
+        return(0);
+    if (!_bn2bin(from->e,to->publicExponent,MAX_RSA_MODULUS_LEN))
+        return(0);
+    if (!_bn2bin(from->d,to->exponent,MAX_RSA_MODULUS_LEN))
+        return(0);
+    if (!_bn2bin(from->p,to->prime[0],MAX_RSA_PRIME_LEN))
+        return(0);
+    if (!_bn2bin(from->q,to->prime[1],MAX_RSA_PRIME_LEN))
+        return(0);
+    if (!_bn2bin(from->dmp1,to->primeExponent[0],MAX_RSA_PRIME_LEN))
+        return(0);
+    if (!_bn2bin(from->dmq1,to->primeExponent[1],MAX_RSA_PRIME_LEN))
+        return(0);
+    if (!_bn2bin(from->iqmp,to->coefficient,MAX_RSA_PRIME_LEN))
+        return(0);
 #endif
     return 1;
 }
@@ -634,8 +634,8 @@ int check_validity_of_cert(
     bio = BIO_new(BIO_s_file());
     BIO_read_filename(bio, cFile);
     if (NULL == (cert = PEM_read_bio_X509(bio, NULL, 0, NULL))) {
-	    BIO_vfree(bio);
-	    return 0;
+        BIO_vfree(bio);
+        return 0;
     }
     // verify certificate
     store = X509_STORE_new();
@@ -668,32 +668,32 @@ int check_validity_of_cert(
 #endif
         BN_CTX *c = BN_CTX_new();
         if (!c) {
-	        X509_free(cert);
-	        EVP_PKEY_free(pubKey);
-	        BIO_vfree(bio);
-	        return 0;
-	    }
+            X509_free(cert);
+            EVP_PKEY_free(pubKey);
+            BIO_vfree(bio);
+            return 0;
+        }
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
         RSA *rsa;
         rsa = EVP_PKEY_get0_RSA(pubKey);
         if (!RSA_blinding_on(rsa, c)) {
 #else
-	    if (!RSA_blinding_on(pubKey->pkey.rsa, c)) {
+        if (!RSA_blinding_on(pubKey->pkey.rsa, c)) {
 #endif
-	        X509_free(cert);
-	        EVP_PKEY_free(pubKey);
-	        BIO_vfree(bio);
-	        BN_CTX_free(c);
-	        return 0;
-	    }
+            X509_free(cert);
+            EVP_PKEY_free(pubKey);
+            BIO_vfree(bio);
+            BN_CTX_free(c);
+            return 0;
+        }
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
         retval = RSA_verify(NID_md5, md5_md, MD5_DIGEST_LENGTH, sfileMsg, sfsize, rsa);
         RSA_blinding_off(rsa);
 #else
-	    retval = RSA_verify(NID_md5, md5_md, MD5_DIGEST_LENGTH, sfileMsg, sfsize, pubKey->pkey.rsa);
-	    RSA_blinding_off(pubKey->pkey.rsa);
+        retval = RSA_verify(NID_md5, md5_md, MD5_DIGEST_LENGTH, sfileMsg, sfsize, pubKey->pkey.rsa);
+        RSA_blinding_off(pubKey->pkey.rsa);
 #endif
-	    BN_CTX_free(c);
+        BN_CTX_free(c);
     }
 #ifdef HAVE_OPAQUE_EVP_PKEY
     if (EVP_PKEY_id(pubKey) == EVP_PKEY_DSA) {
@@ -730,7 +730,7 @@ char *check_validity(
     if (!of) return NULL;
     MD5_Init(&md5CTX);
     while (0 != (rbytes = (int)fread(rbuf, 1, sizeof(rbuf), of))) {
-	    MD5_Update(&md5CTX, rbuf, rbytes);
+        MD5_Update(&md5CTX, rbuf, rbytes);
     }
     MD5_Final(md5_md, &md5CTX);
     fclose(of);
@@ -740,12 +740,12 @@ char *check_validity(
     char file[MAXPATHLEN];
     while (!dir_scan(file, dir, sizeof(file))) {
         char fpath[MAXPATHLEN];
-	    snprintf(fpath, sizeof(fpath), "%s/%s", certPath, file);
+        snprintf(fpath, sizeof(fpath), "%s/%s", certPath, file);
         // TODO : replace '128'  
-	    if (check_validity_of_cert(fpath, md5_md, signature, 128, caPath)) {
-	        dir_close(dir);
-	        return strdup(fpath);
-	    }
+        if (check_validity_of_cert(fpath, md5_md, signature, 128, caPath)) {
+            dir_close(dir);
+            return strdup(fpath);
+        }
     }
 
     dir_close(dir);
@@ -778,7 +778,7 @@ int cert_verify_file(
     if (!of) return false;
     MD5_Init(&md5CTX);
     while (0 != (rbytes = (int)fread(rbuf, 1, sizeof(rbuf), of))) {
-	    MD5_Update(&md5CTX, rbuf, rbytes);
+        MD5_Update(&md5CTX, rbuf, rbytes);
     }
     MD5_Final(md5_md, &md5CTX);
     fclose(of);
@@ -805,10 +805,10 @@ int cert_verify_file(
             bio = BIO_new(BIO_s_file());
             BIO_read_filename(bio, fbuf);
             if (NULL == (cert = PEM_read_bio_X509(bio, NULL, 0, NULL))) {
-        	    BIO_vfree(bio);
+                BIO_vfree(bio);
                 printf("Cannot read certificate ('%s')\n", fbuf);
                 file_counter++;
-        	    continue;
+                continue;
             }
             fflush(stdout);
             subj = X509_get_subject_name(cert);
@@ -816,7 +816,7 @@ int cert_verify_file(
             // ???
             //X509_NAME_free(subj);
             X509_free(cert);
-    	    BIO_vfree(bio);
+            BIO_vfree(bio);
             if (strcmp(buf, signatures->signatures.at(i).subject)) {
                 printf("Subject does not match ('%s' <-> '%s')\n", buf, signatures->signatures.at(i).subject);
                 file_counter++;

--- a/lib/crypt.h
+++ b/lib/crypt.h
@@ -26,6 +26,11 @@
 
 #include <openssl/rsa.h>
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* OpenSSL 1.1.0+ */
+#define HAVE_OPAQUE_EVP_PKEY 1 /* since 1.1.0 -pre3 */
+#define HAVE_OPAQUE_RSA_DSA_DH 1 /* since 1.1.0 -pre5 */
+#endif
+
 #define MAX_RSA_MODULUS_BITS 1024
 #define MAX_RSA_MODULUS_LEN ((MAX_RSA_MODULUS_BITS + 7) / 8)
 #define MAX_RSA_PRIME_BITS ((MAX_RSA_MODULUS_BITS + 1) / 2)

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -62,23 +62,23 @@ void die(const char* p) {
 
 void usage() {
     fprintf(stderr,
-        "Usage: crypt_prog options\n\n"
-        "Options:\n\n"
-        "-genkey n private_keyfile public_keyfile\n"
-        "    create an n-bit key pair\n"
-        "-sign file private_keyfile\n"
-        "    create a signature for a given file, write to stdout\n"
-        "-sign_string string private_keyfile\n"
-        "    create a signature for a given string\n"
-        "-verify file signature_file public_keyfile\n"
-        "    verify a signature\n"
-        "-test_crypt private_keyfile public_keyfile\n"
-        "    test encrypt/decrypt functions\n"
-        "-conkey o2b/b20 priv/pub input_file output_file\n"
-        "    convert keys between BOINC and OpenSSL format\n"
-        "-cert_verify file signature certificate_dir\n"
-        "    verify a signature using a directory of certificates\n"
-    );
+            "Usage: crypt_prog options\n\n"
+            "Options:\n\n"
+            "-genkey n private_keyfile public_keyfile\n"
+            "    create an n-bit key pair\n"
+            "-sign file private_keyfile\n"
+            "    create a signature for a given file, write to stdout\n"
+            "-sign_string string private_keyfile\n"
+            "    create a signature for a given string\n"
+            "-verify file signature_file public_keyfile\n"
+            "    verify a signature\n"
+            "-test_crypt private_keyfile public_keyfile\n"
+            "    test encrypt/decrypt functions\n"
+            "-conkey o2b/b20 priv/pub input_file output_file\n"
+            "    convert keys between BOINC and OpenSSL format\n"
+            "-cert_verify file signature certificate_dir\n"
+            "    verify a signature using a directory of certificates\n"
+           );
 }
 
 unsigned int random_int() {
@@ -93,7 +93,7 @@ unsigned int random_int() {
         die("Can't load ADVAPI32.DLL");
     }
     BOOLEAN (APIENTRY *pfn)(void*, ULONG) =
-    (BOOLEAN (APIENTRY *)(void*,ULONG))GetProcAddress(hLib,"SystemFunction036");
+        (BOOLEAN (APIENTRY *)(void*,ULONG))GetProcAddress(hLib,"SystemFunction036");
     if (pfn) {
         char buff[32];
         ULONG ulCbBuff = sizeof(buff);
@@ -131,7 +131,7 @@ int main(int argc, char** argv) {
     RSA rsa_key;
 #endif
     RSA *rsa_key_;
-	BIO *bio_out=NULL;
+    BIO *bio_out=NULL;
     BIO *bio_err=NULL;
     char *certpath;
     bool b2o=false; // boinc key to openssl key ?
@@ -214,8 +214,8 @@ int main(int argc, char** argv) {
         retval = md5_file(argv[2], md5_buf, size);
         if (retval) die("md5_file");
         retval = check_file_signature(
-            md5_buf, public_key, signature, is_valid
-        );
+                     md5_buf, public_key, signature, is_valid
+                 );
         if (retval) die("check_file_signature");
         if (is_valid) {
             printf("file is valid\n");
@@ -262,9 +262,9 @@ int main(int argc, char** argv) {
             printf("siganture verified using certificate '%s'.\n\n", certpath);
             free(certpath);
         }
-    // this converts, but an executable signed with sign_executable,
-    // and signature converted to OpenSSL format cannot be verified with
-    // OpenSSL
+        // this converts, but an executable signed with sign_executable,
+        // and signature converted to OpenSSL format cannot be verified with
+        // OpenSSL
     } else if (!strcmp(argv[1], "-convsig")) {
         if (argc < 5) {
             usage();
@@ -320,18 +320,18 @@ int main(int argc, char** argv) {
             die("either 'pub' or 'priv' must be defined for -convkey\n");
         }
         OpenSSL_add_all_algorithms();
-		ERR_load_crypto_strings();
-		ENGINE_load_builtin_engines();
-		if (bio_err == NULL) {
-		    bio_err = BIO_new_fp(stdout, BIO_NOCLOSE);
+        ERR_load_crypto_strings();
+        ENGINE_load_builtin_engines();
+        if (bio_err == NULL) {
+            bio_err = BIO_new_fp(stdout, BIO_NOCLOSE);
         }
         //enc=EVP_get_cipherbyname("des");
         //if (enc == NULL)
         //    die("could not get cypher.\n");
         // no encription yet.
         bio_out=BIO_new(BIO_s_file());
-		if (BIO_write_filename(bio_out,argv[5]) <= 0) {
-			perror(argv[5]);
+        if (BIO_write_filename(bio_out,argv[5]) <= 0) {
+            perror(argv[5]);
             die("could not create output file.\n");
         }
         if (b2o) {
@@ -351,11 +351,11 @@ int main(int argc, char** argv) {
 #endif
 
                 //i = PEM_write_bio_RSAPrivateKey(bio_out, &rsa_key,
-        		//				enc, NULL, 0, pass_cb, NULL);
-        		// no encryption yet.
-        		
+                //				enc, NULL, 0, pass_cb, NULL);
+                // no encryption yet.
+
                 //i = PEM_write_bio_RSAPrivateKey(bio_out, &rsa_key,
-        		//				NULL, NULL, 0, pass_cb, NULL);
+                //				NULL, NULL, 0, pass_cb, NULL);
                 fpriv = fopen(argv[5], "w+");
                 if (!fpriv) die("fopen");
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
@@ -364,10 +364,10 @@ int main(int argc, char** argv) {
                 PEM_write_RSAPrivateKey(fpriv, &rsa_key, NULL, NULL, 0, 0, NULL);
 #endif
                 fclose(fpriv);
-    		    //if (i == 0) {
+                //if (i == 0) {
                 //    ERR_print_errors(bio_err);
                 //    die("could not write key file.\n");
-    		    //}
+                //}
             } else {
                 fpub = fopen(argv[4], "r");
                 if (!fpub) {
@@ -381,11 +381,11 @@ int main(int argc, char** argv) {
                     die("fopen");
                 }
                 public_to_openssl(public_key, rsa_key_);
-    		    i = PEM_write_RSA_PUBKEY(fpub, rsa_key_);
-    		    if (i == 0) {
+                i = PEM_write_RSA_PUBKEY(fpub, rsa_key_);
+                if (i == 0) {
                     ERR_print_errors(bio_err);
                     die("could not write key file.\n");
-    		    }
+                }
                 fclose(fpub);
             }
         } else {

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -125,7 +125,11 @@ int main(int argc, char** argv) {
     unsigned char signature_buf[256], buf[256], buf2[256];
     FILE *f, *fpriv, *fpub;
     char cbuf[256];
+#ifdef HAVE_OPAQUE_RSA_DSA_DH
+    RSA *rsa_key;
+#else
     RSA rsa_key;
+#endif
     RSA *rsa_key_;
 	BIO *bio_out=NULL;
     BIO *bio_err=NULL;
@@ -330,7 +334,11 @@ int main(int argc, char** argv) {
                 retval = scan_key_hex(fpriv, (KEY*)&private_key, sizeof(private_key));
                 fclose(fpriv);
                 if (retval) die("scan_key_hex\n");
+#ifdef HAVE_OPAQUE_RSA_DSA_DH
+                private_to_openssl(private_key, rsa_key);
+#else
                 private_to_openssl(private_key, &rsa_key);
+#endif
 
                 //i = PEM_write_bio_RSAPrivateKey(bio_out, &rsa_key,
         		//				enc, NULL, 0, pass_cb, NULL);
@@ -340,7 +348,11 @@ int main(int argc, char** argv) {
         		//				NULL, NULL, 0, pass_cb, NULL);
                 fpriv = fopen(argv[5], "w+");
                 if (!fpriv) die("fopen");
+#ifdef HAVE_OPAQUE_RSA_DSA_DH
+                PEM_write_RSAPrivateKey(fpriv, rsa_key, NULL, NULL, 0, 0, NULL);
+#else
                 PEM_write_RSAPrivateKey(fpriv, &rsa_key, NULL, NULL, 0, 0, NULL);
+#endif
                 fclose(fpriv);
     		    //if (i == 0) {
                 //    ERR_print_errors(bio_err);

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -74,7 +74,7 @@ void usage() {
             "    verify a signature\n"
             "-test_crypt private_keyfile public_keyfile\n"
             "    test encrypt/decrypt functions\n"
-            "-conkey o2b/b20 priv/pub input_file output_file\n"
+            "-convkey o2b/b2o priv/pub input_file output_file\n"
             "    convert keys between BOINC and OpenSSL format\n"
             "-cert_verify file signature certificate_dir\n"
             "    verify a signature using a directory of certificates\n"

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
     FILE *f, *fpriv, *fpub;
     char cbuf[256];
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-    RSA *rsa_key;
+    RSA *rsa_key = RSA_new();
 #else
     RSA rsa_key;
 #endif
@@ -136,6 +136,7 @@ int main(int argc, char** argv) {
     char *certpath;
     bool b2o=false; // boinc key to openssl key ?
     bool kpriv=false; // private key ?
+    BIGNUM *e;
 
     if (argc == 1) {
         usage();
@@ -150,7 +151,16 @@ int main(int argc, char** argv) {
         n = atoi(argv[2]);
 
         srand(random_int());
-        RSA* rp = RSA_generate_key(n,  65537, 0, 0);
+        e = BN_new();
+        retval = BN_set_word(e, (unsigned long)65537);
+        if (retval != 1) {
+            die("BN_set_word");
+        }
+        RSA *rp = RSA_new();
+        retval = RSA_generate_key_ex(rp, n, e, NULL);
+        if (retval != 1) {
+            die("RSA_generate_key_ex");
+        }
         openssl_to_keys(rp, n, private_key, public_key);
         fpriv = fopen(argv[3], "w");
         if (!fpriv) die("fopen");


### PR DESCRIPTION
The upcoming OpenSSL version introduces some API changes (https://wiki.openssl.org/index.php/1.1_API_Changes). This is so far a backwards compatible change that works with the old and the new API. I checked by signing files with both versions and verifying with the other.

Fixes #1565