### PR TITLE
Update Drupal preference wording

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
@@ -200,9 +200,9 @@ function boincwork_admin_prefs_presets_form_submit($form, &$form_state) {
   $prefs = boincwork_get_preset_prefs($preset);
   
   // Processing preferences
-  $prefs['run_on_batteries'] = ($values['processor']['run_on_batteries']) ? 1 : 0;
-  $prefs['run_if_user_active'] = ($values['processor']['run_if_user_active']) ? 1 : 0;
-  $prefs['run_gpu_if_user_active'] = ($values['processor']['run_gpu_if_user_active']) ? 1: 0;
+  $prefs['run_on_batteries'] = ($values['processor']['run_on_batteries']) ? 0 : 1;
+  $prefs['run_if_user_active'] = ($values['processor']['run_if_user_active']) ? 0 : 1;
+  $prefs['run_gpu_if_user_active'] = ($values['processor']['run_gpu_if_user_active']) ? 0: 1;
   $prefs['idle_time_to_run'] = $values['processor']['idle_time_to_run'];
   $prefs['suspend_if_no_recent_input'] = $values['processor']['suspend_if_no_recent_input'];
   $prefs['suspend_cpu_usage'] = $values['processor']['suspend_cpu_usage'];

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
@@ -166,7 +166,6 @@ function boincwork_admin_prefs_presets_form_validate($form, &$form_state) {
   if (!verify_numeric($values['processor']['start_hour'], 0, 23)) form_set_error('start_hour', t('Invalid setting for') . " \"{$form['processor']['start_hour']['#title']} [x] {$form['processor']['start_hour']['#field_suffix']}\"");
   if (!verify_numeric($values['processor']['end_hour'], 0, 23)) form_set_error('end_hour', t('Invalid setting for') . " \"{$form['processor']['end_hour']['#title']} [x] {$form['processor']['end_hour']['#field_suffix']}\"");
   if (!verify_numeric($values['processor']['cpu_scheduling_period_minutes'], 1, 9999)) form_set_error('cpu_scheduling_period_minutes', t('Invalid setting for') . " \"{$form['processor']['cpu_scheduling_period_minutes']['#title']} [x] {$form['processor']['cpu_scheduling_period_minutes']['#field_suffix']}\"");
-  if (!verify_numeric($values['processor']['max_cpus'], 0, 9999)) form_set_error('max_cpus', t('Invalid setting for') . " \"{$form['processor']['max_cpus']['#title']} [x] {$form['processor']['max_cpus']['#field_suffix']}\"");
   if (!verify_numeric($values['processor']['max_ncpus_pct'], 0, 100)) form_set_error('max_ncpus_pct', t('Invalid setting for') . " \"{$form['processor']['max_ncpus_pct']['#title']} [x] {$form['processor']['max_ncpus_pct']['#field_suffix']}\"");
   if (!verify_numeric($values['processor']['cpu_usage_limit'], 0, 100)) form_set_error('cpu_usage_limit', t('Invalid setting for') . " \"{$form['processor']['cpu_usage_limit']['#title']} [x] {$form['processor']['cpu_usage_limit']['#field_suffix']}\"");
 
@@ -211,7 +210,6 @@ function boincwork_admin_prefs_presets_form_submit($form, &$form_state) {
   $prefs['end_hour'] = $values['processor']['end_hour'];
   $prefs['leave_apps_in_memory'] = ($values['processor']['leave_apps_in_memory']) ? 1 : 0;
   $prefs['cpu_scheduling_period_minutes'] = $values['processor']['cpu_scheduling_period_minutes'];
-  $prefs['max_cpus'] = $values['processor']['max_cpus'];
   $prefs['max_ncpus_pct'] = $values['processor']['max_ncpus_pct'];
   $prefs['cpu_usage_limit'] = $values['processor']['cpu_usage_limit'];
   

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -71,7 +71,6 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     'end_hour' => 0,
     'leave_apps_in_memory' => 0,
     'cpu_scheduling_period_minutes' => 60,
-    'max_cpus' => 16,
     'max_ncpus_pct' => 100,
     'cpu_usage_limit' => 100,
     // Storage...
@@ -294,14 +293,6 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#description' => bts('Recommended: @period minutes',
       array('@period' => 60)
     )
-  );
-  $form['prefs']['advanced']['processor']['max_cpus'] = array(
-    '#title' => bts('On multiprocessors, use at most'),
-    '#type' => 'textfield',
-    '#field_suffix' => bts('processors'),
-    '#default_value' => $default['max_cpus'],
-    '#size' => 1,
-    '#description' => bts('Set to 0 for no limit'),
   );
   $form['prefs']['advanced']['processor']['max_ncpus_pct'] = array(
     '#title' => bts('On multiprocessors, use at most'),
@@ -567,7 +558,6 @@ function boincwork_generalprefs_form_validate($form, &$form_state) {
   if (!verify_numeric($values['processor']['start_hour'], 0, 23)) form_set_error('start_hour', bts('Invalid setting for "%preference"', array('%preference' => "{$form['prefs']['advanced']['processor']['start_hour']['#title']} [x] {$form['prefs']['advanced']['processor']['start_hour']['#field_suffix']}")));
   if (!verify_numeric($values['processor']['end_hour'], 0, 23)) form_set_error('end_hour', bts('Invalid setting for "%preference"', array('%preference' => "{$form['prefs']['advanced']['processor']['end_hour']['#title']} [x] {$form['prefs']['advanced']['processor']['end_hour']['#field_suffix']}")));
   if (!verify_numeric($values['processor']['cpu_scheduling_period_minutes'], 1, 9999)) form_set_error('cpu_scheduling_period_minutes', bts('Invalid setting for "%preference"', array('%preference' => "{$form['prefs']['advanced']['processor']['cpu_scheduling_period_minutes']['#title']} [x] {$form['prefs']['advanced']['processor']['cpu_scheduling_period_minutes']['#field_suffix']}")));
-  if (!verify_numeric($values['processor']['max_cpus'], 0, 9999)) form_set_error('max_cpus', bts('Invalid setting for "%preference"', array('%preference' => "{$form['prefs']['advanced']['processor']['max_cpus']['#title']} [x] {$form['prefs']['advanced']['processor']['max_cpus']['#field_suffix']}")));
   if (!verify_numeric($values['processor']['max_ncpus_pct'], 0, 100)) form_set_error('max_ncpus_pct', bts('Invalid setting for "%preference"', array('%preference' => "{$form['prefs']['advanced']['processor']['max_ncpus_pct']['#title']} [x] {$form['prefs']['advanced']['processor']['max_ncpus_pct']['#field_suffix']}")));
   if (!verify_numeric($values['processor']['cpu_usage_limit'], 0, 100)) form_set_error('cpu_usage_limit', bts('Invalid setting for "%preference"', array('%preference' => "{$form['prefs']['advanced']['processor']['cpu_usage_limit']['#title']} [x] {$form['prefs']['advanced']['processor']['cpu_usage_limit']['#field_suffix']}")));
 
@@ -616,7 +606,6 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   $prefs['end_hour'] = $values['processor']['end_hour'];
   $prefs['leave_apps_in_memory'] = ($values['processor']['leave_apps_in_memory']) ? 1 : 0;
   $prefs['cpu_scheduling_period_minutes'] = $values['processor']['cpu_scheduling_period_minutes'];
-  $prefs['max_cpus'] = $values['processor']['max_cpus'];
   $prefs['max_ncpus_pct'] = $values['processor']['max_ncpus_pct'];
   $prefs['cpu_usage_limit'] = $values['processor']['cpu_usage_limit'];
   

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -206,59 +206,55 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#collapsed' => FALSE
   );
   $form['prefs']['advanced']['processor']['run_on_batteries'] = array(
-    '#title' => bts('Run while computer is on battery power?'),
+    '#title' => bts('Suspend when computer is on battery?'),
     '#type' => 'radios',
-    '#description' => bts('Only applies to portable computers'),
+    '#description' => bts('Suspends computing on portables when running on battery power.'),
     '#options' => $form['boolean_options']['#value'],
     '#attributes' => array('class' => 'fancy'),
-    '#default_value' => $default['run_on_batteries']
+    '#default_value' => ($default['run_on_batteries']) ? 0 : 1 // intentional inversion of setting
   );
   $form['prefs']['advanced']['processor']['run_if_user_active'] = array(
-    '#title' => bts('Run while computer is in use?'),
+    '#title' => bts('Suspend when computer is in use?'),
     '#type' => 'radios',
-    '#description' => ' ',
+    '#description' => bts("Suspends computing and file transfers when you're using the computer."),
     '#options' => $form['boolean_options']['#value'],
     '#attributes' => array('class' => 'fancy'),
-    '#default_value' => $default['run_if_user_active']
+    '#default_value' => ($default['run_if_user_active']) ? 0 : 1 // intentional inversion of setting
   );
   $form['prefs']['advanced']['processor']['run_gpu_if_user_active'] = array(
-    '#title' => bts('Run GPU work while computer is in use?'),
+    '#title' => bts('Suspend GPU computing when computer is in use?'),
     '#type' => 'radios',
-    '#description' => bts('Enforced by version @number',
-      array('@number' => '6.6.21+')
-    ),
+    '#description' => bts("Suspends GPU computing when you're using the computer."),
     '#options' => $form['boolean_options']['#value'],
     '#attributes' => array('class' => 'fancy'),
-    '#default_value' => $default['run_gpu_if_user_active']
+    '#default_value' => ($default['run_gpu_if_user_active']) ? 0 : 1 // intentional inversion of setting
   );
   $form['prefs']['advanced']['processor']['idle_time_to_run'] = array(
-    '#title' => bts('"In use" means mouse/keyboard activity in last'),
+    '#title' => bts('"In use" means mouse/keyboard input in last'),
     '#type' => 'textfield',
     '#field_suffix' => bts('minutes'),
     '#default_value' => $default['idle_time_to_run'],
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts('This determines when the computer is considered "in use".')
   );
   $form['prefs']['advanced']['processor']['suspend_if_no_recent_input'] = array(
-    '#title' => bts('Suspend work if no mouse/keyboard activity in last'),
+    '#title' => bts('Suspend when no mouse/keyboard input in last'),
     '#type' => 'textfield',
     '#field_suffix' => bts('minutes'),
     '#default_value' => $default['suspend_if_no_recent_input'],
     '#size' => 1,
-    '#description' => bts('Needed to enter low-power mode on some computers')
+    '#description' => bts('This allows some computers to enter low-power mode when not in use.')
   );
   $form['prefs']['advanced']['processor']['suspend_cpu_usage'] = array(
-    '#title' => bts('Suspend work if CPU usage is above'),
+    '#title' => bts('Suspend when non-BOINC CPU usage is above'),
     '#type' => 'textfield',
     '#field_suffix' => '%',
     '#default_value' => $default['suspend_cpu_usage'],
     '#size' => 1,
-    '#description' => bts('0 means no restriction. Enforced by version @number',
-      array('@number' => '6.10.30+')
-    ),
+    '#description' => bts('Suspend computing when your computer is busy running other programs.'),
   );
   $form['prefs']['advanced']['processor']['hour_label'] = array(
-    '#value' => '<div class="form-item"><label>' . bts('Do work only between the hours of:') . '</label></div>'
+    '#value' => '<div class="form-item"><label>' . bts('Compute only between:') . '</label></div>'
   );
   $form['prefs']['advanced']['processor']['start_hour'] = array(
     '#type' => 'select',
@@ -274,15 +270,15 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#default_value' => $default['end_hour']
   );
   $form['prefs']['advanced']['processor']['hour_description'] = array(
-    '#value' => '<div class="form-item slim"><div class="description">' . bts('No restriction if equal') . '</div></div>'
+    '#value' => '<div class="form-item slim"><div class="description">' . bts('Compute only during a particular period each day.') . '</div></div>'
   );
   $form['prefs']['advanced']['processor']['leave_apps_in_memory'] = array(
-    '#title' => bts('Leave tasks in memory while suspended?'),
+    '#title' => bts('Leave non-GPU tasks in memory while suspended?'),
     '#type' => 'radios',
     '#options' => $form['boolean_options']['#value'],
     '#attributes' => array('class' => 'fancy'),
     '#default_value' => $default['leave_apps_in_memory'],
-    '#description' => bts('Suspended tasks will consume swap space if "yes"')
+    '#description' => bts('If "Yes", suspended tasks stay in memory, and resume with no work lost. If "No", suspended tasks are removed from memory, and resume from their last checkpoint.')
   );
   $form['prefs']['advanced']['processor']['cpu_scheduling_period_minutes'] = array(
     '#title' => bts('Switch between tasks every'),
@@ -290,19 +286,15 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#field_suffix' => bts('minutes'),
     '#default_value' => $default['cpu_scheduling_period_minutes'],
     '#size' => 1,
-    '#description' => bts('Recommended: @period minutes',
-      array('@period' => 60)
-    )
+    '#description' => bts('If you run several projects, BOINC may switch between them this often.')
   );
   $form['prefs']['advanced']['processor']['max_ncpus_pct'] = array(
-    '#title' => bts('On multiprocessors, use at most'),
+    '#title' => bts('Use at most'),
     '#type' => 'textfield',
     '#field_suffix' => bts('% of the processors'),
     '#default_value' => $default['max_ncpus_pct'],
     '#size' => 1,
-    '#description' => bts('Enforced by version @number',
-      array('@number' => '6.1+')
-    ),
+    '#description' => bts('Keep some CPUs free for other applications. Example: 75% means use 6 cores on an 8-core CPU.'),
   );
   $form['prefs']['advanced']['processor']['cpu_usage_limit'] = array(
     '#title' => bts('Use at most'),
@@ -310,7 +302,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#field_suffix' => bts('% of the CPU time'),
     '#default_value' => $default['cpu_usage_limit'],
     '#size' => 1,
-    '#description' => bts('Can be used to reduce CPU heat')
+    '#description' => bts('Suspend/resume computing every few seconds to reduce CPU temperature and energy usage. Example: 75% means compute for 3 seconds, wait for 1 second, and repeat.')
   );
   
   // Disk and memory preferences
@@ -322,46 +314,44 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#collapsed' => FALSE
   );
   $form['prefs']['advanced']['storage']['disk_max_used_gb'] = array(
-    '#title' => bts('Disk: use at most'),
+    '#title' => bts('Disk: use no more than'),
     '#type' => 'textfield',
     '#field_suffix' => 'GB',
     '#default_value' => $default['disk_max_used_gb'],
     '#size' => 1,
-    '#description' => bts('Set to 0 for no limit'),
+    '#description' => bts('Limit the total amount of disk space used by BOINC.'),
   ); 
   $form['prefs']['advanced']['storage']['disk_min_free_gb'] = array(
-    '#title' => bts('Disk: leave free at least'),
+    '#title' => bts('Disk: leave at least'),
     '#type' => 'textfield',
-    '#field_suffix' => 'GB',
+    '#field_suffix' => 'GB free',
     '#default_value' => $default['disk_min_free_gb'],
     '#size' => 1,
-    '#description' => bts('Values smaller than @number are ignored',
-      array('@number' => '0.001')
-    ),
+    '#description' => bts('Limit disk usage to leave this much free space on the volume where BOINC stores data.'),
   );
   $form['prefs']['advanced']['storage']['disk_max_used_pct'] = array(
-    '#title' => bts('Disk: use at most'),
+    '#title' => bts('Disk: use no more than'),
     '#type' => 'textfield',
     '#field_suffix' => bts('% of total'),
     '#default_value' => $default['disk_max_used_pct'],
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts('Limit the percentage of disk space used by BOINC on the volume where it stores data.')
   ); 
   $form['prefs']['advanced']['storage']['disk_interval'] = array(
-    '#title' => bts('Tasks checkpoint to disk at most every'),
+    '#title' => bts('Request tasks to checkpoint at most every'),
     '#type' => 'textfield',
     '#field_suffix' => bts('seconds'),
     '#default_value' => $default['disk_interval'],
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts('This controls how often tasks save their state to disk, so that later they can be continued from that point.')
   );
   $form['prefs']['advanced']['storage']['vm_max_used_pct'] = array(
-    '#title' => bts('Swap space: use at most'),
+    '#title' => bts('Page/swap file: use at most'),
     '#type' => 'textfield',
     '#field_suffix' => bts('% of total'),
     '#default_value' => $default['vm_max_used_pct'],
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts('Limit the swap space (page file) used by BOINC.')
   );
   $form['prefs']['advanced']['storage']['ram_max_used_busy_pct'] = array(
     '#title' => bts('Memory: when computer is in use, use at most'),
@@ -369,7 +359,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#field_suffix' => bts('% of total'),
     '#default_value' => $default['ram_max_used_busy_pct'],
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts("Limit the memory used by BOINC when you're using the computer.")
   );
   $form['prefs']['advanced']['storage']['ram_max_used_idle_pct'] = array(
     '#title' => bts('Memory: when computer is not in use, use at most'),
@@ -377,7 +367,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#field_suffix' => bts('% of total'),
     '#default_value' => $default['ram_max_used_idle_pct'],
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts("Limit the memory used by BOINC when you're not using the computer.")
   );
   
   // Network preferences
@@ -389,20 +379,20 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#collapsed' => FALSE
   );
   $form['prefs']['advanced']['network']['work_buf_min_days'] = array(
-    '#title' => bts('Computer is connected to the Internet about every'),
+    '#title' => bts('Store at least'),
     '#type' => 'textfield',
-    '#field_suffix' => bts('days'),
+    '#field_suffix' => bts('days of work'),
     '#default_value' => $default['work_buf_min_days'],
     '#size' => 1,
-    '#description' => bts('Leave blank or 0 if always connected. @project will try to maintain at least this much work.', array('@project' => PROJECT))
+    '#description' => bts('Store at least enough tasks to keep the computer busy for this long.')
   ); 
   $form['prefs']['advanced']['network']['work_buf_additional_days'] = array(
-    '#title' => bts('Maintain enough work for an additional'),
+    '#title' => bts('Store up to an additional'),
     '#type' => 'textfield',
     '#field_suffix' => bts('days'),
     '#default_value' => $default['work_buf_additional_days'],
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts('Store additional tasks above the minimum level.  Determines how much work is requested when contacting a project.')
   ); 
   $form['prefs']['advanced']['network']['confirm_before_connecting'] = array(
     '#title' => bts('Confirm before connecting to Internet?'),
@@ -410,7 +400,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#options' => $form['boolean_options']['#value'],
     '#attributes' => array('class' => 'fancy'),
     '#default_value' => $default['confirm_before_connecting'],
-    '#description' => bts('Matters only if you have a modem, ISDN, or VPN connection')
+    '#description' => bts('Useful only if you have a modem, ISDN or VPN connection.')
   ); 
   $form['prefs']['advanced']['network']['hangup_if_dialed'] = array(
     '#title' => bts('Disconnect when done?'),
@@ -418,26 +408,26 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#options' => $form['boolean_options']['#value'],
     '#attributes' => array('class' => 'fancy'),
     '#default_value' => $default['hangup_if_dialed'],
-    '#description' => bts('Matters only if you have a modem, ISDN, or VPN connection')
+    '#description' => bts('Useful only if you have a modem, ISDN or VPN connection.')
   );
   $form['prefs']['advanced']['network']['max_bytes_sec_down'] = array(
-    '#title' => bts('Maximum download rate'),
+    '#title' => bts('Limit download rate to'),
     '#type' => 'textfield',
     '#field_suffix' => 'Kbytes/sec',
     '#default_value' => $default['max_bytes_sec_down']/1000,
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts('Limit the download rate of file transfers.')
   ); 
   $form['prefs']['advanced']['network']['max_bytes_sec_up'] = array(
-    '#title' => bts('Maximum upload rate'),
+    '#title' => bts('Limit upload rate to'),
     '#type' => 'textfield',
     '#field_suffix' => 'Kbytes/sec',
     '#default_value' => $default['max_bytes_sec_up']/1000,
     '#size' => 1,
-    '#description' => ' '
+    '#description' => bts('Limit the upload rate of file transfers.')
   );
   $form['prefs']['advanced']['network']['hour_label'] = array(
-    '#value' => '<div class="form-item"><label>' . bts('Use network only between the hours of:') . '</label></div>'
+    '#value' => '<div class="form-item"><label>' . bts('Transfer files only between') . '</label></div>'
   );
   $form['prefs']['advanced']['network']['net_start_hour'] = array(
     '#type' => 'select',
@@ -453,10 +443,10 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#default_value' => $default['net_end_hour']
   );
   $form['prefs']['advanced']['network']['hour_description'] = array(
-    '#value' => '<div class="form-item slim"><div class="description">' . bts('No restriction if equal') . '</div></div>'
+    '#value' => '<div class="form-item slim"><div class="description">' . bts('Transfer files only during a particular period each day.') . '</div></div>'
   ); 
   $form['prefs']['advanced']['network']['daily_xfer_limit_mb'] = array(
-    '#title' => bts('Transfer at most'),
+    '#title' => bts('Limit usage to'),
     '#type' => 'textfield',
     '#field_suffix' => 'Mbytes',
     '#default_value' => $default['daily_xfer_limit_mb'],
@@ -468,17 +458,15 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     '#field_suffix' => bts('days'),
     '#default_value' => $default['daily_xfer_period_days'],
     '#size' => 1,
-    '#description' => bts('Enforced by version @number',
-      array('@number' => '6.10.46+')
-    ),
+    '#description' => bts('Example: BOINC should transfer at most 2000 MB of data every 30 days.'),
   ); 
   $form['prefs']['advanced']['network']['dont_verify_images'] = array(
-    '#title' => bts('Skip image file verification?'),
+    '#title' => bts('Skip data verification for image files?'),
     '#type' => 'radios',
     '#options' => $form['boolean_options']['#value'],
     '#attributes' => array('class' => 'fancy'),
     '#default_value' => $default['dont_verify_images'],
-    '#description' => bts('Check this ONLY if your Internet provider modifies image files (UMTS does this, for example). Skipping verification reduces the security of BOINC.')
+    '#description' => bts('Only select "Yes" if your Internet provider modifies image files. Skipping verification reduces the security of BOINC.')
   );
   
   // The "fancy radios" are made via javascript on document load. In order for
