### PR TITLE
Web: fix job file upload error reporting

### DIFF
--- a/html/ops/test_job_file.php
+++ b/html/ops/test_job_file.php
@@ -1,0 +1,137 @@
+#! /usr/bin/env php
+<?php
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2016 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// Test file upload handler for remote job submission (user/job_file.php)
+// Change filepaths and md5's to your own values
+
+$cli_only = true;
+require_once("../inc/util_ops.inc");
+require_once("../inc/submit.inc");
+
+// global test configuration
+$req = new StdClass;
+$req->project = parse_config(get_config(), "<master_url>");
+//$req->project       = "https://PROJECT_MASTER_URL/"; // use this to override the above value
+$req->authenticator = "xxxx"; // this user must have remote submit permissions
+//$req->batch_id = "1"; // optional, if used with query_files files will be added to this batch if they exist
+//$req->delete_time = now()+14*3600; // optional, if used with query_files this will be updated if the file exists
+
+// files to be uploaded
+$upld_files = array();
+// copy the next lines in order to specify more than one upload file
+//$f_realpath = realpath('/var/spool/sixtrack/input/SixIn-1472649201.zip');
+//$f_md5 = md5_file($f_realpath);
+//$f_md5 = "833d1654e6bfa2cd7c8ca217d210e52a";
+//$upld_files[] = array("path" => $f_realpath, "md5" => $f_md5);
+
+// example test cases:
+//$upld_files[] = array("path" => "", "md5" => md5("jobfileuploadtest"); // Should produce an error
+//$upld_files[] = array("path" => $f_realpath, "md5" => ""; // Should produce an error
+
+// files to be queried
+$query_files = array();
+//$query_files[] = array("md5" => "a7d5cbd6ef395e8a79ef29228076d38d");
+//$query_files[] = array("md5" => "8167c3f9973b7fc85b6cb623644122d5");
+//$query_files[] = array("md5" => "401324352d30888a5df2e5cc65035b17");
+//$query_files[] = array("md5" => "401324352d30888a5df2e5cc65035b18");
+
+function send_request($req, $xml, $files) {
+    $ch = curl_init("$req->project/job_file.php");
+    curl_setopt($ch, CURLOPT_POST, 1);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+    $post = array();
+    $post["request"] = $xml;
+    if ($req->type == "upload") {
+        $i=0;
+        foreach ($files as $f) {
+            if ($f['path'] != "") {
+                $post["file_$i"] = '@'.$f['path'];
+                $i++;
+            }
+        }
+    }
+
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
+    $reply = curl_exec($ch);
+    if ($reply) {
+        print $reply . "\n";
+    } else {
+        print curl_error($ch) . "\n";
+    }
+    curl_close($ch);
+}
+
+function upload_test($req, $files) {
+    $req->type = "upload";
+
+    $xml = "<upload_files>
+        <authenticator>$req->authenticator</authenticator>\n";
+    if (isset($req->delete_time)) {
+        $xml .= "    <delete_time>$req->delete_time</delete_time>\n";
+    }
+    if (isset($req->batch_id)) {
+        $xml .= "    <batch_id>$req->batch_id</batch_id>\n";
+    }
+    foreach ($files as $f) {
+        if ($f['md5'] != "") {
+            $xml .= "    <md5>".$f['md5']."</md5>\n";
+        }
+    }
+
+    $xml .= "</upload_files>";
+
+    send_request($req, $xml, $files);
+}
+
+function query_test($req, $files) {
+    $req->type = "query";
+
+    $xml = "<query_files>
+        <authenticator>$req->authenticator</authenticator>\n";
+    if (isset($req->delete_time)) {
+        $xml .= "    <delete_time>$req->delete_time</delete_time>\n";
+    }
+    if (isset($req->batch_id)) {
+        $xml .= "    <batch_id>$req->batch_id</batch_id>\n";
+    }
+    foreach ($files as $f) {
+        $xml .= "    <md5>".$f['md5']."</md5>\n";
+    }
+    $xml .= "</query_files>";
+
+    send_request($req, $xml, $files);
+}
+
+// main
+if ($argc != 2) {
+    print("Usage: ".$argv[0]." [upload|query]");
+}
+
+switch ($argv[1]) {
+case "upload":
+    upload_test($req, $upld_files);
+    break;
+case "query":
+    query_test($req, $query_files);
+    break;
+default:
+    print("Usage: ".$argv[0]." [upload|query]");
+}
+
+?>

