### PR TITLE
Drupal: Fixed bug where team forum Last post was incorrect.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincteam/boincteam_forum.module
+++ b/drupal/sites/default/boinc/modules/boincteam/boincteam_forum.module
@@ -268,7 +268,7 @@ function boincteam_forum_list($team_id = NULL) {
       $last_post->timestamp = db_result(db_query("
         SELECT ncs.last_comment_timestamp FROM {node} n
         INNER JOIN {boincteam_forum_node} bfn
-        INNER JOIN {node_comment_statistics} ncs ON n.nid = ncs.nid
+        INNER JOIN {node_comment_statistics} ncs ON n.nid = bfn.nid AND n.nid = ncs.nid
         WHERE n.status = 1 AND bfn.tfid = %d
         ORDER BY ncs.last_comment_timestamp DESC
         LIMIT 1",


### PR DESCRIPTION
On main forum page, the team forum Last post field was wrong. I fixed the DB query to return the correct timestamp.

https://dev.gridrepublic.org/browse/DBOINCP-321