### PR TITLE
Fix public API header dependencies.

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -41,6 +41,16 @@
 
 using std::string;
 
+#define strcpy2(x, y) \
+    { \
+        const char* z = y; \
+        if (!z) { \
+            x[0]=0; \
+        } else { \
+            strlcpy(x, z, sizeof(x)); \
+        } \
+    }
+
 extern "C" {
     int isnan(double);
 }

--- a/db/db_base.h
+++ b/db/db_base.h
@@ -43,16 +43,6 @@ inline double safe_atof(const char* s) {
     return atof(s);
 }
 
-#define strcpy2(x, y) \
-    { \
-        const char* z = y; \
-        if (!z) { \
-            x[0]=0; \
-        } else { \
-            strlcpy(x, z, sizeof(x)); \
-        } \
-    }
-
 #define MAX_QUERY_LEN 262144
     // TODO: use string for queries, get rid of this
 

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -20,7 +20,6 @@
 
 #include "miofile.h"
 #include "parse.h"
-#include "str_replace.h"
 
 // #defines or enums that are shared by more than one BOINC component
 // (e.g. client, server, Manager, etc.)
@@ -345,7 +344,7 @@ struct DEVICE_STATUS {
         battery_temperature_celsius = 0;
         wifi_online = false;
         user_active = false;
-        safe_strcpy(device_name, "");
+        strcpy(device_name, "");
     }
 };
 

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -88,7 +88,6 @@
 #include "cal_boinc.h"
 #include "cl_boinc.h"
 #include "opencl_boinc.h"
-#include "str_replace.h"
 
 #define MAX_COPROC_INSTANCES 64
 #define MAX_RSC 8
@@ -438,7 +437,7 @@ struct COPROCS {
         ati.clear();
         intel_gpu.clear();
         COPROC c;
-        safe_strcpy(c.type, "CPU");
+        strcpy(c.type, "CPU");
         c.clear_usage();
         add(c);
     }
@@ -502,7 +501,7 @@ struct COPROCS {
         ati.count = 0;
         intel_gpu.count = 0;
         COPROC c;
-        safe_strcpy(c.type, "CPU");
+        strcpy(c.type, "CPU");
         c.clear_usage();
         add(c);
     }


### PR DESCRIPTION
* Replaced `safe_strcpy()` calls with simple `strcpy()` in inline functions defined in *lib/common_defs.h* and *lib/coproc.h*, because all input data was fixed-length hardcoded literals. That allowed to remove all references to *str_replace.h* (and thus *config.h*) from public headers.
* Moved macro `strcpy2()` from *db/db_base.h* to *db/boinc_db.cpp*, because the latter is the only consumer of that macro which relies on `strlcpy()` function only available internally.

See #1629 [#issuecomment-242757731](https://github.com/BOINC/boinc/pull/1629#issuecomment-242757731) on thoughts regarding `strcpy()` use.

This patch is an alternative attempt to fix issue #1624 in a more proper way.