### PR TITLE
Always use config.h in str_replace.h

### DIFF
--- a/lib/str_replace.h
+++ b/lib/str_replace.h
@@ -20,8 +20,9 @@
 #ifndef STR_REPLACE_H
 #define STR_REPLACE_H
 
-#ifndef _WIN32
 #include "config.h"
+
+#ifndef _WIN32
 #include <sys/types.h>
 #endif
 


### PR DESCRIPTION
So that we always get the correct definition of HAVE_-flags such has HAVE_STRCASECMP.
Without this, builds with MSYS2/CYGWIN64 fail to link (you'll get a "double definition").

I still have some other problems with it, but at least this fixes some of them...