### PR TITLE
VBOX: added boot_iso option

### DIFF
--- a/samples/vboxwrapper/vbox_mscom_impl.cpp
+++ b/samples/vboxwrapper/vbox_mscom_impl.cpp
@@ -407,10 +407,10 @@ int VBOX_VM::create_vm() {
     // Tweak the VM's Boot Options
     //
     vboxlog_msg("Setting Boot Options for VM.");
-    rc = pMachine->SetBootOrder(1, DeviceType_HardDisk);
+    rc = pMachine->SetBootOrder(boot_iso ? 2 : 1, DeviceType_HardDisk);
     if (CHECK_ERROR(rc)) goto CLEANUP;
     
-    rc = pMachine->SetBootOrder(2, DeviceType_DVD);
+    rc = pMachine->SetBootOrder(boot_iso ? 1 : 2, DeviceType_DVD);
     if (CHECK_ERROR(rc)) goto CLEANUP;
 
     pMachine->SetBootOrder(3, DeviceType_Null);

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -256,8 +256,13 @@ int VBOX_VM::create_vm() {
     //
     vboxlog_msg("Setting Boot Options for VM.");
     command  = "modifyvm \"" + vm_name + "\" ";
-    command += "--boot1 disk ";
-    command += "--boot2 dvd ";
+    if (boot_iso) {
+        command += "--boot1 dvd ";
+        command += "--boot2 disk ";        
+    } else {
+        command += "--boot1 disk ";
+        command += "--boot2 dvd ";
+    } 
     command += "--boot3 none ";
     command += "--boot4 none ";
 

--- a/samples/vboxwrapper/vboxjob.cpp
+++ b/samples/vboxwrapper/vboxjob.cpp
@@ -122,6 +122,7 @@ void VBOX_JOB::clear() {
     enable_graphics_support = false;
     enable_vm_savestate_usage = false;
     disable_automatic_checkpoints = false;
+    boot_iso = false;
     pf_guest_port = 0;
     pf_host_port = 0;
     port_forwards.clear();
@@ -180,6 +181,7 @@ int VBOX_JOB::parse() {
         else if (xp.parse_bool("enable_graphics_support", enable_graphics_support)) continue;
         else if (xp.parse_bool("enable_vm_savestate_usage", enable_vm_savestate_usage)) continue;
         else if (xp.parse_bool("disable_automatic_checkpoints", disable_automatic_checkpoints)) continue;
+        else if (xp.parse_bool("boot_iso", boot_iso)) continue;
         else if (xp.parse_int("pf_guest_port", pf_guest_port)) continue;
         else if (xp.parse_int("pf_host_port", pf_host_port)) continue;
         else if (xp.parse_string("copy_to_shared", str)) {

--- a/samples/vboxwrapper/vboxjob.h
+++ b/samples/vboxwrapper/vboxjob.h
@@ -79,6 +79,9 @@ public:
 
     // whether to add an extra cache disk for systems like uCernVM
     bool enable_cache_disk;
+    
+    // whether to put the iso as the first boot device 
+    bool boot_iso; 
 
     // whether to allow network access
     bool enable_network;

--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -30,6 +30,8 @@
 //                  for the particular host.
 // --register_only  Register the VM but don't run it.
 //                  Useful for debugging; see the wiki page
+// --memory_size_mb How much memory (in MB) to give the VM. Overrides the
+//                  value in vbox_job.xml if its present. 
 //
 // Handles:
 // - suspend/resume/quit/abort
@@ -44,6 +46,7 @@
 // Andrew J. Younge (ajy4490 AT umiacs DOT umd DOT edu)
 // Jie Wu <jiewu AT cern DOT ch>
 // Daniel Lombraña González <teleyinex AT gmail DOT com>
+// Marius Millea <mariusmillea AT gmail DOT com>
 
 #ifdef _WIN32
 #include "boinc_win.h"


### PR DESCRIPTION
Added an option `<boot_iso/>` to `vbox_job.xml` which puts the ISO first in the boot order in the case where you are attaching both a disk and an ISO. The default remains to boot from disk as before. Resolves https://github.com/BOINC/boinc/issues/1573. 

I did not add a command line option (I could though), since it seems like the options which have made it as command line options are ones which would need to be controlled on a per-job (rather than per-appversion) basis, and this doesn't seem to me to be one of them. 