### PR TITLE
Drupal: default preference set is now 'standard'.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
@@ -108,6 +108,12 @@ function boincwork_admin_prefs_presets_page($preset = 'standard') {
     $output .= '</div></div>';
   }
   $output .= drupal_get_form('boincwork_admin_prefs_presets_form', $preset);
+
+  $output .= '<div>';
+  $output .= bts('Usage: \'Save configuration\' will save the above preferences into the drupal database. These will be the preset general/computing preferences that will fill in the preferences form once a user loads the Account Preferences page.');
+  $output .= '<p>';
+  $output .= bts('\'Save configuration with disk usage settings from config.xml\' will save the above preferences into the drupal database, but also load disk usage settings from the BOINC project\'s config.xml file. These will overwrite the disk usage settings you have placed above. Caution: A user\'s personal preferences will not change if you load the disk usage settings from config.xml here into the drupal database. They must change their preference settings manually.');
+  $output .= '</div>';
   return $output;
 }
 
@@ -139,6 +145,11 @@ function boincwork_admin_prefs_presets_form(&$form_state, $preset = 'standard') 
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Save configuration')
+  );
+  $form['saveuseconfigxml'] = array (
+      '#type' => 'submit',
+      '#value' => t('Save configuration with disk usage settings from config.xml'),
+      '#validate' => array('boincwork_admin_prefs_preset_saveuseconfigxml'),
   );
   $form['preset'] = array(
     '#type' => 'hidden',
@@ -235,8 +246,9 @@ function boincwork_admin_prefs_presets_form_submit($form, &$form_state) {
   $prefs['daily_xfer_period_days'] = $values['network']['daily_xfer_period_days'];
   $prefs['dont_verify_images'] = ($values['network']['dont_verify_images']) ? 1 : 0;
   
-  // Throw the preset attribute on there so we know which preset to save
-  $prefs['@attributes']['preset'] = $preset;
+  //Remove @attributes to match new format (see boincwork.forms.inc
+  //function boincwork_generalprefs_form)
+  unset($prefs['@attributes']['preset']);
   
   // Update the configuration
   boincwork_save_preset_prefs($prefs, $preset);
@@ -271,3 +283,18 @@ function boincwork_save_preset_prefs($updated_prefs, $preset = 'standard') {
   variable_set('boincwork_preset_prefs', save_configuration($all_presets));
 }
 
+/**
+ * Saves but also loads disk usage settings from config.xml, and
+ * overwrites whatever values are is in form.
+ */
+function boincwork_admin_prefs_preset_saveuseconfigxml($form, &$form_state) {
+    require_boinc(array('db', 'prefs'));
+    $disk_space_config = get_disk_space_config();
+
+    $form_state['values']['storage']['disk_max_used_gb']  = $disk_space_config->disk_max_used_gb;
+    $form_state['values']['storage']['disk_min_free_gb']  = $disk_space_config->disk_min_free_gb;
+    $form_state['values']['storage']['disk_max_used_pct'] = $disk_space_config->disk_max_used_pct;
+
+    //Run the form validate function
+    boincwork_admin_prefs_presets_form_validate($form, $form_state);
+}

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.admin.inc
@@ -110,9 +110,9 @@ function boincwork_admin_prefs_presets_page($preset = 'standard') {
   $output .= drupal_get_form('boincwork_admin_prefs_presets_form', $preset);
 
   $output .= '<div>';
-  $output .= bts('Usage: \'Save configuration\' will save the above preferences into the drupal database. These will be the preset general/computing preferences that will fill in the preferences form once a user loads the Account Preferences page.');
+  $output .= bts('Usage: \'Save configuration\' will save the above preferences into the drupal database. These will be the preset computing (global) preferences that will fill in the preferences form once a user loads the Account Preferences page.');
   $output .= '<p>';
-  $output .= bts('\'Save configuration with disk usage settings from config.xml\' will save the above preferences into the drupal database, but also load disk usage settings from the BOINC project\'s config.xml file. These will overwrite the disk usage settings you have placed above. Caution: A user\'s personal preferences will not change if you load the disk usage settings from config.xml here into the drupal database. They must change their preference settings manually.');
+  $output .= bts('\'Save configuration with disk usage settings from config.xml\' will save the above preferences into the drupal database, but also load disk usage settings from the BOINC project\'s config.xml file. These will overwrite any disk usage settings you have placed above. Caution: A user\'s personal preferences will not change if you load the disk usage settings from config.xml here into the drupal database. They must change their preference settings manually.');
   $output .= '</div>';
   return $output;
 }
@@ -121,7 +121,11 @@ function boincwork_admin_prefs_presets_page($preset = 'standard') {
  * 
  */
 function boincwork_admin_prefs_presets_form(&$form_state, $preset = 'standard') {
-  
+
+  // Check database for preset prefs
+  if (!variable_get('boincwork_preset_prefs', null))
+    drupal_set_message(bts('No presets found in database, loading a default set of preferences for each preset. These will be saved to the database once you click \'Save configuration\'.'), 'status');
+
   // Load a copy of the general prefs form
   $form = boincwork_generalprefs_form($form_state, NULL, $preset);
   if ($key = array_search('boincwork_generalprefs_form_submit', $form['#submit'])) {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -60,15 +60,19 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     break;
     
   case 'custom':
-  default:
     // Just keeps prefs as they are
     $prefs_preset = 'custom';
     unset($prefs['preset']);
+    break;
+  default:
+      $prefs_preset = 'standard';
+      $prefs = boincwork_get_preset_prefs($prefs_preset);
   }
-  
+
+  //This set of preferences is used in the form if no preferences have
+  //been set above, in variable $prefs.
   require_boinc(array('db', 'prefs'));
   $disk_space_config = get_disk_space_config();
-  
   $default = array(
     'preset' => $prefs_preset,
     // Processing...

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -43,11 +43,10 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
     }
     // Set $prefs_preset if preset tag is present in database.
     if (!$prefs_preset) {
-        if (isset($prefs['preset']))
+        if (isset($prefs['preset'])) {
             $prefs_preset = $prefs['preset']['@value'];
-        else
-            $prest_preset = 'custom';
-    }
+        }
+    }// if !$prefs_preset
   }
   
   // Define form defaults
@@ -56,8 +55,8 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
   case 'maximum':
   case 'green':
   case 'minimum':
-    $prefs = boincwork_get_preset_prefs($prefs_preset);
-    break;
+      $prefs = boincwork_get_preset_prefs($prefs_preset);
+      break;
     
   case 'custom':
     // Just keeps prefs as they are
@@ -69,8 +68,8 @@ function boincwork_generalprefs_form(&$form_state, $venue, $prefs_preset = null,
       $prefs = boincwork_get_preset_prefs($prefs_preset);
   }
 
-  //This set of preferences is used in the form if no preferences have
-  //been set above, in variable $prefs.
+  // This set of preferences is used in the form if no preferences
+  // have been set above, in variable $prefs.
   require_boinc(array('db', 'prefs'));
   $disk_space_config = get_disk_space_config();
   $default = array(

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -160,7 +160,6 @@ function boincwork_get_preset_prefs($preset = null) {
           <dont_verify_images>0</dont_verify_images>
         </preset>
       </general_preferences>';
-    drupal_set_message(bts('No presets found in database, loading a default set of preferences for each preset. These will be saved to the database once you click \'Save Changes\'.'), 'status');
   }
   
   // Convert XML data to array format
@@ -1178,7 +1177,8 @@ function boincwork_format_stats($number, $max_digits = 4) {
   //------------------------------------------------------------------------------------------------
   
   function text_to_xml($text) {
-    if (!$xml = DomDocument::loadXML($text)) return false;
+    $xml = new DomDocument();
+    if ( !($xml->loadXML($text)) ) return false;
     return $xml;
   }
   

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -21,8 +21,14 @@ function boincwork_ahah_helper_venue_submit($form, &$form_state) {
 function boincwork_get_preset_prefs($preset = null) {
   $saved_state = variable_get('boincwork_preset_prefs', null);
   
-  // If not configured yet, use these defaults
+  // If not configured yet, use these values as for inital
+  // computing/general preferences.
   if (!$saved_state) {
+    // Get BOINC project disk space configurations from config.xml to
+    // fill in initial preference values.
+    require_boinc(array('db', 'prefs'));
+    $disk_space_config = get_disk_space_config();
+
     $saved_state = '
       <general_preferences>
         <preset name="standard">
@@ -38,9 +44,9 @@ function boincwork_get_preset_prefs($preset = null) {
           <cpu_scheduling_period_minutes>60</cpu_scheduling_period_minutes>
           <max_ncpus_pct>100</max_ncpus_pct>
           <cpu_usage_limit>80</cpu_usage_limit>
-          <disk_max_used_gb>8</disk_max_used_gb>
-          <disk_min_free_gb>4</disk_min_free_gb>
-          <disk_max_used_pct>10</disk_max_used_pct>
+          <disk_max_used_gb>'.$disk_space_config->disk_max_used_gb.'</disk_max_used_gb>
+          <disk_min_free_gb>'.$disk_space_config->disk_min_free_gb.'</disk_min_free_gb>
+          <disk_max_used_pct>'.$disk_space_config->disk_max_used_pct.'</disk_max_used_pct>
           <disk_interval>60</disk_interval>
           <vm_max_used_pct>0</vm_max_used_pct>
           <ram_max_used_busy_pct>15</ram_max_used_busy_pct>
@@ -154,6 +160,7 @@ function boincwork_get_preset_prefs($preset = null) {
           <dont_verify_images>0</dont_verify_images>
         </preset>
       </general_preferences>';
+    drupal_set_message(bts('No presets found in database, loading a default set of preferences for each preset. These will be saved to the database once you click \'Save Changes\'.'), 'status');
   }
   
   // Convert XML data to array format


### PR DESCRIPTION
The default preference set when a user visits the accounts preference page is (now) 'standard'.

Added form submit for BOINC: preferences preset admin interface. Admin may now Save configuration with the disk usage settings from config.xml. In this way, those XML settings will be loaded into the database as the default preferences presets. These presets are in turn used by drupal when the user visits the preferences page. The form on that page will be filled with the preferences from the drupal database.

If there are no preference preset loaded in the drupal database, then the standard preset will be filled in with the disk usage settings from config.xml. Once it is save into the drupal database, the admin must use the Save configuration with disk usage settings from config.xml button in order to reload the disk usage settings from config.xml again.

https://dev.gridrepublic.org/browse/DBOINCP-310