### PR TITLE
Drupal: convert preset attribute to tag

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -36,8 +36,15 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     }
     
     // Determine if a preset is selected or if these are custom settings
-    if (!isset($prefs['@attributes']['preset'])) $prefs['@attributes']['preset'] = 'custom';
-    if (!$prefs_preset) $prefs_preset = $prefs['@attributes']['preset'];
+    // transform old way to store the preset into new way
+    if (isset($prefs['@attributes']['preset'])) {
+        $prefs['preset'] = $prefs['@attributes']['preset'];
+        unset($prefs['@attributes']['preset']);
+    }
+    if (!isset($prefs['preset'])) {
+        $prefs['preset'] = 'custom';
+    }
+    if (!$prefs_preset) $prefs_preset = $prefs['preset'];
   }
   
   // Define form defaults
@@ -621,12 +628,12 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   
   // Save the preset selection (or lack thereof)
   if (!$preset OR $preset == 'custom') {
-    if (isset($prefs['@attributes']['preset'])) {
-      unset($prefs['@attributes']['preset']);
+    if (isset($prefs['preset'])) {
+      unset($prefs['preset']);
     }
   }
   else {
-    $prefs['@attributes']['preset'] = $preset;
+    $prefs['preset'] = $preset;
   }
   
   // If this is a new preference set, be sure to unset the "cleared" attribute

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -625,7 +625,13 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   $prefs['daily_xfer_limit_mb'] = $values['network']['daily_xfer_limit_mb'];
   $prefs['daily_xfer_period_days'] = $values['network']['daily_xfer_period_days'];
   $prefs['dont_verify_images'] = ($values['network']['dont_verify_images']) ? 1 : 0;
-  
+
+  // transform old way to store the preset into new way
+  // ideally this should already have happened in boincwork_generalprefs_form()
+  if (isset($prefs['@attributes']['preset'])) {
+    $prefs['preset'] = $prefs['@attributes']['preset'];
+    unset($prefs['@attributes']['preset']);
+  }
   // Save the preset selection (or lack thereof)
   if (!$preset OR $preset == 'custom') {
     if (isset($prefs['preset'])) {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -41,10 +41,13 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
         $prefs['preset'] = $prefs['@attributes']['preset'];
         unset($prefs['@attributes']['preset']);
     }
-    if (!isset($prefs['preset'])) {
-        $prefs['preset'] = 'custom';
+    // Set $prefs_preset if preset tag is present in database.
+    if (!$prefs_preset) {
+        if (isset($prefs['preset']))
+            $prefs_preset = $prefs['preset']['@value'];
+        else
+            $prest_preset = 'custom';
     }
-    if (!$prefs_preset) $prefs_preset = $prefs['preset'];
   }
   
   // Define form defaults
@@ -60,6 +63,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
   default:
     // Just keeps prefs as they are
     $prefs_preset = 'custom';
+    unset($prefs['preset']);
   }
   
   require_boinc(array('db', 'prefs'));
@@ -634,9 +638,7 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   }
   // Save the preset selection (or lack thereof)
   if (!$preset OR $preset == 'custom') {
-    if (isset($prefs['preset'])) {
-      unset($prefs['preset']);
-    }
+    $prefs['preset'] = 'custom';
   }
   else {
     $prefs['preset'] = $preset;

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -763,9 +763,10 @@ function boincwork_load_prefs($type = 'general', $venue = null, $account = null)
       }
     }
   }
-  return array('@attributes' => array(
-    'name' => $venue, 'preset' => 'standard', 'cleared' => 1
-  ));
+
+  return array('preset' => 'standard',
+    '@attributes' => array('name' => $venue, 'cleared' => 1)
+  );
 }
 
 /**


### PR DESCRIPTION
The additional preset attribute in the venue tag is breaking preference parsing in the scheduler. We now use a tag instead of an attribute and clear any old attributes.
This is only a problem with generalprefs because they get propagated to other projects that do not have a scheduler which ignores the attribute. The Einstein@Home scheduler (only project to use the Drupal webcode right now) was patched to handle extra attributes so we don't need to strip the attribute from projectprefs.