### PR TITLE
Drupal: Add project-specific context to Home string, part of preference set

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -537,7 +537,7 @@ function projectprefs_page($action = null, $venue = null) {
       $path = 'account/prefs/project/edit';
       $venues = array(
         "{$path}/generic" => bts('Generic'),
-        "{$path}/home" => bts('Home'),
+        "{$path}/home" => bts('Home', array(), NULL, 'boinc:preference set'),
         "{$path}/school" => bts('School'),
         "{$path}/work" => bts('Work')
       );


### PR DESCRIPTION
Home string should be have additional context.