### PR TITLE
Drupal: Added code to change database character encoding for BOINC database

### DIFF
--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.admin.inc
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.admin.inc
@@ -234,16 +234,16 @@ function boinccore_admin_default_content_generate($pages = array()) {
 function boinccore_admin_dbopts(&$form_state) {
   $form = array();
   $default = array(
-    'database_encoding' => variable_get('boinc_database_encoding', 'utf-8')
+    'database_encoding' => variable_get('boinc_database_encoding', 'latin1')
   );
 
   $form['boinc_database_encoding'] = array(
-    '#title' => bts('BOINC Database Character encoding (default is UTF-8).'),
+    '#title' => bts('BOINC Database Character encoding (default is latin1).'),
     '#type' => 'radios',
-    '#description' => bts('Choose character the encoding of BOINC database. When the BOINC database is loaded, the command \'SET NAMES (encoding)\' is run before database queries.'),
+    '#description' => bts('Choose the character encoding of the BOINC database. When the BOINC database is loaded, the command \'SET NAMES (encoding)\' is run before queries.'),
     '#options' => array(
-        'utf-8' => 'UTF-8',
         'latin1' => 'latin1 (ISO/IEC 8859-1)',
+        'utf-8' => 'UTF-8',
     ),
     '#attributes' => array('class' => 'fancy'),
     '#default_value' => $default['database_encoding'],

--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.admin.inc
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.admin.inc
@@ -227,3 +227,41 @@ function boinccore_admin_default_content_generate($pages = array()) {
   menu_cache_clear_all();
   return $pages_generated;
 }
+
+/**
+ * BOINC form to set database options
+ **/
+function boinccore_admin_dbopts(&$form_state) {
+  $form = array();
+  $default = array(
+    'database_encoding' => variable_get('boinc_database_encoding', 'utf-8')
+  );
+
+  $form['boinc_database_encoding'] = array(
+    '#title' => bts('BOINC Database Character encoding (default is UTF-8).'),
+    '#type' => 'radios',
+    '#description' => bts('Choose character the encoding of BOINC database. When the BOINC database is loaded, the command \'SET NAMES (encoding)\' is run before database queries.'),
+    '#options' => array(
+        'utf-8' => 'UTF-8',
+        'latin1' => 'latin1 (ISO/IEC 8859-1)',
+    ),
+    '#attributes' => array('class' => 'fancy'),
+    '#default_value' => $default['database_encoding'],
+  );
+
+  return system_settings_form($form);
+}
+
+/**
+ * Validate BOINC db options form.
+ */
+
+function boinccore_admin_dbopts_validate($form, &$form_state) {
+}
+
+/**
+ * Submit BOINC db options form.
+ */
+function boinccore_admin_dbopts_submit($form, &$form_state) {
+  drupal_set_message( bts('Status: BOINC database options settings have been updated.') );
+}

--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.module
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.module
@@ -62,6 +62,15 @@ function boinccore_menu() {
     'type' => MENU_NORMAL_ITEM,
     'file' => 'boinccore.admin.inc'
   );
+  $items['admin/boinc/db-options'] = array(
+    'title' => 'Database Options',
+    'description' => 'Set BOINC Database options.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('boinccore_admin_dbopts'),
+    'access arguments' => array('administer site configuration'),
+    'type' => MENU_NORMAL_ITEM,
+    'file' => 'boinccore.admin.inc'
+  );
   
   // BOINC RPC wrappers
   $items['lookup_account.php'] = array(

--- a/drupal/sites/default/boinc/modules/boincteam/boincteam.module
+++ b/drupal/sites/default/boinc/modules/boincteam/boincteam.module
@@ -1306,3 +1306,31 @@ function boincteam_view_team_panel($team_id) {
   }
   return $output;
 }
+
+/**
+ * Implementation of hook_views_pre_execute()
+ *
+ * Before reading from the BOINC database, set the character encoding
+ * to 'boinc_database_encoding'.
+ */
+function boincteam_views_pre_execute(&$view) {
+  if ($view->name=="boinc_teams") {
+    if (isset($view->base_database)) {
+      db_set_active($view->base_database);
+      $dbenc = variable_get('boinc_database_encoding', 'latin1');
+      if (isset($dbenc) AND $dbenc!='utf-8') {
+        $myenc = "SET NAMES " . $dbenc;
+        db_query($myenc);
+      }
+    }
+  }
+}
+
+/**
+ * Implementation of hook_views_post_execute()
+ */
+function boincteam_views_post_execute(&$view) {
+  if ($view->name=="boinc_teams") {
+    db_query("SET NAMES utf8");
+  }
+}

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
@@ -263,8 +263,6 @@ function boincteam_edit_form(&$form_state, $team_id) {
   
   $team = node_load($team_id);
   $boincteam = boincteam_load(boincteam_lookup_id($team_id));
-  dpm($team->body, "team body");
-  dpm($boincteam->description , "boincteam desc");
   
   $is_boinc_wide = ($boincteam->seti_id > 0) ? TRUE : FALSE;
   
@@ -452,14 +450,12 @@ function boincteam_edit_form_submit($form, &$form_state) {
   $values['description'] = check_markup($values['description'], $input_format);
   
   // Update the team in the BOINC db
-  $dbenc = variable_get('boinc_database_encoding');
+  db_set_active('boinc');
+  $dbenc = variable_get('boinc_database_encoding', 'latin1');
   if (isset($dbenc) AND $dbenc!='utf-8') {
     $myenc = "SET NAMES " . $dbenc;
+    db_query($myenc);
   }
-
-  db_set_active('boinc');
-  drupal_set_message($myenc, 'info');
-  db_query($myenc);
   db_query("
     UPDATE {team} SET
       name = '%s',
@@ -611,13 +607,12 @@ function boincteam_add_admin_form_submit($form, &$form_state) {
   $boincteam_id = boincteam_lookup_id($team_id);
 
   // Update the team in the BOINC db
-  $dbenc = variable_get('boinc_database_encoding');
+  db_set_active('boinc');
+  $dbenc = variable_get('boinc_database_encoding', 'latin1');
   if (isset($dbenc) AND $dbenc!='utf-8') {
     $myenc = "SET NAMES " . $dbenc;
+    db_query($myenc);
   }
-  
-  db_set_active('boinc');
-  db_query($myenc);
   db_query("
     INSERT INTO {team_admin} SET
       teamid = '%d',

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
@@ -263,6 +263,8 @@ function boincteam_edit_form(&$form_state, $team_id) {
   
   $team = node_load($team_id);
   $boincteam = boincteam_load(boincteam_lookup_id($team_id));
+  dpm($team->body, "team body");
+  dpm($boincteam->description , "boincteam desc");
   
   $is_boinc_wide = ($boincteam->seti_id > 0) ? TRUE : FALSE;
   
@@ -450,7 +452,14 @@ function boincteam_edit_form_submit($form, &$form_state) {
   $values['description'] = check_markup($values['description'], $input_format);
   
   // Update the team in the BOINC db
+  $dbenc = variable_get('boinc_database_encoding');
+  if (isset($dbenc) AND $dbenc!='utf-8') {
+    $myenc = "SET NAMES " . $dbenc;
+  }
+
   db_set_active('boinc');
+  drupal_set_message($myenc, 'info');
+  db_query($myenc);
   db_query("
     UPDATE {team} SET
       name = '%s',
@@ -472,6 +481,7 @@ function boincteam_edit_form_submit($form, &$form_state) {
     $values['joinable'],
     $boincteam_id
   );
+  db_query("SET NAMES utf8");
   db_set_active('default');
   
   // Update the team node in Drupal
@@ -599,9 +609,15 @@ function boincteam_add_admin_form_submit($form, &$form_state) {
   
   $team = node_load($team_id);
   $boincteam_id = boincteam_lookup_id($team_id);
-  
+
   // Update the team in the BOINC db
+  $dbenc = variable_get('boinc_database_encoding');
+  if (isset($dbenc) AND $dbenc!='utf-8') {
+    $myenc = "SET NAMES " . $dbenc;
+  }
+  
   db_set_active('boinc');
+  db_query($myenc);
   db_query("
     INSERT INTO {team_admin} SET
       teamid = '%d',
@@ -611,6 +627,7 @@ function boincteam_add_admin_form_submit($form, &$form_state) {
     $boincuser_id,
     time()
   );
+  db_query("SET NAMES utf8");
   db_set_active('default');
   
   // Could assign a role in Drupal here, as needed

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
@@ -16,13 +16,12 @@
 function boincteam_sync() {
 
   // Get the list of teams to import from BOINC db
-  $dbenc = variable_get('boinc_database_encoding');
+  db_set_active('boinc'); 
+  $dbenc = variable_get('boinc_database_encoding', 'latin1');
   if (isset($dbenc) AND $dbenc!='utf-8') {
     $myenc = "SET NAMES " . $dbenc;
+    db_query($myenc);
   }
-
-  db_set_active('boinc');
-  db_query($myenc);
   $boinc_teams = db_query('
     SELECT id, name, description, userid, create_time, seti_id
     FROM team

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
@@ -14,15 +14,22 @@
  * the BOINC database
  */
 function boincteam_sync() {
-  
-  // Get the list of teams to import
+
+  // Get the list of teams to import from BOINC db
+  $dbenc = variable_get('boinc_database_encoding');
+  if (isset($dbenc) AND $dbenc!='utf-8') {
+    $myenc = "SET NAMES " . $dbenc;
+  }
+
   db_set_active('boinc');
+  db_query($myenc);
   $boinc_teams = db_query('
     SELECT id, name, description, userid, create_time, seti_id
     FROM team
     WHERE mod_time > FROM_UNIXTIME(%d)',
     variable_get('boincteam_last_sync', 0)
   );
+  db_query("SET NAMES utf8");
   db_set_active('default');
   
   $existing_teams = array();


### PR DESCRIPTION
Added to admin interface ability to choose what character encoding of the BOINC database. Admin can chose between UTF-8 and latin1.
Added db queries for 'SET NAMES (encoding)' before reading from database, and then re-set to UTF-8 afterwards.
Added above code to select character encoding when syncing boinc teams (for BWTs).
Fixed a number of typos.

https://dev.gridrepublic.org/browse/DBOINCP-344