### PR TITLE
Drupal: Removes auto-save from general preferences

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -1765,6 +1765,7 @@ void VALIDATOR_ITEM::parse(MYSQL_ROW& r) {
     wu.rsc_fpops_bound = atof(r[i++]);
 
     res.id = atol(r[i++]);
+    res.workunitid = atol(r[i++]);
     strcpy2(res.name, r[i++]);
     res.validate_state = atoi(r[i++]);
     res.server_state = atoi(r[i++]);
@@ -1847,6 +1848,7 @@ int DB_VALIDATOR_ITEM_SET::enumerate(
             "   wu.rsc_fpops_est, "
             "   wu.rsc_fpops_bound, "
             "   res.id, "
+            "   res.workunitid, "
             "   res.name, "
             "   res.validate_state, "
             "   res.server_state, "

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -418,8 +418,8 @@ function generalprefs_page($action = null, $venue = null, $advanced = FALSE) {
       $venues = array(
         "{$path}/generic" => bts('Generic'),
         "{$path}/home" => bts('Home', array(), NULL, 'boinc:preference set'),
-        "{$path}/work" => bts('Work'),
-        "{$path}/school" => bts('School')
+        "{$path}/school" => bts('School'),
+        "{$path}/work" => bts('Work')
       );
       variable_set('jump_use_js_venues-Array', 1);
       drupal_add_js(drupal_get_path('module', 'jump') . '/jump.js');
@@ -649,8 +649,8 @@ function projectprefs_page($action = null, $venue = null) {
       $venues = array(
         "{$path}/generic" => bts('Generic'),
         "{$path}/home" => bts('Home'),
-        "{$path}/work" => bts('Work'),
-        "{$path}/school" => bts('School')
+        "{$path}/school" => bts('School'),
+        "{$path}/work" => bts('Work')
       );
       variable_set('jump_use_js_venues-Array', 1);
       drupal_add_js(drupal_get_path('module', 'jump') . '/jump.js');

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -245,6 +245,12 @@ function generalprefs_page($action = null, $venue = null, $advanced = FALSE) {
       $prefs[$pref_set] = drupal_retrieve_form('boincwork_generalprefs_form', $form_state, $pref_set);
       drupal_prepare_form('boincwork_generalprefs_form', $prefs[$pref_set], $form_state);
     }
+    // Get status level messages. The line will "clear" any status
+    // level messages, and not display them to the user. This is here
+    // because we want to clear the status level messages that have
+    // been set in boincwork_generalprefs_form(), which are not
+    // necessary for this combined view.
+    drupal_get_messages('status');
     
     $output .= '<p>' . bts('These apply to all BOINC projects in which you participate.') . '<br/>';
     $output .= bts('On computers attached to multiple projects, the most recently modified preferences will be used.') . '</p>';

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -434,19 +434,6 @@ function generalprefs_page($action = null, $venue = null, $advanced = FALSE) {
     }
     $output .= drupal_get_form('boincwork_generalprefs_form', $venue, NULL, $advanced);
     
-    // If viewing the edit page for a preference set that doesn't exist, create
-    // it in the database with default values
-    $form_state = array();
-    $current_set = drupal_retrieve_form('boincwork_generalprefs_form', $form_state, $venue);
-    drupal_prepare_form('boincwork_generalprefs_form', $current_set, $form_state);
-    
-    if (!$current_set['#established']) {
-      drupal_process_form('boincwork_generalprefs_form', $current_set, $form_state);
-      drupal_set_message(t('A preference set has been created for "@setname"
-        with default settings', array('@setname' => ucfirst($venue))));
-      drupal_execute('boincwork_generalprefs_form', $form_state, $venue);
-    }
-    
     break;
   }
   
@@ -677,19 +664,6 @@ function projectprefs_page($action = null, $venue = null) {
       $output .= '</div>';
     }
     $output .= drupal_get_form('boincwork_projectprefs_form', $venue);
-    
-    // If viewing the edit page for a preference set that doesn't exist, create
-    // it in the database with default values
-    $form_state = array();
-    $current_set = drupal_retrieve_form('boincwork_projectprefs_form', $form_state, $venue);
-    drupal_prepare_form('boincwork_projectprefs_form', $current_set, $form_state);
-    
-    if (!$current_set['#established']) {
-      drupal_process_form('boincwork_projectprefs_form', $current_set, $form_state);
-      drupal_set_message(t('A preference set has been created for "@setname"
-        with default settings', array('@setname' => ucfirst($venue))));
-      drupal_execute('boincwork_projectprefs_form', $form_state, $venue);
-    }
     
     break;
     

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -36,8 +36,15 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     }
     
     // Determine if a preset is selected or if these are custom settings
-    if (!isset($prefs['@attributes']['preset'])) $prefs['@attributes']['preset'] = 'custom';
-    if (!$prefs_preset) $prefs_preset = $prefs['@attributes']['preset'];
+    // transform old way to store the preset into new way
+    if (isset($prefs['@attributes']['preset'])) {
+        $prefs['preset'] = $prefs['@attributes']['preset'];
+        unset($prefs['@attributes']['preset']);
+    }
+    if (!isset($prefs['preset'])) {
+        $prefs['preset'] = 'custom';
+    }
+    if (!$prefs_preset) $prefs_preset = $prefs['preset'];
   }
   
   // Define form defaults
@@ -621,12 +628,12 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   
   // Save the preset selection (or lack thereof)
   if (!$preset OR $preset == 'custom') {
-    if (isset($prefs['@attributes']['preset'])) {
-      unset($prefs['@attributes']['preset']);
+    if (isset($prefs['preset'])) {
+      unset($prefs['preset']);
     }
   }
   else {
-    $prefs['@attributes']['preset'] = $preset;
+    $prefs['preset'] = $preset;
   }
   
   // If this is a new preference set, be sure to unset the "cleared" attribute

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -625,7 +625,13 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   $prefs['daily_xfer_limit_mb'] = $values['network']['daily_xfer_limit_mb'];
   $prefs['daily_xfer_period_days'] = $values['network']['daily_xfer_period_days'];
   $prefs['dont_verify_images'] = ($values['network']['dont_verify_images']) ? 1 : 0;
-  
+
+  // transform old way to store the preset into new way
+  // ideally this should already have happened in boincwork_generalprefs_form()
+  if (isset($prefs['@attributes']['preset'])) {
+    $prefs['preset'] = $prefs['@attributes']['preset'];
+    unset($prefs['@attributes']['preset']);
+  }
   // Save the preset selection (or lack thereof)
   if (!$preset OR $preset == 'custom') {
     if (isset($prefs['preset'])) {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -65,6 +65,12 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     unset($prefs['preset']);
     break;
   default:
+      drupal_set_message(bts(
+          "No preferences found for set '@venue'. Click SAVE CHANGES below to save preferences to your account, and make them effective.",
+          array(
+              '@venue' => $venue,
+          )
+      ), 'status');
     //Use the standard presets by default
     $prefs_preset = 'standard';
     $prefs = boincwork_get_preset_prefs('standard');

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -29,6 +29,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     
     // Load preferences from BOINC account
     $prefs = boincwork_load_prefs('general', $venue);
+    drupal_set_message(t("<pre>prefs".print_r($prefs, true)."</pre>"), 'warning');
     
     // Take note if this is not an established preference set on the account
     if (isset($prefs['@attributes']['cleared'])) {
@@ -42,11 +43,8 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
         unset($prefs['@attributes']['preset']);
     }
     // Set $prefs_preset if preset tag is present in database.
-    if (!$prefs_preset) {
-        if (isset($prefs['preset']))
-            $prefs_preset = $prefs['preset']['@value'];
-        else
-            $prest_preset = 'custom';
+    if ( (!$prefs_preset) AND (isset($prefs['preset'])) ) {
+        $prefs_preset = $prefs['preset']['@value'];
     }
   }// if (!$prefs_preset)
   
@@ -988,24 +986,24 @@ function boincwork_host_merge_form_submit($form, &$form_state) {
  * The structure of the project preferences form
  */
 function boincwork_projectprefs_form(&$form_state, $venue) {
-  
+
   global $user;
   $account = user_load($user->uid);
   
   $established = TRUE;
-  
+
   // Get availability of special BOINC preferences
   require_boinc(array('util'));
   $app_types = get_app_types();
-  
+
   // Load any existing preferences from BOINC account
   $prefs = boincwork_load_prefs('project', $venue);
-  
+
   // Take note if this is not an established preference set on the account
   if (isset($prefs['@attributes']['cleared'])) {
     $established = FALSE;
   }
-  
+
   $venue_is_default = FALSE;
   if ($account->boincuser_default_pref_set) {
     if ($account->boincuser_default_pref_set == $venue) {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -41,10 +41,13 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
         $prefs['preset'] = $prefs['@attributes']['preset'];
         unset($prefs['@attributes']['preset']);
     }
-    if (!isset($prefs['preset'])) {
-        $prefs['preset'] = 'custom';
+    // Set $prefs_preset if preset tag is present in database.
+    if (!$prefs_preset) {
+        if (isset($prefs['preset']))
+            $prefs_preset = $prefs['preset']['@value'];
+        else
+            $prest_preset = 'custom';
     }
-    if (!$prefs_preset) $prefs_preset = $prefs['preset'];
   }
   
   // Define form defaults
@@ -60,6 +63,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
   default:
     // Just keeps prefs as they are
     $prefs_preset = 'custom';
+    unset($prefs['preset']);
   }
   
   require_boinc(array('db', 'prefs'));
@@ -634,9 +638,7 @@ function boincwork_generalprefs_form_submit($form, &$form_state) {
   }
   // Save the preset selection (or lack thereof)
   if (!$preset OR $preset == 'custom') {
-    if (isset($prefs['preset'])) {
-      unset($prefs['preset']);
-    }
+    $prefs['preset'] = 'custom';
   }
   else {
     $prefs['preset'] = $preset;

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -48,7 +48,7 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
         else
             $prest_preset = 'custom';
     }
-  }
+  }// if (!$prefs_preset)
   
   // Define form defaults
   switch($prefs_preset) {
@@ -66,8 +66,9 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     break;
   default:
     //Use the standard presets by default
+    $prefs_preset = 'standard';
     $prefs = boincwork_get_preset_prefs('standard');
-  }
+  }// switch($prefs_preset)
   
   require_boinc(array('db', 'prefs'));
   $disk_space_config = get_disk_space_config();

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -29,7 +29,6 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     
     // Load preferences from BOINC account
     $prefs = boincwork_load_prefs('general', $venue);
-    drupal_set_message(t("<pre>prefs".print_r($prefs, true)."</pre>"), 'warning');
     
     // Take note if this is not an established preference set on the account
     if (isset($prefs['@attributes']['cleared'])) {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -60,10 +60,13 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     break;
     
   case 'custom':
-  default:
     // Just keeps prefs as they are
     $prefs_preset = 'custom';
     unset($prefs['preset']);
+    break;
+  default:
+    //Use the standard presets by default
+    $prefs = boincwork_get_preset_prefs('standard');
   }
   
   require_boinc(array('db', 'prefs'));

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -763,9 +763,10 @@ function boincwork_load_prefs($type = 'general', $venue = null, $account = null)
       }
     }
   }
-  return array('@attributes' => array(
-    'name' => $venue, 'preset' => 'standard', 'cleared' => 1
-  ));
+
+  return array('preset' => 'standard',
+    '@attributes' => array('name' => $venue, 'cleared' => 1)
+  );
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -764,7 +764,7 @@ function boincwork_load_prefs($type = 'general', $venue = null, $account = null)
     }
   }
 
-  return array('preset' => 'standard',
+  return array(
     '@attributes' => array('name' => $venue, 'cleared' => 1)
   );
 }


### PR DESCRIPTION
When a user visits the general computing preferences form, the form will no longer auto-save any of the preferences. Instead the user is given a message saying that there are no preferences set, until s/he clicks SAVE CHANGES.

This PR depends on #1648, which must be merged first. 

https://dev.gridrepublic.org/browse/DBOINCP-296