### PR TITLE
Drupal: Removed view page/option from the computing and project preferences page

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -527,67 +527,6 @@ function projectprefs_page($action = null, $venue = null) {
     drupal_goto('account/prefs/project/combined');
     break;
     
-  case 'view':
-    if ($venue) $pref_sets = array($venue);
-    foreach ($pref_sets as $pref_set) {
-      $form_state = array();
-      $prefs = drupal_retrieve_form('boincwork_projectprefs_form', $form_state, $pref_set);
-      drupal_prepare_form('boincwork_projectprefs_form', $prefs, $form_state);
-      if (isset($prefs['venue'])) {
-        if ($pref_set == 'generic') {
-          // Global preferences
-          $output .= '<h2>' . bts('Primary (generic) preferences') . ' ' . l('(' . bts('Switch View') . ')', 'account/prefs/project/combined') . '</h2>';
-        } else {
-          // Venue specific preferences
-          $output .= '<h2>' . bts('Separate preferences for @venue', array('@venue' => $pref_set)) . '</h2>';
-        }
-        $output .= '<table>';
-        $sections = array(
-          'resource' => $prefs['resource'],
-          'default_venue' => $prefs['default_venue']
-        );
-        if (isset($prefs['#project specific'])) {
-          foreach ((array) $prefs['#project specific'] as $project_specific_section) {
-            $sections[$project_specific_section] = $prefs[$project_specific_section];
-          }
-        }
-        
-        if ($project_has_beta) $sections['beta'] = $prefs['beta'];
-        
-        foreach ($sections as $section) {
-          $output .= '<tr class="section-heading">';
-          $output .= "<td>{$section['#title']}</td></tr>";
-          
-          foreach ($section as $name => $setting) {
-            if ($name{0} == '#') continue;
-            $value = isset($setting['#default_value']) ? $setting['#default_value'] : '';
-            if ($value AND isset($setting['#options'])) $value = $setting['#options'][$value];
-            elseif ($value == '') $value = '---';
-            if (!isset($setting['#title'])) $setting['#title'] = '';
-            if (!isset($setting['#description'])) $setting['#description'] = '';
-            if (!isset($setting['#field_suffix'])) $setting['#field_suffix'] = '';
-            $output .= '<tr>';
-            $output .= "<td>{$setting['#title']}<br/>{$setting['#description']}</td>";
-            $output .= "<td>{$value} {$setting['#field_suffix']}</td>";
-            $output .= '</tr>';
-          }
-        }
-        
-        // Edit preferences link
-        $output .= '<tr>';
-        $output .= '<td></td>';
-        $output .= '<td>' . l(bts('Edit @project preferences', array('@project' => PROJECT)), "account/prefs/project/edit/{$pref_set}") . '</td>';
-        $output .= '</tr>';
-        
-        $output .= '</table>';
-      }
-      else {
-        // Venue preferences not defined
-        $output .= '<p>' . l(bts('Add separate preferences for @venue', array('@venue' => $pref_set)), "account/prefs/project/edit/{$pref_set}") . '</p>';
-      }
-    }
-    break;
-    
   case 'edit':
   default:
     

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -357,58 +357,6 @@ function generalprefs_page($action = null, $venue = null, $advanced = FALSE) {
     
     break;
     
-  case 'view':
-    require_boinc('util');
-    
-    $output .= '<p>' . bts('These apply to all BOINC projects in which you participate.') . '<br/>';
-    $output .= bts('On computers attached to multiple projects, the most recently modified preferences will be used.') . '</p>';
-    
-    if ($venue) $pref_sets = array($venue);
-    foreach ($pref_sets as $pref_set) {
-      $form_state = array();
-      $prefs = drupal_retrieve_form('boincwork_generalprefs_form', $form_state, $pref_set);
-      drupal_prepare_form('boincwork_generalprefs_form', $prefs, $form_state);
-      if (isset($prefs['venue'])) {
-        if ($pref_set == 'generic') {
-          // Global preferences
-          $output .= '<p>' . bts('Preferences last modified: @mod_time', array('@mod_time' => pretty_time_str($prefs['modified']['#value']))) . '</p>';
-          $output .= '<h2>' . bts('Primary (generic) preferences') . ' ' . l('(' . bts('Switch View') . ')', 'account/prefs/computing/combined') . '</h2>';
-        } else {
-          // Venue specific preferences
-          $output .= '<h2>' . bts('Separate preferences for @venue', array('@venue' => $pref_set)) . '</h2>';
-        }
-        $output .= '<table>';
-        
-        $sections = array(
-          'processor' => $prefs['processor'],
-          'storage' => $prefs['storage'],
-          'network' => $prefs['network']
-        );
-        foreach ($sections as $section) {
-          $output .= '<tr class="section-heading">';
-          $output .= "<td>{$section['#title']}</td></tr>";
-          foreach ($section as $name => $setting) {
-            if ($name{0} == '#') continue;
-            $value = isset($setting['#options']) ? $setting['#options'][$setting['#default_value']] : $setting['#default_value'];
-            if ($value == '') $value = '---';
-            if (!isset($setting['#title'])) $setting['#title'] = '';
-            if (!isset($setting['#description'])) $setting['#description'] = '';
-            if (!isset($setting['#field_suffix'])) $setting['#field_suffix'] = '';
-            $output .= '<tr>';
-            $output .= "<td>{$setting['#title']}<br/>{$setting['#description']}</td>";
-            $output .= "<td>{$value} {$setting['#field_suffix']}</td>";
-            $output .= '</tr>';
-          }
-        }
-        $output .= '</table>';
-      } else {
-        // Venue preferences not defined
-        $output .= '<p>' . l(bts('Add separate preferences for @venue', array('@venue' => $pref_set)), "account/prefs/computing/edit/{$pref_set}") . '</p>';
-      }
-    }
-    break;
-    
-    
   case 'edit':
   default:
   


### PR DESCRIPTION
The view page for preferences is obsolete. These two commits remove the pages, one for the computing (general) and the second for the project preferences page.

If the user tries to reach this view page, s/he will be directed to the default edit page.

https://dev.gridrepublic.org/browse/DBOINCP-327