### PR TITLE
Fix c++11 build

### DIFF
--- a/client/cs_trickle.cpp
+++ b/client/cs_trickle.cpp
@@ -326,4 +326,4 @@ void TRICKLE_UP_OP::handle_reply(int http_op_retval) {
         free(req_buf);
         req_buf = 0;
     }
-};
+}

--- a/clientgui/ViewResources.cpp
+++ b/clientgui/ViewResources.cpp
@@ -31,7 +31,7 @@
 #include <wx/arrimpl.cpp>
 #include "res/usage.xpm"
 
-WX_DEFINE_OBJARRAY(wxArrayColour);
+WX_DEFINE_OBJARRAY(wxArrayColour)
 
 IMPLEMENT_DYNAMIC_CLASS(CViewResources, CBOINCBaseView)
 

--- a/clientgui/common/wxPieCtrl.cpp
+++ b/clientgui/common/wxPieCtrl.cpp
@@ -15,7 +15,7 @@
 
 using namespace std;
 
-WX_DEFINE_OBJARRAY(wxPieSeries);
+WX_DEFINE_OBJARRAY(wxPieSeries)
 
 /* ####### wxPiePart */
 wxPiePart::wxPiePart()

--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -1000,7 +1000,7 @@ void DB_CREDITED_JOB::db_parse(MYSQL_ROW &r) {
     clear();
     userid = atol(r[i++]);
     workunitid = atol(r[i++]);
-};
+}
 
 void DB_RESULT::db_print(char* buf){
     ESCAPE(xml_doc_out);

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -29,7 +29,7 @@ libfcgi_sources = \
     msg_log.cpp \
     opencl_boinc.cpp \
     parse.cpp \
-	sched_msgs.cpp \
+    sched_msgs.cpp \
     shmem.cpp \
     str_util.cpp \
     synch.cpp \
@@ -63,13 +63,13 @@ generic_sources = \
     proc_control.cpp \
     project_init.cpp \
     proxy_info.cpp \
-	sched_msgs.cpp \
+    sched_msgs.cpp \
     shmem.cpp \
     str_util.cpp \
     url.cpp \
     util.cpp
 
-if OS_WIN32 
+if OS_WIN32
 win_sources = \
     boinc_win.cpp \
     daemonmgt_win.cpp \
@@ -115,7 +115,7 @@ generic_sources += \
     unix_util.cpp
 win_sources=
 win_headers=
-mac_sources= 
+mac_sources=
 mac_headers=
 
 endif
@@ -153,7 +153,7 @@ pkginclude_HEADERS = \
     prefs.h \
     procinfo.h \
     proxy_info.h \
-	sched_msgs.h \
+    sched_msgs.h \
     stackwalker_imports.h \
     str_util.h \
     url.h \
@@ -195,10 +195,10 @@ libboinc_fcgi_la_CFLAGS = -D_USING_FCGI_ $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLA
 libboinc_fcgi_la_CXXFLAGS = -D_USING_FCGI_ $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
 libboinc_fcgi_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION)
 libboinc_fcgi_la_LIBADD =
-endif 
+endif
 # end of "if ENABLE_FCGI"
 
-# Some OSs may not prefix libraries with lib. 
+# Some OSs may not prefix libraries with lib.
 # For example OS2
 if OS_OS2
 LIBBOINC_STATIC=boinc.${LIBEXT}
@@ -212,12 +212,12 @@ endif
 
 
 if BUILD_STATIC_LIBS
-all_local = $(LIBBOINC_STATIC) 
+all_local = $(LIBBOINC_STATIC)
 if ENABLE_BOINCCRYPT
-all_local += $(LIBBOINC_CRYPT_STATIC) 
+all_local += $(LIBBOINC_CRYPT_STATIC)
 endif
 if ENABLE_FCGI
-all_local += $(LIBBOINC_FCGI_STATIC) 
+all_local += $(LIBBOINC_FCGI_STATIC)
 endif
 endif
 
@@ -238,25 +238,25 @@ $(LIBBOINC_FCGI_STATIC): libboinc_fcgi.la
 clean: clean-am
 	rm -f $(LIBBOINC_STATIC) $(LIBBOINC_CRYPT_STATIC) $(LIBBOINC_FCGI_STATIC)
 
