### PR TITLE
Daemons: enhance validator framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ sched/trickle_credit
 sched/trickle_deadline
 sched/trickle_echo
 sched/update_stats
+sched/validator_test
 sched/wu_check
 tools/cancel_jobs
 tools/create_work

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -786,3 +786,49 @@ bool is_valid_filename(const char* name) {
     }
     return true;
 }
+
+// safely copy a string to char array
+//
+char* safe_copy(string s) {
+    char *p = new char[s.size()+1];
+    std::copy(s.begin(), s.end(), p);
+    p[s.size()]= '\0';
+    return p;
+}
+
+// get the name part of a filepath
+// returns:
+//   0 on success
+//  -1 when fpath is empty
+//  -2 when fpath is a directory
+int path_to_filename(string fpath, string& fname) {
+    std::string::size_type n;
+    if (fpath.size() == 0) {
+        return -1;
+    }
+    n = fpath.rfind("/");
+    if (n == std::string::npos) {
+        fname = fpath;
+    } else if (n == fpath.size()-1) {
+        return -2;
+    } else {
+        fname = fpath.substr(n+1);
+    }
+    return 0;
+}
+
+// get the name part of a filepath
+//
+// wrapper for path_to_filename(string, string&)
+int path_to_filename(string fpath, char* &fname) {
+    string name;
+    int ret;
+    if (ret = path_to_filename(fpath, name)) {
+        return ret;
+    } else {
+        fname = new char[name.size()+1];
+        std::copy(name.begin(), name.end(), fname);
+        fname[name.size()]= '\0';
+    }
+    return 0;
+}

--- a/lib/str_util.h
+++ b/lib/str_util.h
@@ -104,4 +104,7 @@ extern std::vector<std::string> split(std::string, char delim);
 
 extern bool is_valid_filename(const char*);
 
+extern char* safe_copy(std::string s);
+extern int path_to_filename(std::string fpath, std::string& fname);
+extern int path_to_filename(std::string fpath, char* &fname);
 #endif

--- a/sched/makefile_validator_test
+++ b/sched/makefile_validator_test
@@ -5,7 +5,8 @@
 VALIDATOR_SRC = sample_bitwise_validator.cpp
 
 # where libmysqlclient is
-MYSQL_LIB_DIR = /usr/lib64/mysql
+MYSQL_LIB := $(shell mysql_config --libs)
+MYSQL_INC := $(shell mysql_config --include)
 
-validator_test: validator_test.cpp $(VALIDATOR_SRC)
-	g++ -g -I.. -I../lib -I../db -o validator_test validator_test.cpp $(VALIDATOR_SRC) validate_util.o -L . -lsched -L ../lib -lboinc -L $(MYSQL_LIB_DIR) -lmysqlclient
+validator_test: validator_test.cpp $(VALIDATOR_SRC) makefile_validator_test
+	g++ -g -I.. -I../lib -I../db $(MYSQL_INC) -o validator_test validator_test.cpp $(VALIDATOR_SRC) validate_util.o -L . -lsched -L ../lib -lboinc $(MYSQL_LIB)

--- a/sched/sample_bitwise_validator.cpp
+++ b/sched/sample_bitwise_validator.cpp
@@ -38,7 +38,6 @@
 using std::string;
 using std::vector;
 
-bool first = true;
 bool is_gzip = false;
     // if true, files are gzipped; skip header when comparing
 
@@ -46,6 +45,25 @@ struct FILE_CKSUM_LIST {
     vector<string> files;   // list of MD5s of files
     ~FILE_CKSUM_LIST(){}
 };