@@ -596,9 +584,9 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   $prefs = boincwork_load_prefs('general', $venue);
   
   // Processing preferences
-  $prefs['run_on_batteries'] = ($values['processor']['run_on_batteries']) ? 1 : 0;
-  $prefs['run_if_user_active'] = ($values['processor']['run_if_user_active']) ? 1 : 0;
-  $prefs['run_gpu_if_user_active'] = ($values['processor']['run_gpu_if_user_active']) ? 1: 0;
+  $prefs['run_on_batteries'] = ($values['processor']['run_on_batteries']) ? 0 : 1;
+  $prefs['run_if_user_active'] = ($values['processor']['run_if_user_active']) ? 0 : 1;
+  $prefs['run_gpu_if_user_active'] = ($values['processor']['run_gpu_if_user_active']) ? 0 : 1;
   $prefs['idle_time_to_run'] = $values['processor']['idle_time_to_run'];
   $prefs['suspend_if_no_recent_input'] = $values['processor']['suspend_if_no_recent_input'];
   $prefs['suspend_cpu_usage'] = $values['processor']['suspend_cpu_usage'];
@@ -1075,7 +1063,7 @@ function boincwork_projectprefs_form(&$form_state, $venue) {
         '#options' => $form['boolean_options']['#value'],
         '#attributes' => array('class' => 'fancy'),
         '#default_value' => $default['no_cpu'] ? 0 : 1,
-        '#description' => bts('Enforced by version @number', array('@number' => '6.10+'))
+        '#description' => bts('Request CPU-only tasks from this project.')
       );
     }
     if ($app_types->cuda) {
@@ -1085,7 +1073,7 @@ function boincwork_projectprefs_form(&$form_state, $venue) {
         '#options' => $form['boolean_options']['#value'],
         '#attributes' => array('class' => 'fancy'),
         '#default_value' => $default['no_cuda'] ? 0 : 1,
-        '#description' => bts('Enforced by version @number', array('@number' => '6.10+'))
+        '#description' => bts('Request NVIDIA GPU tasks from this project.')
       );
     }
     if ($app_types->ati) {
@@ -1095,7 +1083,7 @@ function boincwork_projectprefs_form(&$form_state, $venue) {
         '#options' => $form['boolean_options']['#value'],
         '#attributes' => array('class' => 'fancy'),
         '#default_value' => $default['no_ati'] ? 0 : 1,
-        '#description' => bts('Enforced by version @number', array('@number' => '6.10+'))
+        '#description' => bts('Request ATI GPU tasks from this project.')
       );
     }
     if ($app_types->intel_gpu) {
@@ -1105,7 +1093,7 @@ function boincwork_projectprefs_form(&$form_state, $venue) {
         '#options' => $form['boolean_options']['#value'],
         '#attributes' => array('class' => 'fancy'),
         '#default_value' => $default['no_intel_gpu'] ? 0 : 1,
-        '#description' => bts('Enforced by version @number', array('@number' => '7.0.27+'))
+        '#description' => bts('Request Intel GPU tasks from this project.')
       );
     }
   }

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -36,7 +36,6 @@ function boincwork_get_preset_prefs($preset = null) {
           <end_hour>0</end_hour>
           <leave_apps_in_memory>1</leave_apps_in_memory>
           <cpu_scheduling_period_minutes>60</cpu_scheduling_period_minutes>
-          <max_cpus>16</max_cpus>
           <max_ncpus_pct>100</max_ncpus_pct>
           <cpu_usage_limit>80</cpu_usage_limit>
           <disk_max_used_gb>8</disk_max_used_gb>
@@ -69,7 +68,6 @@ function boincwork_get_preset_prefs($preset = null) {
           <end_hour>0</end_hour>
           <leave_apps_in_memory>1</leave_apps_in_memory>
           <cpu_scheduling_period_minutes>60</cpu_scheduling_period_minutes>
-          <max_cpus>16</max_cpus>
           <max_ncpus_pct>100</max_ncpus_pct>
           <cpu_usage_limit>100</cpu_usage_limit>
           <disk_max_used_gb>100</disk_max_used_gb>
@@ -102,7 +100,6 @@ function boincwork_get_preset_prefs($preset = null) {
           <end_hour>0</end_hour>
           <leave_apps_in_memory>1</leave_apps_in_memory>
           <cpu_scheduling_period_minutes>60</cpu_scheduling_period_minutes>
-          <max_cpus>16</max_cpus>
           <max_ncpus_pct>100</max_ncpus_pct>
           <cpu_usage_limit>80</cpu_usage_limit>
           <disk_max_used_gb>8</disk_max_used_gb>
@@ -135,7 +132,6 @@ function boincwork_get_preset_prefs($preset = null) {
           <end_hour>8</end_hour>
           <leave_apps_in_memory>0</leave_apps_in_memory>
           <cpu_scheduling_period_minutes>120</cpu_scheduling_period_minutes>
-          <max_cpus>4</max_cpus>
           <max_ncpus_pct>25</max_ncpus_pct>
           <cpu_usage_limit>40</cpu_usage_limit>
           <disk_max_used_gb>2</disk_max_used_gb>

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -674,10 +674,10 @@ function boincwork_make_prefs_table($prefs, $top_level = TRUE) {
       if (in_array($key, array('start_hour', 'net_start_hour'))) {
         switch ($key) {
         case 'start_hour':
-          $element['#title'] = bts('Do work only between the hours of:');
+          $element['#title'] = bts('Compute only between:');
           break;
         case 'net_start_hour':
-          $element['#title'] = bts('Use network only between the hours of:');
+          $element['#title'] = bts('Transfer files only between:');
           break;
         default:
         }


### PR DESCRIPTION
The wording of preferences now mostly match those used on the regular BOINC website so volunteers are not confused about the meanings.
Special note: The preferences run_on_batteries, run_if_user_active and run_gpu_if_user_active are now shown inverse to how they are stored because of the changed description.