-endif 
+endif
 # end of "if ENABLE_LIBRARIES"
 
 EXTRA_PROGRAMS = md5_test shmem_test msg_test
 
 EXTRA_DIST = *.h *.cpp
 
-md5_test_SOURCES = md5_test.cpp 
+md5_test_SOURCES = md5_test.cpp
 md5_test_CXXFLAGS = $(PTHREAD_CFLAGS)
 md5_test_LDADD = $(LIBBOINC)
-shmem_test_SOURCES = shmem_test.cpp 
+shmem_test_SOURCES = shmem_test.cpp
 shmem_test_CXXFLAGS = $(PTHREAD_CFLAGS)
 shmem_test_LDADD = $(LIBBOINC)
-msg_test_SOURCES = msg_test.cpp 
+msg_test_SOURCES = msg_test.cpp
 msg_test_CXXFLAGS = $(PTHREAD_CFLAGS)
 msg_test_LDADD = $(LIBBOINC)
-crypt_prog_SOURCES = crypt_prog.cpp 
+crypt_prog_SOURCES = crypt_prog.cpp
 crypt_prog_CXXFLAGS = $(PTHREAD_CFLAGS) $(SSL_CXXFLAGS)
-crypt_prog_LDADD = $(LIBBOINC_CRYPT_STATIC) $(LIBBOINC) $(SSL_LIBS) 
-parse_test_SOURCES = parse_test.cpp 
+crypt_prog_LDADD = $(LIBBOINC_CRYPT_STATIC) $(LIBBOINC) $(SSL_LIBS)
+parse_test_SOURCES = parse_test.cpp
 parse_test_CXXFLAGS = $(PTHREAD_CFLAGS)
 parse_test_LDADD = $(LIBBOINC)

--- a/lib/boinc_fcgi.cpp
+++ b/lib/boinc_fcgi.cpp
@@ -97,4 +97,4 @@ void perror(const char *s) {
     return FCGI_perror(s);
 }
 
-};  // end of namespace FCGI
+} // end of namespace FCGI

--- a/lib/boinc_fcgi.h
+++ b/lib/boinc_fcgi.h
@@ -83,7 +83,7 @@ void perror(const char *s);
 
 // More left to do here.  Just the minimum for BOINC done.
 
-};  // end of namespace FCGI
+} // end of namespace FCGI
  
 using namespace FCGI;
 #endif // __cplusplus

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -666,7 +666,7 @@ void COPROC_ATI::write_xml(MIOFILE& f, bool scheduler_rpc) {
     }
         
     f.printf("</coproc_ati>\n");
