### PR TITLE
BOINC GAHP: print SVN_VERSION with --version CLA

### DIFF
--- a/samples/condor/Makefile
+++ b/samples/condor/Makefile
@@ -3,8 +3,8 @@ all: boinc_gahp
 clean:
 	rm boinc_gahp
 
-boinc_gahp: boinc_gahp.cpp ../../lib/remote_submit.h ../../lib/remote_submit.cpp
-	g++ -g -O0 -I../../lib \
+boinc_gahp: boinc_gahp.cpp ../../lib/remote_submit.h ../../lib/remote_submit.cpp ../../svn_version.h
+	g++ -g -O0 -I../../lib -I../.. \
 	-o boinc_gahp boinc_gahp.cpp ../../lib/remote_submit.cpp \
 	-L../../lib -lboinc -lpthread -lcurl
 

--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -34,6 +34,7 @@
 #include "md5_file.h"
 #include "parse.h"
 #include "remote_submit.h"
+#include "svn_version.h"
 
 using std::map;
 using std::pair;
@@ -702,8 +703,7 @@ int COMMAND::parse_command() {
 }
 
 void print_version(bool startup) {
-    BPRINTF("%s$GahpVersion: 1.0 %s BOINC\\ GAHP $\n", startup ? "" : "S ",
-            __DATE__);
+    BPRINTF("%s$GahpVersion: 1.0 %s BOINC\\ GAHP $\n", startup ? "" : "S ", __DATE__);
 }
 
 int n_results() {
@@ -859,7 +859,13 @@ void read_config() {
     }
 }
 
-int main() {
+int main(int argc, char*argv[]) {
+    if (argc>1) {
+        if (!strcmp(argv[1],"--version")) {
+            fprintf(stderr,SVN_VERSION"\n");
+            return 0;
+        }
+    }
     read_config();
     strcpy(response_prefix, "");
     print_version(true);
@@ -870,4 +876,5 @@ int main() {
         handle_command(p);
         fflush(stdout);
     }
+    return 0;
 }


### PR DESCRIPTION
The hardcoded version information written by boinc_gahp is not very helpful when I need to record which code version a particular binary was built from.

If there is a more suitable (i.e. GAHP protocol conformant) way to write SVN_VERSION to stdout I would be fine with that, too. If so, pleas implement this and reject this merge request.