+
+int validate_handler_init(int argc, char** argv) {
+    // handle project specific arguments here
+    for (int i=1; i<argc; i++) {
+        if (is_arg(argv[i], "is_gzip")) {
+            is_gzip = true;
+        }
+    }
+    return 0;
+}
+
+void validate_handler_usage() {
+    // describe the project specific arguments here
+    fprintf(stderr,
+        "    Custom options:\n"
+        "    [--is_gzip]  files are gzipped; skip header when comparing\n"
+    );
+}
+
 
 bool files_match(FILE_CKSUM_LIST& f1, FILE_CKSUM_LIST& f2) {
     if (f1.files.size() != f2.files.size()) return false;
@@ -55,25 +73,12 @@ bool files_match(FILE_CKSUM_LIST& f1, FILE_CKSUM_LIST& f2) {
     return true;
 }
 
-void parse_cmdline() {
-    for (int i=1; i<g_argc; i++) {
-        if (!strcmp(g_argv[i], "--is_gzip")) {
-            is_gzip = true;
-        }
-    }
-}
-
 int init_result(RESULT& result, void*& data) {
     int retval;
     FILE_CKSUM_LIST* fcl = new FILE_CKSUM_LIST;
     vector<OUTPUT_FILE_INFO> files;
     char md5_buf[MD5_LEN];
     double nbytes;
-
-    if (first) {
-        parse_cmdline();
-        first = false;
-    }
 
     retval = get_output_file_infos(result, files);
     if (retval) {

--- a/sched/sample_substr_validator.cpp
+++ b/sched/sample_substr_validator.cpp
@@ -23,37 +23,44 @@
 // (default: accept it if the string is present)
 
 #include "sched_msgs.h"
+#include "sched_util_basic.h"
 #include "validate_util2.h"
 #include "validator.h"
 
-bool first = true;
 char* stderr_string;
 bool reject_if_present = false;
 
-void parse_cmdline() {
+int validate_handler_init(int argc, char** argv) {
+    // handle project specific arguments here
     bool found = false;
-    for (int i=1; i<g_argc; i++) {
-        if (!strcmp(g_argv[i], "--stderr_string")) {
-            stderr_string = g_argv[++i];
+    for (int i=1; i<argc; i++) {
+        if (is_arg(argv[i], "stderr_string")) {
+            stderr_string = argv[++i];
             found = true;
-        }
-        if (!strcmp(g_argv[i], "--reject_if_present")) {
+        } else if (is_arg(argv[i], "reject_if_present")) {
             reject_if_present = true;
         }
     }
+
     if (!found) {
         log_messages.printf(MSG_CRITICAL,
             "--stderr_string missing from command line\n"
         );
-        exit(1);
+        return 1;
     }
+    return 0;
+}
+
+void validate_handler_usage() {
+    // describe the project specific arguments here
+    fprintf(stderr,
+        "    Custom options:\n"
+        "    --stderr_string X     accept task if X is present in stderr_out\n"
+        "    [--reject_if_present] reject (invalidate) the task if X is present\n"
+    );
 }
 
 int init_result(RESULT& r, void*&) {
-    if (first) {
-        parse_cmdline();
-        first = false;
-    }
     if (strstr(r.stderr_out, stderr_string)) {
         return reject_if_present?-1:0;
     } else {

--- a/sched/sample_trivial_validator.cpp
+++ b/sched/sample_trivial_validator.cpp
@@ -19,6 +19,19 @@
 
 #include "validate_util2.h"
 
+int validate_handler_init(int, char**) {
+    return 0;
+}
+
+void validate_handler_usage() {
+    // describe the project specific arguments here
+    //fprintf(stderr,
+    //    "    Custom options:\n"
+    //    "    [--project_option X]  a project specific option\n"
+    //);
+}
+
+
 int init_result(RESULT&, void*&) {
     return 0;
 }

--- a/sched/validate_util.cpp
+++ b/sched/validate_util.cpp
@@ -29,6 +29,7 @@
 #include "str_replace.h"
 #include "util.h"
 
+#include "str_util.h"
 #include "sched_util.h"
 #include "sched_config.h"
 #include "sched_msgs.h"
@@ -74,6 +75,9 @@ int get_output_file_info(RESULT const& result, OUTPUT_FILE_INFO& fi) {
             if (retval) return retval;
             if (standalone) {
                 safe_strcpy(path, fi.name.c_str());
+                if (!path_to_filename(fi.name, name)) {
+                    fi.name = name;
+                }
             } else {
                 dir_hier_path(
                     fi.name.c_str(), config.upload_dir,
@@ -102,6 +106,9 @@ int get_output_file_infos(RESULT const& result, vector<OUTPUT_FILE_INFO>& fis) {
             if (retval) return retval;
             if (standalone) {
                 safe_strcpy(path, fi.name.c_str());
+                if (!path_to_filename(fi.name, name)) {
+                    fi.name = name;
+                }
             } else {
                 dir_hier_path(
                     fi.name.c_str(), config.upload_dir,
@@ -208,7 +215,7 @@ int get_credit_from_wu(WORKUNIT& wu, vector<RESULT>&, double& credit) {
     double x;
     int retval;
     DB_WORKUNIT dbwu;
-    
+
     dbwu.id = wu.id;
     retval = dbwu.get_field_str("xml_doc", dbwu.xml_doc, sizeof(dbwu.xml_doc));
     if (!retval) {

--- a/sched/validate_util.h
+++ b/sched/validate_util.h
@@ -53,5 +53,8 @@ extern bool standalone;
     // used by validator_test.
 extern void remove_random_from_filename(const char* in, char* out);
 
+extern int validate_handler_init(int argc, char** argv);
+extern void validate_handler_usage();
+
 #endif
 

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -789,7 +789,6 @@ void usage(char* name) {
         "    [--max_wu_id n]            Process only WUs with id <= n\n"
         "    [--min_wu_id n]            Process only WUs with id >= n\n"
         "    [--max_granted_credit X]   Grant no more than this amount of credit to a result\n"
-        "    [--grant_claimed_credit]   Grant the claimed credit, regardless of what other results for this workunit claimed\n"
         "    [--update_credited_job]    Add record to credited_job table after granting credit\n"
         "    [--credit_from_wu]         Credit is specified in WU XML\n"
         "    [--credit_from_runtime X]  Grant credit based on runtime (max X seconds)and estimated FLOPS\n"

--- a/sched/validator.h
+++ b/sched/validator.h
@@ -24,6 +24,3 @@ extern WORKUNIT* g_wup;
     // A pointer to the WU currently being processed;
     // you can access this in your init_result() etc. functions
     // (which are passed RESULT but not WORKUNIT)
-
-extern int g_argc;
-extern char** g_argv;

--- a/sched/validator_test.cpp
+++ b/sched/validator_test.cpp
@@ -28,17 +28,25 @@
 
 #include <stdio.h>
 
+#include "svn_version.h"
+#include "sched_util_basic.h"
 #include "validate_util.h"
 #include "validate_util2.h"
 
-int g_argc;
-char **g_argv;
-
 void usage(char* prog) {
     fprintf(stderr,
-        "usage: %s file1 file2\n", prog
+        "This program is a test validator; \n"
+        "You can test your custom handler with this\n"
     );
-    exit(1);
+    fprintf(stderr, "usage: %s [options] file1 file2\n"
+        "    Options:\n"
+        "    [-h|--help]     Print this usage information and exit\n"
+        "    [-v|--version]  Print version information and exit\n"
+        "    file1           Path to file to be compared (must be second to last)\n"
+        "    file2           Path to file to be compared (must be last)\n"
+        "\n",
+        prog);
+    validate_handler_usage();
 }
 
 int get_output_file_info(RESULT r, OUTPUT_FILE_INFO& fi) {
@@ -47,18 +55,34 @@ int get_output_file_info(RESULT r, OUTPUT_FILE_INFO& fi) {
 }
 
 int main(int argc, char** argv) {
-    if (argc != 3) {
+    int retval;
+
+    if (argc > 1) {
+      if (is_arg(argv[1], "h") || is_arg(argv[1], "help")) {
         usage(argv[0]);
+        exit(0);
+      } else if (is_arg(argv[1], "v") || is_arg(argv[1], "version")) {
+        printf("%s\n", SVN_VERSION);
+        exit(0);
+      }
     }
+    if (argc < 3) {
+        usage(argv[0]);
+        exit(0);
+    }
+
+    retval = validate_handler_init(argc, argv);
+    if (retval) exit(1);
+
     void* data1, *data2;
     RESULT r1, r2;
     bool match;
 
     standalone = true;
 
-    sprintf(r1.xml_doc_in, "<file_ref><file_name>%s</file_name></file_ref>", argv[1]);
-    sprintf(r2.xml_doc_in, "<file_ref><file_name>%s</file_name></file_ref>", argv[2]);
-    int retval;
+    sprintf(r1.xml_doc_in, "<file_ref><file_name>%s</file_name></file_ref>", argv[argc-2]);
+    sprintf(r2.xml_doc_in, "<file_ref><file_name>%s</file_name></file_ref>", argv[argc-1]);
+
     retval = init_result(r1, data1);
     if (retval) {
         fprintf(stderr, "init_result(r1) returned %d\n", retval);


### PR DESCRIPTION
The validator handler can now pass unknown arguments to the project specific handler.
Projects that have their own validator need to implement the validate_handler_init() function and handle project specific arguments there. They also need to supply a validate_handler_usage() function that printf()'s a description of the custom options. For examples see sample_substr_validator.cpp or script_validator.cpp
The validator test harness was also adopted to use this new functions.

This brings the implementation of the validator framework on the same level as the assimilator framework where similar changes where made in 0038d275c and dd004404a.