-};
+}
 #endif
 
 void COPROC_ATI::clear() {
@@ -875,7 +875,7 @@ void COPROC_INTEL::write_xml(MIOFILE& f, bool scheduler_rpc) {
     }
         
     f.printf("</coproc_intel_gpu>\n");
-};
+}
 #endif
 
 void COPROC_INTEL::clear() {

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -541,7 +541,7 @@ void COPROC_NVIDIA::set_peak_flops() {
         // OpenCL w/ cl_nv_device_attribute_query extension
         // Per: https://www.khronos.org/registry/cl/extensions/nv/cl_nv_device_attribute_query.txt
         //
-        // The theoretical single-precision processing power of a Maxwell GPU in GFLOPS is computed as 2 (operations per FMA instruction per CUDA core per cycle) × number of CUDA cores × core clock speed (in GHz).
+        // The theoretical single-precision processing power of a Maxwell GPU in GFLOPS is computed as 2 (operations per FMA instruction per CUDA core per cycle) Ã— number of CUDA cores Ã— core clock speed (in GHz).
         // Per: https://en.wikipedia.org/wiki/Maxwell_(microarchitecture)#Performance
         // Per: https://en.wikipedia.org/wiki/List_of_Nvidia_graphics_processing_units
         //

--- a/lib/mfile.cpp
+++ b/lib/mfile.cpp
@@ -31,7 +31,6 @@
 #endif
 
 #include "error_numbers.h"
-#include "str_replace.h"
 #include "filesys.h"
 
 #include "mfile.h"

--- a/lib/miofile.cpp
+++ b/lib/miofile.cpp
@@ -77,9 +77,12 @@ int MIOFILE::printf(const char* format, ...) {
 
     va_list ap;
     va_start(ap, format);
+#ifndef _USING_FCGI_
     if (mf) {
         retval = mf->vprintf(format, ap);
-    } else if (f) {
+    } else
+#endif
+    if (f) {
         retval = vfprintf(f, format, ap);
     } else {
         size_t cursize = strlen(wbuf);

--- a/lib/opencl_boinc.cpp
+++ b/lib/opencl_boinc.cpp
@@ -43,6 +43,7 @@
 
 #include "opencl_boinc.h"
 
+#ifndef _USING_FCGI_
 void OPENCL_DEVICE_PROP::write_xml(MIOFILE& f, const char* tag, bool temp_file) {
     f.printf(
         "   <%s>\n"
@@ -108,6 +109,7 @@ void OPENCL_DEVICE_PROP::write_xml(MIOFILE& f, const char* tag, bool temp_file) 
     }
     f.printf("   </%s>\n", tag);
 }
+#endif
 
 int OPENCL_DEVICE_PROP::parse(XML_PARSER& xp, const char* end_tag) {
     int n;
@@ -310,6 +312,7 @@ void OPENCL_CPU_PROP::clear() {
 }
 
 void OPENCL_CPU_PROP::write_xml(MIOFILE& f) {
+#ifndef _USING_FCGI_
     f.printf(
         "<opencl_cpu_prop>\n"
         "   <platform_vendor>%s</platform_vendor>\n",
@@ -317,6 +320,7 @@ void OPENCL_CPU_PROP::write_xml(MIOFILE& f) {
     );
     opencl_prop.write_xml(f, "opencl_cpu_info");
     f.printf("</opencl_cpu_prop>\n");
+#endif
 }
 
 int OPENCL_CPU_PROP::parse(XML_PARSER& xp) {

--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -80,7 +80,9 @@ struct OPENCL_DEVICE_PROP {
     int opencl_device_index;            // zero-based device number within this OpenCL platform
     bool warn_bad_cuda;                 // If true, warn we can't use GPU due to CUDA version
 
+#ifndef _USING_FCGI_
     void write_xml(MIOFILE&, const char* tag, bool temp_file=false);
+#endif
     int parse(XML_PARSER&, const char* end_tag);
     void description(char* buf, int buflen, const char* type);
 };

--- a/sched/hr.cpp
+++ b/sched/hr.cpp
@@ -63,7 +63,7 @@ inline int os(HOST& host){
     else if (strcasestr(host.os_name, "FreeBSD")) return freebsd;
     else if (strcasestr(host.os_name, "Android")) return android;
     else return noos;
-};
+}
 
 inline int cpu_coarse(HOST& host){
     if (strcasestr(host.p_vendor, "Intel")) return Intel;
@@ -127,7 +127,7 @@ inline int cpu_fine(HOST& host){
     if (strcasestr(host.p_vendor, "Macintosh")) return Macintosh;
     if (strcasestr(host.p_vendor, "ARM")) return ARM;
     return nocpu;
-};
+}
 
 // call this ONLY if hr_unknown_class() returns false
 

--- a/sched/sched_shmem.h
+++ b/sched/sched_shmem.h
@@ -108,7 +108,12 @@ struct SCHED_SHMEM {
     APP apps[MAX_APPS];
     APP_VERSION app_versions[MAX_APP_VERSIONS];
     ASSIGNMENT assignments[MAX_ASSIGNMENTS];
+// zero size arrays are defined differently since C++11
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
+    WU_RESULT wu_results[];
+#else
     WU_RESULT wu_results[0];
+#endif
 
     void init(int nwu_results);
     int verify();


### PR DESCRIPTION
Fixes several issues when enforcing C++11 standard using GCC6. Most notably the fcgi compile where I'm not entirely sure if 0a30950 is the correct solution.
