### PR TITLE
Drupal: Changed news view menu type to "Normal Menu".

### DIFF
--- a/drupal/sites/all/features/news/news.views_default.inc
+++ b/drupal/sites/all/features/news/news.views_default.inc
@@ -365,7 +365,7 @@ function news_views_default_views() {
   $handler->override_option('row_plugin', 'fields');
   $handler->override_option('path', 'news');
   $handler->override_option('menu', array(
-    'type' => 'default tab',
+    'type' => 'normal',
     'title' => 'News',
     'description' => '',
     'weight' => '0',


### PR DESCRIPTION
Fixes issue where Drupal would add extra <span> tag to the menu link.

https://dev.gridrepublic.org/browse/DBOINCP-348