### PR TITLE
Drupal: Change top host, user, and team views

### DIFF
--- a/drupal/sites/all/features/teams/teams.views_default.inc
+++ b/drupal/sites/all/features/teams/teams.views_default.inc
@@ -3169,8 +3169,8 @@ else {
   $handler->override_option('link_to_view', 0);
   $handler->override_option('inherit_panels_path', 0);
   $handler = $view->new_display('page', 'Page', 'page_1');
-  $handler->override_option('items_per_page', 50);
-  $handler->override_option('use_pager', '1');
+  $handler->override_option('items_per_page', 100);
+  $handler->override_option('use_pager', '0');
   $handler->override_option('style_plugin', 'table');
   $handler->override_option('style_options', array(
     'grouping' => '',

--- a/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
+++ b/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
@@ -6359,6 +6359,8 @@ else {
   ));
   $handler->override_option('arguments', array());
   $handler->override_option('filters', array());
+  $handler->override_option('items_per_page', 25);
+  $handler->override_option('use_pager', '0');
   $handler->override_option('style_options', array(
     'grouping' => '',
     'override' => 1,
@@ -10131,8 +10133,8 @@ else {
   $handler->override_option('cache', array(
     'type' => 'none',
   ));
-  $handler->override_option('items_per_page', 50);
-  $handler->override_option('use_pager', '1');
+  $handler->override_option('items_per_page', 100);
+  $handler->override_option('use_pager', '0');
   $handler->override_option('style_plugin', 'table');
   $handler->override_option('style_options', array(
     'grouping' => '',
@@ -10504,7 +10506,6 @@ else {
   ));
   $handler->override_option('title', 'Top participants');
   $handler->override_option('items_per_page', 10);
-  $handler->override_option('use_pager', '0');
   $handler->override_option('use_more', 1);
   $handler->override_option('use_more_always', 0);
   $handler->override_option('use_more_text', 'view more');

--- a/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
+++ b/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
@@ -6359,7 +6359,7 @@ else {
   ));
   $handler->override_option('arguments', array());
   $handler->override_option('filters', array());
-  $handler->override_option('items_per_page', 25);
+  $handler->override_option('items_per_page', 50);
   $handler->override_option('use_pager', '0');
   $handler->override_option('style_options', array(
     'grouping' => '',


### PR DESCRIPTION
Changed users, teams, and hosts views to show 100, 100, and 50 results without a pager.