### PR TITLE
Fixing Gridmanager fast looping issue

### DIFF
--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -219,7 +219,6 @@ int process_input_files(SUBMIT_REQ& req, string& error_msg) {
     vector<string> upload_boinc_names, upload_paths;
     for (unsigned int i=0; i<absent_files.size(); i++) {
         int j = absent_files[i];
-        printf("file %d is absent\n", j);
         upload_boinc_names.push_back(boinc_names[j]);
         upload_paths.push_back(paths[j]);
     }


### PR DESCRIPTION
This fixes an issue which causes the Gridmanager to log about 10K entries every second that look like:

08/05/16 23:10:38 [105816] GAHP[105817] -> 'S' '0'
08/05/16 23:10:38 [105816] GAHP[105817] <- 'RESULTS'
08/05/16 23:10:38 [105816] GAHP[105817] -> 'S' '0'
08/05/16 23:10:38 [105816] GAHP[105817] <- 'RESULTS' 
