### PR TITLE
Fixed wrapper execution time error in android 

### DIFF
--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -304,9 +304,10 @@ void macro_substitute(string &str) {
     fprintf(stderr, "[DEBUG] replacing '%s' with '%s'\n", "$PWD", nt);
 #endif
 #else
-    str_replace_all(str, "$PWD", getenv("PWD"));
+    char cwd[1024];
+    str_replace_all(str, "$PWD", getcwd(cwd, sizeof(cwd)));
 #ifdef DEBUG
-    fprintf(stderr, "[DEBUG] replacing '%s' with '%s'\n", "$PWD", getenv("PWD"));
+    fprintf(stderr, "[DEBUG] replacing '%s' with '%s'\n", "$PWD", getcwd(cwd, sizeof(cwd)));
 #endif
 #endif
 }


### PR DESCRIPTION
Android wrapper had an execution time error because de env variable $PWD was not found. Changing getenv("$PWD") for getcwd() fixes the issue.
