### PR TITLE
Drupal fix ignore user comment

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
@@ -173,6 +173,18 @@
       <?php endif; ?>
     </div>
   </div> <!-- /.comment-body -->
+
+  <?php
+    static $authors;
+    if (_ignore_user_ignored_user($comment->uid)) {
+//      if (!$authors[$comment->uid]) {
+//        $authors[$comment->uid] = user_load(array('uid' => $comment->uid));
+//      }
+      print '</div> <!-- /.ignore-user-content -->';
+      print '</div> <!-- /.ignore-user-container -->';
+    }
+    ?>
+
 </div> <!-- /.comment -->
 
 <?php if ($status == 'comment-preview'): ?>

--- a/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
@@ -177,13 +177,10 @@
   <?php
     static $authors;
     if (_ignore_user_ignored_user($comment->uid)) {
-//      if (!$authors[$comment->uid]) {
-//        $authors[$comment->uid] = user_load(array('uid' => $comment->uid));
-//      }
       print '</div> <!-- /.ignore-user-content -->';
       print '</div> <!-- /.ignore-user-container -->';
     }
-    ?>
+  ?>
 
 </div> <!-- /.comment -->
 


### PR DESCRIPTION
Drupal: Fixed bug where ignoring a user will not only hid his/her post, but all posts beneath it.

Fixed by added code to end of comment.tpl.php, adding two additional </div> close tags to match the two open <div> tags created above.

https://dev.gridrepublic.org/browse/DBOINCP-282