### PR TITLE
Drupal: show signatures in comments again

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -332,8 +332,10 @@ function boinc_preprocess_node_team_forum(&$vars, $hook) {
  * @param $hook
  *   The name of the template being rendered ("comment" in this case.)
  */
-///* -- Delete this line if you want to use this function
 function boinc_preprocess_comment(&$vars, $hook) {
+    // Show signatures based on user preference
+    $vars['show_signatures'] = ($user->hide_signatures) ? FALSE : TRUE;
+
     $links = $vars['links'];
     $moderator_links = array();
     _boinc_create_moderator_links($links, $moderator_links);


### PR DESCRIPTION
Commit f64e644f inadvertently removed a crucial line that prevents signatures from being shown. I also got rid of the commented out comment that gave the impression that this function is not used.