### PR TITLE
Drupal: Fix bug where "Mark forums as read" link led to Access Denied.

### DIFF
--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
@@ -142,8 +142,10 @@ function forum_access_init() {
                 // Obtain the tid from a URL path containing
                 // community/forum/%tid, this will prevent users from
                 // loading forums they are not allowed to access.
-
-                if (isset($tid)) {
+                // However, only tid>1 are terms we care about. (This
+                // allows forum_tweaks mark-read functionality to
+                // work.)
+                if (isset($tid) and ($tid>1)) {
                     if (!forum_access_access($tid, 'view')) {
                         drupal_access_denied();
                         module_invoke_all('exit');


### PR DESCRIPTION
Modified forum_access module to allow for the link "community/forum/0/read" which is necessary for the mark forum as read link.

https://dev.gridrepublic.org/browse/DBOINCP-332