### PR TITLE
Drupal: Changed news views display-

### DIFF
--- a/drupal/sites/all/features/news/news.views_default.inc
+++ b/drupal/sites/all/features/news/news.views_default.inc
@@ -256,8 +256,10 @@ function news_views_default_views() {
         'text' => '',
         'make_link' => 0,
         'path' => '',
+        'absolute' => 0,
         'link_class' => '',
         'alt' => '',
+        'rel' => '',
         'prefix' => '',
         'suffix' => '',
         'target' => '',
@@ -272,7 +274,8 @@ function news_views_default_views() {
       'empty' => '',
       'hide_empty' => 0,
       'empty_zero' => 0,
-      'text' => 'discuss',
+      'hide_alter_empty' => 1,
+      'text' => 'more',
       'exclude' => 0,
       'id' => 'view_node',
       'table' => 'node',
@@ -305,7 +308,7 @@ function news_views_default_views() {
         'strip_tags' => 0,
       ),
       'empty' => '0',
-      'hide_empty' => 0,
+      'hide_empty' => 1,
       'empty_zero' => 0,
       'hide_alter_empty' => 0,
       'set_precision' => FALSE,
@@ -527,6 +530,41 @@ return variable_get(\'site_name\', \'BOINC\');
       ),
       'relationship' => 'none',
     ),
+    'comment' => array(
+      'label' => 'Comment status',
+      'alter' => array(
+        'alter_text' => 0,
+        'text' => '',
+        'make_link' => 0,
+        'path' => '',
+        'absolute' => 0,
+        'link_class' => '',
+        'alt' => '',
+        'rel' => '',
+        'prefix' => '',
+        'suffix' => '',
+        'target' => '',
+        'help' => '',
+        'trim' => 0,
+        'max_length' => '',
+        'word_boundary' => 1,
+        'ellipsis' => 1,
+        'html' => 0,
+        'strip_tags' => 0,
+      ),
+      'empty' => '',
+      'hide_empty' => 0,
+      'empty_zero' => 0,
+      'hide_alter_empty' => 1,
+      'exclude' => 1,
+      'id' => 'comment',
+      'table' => 'node',
+      'field' => 'comment',
+      'override' => array(
+        'button' => 'Use default',
+      ),
+      'relationship' => 'none',
+    ),
     'title' => array(
       'label' => '',
       'alter' => array(
@@ -692,9 +730,11 @@ return variable_get(\'site_name\', \'BOINC\');
       'empty_zero' => 0,
       'hide_alter_empty' => 1,
       'value' => '<?php
-  $cid = boincuser_get_first_unread_comment_id($data->nid);
-  $link = ($cid) ? "goto/comment/{$cid}" : "node/{$data->nid}";
-  return l(bts(\'discuss\'), $link);
+  if ($data->node_comment == COMMENT_NODE_READ_WRITE) {
+    $cid = boincuser_get_first_unread_comment_id($data->nid);
+    $link = ($cid) ? "goto/comment/{$cid}" : "node/{$data->nid}";
+    return l(bts(\'discuss\'), $link);
+  }
 ?>',
       'exclude' => 0,
       'id' => 'phpcode',
@@ -728,7 +768,7 @@ return variable_get(\'site_name\', \'BOINC\');
         'strip_tags' => 0,
       ),
       'empty' => '0',
-      'hide_empty' => 0,
+      'hide_empty' => 1,
       'empty_zero' => 0,
       'hide_alter_empty' => 0,
       'set_precision' => FALSE,


### PR DESCRIPTION
1. Main News page
  - Changed link from DISCUSS to MORE to match front-page news box.
  - Removed comment count if number of comments is zero, to match front-page news box.
2. Front-page news box
  - Added PHP code to determine if the node has comments enabled. If yes, then a DISCUSS link will appear after the news item.
  - Removed comment count if number of comments is zero. By definition nodes with read-only/disabled comments will have zero comments.

Fixes:
https://dev.gridrepublic.org/browse/DBOINCP-262
https://dev.gridrepublic.org/browse/DBOINCP-289