### PR TITLE
Drupal: Site home page message translation set as project-specific.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
@@ -311,3 +311,39 @@ function boincuser_admin_scheduler_submit($form, &$form_state) {
 }
 
 
+/**
+  * Other BOINC options that don't fit elsewhere
+  */
+function boincuser_admin_other($form, &$form_state) {
+  $form = array();
+
+  //form defaults
+  $default = array(
+      'boinc_other_frontpage' => variable_get('boinc_other_frontpage', ''),
+  );
+  
+  // Define the form
+  $form['boinc_other_frontpage'] = array (
+    '#type' => 'textarea',
+    '#title' => bts('Message for site\'s Home Page'),
+    '#default_value' => $default['boinc_other_frontpage'],
+    '#cols' => 60,
+    '#rows' => 8,
+    '#description' => bts('Text to be displayed on the site\'s Home landing page.'),
+  );
+    
+  return system_settings_form($form);
+}
+
+/**
+  * Validate BOINC other form
+  */
+function boincuser_admin_other_validate($form, &$form_state) {
+}
+
+/**
+  * Submit BOINC other form
+  */
+function boincuser_admin_other_submit($form, &$form_state) {
+  drupal_set_message( bts("Status: BOINC other settings have been updated") );
+}

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -163,6 +163,15 @@ function boincuser_menu() {
     'type' => MENU_NORMAL_ITEM,
     'file' => 'boincuser.admin.inc'
   );
+  $items['admin/boinc/other'] = array(
+    'title' => 'Other Options',
+    'description' => 'Set other BOINC options.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('boincuser_admin_other'),
+    'access arguments' => array('administer site configuration'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'boincuser.admin.inc'
+  );
   
   $items['create_account.php'] = array(
     'title' => 'Create Account RPC',
@@ -1241,6 +1250,9 @@ function join_page($type = null) {
 function boincuser_home_page() {
   global $user;
   $site_name = variable_get('site_name', '');
+  // get the front page message from database; this is set in the admin interface under BOINC Other
+  $site_message = variable_get('boinc_other_frontpage','');
+
   // Determine the user of the day
   $current_uotd = db_fetch_object(db_query("
     SELECT
@@ -1261,7 +1273,7 @@ function boincuser_home_page() {
   $output .= ($user->uid) ? bts('Welcome back!') : ($site_name ? bts('What is @this_project?', array('@this_project' => $site_name)) : bts('Welcome!'));
   $output .= '</h2>';
   $output .= '<div class="boinc-overview balance-height-front">';
-  $output .= '  <div>' . bts("Einstein@Home is a program that uses your computer's idle time to run a screensaver to search for gravitational waves from spinning neutron stars (also called pulsars) using data from the LIGO gravitational wave detector.") . ' ' . l(bts('Learn more'), 'about') . '</div>';
+  $output .= '  <div>' . bts($site_message, array(), NULL, "project:front page") . ' ' . l(bts('Learn more'), 'about') . '</div>';
   if ($user->uid) {
     $output .= '  <div>' . l(bts('View account'), 'dashboard', array('attributes' => array('class' => 'join button'))) . '</div>';
   }


### PR DESCRIPTION
Site home page message is now an option that is set in the admin interface, BOINC Other.
The message is placed on the home page and is labeled as a project-specific string.

https://dev.gridrepublic.org/browse/DBOINCP-317