### PR TITLE
Validator: implement "suspicious" results

### DIFF
--- a/sched/validate_util2.cpp
+++ b/sched/validate_util2.cpp
@@ -91,6 +91,10 @@ int check_set(
             retry = true;
             had_error[i] = true;
         } else if (retval == VAL_RESULT_SUSPICIOUS) {
+            log_messages.printf(MSG_NORMAL,
+                "[RESULT#%lu %s] considered to be suspicious\n",
+                results[i].id, results[i].name
+            );
             suspicious_results++;
         } else if (retval) {
             log_messages.printf(MSG_CRITICAL,

--- a/sched/validate_util2.cpp
+++ b/sched/validate_util2.cpp
@@ -80,6 +80,7 @@ int check_set(
         had_error[i] = false;
     }
     int good_results = 0;
+    int suspicious_results = 0;
     for (i=0; i<n; i++) {
         retval = init_result(results[i], data[i]);
         if (retval == ERR_OPENDIR) {
@@ -89,6 +90,8 @@ int check_set(
             );
             retry = true;
             had_error[i] = true;
+        } else if (retval == VAL_RESULT_SUSPICIOUS) {
+            suspicious_results++;
         } else if (retval) {
             log_messages.printf(MSG_CRITICAL,
                 "check_set: init_result([RESULT#%lu %s]) failed: %s\n",
@@ -101,6 +104,14 @@ int check_set(
             good_results++;
         }
     }
+
+    // don't count a single "suspicious" result as "good",
+    // but do if there are more results to compare it with
+    //
+    if (suspicious_results > 1 || good_results > 0) {
+        good_results += suspicious_results;
+    }
+
     if (good_results < wu.min_quorum) goto cleanup;
 
     // Compare results

--- a/sched/validate_util2.h
+++ b/sched/validate_util2.h
@@ -18,6 +18,9 @@
 #ifndef _VALIDATE_UTIL2_
 #define _VALIDATE_UTIL2_
 
+// return value of init_result if an "adaptive replication" result looks suspicious
+#define VAL_RESULT_SUSPICIOUS 1
+
 #include <vector>
 
 #include "boinc_db_types.h"
@@ -31,4 +34,5 @@ extern int check_set(
     DB_ID_TYPE& canonicalid, double& credit_deprecated, bool& retry
 );
 extern void check_pair(RESULT& r1, RESULT& r2, bool& retry);
+
 #endif


### PR DESCRIPTION
A validator now has the possibility to mark a single result as "suspicious" by making init_result() return VAL_RESULT_SUSPICIOUS. If this is the single quorum result of an adaptive replication, this will trigger another task to be generated for validation.
