### PR TITLE
Boinc gahp fixes

### DIFF
--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -534,7 +534,7 @@ void handle_fetch_output(COMMAND& c) {
         } else {
             sprintf(dst_path, "%s/%s", req.dir, of.dest);
         }
-        sprintf(buf, "mv %s/%s %s", req.dir, of.src, dst_path);
+        sprintf(buf, "mv '%s/%s' '%s'", req.dir, of.src, dst_path);
         retval = system(buf);
         if (retval) {
             s = string("mv\\ failed");

--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -459,7 +459,7 @@ void handle_fetch_output(COMMAND& c) {
         } else {
             sprintf(path, "%s/%s", req.dir, req.stderr_filename.c_str());
         }
-        FILE* f = fopen(path, "w");
+        FILE* f = fopen(path, "a");
         if (!f) {
             sprintf(buf, "can't\\ open\\ stderr\\ output\\ file\\ %s ", path);
             s = string(buf);

--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -505,9 +505,14 @@ void handle_fetch_output(COMMAND& c) {
             char* lname = req.file_descs[i].src;
             int j = output_file_index(td, lname);
             if (j < 0) {
-                sprintf(buf, "requested\\ file\\ %s\\ not\\ in\\ template", lname);
-                s = string(buf);
-                goto done;
+                if (i >= td.output_files.size()) {
+                      sprintf(buf, "too\\ many\\ output\\ files\\ specified\\ submit:%d\\ template:%d",
+                          i, td.output_files.size()
+                      );
+                    s = string(buf);
+                    goto done;
+                }
+                j = i;
             }
             sprintf(path, "%s/%s", req.dir, lname);
             retval = get_output_file(


### PR DESCRIPTION
- If there can't be found a Condor output file with a matching name in the output template, use the position of the file in the lists of output files to identify it.

- Prepare for the (rare) case where a Condor output file path contains blanks

- Append to an existing stderr / error file instead of overwriting it (Condor-style instead of BOINC style)