### PR TITLE
Make project_dont_detach_when_done RPC work correctly

### DIFF
--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -310,7 +310,7 @@ static void handle_project_dont_detach_when_done(GUI_RPC_CONN& grc) {
     if (!p) return;
     gstate.set_client_state_dirty("Project modified by user");
     msg_printf(p, MSG_INFO, "detach when done cleared by user");
-    p->detach_when_done = true;
+    p->detach_when_done = false;
     p->dont_request_more_work = false;
     grc.mfout.printf("<success/>\n");
 }


### PR DESCRIPTION
The dont_detach_when_done RPC does not work as expected, it does not reset the flag. Looks like no one has noticed since the bug was introduced 5 years ago in c61103ac26bff4a40023dbc6a92781247e8801d8. This should fix it.