### PR TITLE
Drupal: Removed autosave from prefrences page

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -434,17 +434,17 @@ function generalprefs_page($action = null, $venue = null, $advanced = FALSE) {
     }
     $output .= drupal_get_form('boincwork_generalprefs_form', $venue, NULL, $advanced);
     
-    // If viewing the edit page for a preference set that doesn't exist, create
-    // it in the database with default values
+    // If viewing the edit page for a preference set that doesn't
+    // exist, inform the user that preferences are not set.
     $form_state = array();
     $current_set = drupal_retrieve_form('boincwork_generalprefs_form', $form_state, $venue);
     drupal_prepare_form('boincwork_generalprefs_form', $current_set, $form_state);
-    
+
     if (!$current_set['#established']) {
-      drupal_process_form('boincwork_generalprefs_form', $current_set, $form_state);
-      drupal_set_message(t('A preference set has been created for "@setname"
-        with default settings', array('@setname' => ucfirst($venue))));
-      drupal_execute('boincwork_generalprefs_form', $form_state, $venue);
+      drupal_set_message(bts(
+          "No preferences found for set '@venue'. Click SAVE CHANGES below to save the following preferences to your account.",
+          array( '@venue' => $venue, )
+      ), 'status');
     }
     
     break;
@@ -678,17 +678,17 @@ function projectprefs_page($action = null, $venue = null) {
     }
     $output .= drupal_get_form('boincwork_projectprefs_form', $venue);
     
-    // If viewing the edit page for a preference set that doesn't exist, create
-    // it in the database with default values
+    // If viewing the edit page for a preference set that doesn't
+    // exist, inform the user that preferences are not set.
     $form_state = array();
     $current_set = drupal_retrieve_form('boincwork_projectprefs_form', $form_state, $venue);
     drupal_prepare_form('boincwork_projectprefs_form', $current_set, $form_state);
     
     if (!$current_set['#established']) {
-      drupal_process_form('boincwork_projectprefs_form', $current_set, $form_state);
-      drupal_set_message(t('A preference set has been created for "@setname"
-        with default settings', array('@setname' => ucfirst($venue))));
-      drupal_execute('boincwork_projectprefs_form', $form_state, $venue);
+      drupal_set_message(bts(
+          "No preferences found for set '@venue'. Click SAVE CHANGES below to save the following preferences to your account.",
+          array( '@venue' => $venue, )
+      ), 'status');
     }
     
     break;

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -418,8 +418,8 @@ function generalprefs_page($action = null, $venue = null, $advanced = FALSE) {
       $venues = array(
         "{$path}/generic" => bts('Generic'),
         "{$path}/home" => bts('Home', array(), NULL, 'boinc:preference set'),
-        "{$path}/work" => bts('Work'),
-        "{$path}/school" => bts('School')
+        "{$path}/school" => bts('School'),
+        "{$path}/work" => bts('Work')
       );
       variable_set('jump_use_js_venues-Array', 1);
       drupal_add_js(drupal_get_path('module', 'jump') . '/jump.js');
@@ -662,8 +662,8 @@ function projectprefs_page($action = null, $venue = null) {
       $venues = array(
         "{$path}/generic" => bts('Generic'),
         "{$path}/home" => bts('Home'),
-        "{$path}/work" => bts('Work'),
-        "{$path}/school" => bts('School')
+        "{$path}/school" => bts('School'),
+        "{$path}/work" => bts('Work')
       );
       variable_set('jump_use_js_venues-Array', 1);
       drupal_add_js(drupal_get_path('module', 'jump') . '/jump.js');

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -526,7 +526,7 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
     break;
     
   case 'apps':
-    $title = is_array($element['title']) ? $element['title']['@value'] : $element['title'];
+    $title = is_array($elements['title']) ? $elements['title']['@value'] : $elements['title'];
     
       // Translate elements as appropriate
       if ($title) {
@@ -576,6 +576,7 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
         '#disabled' => !$app_enabled
       );
     }
+    
     break;
     
   case 'group':
@@ -749,6 +750,10 @@ function boincwork_load_prefs($type = 'general', $venue = null, $account = null)
   // Return general preferences or a subset based on venue
   if (!$venue OR $venue == 'generic') {
     unset($main_prefs['venue']);
+    // Use the @position array as condition as to whether the
+    // preferences have already been set.
+    if (!isset($main_prefs['@position']))
+        $main_prefs['@attributes'] = array('cleared' => 1);
     return $main_prefs;
   }
   else {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -750,9 +750,10 @@ function boincwork_load_prefs($type = 'general', $venue = null, $account = null)
   // Return general preferences or a subset based on venue
   if (!$venue OR $venue == 'generic') {
     unset($main_prefs['venue']);
-    // Use the @position array as condition as to whether the
-    // preferences have already been set.
-    if (!isset($main_prefs['@position']))
+    // Use the length of the $main_prefs array as a condition as to
+    // whether the preferences have already been set. This is
+    // HARDCODED here.
+    if (count($main_prefs) < 3)
         $main_prefs['@attributes'] = array('cleared' => 1);
     return $main_prefs;
   }

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -764,7 +764,7 @@ function boincwork_load_prefs($type = 'general', $venue = null, $account = null)
     }
   }
 
-  return array('preset' => 'standard',
+  return array(
     '@attributes' => array('name' => $venue, 'cleared' => 1)
   );
 }


### PR DESCRIPTION
New behavior: when the user loads the general or project preferences page, Drupal will display a message saying there are no preferences set. No longer auto-saves preferences upon visiting the page.

https://dev.gridrepublic.org/browse/DBOINCP-296