### PR TITLE
Drupal: Fixed fixed-width CSS for smaller browser windows.

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/css/layout-fixed.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/layout-fixed.css
@@ -25,7 +25,7 @@ body {
 }
 
 #page-wrapper {
-  min-width: 960px;
+  min-width: 980px;
 }
 
 .region-page-closure {
@@ -134,7 +134,7 @@ body {
 
 #navigation .section {
   margin: 0 auto;
-  width: 960px;
+  width: 980px;
 }
 
 #navigation ul /* Primary and secondary links */ {

--- a/drupal/sites/default/boinc/themes/boinc/css/layout-fixed.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/layout-fixed.css
@@ -24,7 +24,10 @@
 body {
 }
 
-/*#page-wrapper,*/
+#page-wrapper {
+  min-width: 960px;
+}
+
 .region-page-closure {
   /*
    * If you want to make the page a fixed width and centered in the viewport,
@@ -131,7 +134,7 @@ body {
 
 #navigation .section {
   margin: 0 auto;
-  width: 980px;
+  width: 960px;
 }
 
 #navigation ul /* Primary and secondary links */ {

--- a/drupal/sites/default/boinc/themes/boinc/css/tabs.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/tabs.css
@@ -57,7 +57,7 @@ ul.tab-list a {
 }
 
 ul.primary, ul.secondary {
-  width: 980px;
+  width: 960px;
   margin: 0 auto;
   padding: 0 0 0 12px; /* LTR */
   border-width: 0;

--- a/drupal/sites/default/boinc/themes/boinc/css/tabs.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/tabs.css
@@ -57,7 +57,7 @@ ul.tab-list a {
 }
 
 ul.primary, ul.secondary {
-  width: 960px;
+  width: 980px;
   margin: 0 auto;
   padding: 0 0 0 12px; /* LTR */
   border-width: 0;


### PR DESCRIPTION
* Adds page-wrapper min-width: ~~960px;~~ changed to 980px;
* ~~Fixes navigation bar width, should be width: 960px;~~ removed, navigation bar remains at 980px.

https://dev.gridrepublic.org/browse/DBOINCP-345