### PR TITLE
Drupal: Added comment_create permission to forum_access module.

### DIFF
--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.module
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.module
@@ -502,11 +502,45 @@ function boinccore_form_alter(&$form, $form_state, $form_id) {
 function boinccore_link_alter(&$links, $node, $comment = NULL) {
   //echo '<pre>' . print_r($links, true) . '</pre>';
   foreach ($links as $module => $link) {
-    if (strstr($module, 'ignore_user')) {
-      // Remove the ignore user link
+    // Remove the ignore user link or subscription link
+    if (strstr($module, 'ignore_user') OR strstr($module, 'flag-subscriptions')) {
       unset($links[$module]);
     }
   }
+  // Node first, then comment: to be consistent with boinccore_link() function
+  if (!($comment)) {
+      // modify the comment_add link
+      if (isset($links['comment_add'])) {
+          $links['comment_add']['title'] = bts('Reply');
+          $links['comment_add']['attributes'] = array(
+              'title' => bts('Reply to this comment')
+          );
+      }
+      // modify quote link
+      if (isset($links['quote'])) {
+          $links['quote']['attributes'] = array(
+              'title' => bts('Reply to this topic with a quote')
+          );
+      }
+  }
+  else {
+      // Standard EDIT, DELETE, and REPLY links are created by Drupal, but we want to alter them
+      if (isset($links['comment_delete'])) {
+          $links['comment_delete']['attributes'] = array(
+              'title' => bts('Delete this comment')
+          );
+      }
+      if (isset($links['comment_edit'])) {
+          $links['comment_edit']['attributes'] = array(
+              'title' => bts('Edit this comment')
+          );
+      }
+      if (isset($links['comment_reply'])) {
+          $links['comment_reply']['attributes'] = array(
+              'title' => bts('Reply to this comment')
+          );
+      }
+  }// if !$comment
 }
 
 /**
@@ -523,10 +557,129 @@ function boinccore_locale($op = 'groups', $group = NULL) {
   }
 }
 
-/*
+
 function boinccore_link($type, $object, $teaser = FALSE) {
   // Add custom links with this hook
-  $links = array();
+
+  if ($type=='node') {
+      if ( ($object->type=='forum') OR ($object->type=='team_forum') ) {
+          // Add topic moderator controls
+          if (user_access('edit any forum topic')) {
+              $node_control = "node_control/{$object->nid}";
+              if ($object->status) {
+                  $links['hide'] = array(
+                      'title' => bts('Hide'),
+                      'href' => "{$node_control}/hide",
+                      'attributes' => array(
+                          'title' => bts('Hide this topic')
+                      )
+                  );
+              }
+              else {
+                  $links['unhide'] = array(
+                      'title' => bts('Unhide'),
+                      'href' => "{$node_control}/unhide",
+                      'attributes' => array(
+                          'title' => bts('Unhide this topic')
+                      )
+                  );
+              }
+              if ($object->comment == COMMENT_NODE_READ_WRITE) {
+                  $links['lock'] = array(
+                      'title' => bts('Lock'),
+                      'href' => "{$node_control}/lock",
+                      'attributes' => array(
+                          'title' => bts('Lock this thread for comments')
+                      )
+                  );
+              }
+              else {
+                  $links['unlock'] = array(
+                      'title' => bts('Unlock'),
+                      'href' => "{$node_control}/unlock",
+                      'attributes' => array(
+                          'title' => bts('Unlock this thread for comments')
+                      )
+                  );
+              }
+              if ($object->sticky) {
+                  $links['make_unsticky'] = array(
+                      'title' => bts('Make unsticky'),
+                      'href' => "{$node_control}/unsticky",
+                      'attributes' => array(
+                          'title' => bts('Remove sticky status from this topic')
+                      )
+                  );
+              }
+              else {
+                  $links['make_sticky'] = array(
+                      'title' => bts('Make sticky'),
+                      'href' => "{$node_control}/sticky",
+                      'attributes' => array(
+                          'title' => bts('Make this topic sticky')
+                      )
+                  );
+              }
+          }// if user_access('edit any forum topic')
+      }
+  }
+  else if ($type=='comment') {
+      $node = node_load($object->nid);
+      $nid = $object->nid;
+      $cid = $object->cid;
+
+      // QUOTE
+      if ($node->comment == COMMENT_NODE_READ_WRITE) {
+          $links['quote'] = array(
+              'title' => bts('Quote'),
+              'href' => "comment/reply/{$nid}/{$cid}",
+              'attributes' => array(
+                  'title' => bts('Reply to this comment with a quote')
+              ),
+              'fragment' => 'comment-form',
+              'query' => 'quote=1',
+          );
+      }      
+      // HIDE and COVERT comment
+      // The following are moderator only links
+      if (user_access('administer comments')) {
+          // Add hide link
+          $comment_control = "comment_control/{$cid}";
+          if ($vars['comment']->status == 0) {
+              $links['hide'] = array(
+                  'title' => bts('Hide'),
+                  'href' => "{$comment_control}/hide",
+                  'attributes' => array(
+                      'title' => bts('Hide this comment')
+                  )
+              );
+          }
+          else {
+              $links['unhide'] = array(
+                  'title' => bts('Unhide'),
+                  'href' => "{$comment_control}/unhide",
+                  'attributes' => array(
+                      'title' => bts('Unhide this comment')
+                  )
+              );
+          }
+  
+          // Add link to convert comment into a new topic
+          $reply_count = db_result(db_query(' SELECT COUNT(*) FROM comments WHERE pid = %d', $cid ));
+          if ($reply_count == 0) {
+              $links['convert'] = array(
+                  'title' => bts('Convert'),
+                  'href' => "{$comment_control}/convert",
+                  'attributes' => array(
+                      'title' => bts('Convert this comment to a new topic')
+                  ) 
+              );
+          }
+      }// if user_access('administer comments')
+  }//if $type
+
+
+/*
   if ($type == 'comment') {
     if (user_access('administer comments')) {
       $comment_control = "comment_control/{$object->cid}";
@@ -538,12 +691,17 @@ function boinccore_link($type, $object, $teaser = FALSE) {
             'title' => bts('Hide this comment')
           )
         );
+
+      // if comment is not locked
+      
+        
       }
     }
   }
+*/
   return $links;
 }
-// */
+
 
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
  * Page callbacks from hook_menu()

--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.module
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.module
@@ -511,7 +511,7 @@ function boinccore_link_alter(&$links, $node, $comment = NULL) {
   if (!($comment)) {
       // modify the comment_add link
       if (isset($links['comment_add'])) {
-          $links['comment_add']['title'] = bts('Reply');
+          $links['comment_add']['title'] = bts('reply');
           $links['comment_add']['attributes'] = array(
               'title' => bts('Reply to this comment')
           );
@@ -645,7 +645,7 @@ function boinccore_link($type, $object, $teaser = FALSE) {
       if (user_access('administer comments')) {
           // Add hide link
           $comment_control = "comment_control/{$cid}";
-          if ($vars['comment']->status == 0) {
+          if ($object->status == 0) {
               $links['hide'] = array(
                   'title' => bts('Hide'),
                   'href' => "{$comment_control}/hide",
@@ -678,27 +678,6 @@ function boinccore_link($type, $object, $teaser = FALSE) {
       }// if user_access('administer comments')
   }//if $type
 
-
-/*
-  if ($type == 'comment') {
-    if (user_access('administer comments')) {
-      $comment_control = "comment_control/{$object->cid}";
-      if ($object->status == 0) {
-        $links['hide'] = array(
-          'title' => bts('Hide'),
-          'href' => "{$comment_control}/hide",
-          'attributes' => array(
-            'title' => bts('Hide this comment')
-          )
-        );
-
-      // if comment is not locked
-      
-        
-      }
-    }
-  }
-*/
   return $links;
 }
 

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.admin.inc
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.admin.inc
@@ -64,8 +64,8 @@ function _forum_access_forum_form(&$form, &$form_state, $is_container) {
       '#value' => '<div>'. t('Note that users need') .'<ul style="margin-top: 0"><li>'.
                            t('the !access_content and !access_comments permissions <strong>AND <em>View</em></strong> to be able to see this forum and its content at all,', $variables) .'</li><li>'.
                            t('the !create_forum_topics (and similar) permissions <strong>AND <em>Post</em></strong> to be able to create forum content, and', $variables) .'</li><li>'.
-                           t('the !post_comments and (probably) !post_comments_without_approval permission <!TAG>AND <em>Post</em></!TAG> to be able to post comments/replies;', $variables + array('!TAG' => (variable_get('forum_access_D5_legacy_mode', FALSE) ? 'del title="'. t('Drupal 5 legacy mode') .'"' : 'strong'))) .'</li><li>'.
-                           t('the !edit_own_forum_topics or !edit_any_forum_topics (and similar) permissions (<strong>OR <em>Edit</em></strong>) can be added if desired, <strong>plus</strong>', $variables) .'</li><li>'.
+                           t('the !post_comments and (probably) !post_comments_without_approval permission <!TAG>AND <em>Comment</em></!TAG> to be able to post comments/replies;', $variables + array('!TAG' => (variable_get('forum_access_D5_legacy_mode', FALSE) ? 'del title="'. t('Drupal 5 legacy mode') .'"' : 'strong'))) .'</li><li>'.
+                           t('the !edit_own_forum_topics or !edit_any_forum_topics (and similar) permissions <strong>AND (<em>Edit</em> AND <em>Comment</em></strong>) can be added if desired, <strong>plus</strong>', $variables) .'</li><li>'.
                            t('the !delete_own_forum_topics or !delete_any_forum_topics (and similar) permissions (<strong>OR <em>Delete</em></strong>) if desired;', $variables) .'</li><li>'.
                            t('the !administer_comments (global!) permission <strong>OR <em>Edit</em>/<em>Delete</em></strong> to be able to edit/delete comments;', $variables) .'</li><li>'.
                            t('the !administer_forums permission <strong>AND <em>View</em></strong> to be able to administer forums (and change access!).', $variables) .'</li></ul>'.
@@ -126,6 +126,12 @@ function _forum_access_forum_form(&$form, &$form_state, $is_container) {
       '#title' => t('Post in this forum'),
       '#suffix' => '</div>',
     );
+    $form['forum_access']['headers']['comment_create'] = array(
+      '#type' => 'item',
+      '#prefix' => '<div class="forum-access-div">',
+      '#title' => t('Comment on posts'),
+      '#suffix' => '</div>',
+    );
     $form['forum_access']['headers']['update'] = array(
       '#type' => 'item',
       '#prefix' => '<div class="forum-access-div">',
@@ -140,9 +146,9 @@ function _forum_access_forum_form(&$form, &$form_state, $is_container) {
     );
   }
   $form['forum_access']['headers']['clearer'] = array(
-    '#value' => '<div class="forum-access-clearer"></div>',
+      '#value' => '<div class="forum-access-clearer"></div>',
   );
-
+  
   // Column content (checkboxes):
   $form['forum_access']['view'] = array(
     '#type' => 'checkboxes',
@@ -161,6 +167,14 @@ function _forum_access_forum_form(&$form, &$form_state, $is_container) {
     '#process' => array('expand_checkboxes', '_forum_access_forum_form_disable_checkboxes'),
   );
   if (!$is_container) {
+    $form['forum_access']['comment_create'] = array(
+      '#type' => 'checkboxes',
+      '#prefix' => '<div class="forum-access-div">',
+      '#suffix' => '</div>',
+      '#options' => $roles,
+      '#default_value' => $settings['comment_create'],
+      '#process' => array('expand_checkboxes', '_forum_access_forum_form_disable_checkboxes'),
+    );
     $form['forum_access']['update'] = array(
       '#type' => 'checkboxes',
       '#prefix' => '<div class="forum-access-div">',
@@ -435,6 +449,8 @@ function _forum_access_forum_form_disable_checkboxes($element) {
     elseif ($element['#parents'][1] == 'create') {
       // Do nothing (Post is always mutable).
     }
+    elseif ($element['#parents'][1] == 'comment_create') {
+    }
     elseif ($element['#parents'][1] == 'view' && isset($permissions[$rid]['administer forums'])) {
       $element[$rid]['#title'] = '<em>'. $element[$rid]['#title'] .'</em>';
       $element[$rid]['#prefix'] = '<span title="'. t("This role has the '@administer_forums' permission, and granting '@View' enables the role holders to change the settings on this page, including @Access_control!", array('@administer_forums' => $tr('administer forums'), '@View' => t('View'), '@Access_control' => t('Access control'))) .'">';
@@ -485,7 +501,7 @@ function _forum_access_forum_form_after_build($form, &$form_state) {
     $form['template']['#collapsed'] = FALSE;
 
     $settings = _forum_access_get_settings($template_tid);
-    foreach (array('view', 'create', 'update', 'delete') as $grant_type) {
+    foreach (array('view', 'create', 'comment_create', 'update', 'delete') as $grant_type) {
       if (empty($form[$grant_type])) {
         continue;
       }
@@ -500,7 +516,8 @@ function _forum_access_forum_form_after_build($form, &$form_state) {
     }
   }
   elseif (is_array(reset($form_state['values']['forum_access']['template']['taxonomy']))) {
-    $template_tid = reset(reset($form_state['values']['forum_access']['template']['taxonomy']));
+      $imv = reset($form_state['values']['forum_access']['template']['taxonomy']);
+    $template_tid = reset($imv);
   }
   if (isset($template_tid)) {
     $form['template']['select_by_default']['#value'] = ($template_tid && $template_tid == variable_get('forum_access_default_template_tid', 0));
@@ -549,7 +566,7 @@ function _forum_access_form_submit($form, &$form_state) {
   $is_changed = $is_changed || !empty($access['force_update']);
   $form_initial_values = $form;  // avoid Coder warning
   $form_initial_values = $form_initial_values['forum_access'];
-  foreach (array('view', 'create', 'update', 'delete') as $grant_type) {
+  foreach (array('view', 'create', 'comment_create', 'update', 'delete') as $grant_type) {
     if (isset($form_initial_values[$grant_type])) {
       $defaults = $form_initial_values[$grant_type]['#default_value'];
       $defaults = array_flip($defaults);
@@ -586,13 +603,13 @@ function _forum_access_form_submit($form, &$form_state) {
         $access['view'][$rid] = FALSE;
       }
       if ($access['view'][$rid] || $access['create'][$rid]) {
-        db_query("INSERT INTO {forum_access} (tid, rid, grant_view, grant_update, grant_delete, grant_create, priority) VALUES (%d, %d, %d, %d, %d, %d, %d)",
-          $tid, $rid, !empty($access['view'][$rid]), 0, 0, !empty($access['create'][$rid]), $fa_priority);
+        db_query("INSERT INTO {forum_access} (tid, rid, grant_view, grant_update, grant_delete, grant_create, grant_comment_create, priority) VALUES (%d, %d, %d, %d, %d, %d, %d, %d)",
+        $tid, $rid, !empty($access['view'][$rid]), 0, 0, !empty($access['create'][$rid]), 0, $fa_priority);
       }
     }
     else {
-      db_query("INSERT INTO {forum_access} (tid, rid, grant_view, grant_update, grant_delete, grant_create, priority) VALUES (%d, %d, %d, %d, %d, %d, %d)",
-        $tid, $rid, (bool) $checked, !empty($access['update'][$rid]), !empty($access['delete'][$rid]), !empty($access['create'][$rid]), $fa_priority);
+      db_query("INSERT INTO {forum_access} (tid, rid, grant_view, grant_update, grant_delete, grant_create, grant_comment_create, priority) VALUES (%d, %d, %d, %d, %d, %d, %d, %d)",
+      $tid, $rid, (bool) $checked, !empty($access['update'][$rid]), !empty($access['delete'][$rid]), !empty($access['create'][$rid]), !empty($access['comment_create'][$rid]), $fa_priority);
     }
   }
   $tr = 't';
@@ -720,11 +737,12 @@ function _forum_access_forum_admin_settings_form(&$form, &$form_state) {
  * Helper function to retrieve the settings for a forum.
  */
 function _forum_access_get_settings($tid = NULL) {
-  $return = array('view' => array(), 'create' => array(), 'update' => array(), 'delete' => array(), 'priority' => 0);
+    $return = array('view' => array(), 'create' => array(), 'comment_create' => array(), 'update' => array(), 'delete' => array(), 'priority' => 0);
   if (!isset($tid)) {
-    // Default to all users can read; all logged in users can post.
+    // Default to all users can read; all logged in users can post and comment.
     $return['view'] = array(DRUPAL_ANONYMOUS_RID, DRUPAL_AUTHENTICATED_RID);
     $return['create'] = array(DRUPAL_AUTHENTICATED_RID);
+    $return['comment_create'] = array(DRUPAL_AUTHENTICATED_RID);
   }
   else {
     $result = db_query("SELECT * FROM {forum_access} where tid = %d", $tid);
@@ -740,6 +758,9 @@ function _forum_access_get_settings($tid = NULL) {
       }
       if ($access->grant_create) {
         $return['create'][] = $access->rid;
+      }
+      if ($access->grant_comment_create) {
+        $return['comment_create'][] = $access->rid;
       }
       if ($access->rid == DRUPAL_AUTHENTICATED_RID) {  // this is our reference
         $return['priority'] = $access->priority;

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.admin.inc
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.admin.inc
@@ -602,9 +602,9 @@ function _forum_access_form_submit($form, &$form_state) {
         // ... otherwise forget View.
         $access['view'][$rid] = FALSE;
       }
-      if ($access['view'][$rid] || $access['create'][$rid]) {
+      if ($access['view'][$rid] || $access['create'][$rid] || $access['comment_create'][$rid]) {
         db_query("INSERT INTO {forum_access} (tid, rid, grant_view, grant_update, grant_delete, grant_create, grant_comment_create, priority) VALUES (%d, %d, %d, %d, %d, %d, %d, %d)",
-        $tid, $rid, !empty($access['view'][$rid]), 0, 0, !empty($access['create'][$rid]), 0, $fa_priority);
+        $tid, $rid, !empty($access['view'][$rid]), 0, 0, !empty($access['create'][$rid]), !empty($access['comment_create'][$rid]), $fa_priority);
       }
     }
     else {

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.admin.inc
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.admin.inc
@@ -474,7 +474,8 @@ function _forum_access_forum_form_disable_checkboxes($element) {
 function _forum_access_forum_form_after_build_acl0($form, $form_state) {
   if (isset($form['#post']['forum_access']['template']['taxonomy'])) {
     // Get ACL's user_list for the template and replace it before ACL's after_build function gets its shot at it.
-    $template_tid = reset(array_values($form['#post']['forum_access']['template']['taxonomy']));
+    $imv = array_values($form['#post']['forum_access']['template']['taxonomy']);
+    $template_tid = reset($imv);
     if ($acl_id = acl_get_id_by_number('forum_access', $template_tid)) {
       $f = acl_edit_form($acl_id, 'DUMMY');
       $form['user_list']['#value'] = $f['user_list']['#default_value'];

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.css
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.css
@@ -1,5 +1,5 @@
 .forum-access-div {
-  width: 25%;
+  width: 20%;
   margin: 0;
   padding: 0;
   float: left;

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.info
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.info
@@ -7,8 +7,7 @@ core = 6.x
 
 
 ; Information added by drupal.org packaging script on 2012-05-04
-version = "6.x-1.8-boinc-1-dev"
+version = "6.x-1.8-boinc-2-dev"
 core = "6.x"
 project = "forum_access"
-datestamp = "1393530079"
-
+datestamp = "1476375513"

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.install
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.install
@@ -51,6 +51,7 @@ function forum_access_schema() {
       'rid'           => array(
         'description' => 'The {role}.rid to which this {forum_access} entry applies.',
         'type'        => 'int',
+        'unsigned'    => TRUE,
         'not null'    => TRUE,
         'default'     => 0),
       'grant_view'    => array(

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.install
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.install
@@ -81,6 +81,13 @@ function forum_access_schema() {
         'unsigned'    => TRUE,
         'not null'    => TRUE,
         'default'     => 0),
+      'grant_comment_create'  => array(
+        'description' => 'Whether to grant "comment create" permission.',
+        'type'        => 'int',
+        'size'        => 'tiny',
+        'unsigned'    => TRUE,
+        'not null'    => TRUE,
+        'default'     => 0),
       'priority'  => array(
         'description' => 'The priority of this grant.',
         'type'        => 'int',
@@ -346,3 +353,26 @@ function forum_access_update_6108() {
   return $ret;
 }
 
+/** 
+ * Add support for 'comment' permission, #545916 backport.
+ */
+function forum_access_update_6109() {
+  $res = array();
+  $spec = array(
+      'description' => 'Whether to grant "comment_create" permission.',
+      'type'        => 'int',
+      'size'        => 'tiny',
+      'unsigned'    => TRUE,
+      'not null'    => TRUE,
+      'default'     => 0,
+    );
+  db_add_field($res, 'forum_access', 'grant_comment_create', $spec);
+
+  /*
+   * In previous versions of forum_access, the ability to comment was
+   * given to anyone with the ability to post('create') a new forum
+   * topic.
+   */
+  db_query("UPDATE forum_access SET grant_comment_create=grant_create");
+  return $result;
+}

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
@@ -61,6 +61,7 @@ function forum_access_node_access_records($node) {
           'grant_view' => $grant->grant_view,
           'grant_update' => $grant->grant_update,
           'grant_delete' => $grant->grant_delete,
+          'grant_comment_create' => $grant->grant_comment_create,
           'priority' => $grant->priority,
         );
       }
@@ -382,7 +383,7 @@ if (!variable_get('forum_access_D5_legacy_mode', FALSE)) {
  * Implementation of hook_link_alter().
  *
  * For nodes, remove the 'Add new comment' link, if the user does not have the
- * 'create' permission; for comments, add any missing links (D6.17+).
+ * 'comment_create' permission; for comments, add any missing links (D6.17+).
  */
 function forum_access_link_alter(&$links, $node, $comment = NULL) {
   global $user;
@@ -398,7 +399,7 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
   }
   if (empty($comment)) {
     // Check links for the node.
-    if ($tid && isset($links['comment_add']) && !forum_access_access($tid, 'create')) {
+    if ($tid && isset($links['comment_add']) && !forum_access_access($tid, 'comment_create')) {
       unset($links['comment_add']);
     }
   }
@@ -408,7 +409,7 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
     //dpm($node, "forum_access_link_alter() - node:");
     //dpm($comment, "forum_access_link_alter() - comment:");
     $required_keys = array(
-      'create' => 'comment_reply',
+      'comment_create' => 'comment_reply',
       'update' => 'comment_edit',
       'delete' => 'comment_delete',
     );
@@ -421,6 +422,7 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
         $link_is_missing = TRUE;
       }
     }
+
     if (isset($required_keys['create']) && !user_access('post comments')) {
       unset($required_keys['create']);
     }

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
@@ -185,7 +185,6 @@ function forum_access_init() {
  * Alter the node/comment create/edit forms and various admin forms.
  */
 function forum_access_form_alter(&$form, &$form_state, $form_id) {
-  //dpm($form, "form_id($form_id)");
   if (isset($form['type']['#value']) && $form['type']['#value'] .'_node_form' == $form_id) {
     module_load_include('node.inc', 'forum_access');
     _forum_access_node_form($form, $form_state);
@@ -241,7 +240,6 @@ function forum_access_form_alter(&$form, &$form_state, $form_id) {
  */
 function forum_access_db_rewrite_sql($query, $primary_table, $primary_field, $args) {
   global $user;
-  //dpm($query, "hook_db_rewrite_sql($primary_table.$primary_field)");
   $sql = NULL;
   switch ($primary_field) {
     case 'tid':
@@ -275,7 +273,6 @@ function forum_access_db_rewrite_sql($query, $primary_table, $primary_field, $ar
       }
       break;
   }
-  //dpm($sql, "rewritten:");
   return $sql;
 }
 
@@ -420,13 +417,14 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
     // Check links for the node.
     if ($tid && isset($links['comment_add']) && !forum_access_access($tid, 'comment_create')) {
       unset($links['comment_add']);
+      // Hack to manually remote quote link
+      if ( isset($links['quote']) ) {
+          unset($links['quote']);
+      }
     }
   }
   else {
     // Check links for the comment.
-    //dpm($links, "forum_access_link_alter() - links BEFORE:");
-    //dpm($node, "forum_access_link_alter() - node:");
-    //dpm($comment, "forum_access_link_alter() - comment:");
     $required_keys = array(
       'comment_create' => 'comment_reply',
       'update' => 'comment_edit',
@@ -442,8 +440,13 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
       }
     }
 
-    if (isset($required_keys['create']) && !user_access('post comments')) {
-      unset($required_keys['create']);
+    // Hack to manually remote quote link if comment_reply link is no longer set
+    if ( (!(isset($links['comment_reply']))) AND isset($links['quote']) ) {
+        unset($links['quote']);
+    }
+    
+    if (isset($required_keys['comment_create']) && !user_access('post comments')) {
+      unset($required_keys['comment_create']);
     }
     if (!empty($link_is_missing)) {
       // One of the $required_links should be present, because the current
@@ -484,8 +487,7 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
       // Now return the stored links.
       $links = $stored_links;
     }
-    //dpm($links, "forum_access_link_alter() - links AFTER:");
-  }
+  }// if empty($comment)
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
@@ -134,7 +134,26 @@ function forum_access_init() {
         }
       }
       break;
-  }
+
+    case 'community':
+        if (arg(1)=='forum') {
+            if (is_numeric(arg(2))) {
+                $tid=arg(2);
+                // Obtain the tid from a URL path containing
+                // community/forum/%tid, this will prevent users from
+                // loading forums they are not allowed to access.
+
+                if (isset($tid)) {
+                    if (!forum_access_access($tid, 'view')) {
+                        drupal_access_denied();
+                        module_invoke_all('exit');
+                        exit;
+                    }
+                }// isset($tid)
+            }// is_numeric(arg(2))
+        }// arg(1)==forum
+    break;
+  }// switch
   if (isset($nid)) {
     $node = node_load($nid);
     if ($tid = _forum_access_get_tid($node)) {

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
@@ -118,7 +118,7 @@ function _forum_access_comment_form(&$form, &$form_state) {
   if ($user->uid != 1 && isset($form['nid']['#value'])) {
     $node = node_load($form['nid']['#value']);
     if ($tid = _forum_access_get_tid($node)) {
-      if (!forum_access_access($tid, 'create')) {
+      if (!forum_access_access($tid, 'comment_create')) {
         switch (arg(0)) {
           case 'node':
             $form = NULL; // remove the in-line comment form
@@ -206,7 +206,7 @@ function _forum_access_preprocess_comment(&$variables) {
     _forum_access_disable_moderator();
   }
 
-  if (isset($links['comment_reply']) && (!preg_match('#<li class="[^"]*comment_reply[^"]*".*</li>#U', $variables['links']) || !user_access('post comments') || !forum_access_access($tid, 'create', NULL, FALSE))) {
+  if (isset($links['comment_reply']) && (!preg_match('#<li class="[^"]*comment_reply[^"]*".*</li>#U', $variables['links']) || !user_access('post comments') || !forum_access_access($tid, 'comment_create', NULL, FALSE))) {
     unset($links['comment_reply']);
   }
   if (isset($links['comment_edit']) && !forum_access_access($tid, 'update', NULL, FALSE) && !comment_access('edit', $variables['comment'])) {

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
@@ -127,11 +127,14 @@ function _forum_access_comment_form(&$form, &$form_state) {
                   '#type'  => 'item',
                   '#value' => 'You do not have permission to post comments in this forum.',);
             break;
-          case 'comment':
-              drupal_set_message(t("ERROR: You do not have permission to post comments in this forum."), 'error');
-              drupal_goto("node/$node->nid");
-            exit;
-        }
+            case 'comment':
+                if (arg(1)=='reply') {
+                    drupal_set_message(t("ERROR: You do not have permission to post comments in this forum."), 'error');
+                    drupal_goto("node/$node->nid");
+                    exit;
+                }
+            break;
+        }//switch arg(0)
       }
       else {
         if (isset($form['admin']) && !empty($user->_forum_access_moderator)) {
@@ -205,7 +208,6 @@ function _forum_access_preprocess_comment(&$variables) {
 
   $tid = $variables['node']->tid;
   $links = module_invoke_all('link', 'comment', $variables['comment'], 0);
-
   if (!empty($user->_forum_access_moderator) && arg(0) == 'node' && arg(2) == NULL) {
     _forum_access_disable_moderator();
   }

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
@@ -121,11 +121,15 @@ function _forum_access_comment_form(&$form, &$form_state) {
       if (!forum_access_access($tid, 'comment_create')) {
         switch (arg(0)) {
           case 'node':
-            $form = NULL; // remove the in-line comment form
+              // Remove the in-line comment form, replace with text message to user.
+              $form = NULL;
+              $form['from'] = array(
+                  '#type'  => 'item',
+                  '#value' => 'You do not have permission to post comments in this forum.',);
             break;
           case 'comment':
-            drupal_access_denied();
-            module_invoke_all('exit');
+              drupal_set_message(t("ERROR: You do not have permission to post comments in this forum."), 'error');
+              drupal_goto("node/$node->nid");
             exit;
         }
       }


### PR DESCRIPTION
Made changes to `forum_access` module and its corresponding database table to include a separate permission for `comment_create`, which grants users the ability to create comments in a particular forum.

Moved link generation from boinc template into `boinccore` module, so `forum_access` module may alter the links based on a user's permissions.
https://dev.gridrepublic.org/browse/DBOINCP-316

`forum_access` module install modified to use type unsigned int on field `rid` (instead of int).
https://dev.gridrepublic.org/browse/DBOINCP-324