### PR TITLE
Fix installation of `boinc-client` service script.

### DIFF
--- a/client/scripts/Makefile.am
+++ b/client/scripts/Makefile.am
@@ -3,7 +3,7 @@
 install-exec-hook:
 	chmod +x boinc-client
 	$(INSTALL) -d $(DESTDIR)$(sysconfdir)/init.d
-	$(INSTALL) -b $(srcdir)/boinc-client $(DESTDIR)$(sysconfdir)/init.d/boinc-client
+	$(INSTALL) -b boinc-client $(DESTDIR)$(sysconfdir)/init.d/boinc-client
 	if [ -d /etc/sysconfig ] ; then \
 	  $(INSTALL) -d $(DESTDIR)$(sysconfdir)/sysconfig ; \
 	  $(INSTALL) $(srcdir)/boinc-client.conf $(DESTDIR)$(sysconfdir)/sysconfig/boinc-client ; \


### PR DESCRIPTION
Adjusted `client/scripts/Makefile.am` to support out-of-tree builds, because `make install` was trying to find `boinc-client` in its source directory rather than in build workspace.
