### PR TITLE
BOINC GAHP condor input template

### DIFF
--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -20,6 +20,7 @@
 // server-side utility functions for remote job submissions and control
 
 require_once("../inc/submit_db.inc");
+require_once("../inc/util_basic.inc");
 
 // the physical name of a file is jf_(md5).
 // Prepend the jf_ to make the source of the file clear
@@ -133,6 +134,8 @@ function retire_batch($batch) {
             "assimilate_state=".ASSIMILATE_DONE.", transition_time=$now"
         );
     }
+    $path = project_dir() . "/templates/batch_" . $batch->id . "_in";
+    if (file_exists($path)) unlink($path);
     $batch->update("state=".BATCH_STATE_RETIRED);
 }
 

--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -192,6 +192,22 @@ function upload_files($r) {
     ";
 }
 
+function upload_template($r) {
+    list($user, $user_submit) = authenticate_user($r, null);
+    $batch_id = (int)$r->batch_id;
+    $name = "file_0";
+    $tmp_name = $_FILES[$name]['tmp_name'];
+    if (!is_uploaded_file($tmp_name)) {
+        xml_error(-1, "$tmp_name is not an uploaded file");
+    }
+    $path = project_dir() . "/templates/batch_" . $batch_id . "_in";
+    if (!rename($tmp_name, $path)) {
+        unlink($tmp_name);
+        xml_error(-1, "could not move $tmp_name to $path");
+    }
+    echo "<success/>\n";
+}
+
 if (0) {
 $r = simplexml_load_string("<query_files>\n<batch_id>0</batch_id>\n   <md5>80bf244b43fb5d39541ea7011883b7e0</md5>\n   <md5>a6037b05afb05f36e6a85a7c5138cbc1</md5>\n</query_files>\n ");
 submit_batch($r);
@@ -215,6 +231,9 @@ case 'query_files':
     break;
 case 'upload_files':
     upload_files($r);
+    break;
+case 'upload_template':
+    upload_template($r);
     break;
 default:
     xml_error(-1, "no such action");

--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -193,6 +193,7 @@ function upload_files($r) {
 }
 
 function upload_template($r) {
+    xml_start_tag("upload_template");
     list($user, $user_submit) = authenticate_user($r, null);
     $batch_id = (int)$r->batch_id;
     $name = "file_0";
@@ -205,7 +206,9 @@ function upload_template($r) {
         unlink($tmp_name);
         xml_error(-1, "could not move $tmp_name to $path");
     }
-    echo "<success/>\n";
+    echo "<success/>
+        </upload_template>
+    ";
 }
 
 if (0) {

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -666,7 +666,7 @@ function handle_set_expire_time($r) {
     echo "</set_expire_time>\n";
 }
 
-function get_templates($r) {
+function get_templates($r, $get_input=true) {
     xml_start_tag("get_templates");
     $app_name = (string)($r->app_name);
     if ($app_name) {
@@ -678,14 +678,20 @@ function get_templates($r) {
     }
 
     list($user, $user_submit) = authenticate_user($r, $app);
-    $in = file_get_contents(project_dir() . "/templates/".$app->name."_in");
+    if ($get_input) {
+        $in = file_get_contents(project_dir() . "/templates/".$app->name."_in");
+    }
     $out = file_get_contents(project_dir() . "/templates/".$app->name."_out");
-    if ($in === false || $out === false) {
+    if (($get_input && $in === false) || $out === false) {
         xml_error(-1, "template file missing");
     }
     echo "<templates>\n$in\n$out\n</templates>
         </get_templates>
     ";
+}
+
+function get_output_template($r) {
+    return get_templates($r, false);
 }
 
 function ping($r) {
@@ -757,6 +763,7 @@ switch ($r->getName()) {
     case 'create_batch': create_batch($r); break;
     case 'estimate_batch': estimate_batch($r); break;
     case 'get_templates': get_templates($r); break;
+    case 'get_output_template': get_output_template($r); break;
     case 'ping': ping($r); break;
     case 'query_batch': query_batch($r); break;
     case 'query_batch2': query_batch2($r); break;

--- a/lib/remote_submit.cpp
+++ b/lib/remote_submit.cpp
@@ -864,11 +864,12 @@ int get_templates(
     const char* app_name,
     const char* job_name,
     TEMPLATE_DESC &td,
-    string &error_msg
+    string &error_msg,
+    bool output_only
 ) {
     string request;
     char url[1024], buf[256];
-    request = "<get_templates>\n";
+    request = output_only?"<get_output_template>\n":"<get_templates>\n";
     sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
     if (app_name) {
@@ -878,7 +879,7 @@ int get_templates(
         sprintf(buf, "<job_name>%s</job_name>\n", job_name);
         request += string(buf);
     }
-    request += "</get_templates>\n";
+    request += output_only?"</get_output_template>\n":"</get_templates>\n";
     sprintf(url, "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
@@ -894,7 +895,7 @@ int get_templates(
     mf.init_file(reply);
     while (!xp.get_tag()) {
 #ifdef SHOW_REPLY
-        printf("get_templates reply: %s\n", xp.parsed_tag);
+        printf(output_only?"get_templates reply: %s\n":"get_output_template reply: %s\n", xp.parsed_tag);
 #endif
         if (xp.match_tag("templates")) {
             retval = td.parse(xp);
@@ -910,6 +911,17 @@ int get_templates(
     }
     fclose(reply);
     return retval;
+}
+
+int get_output_template(
+    const char* project_url,
+    const char* authenticator,
+    const char* app_name,
+    const char* job_name,
+    TEMPLATE_DESC &td,
+    string &error_msg
+) {
+    return get_templates(project_url, authenticator, app_name, job_name, td, error_msg, true);
 }
 
 int TEMPLATE_DESC::parse(XML_PARSER& xp) {

--- a/lib/remote_submit.cpp
+++ b/lib/remote_submit.cpp
@@ -395,7 +395,8 @@ int submit_jobs(
     char app_name[256],
     int batch_id,
     vector<JOB> jobs,
-    string& error_msg
+    string& error_msg,
+    const char* wu_template
 ) {
     char buf[1024], url[1024];
     sprintf(buf,
@@ -409,6 +410,9 @@ int submit_jobs(
         app_name
     );
     string request = buf;
+    if (wu_template) {
+        request += "  <workunit_template_file>" + (string)wu_template + "</workunit_template_file>\n";
+    }
     for (unsigned int i=0; i<jobs.size(); i++) {
         JOB job = jobs[i];
         request += "<job>\n";

--- a/lib/remote_submit.h
+++ b/lib/remote_submit.h
@@ -131,6 +131,14 @@ extern int upload_files (
     std::string& error_msg
 );
 
+extern int upload_template (
+    const char* project_url,
+    const char* authenticator,
+    std::string path,
+    int batch_id,
+    std::string& error_msg
+);
+
 extern int create_batch(
     const char* project_url,
     const char* authenticator,

--- a/lib/remote_submit.h
+++ b/lib/remote_submit.h
@@ -147,7 +147,8 @@ extern int submit_jobs(
     char app_name[256],
     int batch_id,
     std::vector<JOB> jobs,
-    std::string& error_msg
+    std::string& error_msg,
+    const char* wu_template = NULL
 );
 
 extern int estimate_batch(

--- a/lib/remote_submit.h
+++ b/lib/remote_submit.h
@@ -261,6 +261,16 @@ extern int get_templates(
     const char* app_name,   // either this
     const char* job_name,   // or this must be non-NULL
     TEMPLATE_DESC&,
+    std::string& error_msg,
+    bool output_only = false
+);
+
+extern int get_output_template(
+    const char* project_url,
+    const char* authenticator,
+    const char* app_name,   // either this
+    const char* job_name,   // or this must be non-NULL
+    TEMPLATE_DESC&,
     std::string& error_msg
 );
 

--- a/samples/condor/Makefile
+++ b/samples/condor/Makefile
@@ -3,8 +3,8 @@ all: boinc_gahp
 clean:
 	rm boinc_gahp
 
-boinc_gahp: boinc_gahp.cpp ../../lib/remote_submit.h ../../lib/remote_submit.cpp
-	g++ -g -O0 -I../../lib \
+boinc_gahp: boinc_gahp.cpp ../../lib/remote_submit.h ../../lib/remote_submit.cpp ../../svn_version.h
+	g++ -g -O0 -I../../lib -I../.. \
 	-o boinc_gahp boinc_gahp.cpp ../../lib/remote_submit.cpp \
 	-L../../lib -lboinc -lpthread -lcurl
 

--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -34,6 +34,7 @@
 #include "md5_file.h"
 #include "parse.h"
 #include "remote_submit.h"
+#include "svn_version.h"
 
 using std::map;
 using std::pair;
@@ -702,8 +703,7 @@ int COMMAND::parse_command() {
 }
 
 void print_version(bool startup) {
-    BPRINTF("%s$GahpVersion: 1.0 %s BOINC\\ GAHP $\n", startup ? "" : "S ",
-            __DATE__);
+    BPRINTF("%s$GahpVersion: 1.0 %s BOINC\\ GAHP $\n", startup ? "" : "S ", __DATE__);
 }
 
 int n_results() {
@@ -859,7 +859,13 @@ void read_config() {
     }
 }
 
-int main() {
+int main(int argc, char*argv[]) {
+    if (argc>1) {
+        if (!strcmp(argv[1],"--version")) {
+            fprintf(stderr,SVN_VERSION"\n");
+            return 0;
+        }
+    }
     read_config();
     strcpy(response_prefix, "");
     print_version(true);
@@ -870,4 +876,5 @@ int main() {
         handle_command(p);
         fflush(stdout);
     }
+    return 0;
 }

--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -254,6 +254,65 @@ int process_input_files(SUBMIT_REQ& req, string& error_msg) {
     return 0;
 }
 
+// check the input files for a possible local input template file,
+// i.e. a file with name ending in "_input_template.xml"
+// if such a file is found, remove it from the list of input files
+// and return the path in wu_template. Otherwise set wu_tempate to NULL.
+//
+void process_local_input_template(SUBMIT_REQ& req, char*& wu_template, string& error_msg) {
+    unsigned int i, j;
+
+    if (wu_template) free(wu_template);
+    wu_template = NULL;
+
+    // scan for input files beginning with "WU_TEMPLATE:"
+    //
+    for (i=0; i<req.jobs.size(); i++) {
+        JOB& job = req.jobs[i];
+        vector<INFILE> infiles;
+        for (j=0; j<job.infiles.size(); j++) {
+            INFILE& infile = job.infiles[j];
+            char* c = strstr(infile.src_path, "_input_template.xml");
+            if (c && (strlen(c) == strlen("_input_template.xml"))) {
+                wu_template = strdup(infile.src_path);
+            } else {
+                infiles.push_back(infile);
+            }
+        }
+        // if we found a TEMPLATE, eliminate this from the input file list
+        //
+        if (wu_template) {
+            req.jobs[i].infiles = infiles;
+        }
+    }
+}
+
+// upload wu_template as batch_<batch_id>_in
+//
+int upload_input_template(SUBMIT_REQ& req, char*& wu_template, string& error_msg) {
+    int retval;
+    char buf[64];
+
+    retval = upload_template(
+        project_url,
+        authenticator,
+        wu_template,
+        req.batch_id,
+        error_msg
+    );
+    if (retval) {
+#ifdef DEBUG
+        printf("upload_template() failed (%d): %s\n", retval, error_msg.c_str());
+#endif
+        return retval;
+    }
+
+    free(wu_template);
+    sprintf(buf,"batch_%d_in", req.batch_id);
+    wu_template = strdup(buf);
+    return 0;
+}
+
 // parse the text coming from Condor
 //
 int COMMAND::parse_submit(char* p) {
@@ -292,9 +351,14 @@ void handle_submit(COMMAND& c) {
     int retval;
     string error_msg, s;
     char buf[1024];
+    char*wu_template = NULL;
 
+    // check for a possibe local input template
+    process_local_input_template(req, wu_template, error_msg);
+
+    // if there is a local input template file, only check a remote output template
     retval = get_templates(
-        project_url, authenticator, req.app_name, NULL, td, error_msg
+        project_url, authenticator, req.app_name, NULL, td, error_msg, wu_template
     );
     if (retval) {
         sprintf(buf, "error\\ getting\\ templates:\\ %d\\ ", retval);
@@ -302,6 +366,8 @@ void handle_submit(COMMAND& c) {
         c.out = strdup(s.c_str());
         return;
     }
+
+    // create batch
     double expire_time = time(0) + 3600;
     retval = create_batch(
         project_url, authenticator, req.batch_name, req.app_name, expire_time,
@@ -313,6 +379,19 @@ void handle_submit(COMMAND& c) {
         c.out = strdup(s.c_str());
         return;
     }
+
+    // now that we have a batch_id, we can uplaod a possible template as "batch_<batch_id>_in"
+    if (wu_template) {
+        retval = upload_input_template(req, wu_template, error_msg);
+        if (retval) {
+            sprintf(buf, "error\\ uploading\\ input\\ template:\\ %d\\ ", retval);
+            s = string(buf) + escape_str(error_msg);
+            c.out = strdup(s.c_str());
+            return;
+        }
+    }
+
+    // process remaining input files
     retval = process_input_files(req, error_msg);
     if (retval) {
         sprintf(buf, "error\\ processing\\ input\\ files:\\ %d\\ ", retval);
@@ -321,10 +400,12 @@ void handle_submit(COMMAND& c) {
         return;
     }
 
+    // submit
     retval = submit_jobs(
         project_url, authenticator,
-        req.app_name, req.batch_id, req.jobs, error_msg
+        req.app_name, req.batch_id, req.jobs, error_msg, wu_template
     );
+    if (wu_template) free(wu_template);
     if (retval) {
         sprintf(buf, "error\\ submitting\\ jobs:\\ %d\\ ", retval);
         s = string(buf) + escape_str(error_msg);
@@ -442,7 +523,7 @@ void handle_fetch_output(COMMAND& c) {
     // get the output template
     //
     retval = get_templates(
-        project_url, authenticator, NULL, req.job_name, td, error_msg
+        project_url, authenticator, NULL, req.job_name, td, error_msg, true
     );
     if (retval) {
         sprintf(buf, "error\\ getting\\ templates:\\ %d\\ ", retval);


### PR DESCRIPTION
This is a _preliminary_ implementation of my feature request to allow submitting an arbitrary input/workunit template file from Condor.

If the name of an input file specified in condor submit ends in "_input_tempplate.xml", it is removed from the list of "normal" input files, uploaded separately to the server and used as an input template for the current batch.

I guess that augmenting the GAHP protocol as requested and implementing that change on the Condor side will take some time that I am not willing to wait. However with this patch, the functionality on the BOINC side then is already implemented, and once this change is made at the Condor end, only one function (process_local_input_template()) needs to be changed in BOINC GAHP to adapt to that.