--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -239,7 +239,7 @@ function upload_files($r) {
             );
             if (!$jf_id) {
                 $upload_error .= "BoincJobFile::insert($md5) failed: " . BoincDb::error() . " ";
-                $unlink($path);
+                unlink($path);
                 continue;
             }
             if ($batch_id) {

--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -1,7 +1,7 @@
 <?php
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2013 University of California
+// Copyright (C) 2016 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -77,6 +77,25 @@ require_once("../inc/submit_db.inc");
 require_once("../inc/dir_hier.inc");
 require_once("../inc/xml.inc");
 require_once("../inc/submit_util.inc");
+
+function upload_error_description($errno) {
+    switch($errno) {
+        case UPLOAD_ERR_INI_SIZE:
+            return "The uploaded file exceeds upload_max_filesize of php.ini."; break;
+        case UPLOAD_ERR_FORM_SIZE:
+            return "The uploaded file exceeds the MAX_FILE_SIZE specified in the HTML form."; break;
+        case UPLOAD_ERR_PARTIAL:
+            return "The uploaded file was only partially uploaded."; break;
+        case UPLOAD_ERR_NO_FILE:
+            return "No file was uploaded."; break;
+        case UPLOAD_ERR_NO_TMP_DIR:
+            return "Missing a temporary folder."; break;
+        case UPLOAD_ERR_CANT_WRITE:
+            return "Failed to write file to disk."; break;
+        case UPLOAD_ERR_EXTENSION:
+            return "A PHP extension stopped the file upload."; break;
+    }
+}
 
 function query_files($r) {
     xml_start_tag("query_files");
@@ -162,30 +181,79 @@ function upload_files($r) {
     $delete_time = (int)$r->delete_time;
     $batch_id = (int)$r->batch_id;
     //print_r($_FILES);
-    $i = 0;
-    foreach ($r->md5 as $f) {
-        $md5 = (string)$f;
-        $name = "file_$i";
-        $tmp_name = $_FILES[$name]['tmp_name'];
+    $upload_error = "";
+    $files_md5 = array();
+    $files_upl = array();
+    foreach ($r->md5 as $cs) {
+        $files_md5[] = (string)$cs;
+    }
+
+    foreach ($_FILES as $f) {
+        $name = $f['name'];
+        $tmp_name = $f['tmp_name'];
+
+        if ($f['error'] != UPLOAD_ERR_OK) {
+            $reason = upload_error_description($f['error']);
+            $upload_error .= "$name upload failed because: $reason; ";
+            unlink($tmp_name);
+            continue;
+        }
         if (!is_uploaded_file($tmp_name)) {
-            xml_error(-1, "$tmp_name is not an uploaded file");
+            $upload_error .= "$name was not uploaded correctly; ";
+            continue;
         }
-        $fname = job_file_name($md5);
-        $path = dir_hier_path($fname, project_dir() . "/download", $fanout);
-        rename($tmp_name, $path);
-        $now = time();
-        $jf_id = BoincJobFile::insert(
-            "(md5, create_time, delete_time) values ('$md5', $now, $delete_time)"
-        );
-        if (!$jf_id) {
-            xml_error(-1, "upload_files(): BoincJobFile::insert($md5) failed: ".BoincDb::error());
+        $md5 = md5_file($tmp_name);
+        if (!in_array($md5, $files_md5)) {
+            $upload_error .= "$name md5 value ($md5) missing in request XML; ";
+            unlink($tmp_name);
+            continue;
+        } else {
+            // remove md5 from array so we can check if all files are uploaded
+            $files_md5 = array_diff($files_md5, array($md5));
         }
-        if ($batch_id) {
-            BoincBatchFileAssoc::insert(
-                "(batch_id, job_file_id) values ($batch_id, $jf_id)"
+        $files_upl[] = array("name" => $name, "tmp_name" => $tmp_name, "size" => $f['size'], "md5" => $md5 );
+    }
+
+    if (count($files_md5) > 0) {
+        $upload_error .= "More md5's specified in request XML than files uploaded; ";
+        foreach ($files_upl as $f) {
+            unlink($f['tmp_name']);
+        }
+    }
+
+    if ($upload_error == "") {
+        foreach ($files_upl as $f) {
+            $tmp_name = $f['tmp_name'];
+            $md5 = $f['md5'];
+            $fname = job_file_name($md5);
+            // TODO: apache should not have access to the whole download/ directory
+            $path = dir_hier_path($fname, project_dir() . "/download", $fanout);
+            if (!move_uploaded_file($tmp_name, $path)) {
+                $upload_error .= "could not move $tmp_name to $path; ";
+                unlink($tmp_name);
+                continue;
+            }
+            $now = time();
+            $jf_id = BoincJobFile::insert(
+                "(md5, create_time, delete_time) values ('$md5', $now, $delete_time)"
             );
+            if (!$jf_id) {
+                $upload_error .= "BoincJobFile::insert($md5) failed: " . BoincDb::error() . " ";
+                $unlink($path);
+                continue;
+            }
+            if ($batch_id) {
+                // this is not considered serious but can not be reported right now
+                BoincBatchFileAssoc::insert(
+                    "(batch_id, job_file_id) values ($batch_id, $jf_id)"
+                );
+            }
         }
-        $i++;
+    }
+
+    if ($upload_error != "") {
+        // this will exit()
+        xml_error(-1, "upload_files(): " . $upload_error);
     }
     echo "<success/>
         </upload_files>


### PR DESCRIPTION
The upload_files function did not do a good job on error reporting. It now can handle and report several more problems.
- Loop over the uploaded files not the supplied md5 values so we can detect a discrepancy between the two
- Check upload error value provided by PHP (catches filesize limit problems, permission problems and partial uploads)
- Calculate md5 of uploaded file and check with supplied values (The size of uploaded files is typical small enough so this is not a problem)
- Report any error condition in the response and delete the uploaded files (especially if they are in the PHP temp directory)
- Added script to debug upload problems
