### PR TITLE
Fix issue #1730: Please allow enabling "Report results immediately" for selected app or project 

### DIFF
--- a/client/app_config.cpp
+++ b/client/app_config.cpp
@@ -164,6 +164,13 @@ int APP_CONFIGS::parse(XML_PARSER& xp, PROJECT* p) {
             app_version_configs.push_back(avc);
             continue;
         }
+        if (xp.match_tag("options")) {
+            OPTIONS_CONFIG oc;
+            int retval = oc.parse(xp, p);
+            if (retval) return retval;
+            options_config = oc;
+            continue;
+        }
         if (xp.parse_int("project_max_concurrent", n)) {
             if (n >= 0) {
                 have_max_concurrent = true;
@@ -260,6 +267,40 @@ int APP_CONFIGS::config_app_versions(PROJECT* p, bool show_warnings) {
     return 0;
 }
 
+OPTIONS_CONFIG::OPTIONS_CONFIG() {
+    defaults();
+}
+
+void OPTIONS_CONFIG::defaults() {
+    report_results_immediately = false;
+}
+
+int OPTIONS_CONFIG::parse(XML_PARSER& xp, PROJECT* p) {
+    memset(this, 0, sizeof(OPTIONS_CONFIG));
+
+    while (!xp.get_tag()) {
+        if (!xp.is_tag) {
+            msg_printf_notice(p, false, NULL,
+                "unexpected text '%s' in app_config.xml", xp.parsed_tag
+            );
+            return ERR_XML_PARSE;
+        }
+        if (xp.match_tag("/options")) return 0;
+        if (xp.parse_bool("report_results_immediately", report_results_immediately)) continue;
+        if (log_flags.unparsed_xml) {
+            msg_printf(p, MSG_INFO,
+                "Unparsed line in app_config.xml: %s",
+                xp.parsed_tag
+            );
+        }
+        xp.skip_unexpected(log_flags.unparsed_xml, "OPTIONS_CONFIG::parse");
+    }
+    msg_printf_notice(p, false, NULL,
+        "Missing </options> in app_config.xml"
+    );
+    return ERR_XML_PARSE;
+}
+
 void max_concurrent_init() {
     for (unsigned int i=0; i<gstate.apps.size(); i++) {
         gstate.apps[i]->n_concurrent = 0;
@@ -282,6 +323,7 @@ static void clear_app_config(PROJECT* p) {
         app->max_concurrent = 0;
     }
 }
+
 
 // check for app_config.xml files, and parse them.
 // Called at startup and on read_cc_config() RPC

--- a/client/app_config.h
+++ b/client/app_config.h
@@ -48,10 +48,19 @@ struct APP_VERSION_CONFIG {
     int parse(XML_PARSER&, PROJECT*);
 };
 
+struct OPTIONS_CONFIG {
+    bool report_results_immediately;
+
+    OPTIONS_CONFIG();
+    void defaults();
+    int parse(XML_PARSER&, PROJECT*);
+};
+
 struct APP_CONFIGS {
     std::vector<APP_CONFIG> app_configs;
     std::vector<APP_VERSION_CONFIG> app_version_configs;
     int project_max_concurrent;
+    OPTIONS_CONFIG options_config;
 
     int parse(XML_PARSER&, PROJECT*);
     int parse_file(FILE*, PROJECT*);
@@ -59,6 +68,7 @@ struct APP_CONFIGS {
     void clear() {
         app_configs.clear();
         app_version_configs.clear();
+        options_config.defaults();
         project_max_concurrent = 0;
     }
 };

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -1294,7 +1294,7 @@ PROJECT* CLIENT_STATE::find_project_with_overdue_results(
             return p;
         }
 
-        if (cc_config.report_results_immediately) {
+        if (cc_config.report_results_immediately || p->app_configs.options_config.report_results_immediately) {
             return p;
         }
 


### PR DESCRIPTION
As suggested by  sirzooro, this fix adds a new section `<options>` in app_config.xml file.
In section  `<options>`, this fix adds option `report_results_immediately`