### PR TITLE
Drupal: fix preview box bug

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
@@ -110,11 +110,11 @@
       print comment_render($node);
     }
   ?>
-  
   <?php // Only show this post on the first or last page, depending on sort ?>
   <?php if (($oldest_post_first AND $first_page) OR (!$oldest_post_first AND $last_page)): ?>
-    
-    <?php if (!$oldest_post_first): ?>
+
+<?// DBOINCP-300: added node comment count condition in order to get Preview working ?>
+    <?php if ( (!$oldest_post_first) AND ($comment_count>0) ): ?>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixed bug where users who choose forum preference "Newest Post First" had an error in how a new forum post was previewed. Added a if conditional where if the number of comments is zero, the forum topic template does not try to create an additional set of div-tags. As a result the Preview link now works.

https://dev.gridrepublic.org/browse/DBOINCP-300