### PR TITLE
Fixes from testing the job and cpu limiting functionality

### DIFF
--- a/sched/sched_send.cpp
+++ b/sched/sched_send.cpp
@@ -171,7 +171,10 @@ void WORK_REQ::get_job_limits() {
         if (effective_ngpus) effective_ngpus = 1;
     }
 
-    if (config.max_wus_to_send) {
+    if (project_prefs.max_jobs){
+      g_wreq->max_jobs_per_rpc = project_prefs.max_jobs;
+      ninstances[PROC_TYPE_CPU] = project_prefs.max_jobs;
+    } else if (config.max_wus_to_send) {
         g_wreq->max_jobs_per_rpc = mult * config.max_wus_to_send;
     } else {
         g_wreq->max_jobs_per_rpc = 999999;

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -220,10 +220,10 @@ void PROJECT_PREFS::parse() {
     if (parse_bool(buf,"no_intel_gpu", flag)) {
         dont_use_proc_type[PROC_TYPE_INTEL_GPU] = flag;
     }
-    if (parse_int(buf, "max_cpus", temp_int)) {
+    if (parse_int(buf, "<max_cpus>", temp_int)) {
         max_cpus = temp_int;
     }
-    if (parse_int(buf, "max_jobs", temp_int)) {
+    if (parse_int(buf, "<max_jobs>", temp_int)) {
         max_jobs = temp_int;
     }
 }


### PR DESCRIPTION
The parsing has been fixed and the max_jobs_per_rpc  and max_jobs_in_progress settings now use project_prefs.max_jobs for their values.