### PR TITLE
Drupal: Fixed bug, user can edit own team forum topic

### DIFF
--- a/drupal/sites/default/boinc/modules/boincteam/boincteam_forum.module
+++ b/drupal/sites/default/boinc/modules/boincteam/boincteam_forum.module
@@ -143,7 +143,16 @@ function boincteam_forum_node_validate($node) {
   switch($node->type) {
   case 'team_forum':
     $account = user_load($node->uid);
-    $team_id = boincteam_forum_lookup_nid($node->tfid);
+    // Get tfid from node, but if empty/null, get it from the database
+    if (!($node->tfid)) {
+        $tfid = db_result(db_query("
+      SELECT tfid FROM {boincteam_forum_node}
+      WHERE nid = %d", $node->nid
+        ));
+    } else {
+        $tfid = $node->tfid;
+    }
+    $team_id = boincteam_forum_lookup_nid($tfid);
     if (!$account->team OR $account->team != $team_id) {
       drupal_set_message(t('Failed to add team forum topic.'), 'error');
       drupal_goto('community/forum');

--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view--boinc-team-forum-topics.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view--boinc-team-forum-topics.tpl.php
@@ -102,7 +102,10 @@
   
   <ul class="links">
     <li class="forum first last">
-      <?php print l(bts('Post new topic'), "node/add/team-forum/{$team_forum_id}"); ?>
+      <?php $account=user_load($user->uid); ?>
+      <?php if ($account->team AND $account->team == $team_forum->nid): ?>
+        <?php print l(bts('Post new topic'), "node/add/team-forum/{$team_forum_id}"); ?>
+      <?php endif; ?>
     </li>
   </ul>
   <div class="clearfix"></div>


### PR DESCRIPTION
Fixed bug, now user can edit own team forum topics.
Fixed bug, now only team members see the Post New Topic link in team forum topic list.

https://dev.gridrepublic.org/browse/DBOINCP-319