### PR TITLE
Drupal: Fixed CSS style for stick-header

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/css/views-styles.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/views-styles.css
@@ -146,6 +146,14 @@
 /**
  * Computer and task lists
  */
+.sticky-header .views-field-expavg-credit,
+.sticky-header .views-field-total-credit,
+.sticky-header .views-field-elapsed-time,
+.sticky-header .views-field-cpu-time,
+.sticky-header .views-field-claimed-credit-1,
+.sticky-header .views-field-granted-credit {
+  text-align: right;
+}
 .views-table .views-field-expavg-credit,
 .views-table .views-field-total-credit,
 .views-table .views-field-elapsed-time,


### PR DESCRIPTION
Fixed CSS style so sticky-header has same CSS as main table header.

https://dev.gridrepublic.org/browse/DBOINCP-313