### PR TITLE
Drupal: add ignore users to community preferences

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1565,7 +1565,25 @@ function communityprefs_form(&$form_state) {
       '#default_value' => isset($account->hide_signatures) ? $account->hide_signatures : 0,
     );
   }
-  
+
+  //Ignored users list
+  if (module_exists('ignore_user')) {
+    $form['forums']['ignored_users'] = array(
+      '#value' => '<div class="form-item">'
+        . '<label>'
+	. bts('Ignore Users in forums:')
+	. '</label>'
+        . l(
+	    bts('View/Edit'),
+	    'ignore_user/list',
+	    array('attributes' => array('class' => 'form-link'))
+	   )
+	. ' your ignored users list.'
+	. '</div>',
+    );
+  }//endif module_exists('ignore_user')
+
+  //Bottom separator
   $form['separator_bottom'] = array(
     '#value' => '<div class="separator buttons"></div>',
     '#weight' => 999,

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1573,12 +1573,12 @@ function communityprefs_form(&$form_state) {
         . '<label>'
 	. bts('Ignore Users in forums:')
 	. '</label>'
-        . l(
-	    bts('View/Edit'),
-	    'ignore_user/list',
+        . bts('<a href="@ignore-user-list">View/Edit</a> your ignored users list.',
+	  array(
+	    '@ignore-user-list' => url('ignore_user/list'),
 	    array('attributes' => array('class' => 'form-link'))
-	   )
-	. ' your ignored users list.'
+	  )
+	)
 	. '</div>',
     );
   }//endif module_exists('ignore_user')


### PR DESCRIPTION
Added link in community preferences to allow users to view and edit their ignored users.

https://dev.gridrepublic.org/browse/DBOINCP-256