### PR TITLE
Drupal: Changed More (computers) link on Account Dashboard.

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view-table--boinc-account-computers--panel-pane-1.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view-table--boinc-account-computers--panel-pane-1.tpl.php
@@ -32,7 +32,7 @@
 </table>
 <ul class="more-link tab-list">
   <li class="first tab">
-    <?php print l(bts('More'), 'account/computers/all'); ?>
+    <?php print l(bts('More'), 'account/computers'); ?>
   </li>
   <li class="first alt tab">
     <?php print l(bts('Tasks'), 'account/tasks/active'); ?>


### PR DESCRIPTION
Was: account/computers/all
Now: account/computers

https://dev.gridrepublic.org/browse/DBOINCP-326