### PR TITLE
remote submission: log xml requests to file specified as <remote_submisson_log>

### DIFF
--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -203,6 +203,18 @@ if (0) {
     exit;
 }
 
+$request_log = parse_config(get_config(), "<remote_submission_log>");
+if ($request_log) {
+    $request_log_dir = parse_config(get_config(), "<log_dir>");
+    if ($request_log_dir) {
+        $request_log = $request_log_dir . "/" . $request_log;
+    }
+    if ($file = fopen($request_log, "a+")) {
+        fwrite($file, "\n<job_file date=\"" . date(DATE_ATOM) . "\">\n" . $_POST['request'] . "\n</job_file>\n");
+        fclose($file);
+    }
+}
+
 xml_header();
 $r = simplexml_load_string($_POST['request']);
 if (!$r) {

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -744,9 +744,20 @@ if (0) {
     require_once("submit_test.inc");
 }
 
+$request_log = parse_config(get_config(), "<remote_submission_log>");
+if ($request_log) {
+    $request_log_dir = parse_config(get_config(), "<log_dir>");
+    if ($request_log_dir) {
+        $request_log = $request_log_dir . "/" . $request_log;
+    }
+    if ($file = fopen($request_log, "a+")) {
+        fwrite($file, "\n<submit_rpc_handler date=\"" . date(DATE_ATOM) . "\">\n" . $_POST['request'] . "\n</submit_rpc_handler>\n");
+        fclose($file);
+    }
+}
+
 xml_header();
 $r = simplexml_load_string($_POST['request']);
-
 if (!$r) {
     xml_error(-1, "can't parse request message");
 }


### PR DESCRIPTION
When a file is specified as `<remote_submisson_log>` in config.xml, the requests to submit_rpc_handler.php and job_file.php are logged to that file before being processed.

If a `<log_dir>` is specified in config_xml, the filename is taken relative to that directory.

Useful for debugging.
