### PR TITLE
Drupal: Fixes profile search result issue regarding 'Joined' date.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1786,3 +1786,42 @@ function boincuser_get_profile_links($uid) {
 </ul>
 */
 }
+
+/*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * 
+ * Call backs for apachesolr
+ *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */
+
+/**
+ * Implementation of hook_apachesolr_index_documents_alter()
+ *
+ * This function modifies the Apache Solr Document to use the user's
+ * join date as the "ds_create" timestamp.
+ * 
+ * @param array $documents
+ *   Array of ApacheSolrDocument which are to be indexed
+ * @param string $entity
+ *   The entity object, typically a node object.
+ * @param string $entity_type
+ *   The entity's type, typically 'node'.
+ * @param $env_id
+ *   Environment ID for apache solr.
+ */
+function boincuser_apachesolr_index_documents_alter(array &$documents, $entity, $entity_type, $env_id) {
+
+  foreach ($documents as $document) {
+    if ( $document->entity_type=='node' AND $document->bundle=='profile' ) {
+      dd($document, "index documents alter - document");
+      // Node information.
+      $nid = $document->entity_id;
+      $node = node_load($nid);
+      $account = user_load($node->uid);
+      dd($account, "index document alter - account");
+
+      // Replace the Solr document's created field with the date the user 
+      // account was created. This replaces the node creation date typically 
+      // used for indexing nodes.
+      $document->ds_created = apachesolr_date_iso($account->created);
+    }
+  }
+
+}

--- a/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
@@ -53,22 +53,15 @@
 <?php
   case 'Profile':
   case 'profile':
-    $parsed_url = parse_url($url);
-    $base_length = strlen($base_path);
-    $core_path = trim(substr($parsed_url['path'], $base_length), '/');
-    $path = drupal_lookup_path('source', $core_path);
-    $matches = array();
-    if (preg_match('/node\/([0-9]+)/', $path, $matches)) {
-      $node = node_load($matches[1]);
-      $account = user_load($node->uid);
+    $nid = $result['fields']['entity_id'];
+    $node = node_load($nid);
+    $account = user_load($node->uid);
+    if (isset($account)) {
       $user_image = boincuser_get_user_profile_image($account->uid);
       $url = "{$base_path}account/{$account->uid}";
-      $forum = $node->taxonomy[$node->forum_tid]->name;
-      if ($forum) {
-        $title_prefix = "{$forum} : ";
+      if (empty($title)) {
+        $title = $account->name;
       }
-      //echo '<pre>' . print_r($node,1) . '</pre>';
-      //echo '<pre>' . print_r($account,1) . '</pre>';
     }
   ?>
   <div class="result user">


### PR DESCRIPTION
- Fixed search result template to get NID from search result directly.
- Added to boincuser module hook into Apache Solr index to use user account creation date instead of the node creation date.

https://dev.gridrepublic.org/browse/DBOINCP-287