### PR TITLE
Manager: add 'Apply' button to Event Log options dialog

### DIFF
--- a/clientgui/DlgDiagnosticLogFlags.h
+++ b/clientgui/DlgDiagnosticLogFlags.h
@@ -49,18 +49,22 @@ public:
     void OnSize(wxSizeEvent& event);
 	void OnOK(wxCommandEvent& event);
 	void OnSetDefaults(wxCommandEvent& event);
+    void OnApply(wxCommandEvent& event);
+    void OnCheckBox(wxCommandEvent& event);
 private:
 	//generic layout methods
     bool SaveState();
     bool RestoreState();
     
     void CreateCheckboxes();
+    void SaveFlags();
     
     LOG_FLAGS           log_flags;
     CC_CONFIG           m_cc_config;
     
     wxGridSizer*        m_headingSizer;
     std::vector <wxCheckBox*> m_checkbox_list;
+    wxButton*           m_btnApply;
 
 protected:
     wxString            m_headingText;


### PR DESCRIPTION
Activates 'Apply' button when the checkboxes change their state or 'Defaults' button is pressed. 
As requested in issue #1689.