### PR TITLE
Fix Windows build by including needed headers.

### DIFF
--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -54,6 +54,7 @@
 
 #include "diagnostics.h"
 #include "str_replace.h"
+#include "str_util.h"
 #include "stackwalker_win.h"
 #include "stackwalker_imports.h"
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -21,6 +21,7 @@
 #else
 #include "stdwx.h"
 #endif
+#include "str_replace.h"
 #include "win_util.h"
 #endif
 

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -30,6 +30,7 @@
 #include "filesys.h"
 #include "win_util.h"
 #include "str_replace.h"
+#include "str_util.h"
 
 
 /**


### PR DESCRIPTION
These are some minor fixes (all regarding *lib/str_replace.h* and *lib/str_util.h*) I had to apply when building *libboinc_staticcrt* and *libboincapi_staticcrt* for Windows while porting my application — there may be other fixes needed by other projects.