### PR TITLE
MGR: Client version check

### DIFF
--- a/client/client_state.h
+++ b/client/client_state.h
@@ -238,7 +238,7 @@ struct CLIENT_STATE {
 // --------------- acct_setup.cpp:
     PROJECT_INIT project_init;
     PROJECT_ATTACH project_attach;
-    void new_version_check();
+    void new_version_check(bool force = false);
     void all_projects_list_check();
     double new_version_check_time;
     double all_projects_list_check_time;

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -140,8 +140,8 @@ void newer_version_startup_check() {
 
 #define NEW_VERSION_CHECK_PERIOD (14*86400)
 
-void CLIENT_STATE::new_version_check() {
-    if ((new_version_check_time == 0) ||
+void CLIENT_STATE::new_version_check(bool force) {
+    if (force || (new_version_check_time == 0) ||
         (now - new_version_check_time > NEW_VERSION_CHECK_PERIOD)) {
             // get_current_version_op.handle_reply()
             // updates new_version_check_time

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -87,15 +87,15 @@ static void show_newer_version_msg(const char* new_vers) {
     if (cc_config.client_new_version_text.empty()) {
         msg_printf_notice(0, true,
             "http://boinc.berkeley.edu/manager_links.php?target=notice&controlid=download",
-            "%s (%s) <a href=%s>%s</a>",
-            _("A new version of BOINC is available."),
+            "%s (%s). <a href=%s>%s</a>",
+            _("A new version of BOINC is available"),
             new_vers,
             cc_config.client_download_url.c_str(),
             _("Download")
         );
     } else {
         msg_printf_notice(0, true, NULL,
-            "%s (%s) <a href=%s>%s</a>",
+            "%s (%s). <a href=%s>%s</a>",
             cc_config.client_new_version_text.c_str(),
             new_vers,
             cc_config.client_download_url.c_str(),

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -996,6 +996,8 @@ static void handle_acct_mgr_rpc_poll(GUI_RPC_CONN& grc) {
 }
 
 static void handle_get_newer_version(GUI_RPC_CONN& grc) {
+    gstate.new_version_check(true);
+
     grc.mfout.printf(
         "<newer_version>%s</newer_version>\n"
         "<download_url>%s</download_url>\n",

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -196,7 +196,7 @@ BEGIN_EVENT_TABLE (CAdvancedFrame, CBOINCBaseFrame)
     EVT_MENU(ID_HELPBOINCMANAGER, CAdvancedFrame::OnHelpBOINC)
     EVT_MENU(ID_HELPBOINCWEBSITE, CAdvancedFrame::OnHelpBOINC)
     EVT_MENU(wxID_ABOUT, CAdvancedFrame::OnHelpAbout)
-    EVT_MENU(wxID_CHECK_VERSION, CAdvancedFrame::OnCheckVersion)
+    EVT_MENU(ID_CHECK_VERSION, CAdvancedFrame::OnCheckVersion)
     EVT_HELP(wxID_ANY, CAdvancedFrame::OnHelp)
     // Custom Events & Timers
     EVT_FRAME_CONNECT(CAdvancedFrame::OnConnect)
@@ -696,7 +696,7 @@ bool CAdvancedFrame::CreateMenu() {
         pSkinAdvanced->GetApplicationShortName().c_str()
     );
     menuHelp->Append(
-        wxID_CHECK_VERSION,
+        ID_CHECK_VERSION,
         strMenuName,
         strMenuDescription
     );

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1685,25 +1685,7 @@ void CAdvancedFrame::OnHelpAbout(wxCommandEvent& WXUNUSED(event)) {
 void CAdvancedFrame::OnCheckVersion(wxCommandEvent& WXUNUSED(event)) {
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnCheckVersion - Function Begin"));
 
-    std::string version, url;
-    wxString message, title;
-    title.Printf(_("Version Update"));
-    CMainDocument* pDoc = wxGetApp().GetDocument();
-    CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
-    if (pDoc->IsConnected()) {
-        pDoc->rpc.get_newer_version(version, url);
-
-        if (!version.empty() && !url.empty()) {
-            message.Printf("%s: %s", _("A new version of BOINC is available for downloading here"), url);
-        }
-        else {
-            message.Printf("%s", _("No new version available for downloading"), url);
-        }
-    }
-    else {
-        message.Printf("%s is not connected to the client", pSkinAdvanced->GetApplicationName().c_str());
-    }
-    wxGetApp().SafeMessageBox(message, title);
+    wxGetApp().GetDocument()->CheckForVersionUpdate(true);
 
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnCheckVersion - Function End"));
 }

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -196,6 +196,7 @@ BEGIN_EVENT_TABLE (CAdvancedFrame, CBOINCBaseFrame)
     EVT_MENU(ID_HELPBOINCMANAGER, CAdvancedFrame::OnHelpBOINC)
     EVT_MENU(ID_HELPBOINCWEBSITE, CAdvancedFrame::OnHelpBOINC)
     EVT_MENU(wxID_ABOUT, CAdvancedFrame::OnHelpAbout)
+    EVT_MENU(wxID_CHECK_VERSION, CAdvancedFrame::OnCheckVersion)
     EVT_HELP(wxID_ANY, CAdvancedFrame::OnHelp)
     // Custom Events & Timers
     EVT_FRAME_CONNECT(CAdvancedFrame::OnConnect)
@@ -682,6 +683,21 @@ bool CAdvancedFrame::CreateMenu() {
     menuHelp->Append(
         ID_HELPBOINCWEBSITE,
         strMenuName, 
+        strMenuDescription
+    );
+    menuHelp->AppendSeparator();
+
+    strMenuName.Printf(
+        _("Check for new %s version"),
+        pSkinAdvanced->GetApplicationShortName().c_str()
+    );
+    strMenuDescription.Printf(
+        _("Check for new %s version"),
+        pSkinAdvanced->GetApplicationShortName().c_str()
+    );
+    menuHelp->Append(
+        wxID_CHECK_VERSION,
+        strMenuName,
         strMenuDescription
     );
     menuHelp->AppendSeparator();
@@ -1666,6 +1682,31 @@ void CAdvancedFrame::OnHelpAbout(wxCommandEvent& WXUNUSED(event)) {
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnHelpAbout - Function End"));
 }
 
+void CAdvancedFrame::OnCheckVersion(wxCommandEvent& WXUNUSED(event)) {
+    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnCheckVersion - Function Begin"));
+
+    std::string version, url;
+    wxString message, title;
+    title.Printf(_("Version Update"));
+    CMainDocument* pDoc = wxGetApp().GetDocument();
+    CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
+    if (pDoc->IsConnected()) {
+        pDoc->rpc.get_newer_version(version, url);
+
+        if (!version.empty() && !url.empty()) {
+            message.Printf("%s: %s", _("A new version of BOINC is available for downloading here"), url);
+        }
+        else {
+            message.Printf("%s", _("No new version available for downloading"), url);
+        }
+    }
+    else {
+        message.Printf("%s is not connected to the client", pSkinAdvanced->GetApplicationName().c_str());
+    }
+    wxGetApp().SafeMessageBox(message, title);
+
+    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnCheckVersion - Function End"));
+}
 
 void CAdvancedFrame::OnRefreshView(CFrameEvent& WXUNUSED(event)) {
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnRefreshView - Function Begin"));

--- a/clientgui/AdvancedFrame.h
+++ b/clientgui/AdvancedFrame.h
@@ -88,6 +88,7 @@ public:
     void OnHelp( wxHelpEvent& event );
     void OnHelpBOINC( wxCommandEvent& event );
     void OnHelpAbout( wxCommandEvent& event );
+    void OnCheckVersion( wxCommandEvent& event );
 
     void OnRefreshState( wxTimerEvent& event );
     void OnFrameRender( wxTimerEvent& event );

--- a/clientgui/Events.h
+++ b/clientgui/Events.h
@@ -95,6 +95,7 @@
 #define ID_HELPBOINC                            6035  // Locked: Used by manager_links.php
 #define ID_HELPBOINCWEBSITE                     6024  // Locked: Used by manager_links.php
 #define ID_HELPBOINCMANAGER                     6025  // Locked: Used by manager_links.php
+#define ID_CHECK_VERSION                        6026
 //#define wxID_ABOUT
 
 // Views

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -164,6 +164,7 @@ void CNetworkConnection::Poll() {
             if (!retval) {
                 wxLogTrace(wxT("Function Status"), wxT("CNetworkConnection::Poll - Connection Success"));
                 SetStateSuccess(m_strNewComputerName, m_strNewComputerPassword);
+                m_pDocument->CheckForVersionUpdate();
             } else if (ERR_AUTHENTICATOR == retval) {
                 wxLogTrace(wxT("Function Status"), wxT("CNetworkConnection::Poll - RPC Authorization - ERR_AUTHENTICATOR"));
                 SetStateErrorAuthentication();
@@ -1278,6 +1279,21 @@ bool CMainDocument::IsUserAuthorized() {
     return true;
 }
 
+void CMainDocument::CheckForVersionUpdate() {
+    std::string version, url;
+    // It seems that this check will work if the client will check newer file version on start.
+    // Client will check this even the last check was more that 14 days ago and on start only.
+    // Client newer saves this information in its internal files 
+    // and never reread 'get_current_version.xml' between checks.
+    // In any other cases result will be empty.
+    rpc.get_newer_version(version, url);
+
+    if (!version.empty() && !url.empty()) {
+        char message[MAXPATHLEN];
+        snprintf(message, sizeof(message), "%s: %s", wxT("You can download it here"), url);
+        wxGetApp().SafeMessageBox(message, wxT("A new version of BOINC is available."));
+    }
+}
 
 int CMainDocument::CachedProjectStatusUpdate(bool bForce) {
     int     i = 0;

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -1281,11 +1281,6 @@ bool CMainDocument::IsUserAuthorized() {
 
 void CMainDocument::CheckForVersionUpdate() {
     std::string version, url;
-    // It seems that this check will work if the client will check newer file version on start.
-    // Client will check this even the last check was more that 14 days ago and on start only.
-    // Client newer saves this information in its internal files 
-    // and never reread 'get_current_version.xml' between checks.
-    // In any other cases result will be empty.
     rpc.get_newer_version(version, url);
 
     if (!version.empty() && !url.empty()) {

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -1282,12 +1282,6 @@ bool CMainDocument::IsUserAuthorized() {
 void CMainDocument::CheckForVersionUpdate() {
     std::string version, url;
     rpc.get_newer_version(version, url);
-
-    if (!version.empty() && !url.empty()) {
-        char message[MAXPATHLEN];
-        snprintf(message, sizeof(message), "%s: %s", wxT("You can download it here"), url);
-        wxGetApp().SafeMessageBox(message, wxT("A new version of BOINC is available."));
-    }
 }
 
 int CMainDocument::CachedProjectStatusUpdate(bool bForce) {

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -1284,7 +1284,7 @@ void CMainDocument::CheckForVersionUpdate(bool showMessage) {
     std::string version, url;
     wxString message, title;
     title.Printf(_("Version Update"));
-    std::string applicationName = wxGetApp().GetSkinManager()->GetAdvanced()->GetApplicationName();
+    wxString applicationName = wxGetApp().GetSkinManager()->GetAdvanced()->GetApplicationName();
     if (IsConnected()) {
         rpc.get_newer_version(version, url);
 
@@ -1299,7 +1299,7 @@ void CMainDocument::CheckForVersionUpdate(bool showMessage) {
         }
     }
     else {
-        message.Printf("%s is not connected to the client", applicationName.c_str());
+        message.Printf("%s is not connected to the client", applicationName);
     }
     if (showMessage) {
         wxGetApp().SafeMessageBox(message, title);

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -37,6 +37,7 @@
 #include "BOINCTaskBar.h"
 #include "DlgEventLog.h"
 #include "Events.h"
+#include "SkinManager.h"
 
 #ifndef _WIN32
 #include <sys/wait.h>
@@ -1279,9 +1280,30 @@ bool CMainDocument::IsUserAuthorized() {
     return true;
 }
 
-void CMainDocument::CheckForVersionUpdate() {
+void CMainDocument::CheckForVersionUpdate(bool showMessage) {
     std::string version, url;
-    rpc.get_newer_version(version, url);
+    wxString message, title;
+    title.Printf(_("Version Update"));
+    std::string applicationName = wxGetApp().GetSkinManager()->GetAdvanced()->GetApplicationName();
+    if (IsConnected()) {
+        rpc.get_newer_version(version, url);
+
+        if (!showMessage)
+            return;
+
+        if (!version.empty() && !url.empty()) {
+            message.Printf("%s: %s", _("A new version of BOINC is available for downloading here"), url);
+        }
+        else {
+            message.Printf("%s", _("No new version available for downloading"), url);
+        }
+    }
+    else {
+        message.Printf("%s is not connected to the client", applicationName.c_str());
+    }
+    if (showMessage) {
+        wxGetApp().SafeMessageBox(message, title);
+    }
 }
 
 int CMainDocument::CachedProjectStatusUpdate(bool bForce) {

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -167,7 +167,7 @@ public:
 
     bool                        IsUserAuthorized();
 
-    void                        CheckForVersionUpdate();
+    void                        CheckForVersionUpdate(bool showMessage = false);
 
     CNetworkConnection*         m_pNetworkConnection;
     CBOINCClientManager*        m_pClientManager;

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -167,6 +167,8 @@ public:
 
     bool                        IsUserAuthorized();
 
+    void                        CheckForVersionUpdate();
+
     CNetworkConnection*         m_pNetworkConnection;
     CBOINCClientManager*        m_pClientManager;
     AsyncRPC                    rpc;

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -84,6 +84,7 @@ BEGIN_EVENT_TABLE(CSimpleFrame, CBOINCBaseFrame)
     EVT_MENU(ID_HELPBOINCMANAGER, CSimpleFrame::OnHelpBOINC)
     EVT_MENU(ID_HELPBOINCWEBSITE, CSimpleFrame::OnHelpBOINC)
     EVT_MENU(wxID_ABOUT, CSimpleFrame::OnHelpAbout)
+    EVT_MENU(ID_CHECK_VERSION, CSimpleFrame::OnCheckVersion)
 	EVT_MENU(ID_EVENTLOG, CSimpleFrame::OnEventLog)
     EVT_MOVE(CSimpleFrame::OnMove)
 #ifdef __WXMAC__
@@ -254,6 +255,21 @@ CSimpleFrame::CSimpleFrame(wxString title, wxIconBundle* icons, wxPoint position
     menuHelp->Append(
         ID_HELPBOINCWEBSITE,
         strMenuName, 
+        strMenuDescription
+    );
+    menuHelp->AppendSeparator();
+
+    strMenuName.Printf(
+        _("Check for new %s version"),
+        pSkinAdvanced->GetApplicationShortName().c_str()
+    );
+    strMenuDescription.Printf(
+        _("Check for new %s version"),
+        pSkinAdvanced->GetApplicationShortName().c_str()
+    );
+    menuHelp->Append(
+        ID_CHECK_VERSION,
+        strMenuName,
         strMenuDescription
     );
     menuHelp->AppendSeparator();
@@ -609,6 +625,32 @@ void CSimpleFrame::OnHelpAbout(wxCommandEvent& /*event*/) {
     m_pBackgroundPanel->SetDlgOpen(false);
 
     wxLogTrace(wxT("Function Start/End"), wxT("CSimpleFrame::OnHelpAbout - Function End"));
+}
+
+void CSimpleFrame::OnCheckVersion(wxCommandEvent& WXUNUSED(event)) {
+    wxLogTrace(wxT("Function Start/End"), wxT("CSimpleFrame::OnCheckVersion - Function Begin"));
+
+    std::string version, url;
+    wxString message, title;
+    title.Printf(_("Version Update"));
+    CMainDocument* pDoc = wxGetApp().GetDocument();
+    CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
+    if (pDoc->IsConnected()) {
+        pDoc->rpc.get_newer_version(version, url);
+
+        if (!version.empty() && !url.empty()) {
+            message.Printf("%s: %s", _("A new version of BOINC is available for downloading here"), url);
+        }
+        else {
+            message.Printf("%s", _("No new version available for downloading"), url);
+        }
+    }
+    else {
+        message.Printf("%s is not connected to the client", pSkinAdvanced->GetApplicationName().c_str());
+    }
+    wxGetApp().SafeMessageBox(message, title);
+
+    wxLogTrace(wxT("Function Start/End"), wxT("CSimpleFrame::OnCheckVersion - Function End"));
 }
 
 

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -630,25 +630,7 @@ void CSimpleFrame::OnHelpAbout(wxCommandEvent& /*event*/) {
 void CSimpleFrame::OnCheckVersion(wxCommandEvent& WXUNUSED(event)) {
     wxLogTrace(wxT("Function Start/End"), wxT("CSimpleFrame::OnCheckVersion - Function Begin"));
 
-    std::string version, url;
-    wxString message, title;
-    title.Printf(_("Version Update"));
-    CMainDocument* pDoc = wxGetApp().GetDocument();
-    CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
-    if (pDoc->IsConnected()) {
-        pDoc->rpc.get_newer_version(version, url);
-
-        if (!version.empty() && !url.empty()) {
-            message.Printf("%s: %s", _("A new version of BOINC is available for downloading here"), url);
-        }
-        else {
-            message.Printf("%s", _("No new version available for downloading"), url);
-        }
-    }
-    else {
-        message.Printf("%s is not connected to the client", pSkinAdvanced->GetApplicationName().c_str());
-    }
-    wxGetApp().SafeMessageBox(message, title);
+    wxGetApp().GetDocument()->CheckForVersionUpdate(true);
 
     wxLogTrace(wxT("Function Start/End"), wxT("CSimpleFrame::OnCheckVersion - Function End"));
 }

--- a/clientgui/sg_BoincSimpleFrame.h
+++ b/clientgui/sg_BoincSimpleFrame.h
@@ -114,6 +114,7 @@ public:
     void OnHelp( wxHelpEvent& event );
     void OnHelpBOINC( wxCommandEvent& event );
     void OnHelpAbout( wxCommandEvent& event );
+    void OnCheckVersion( wxCommandEvent& event );
 
     void OnProjectsAttachToProject(wxCommandEvent& event);
 

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -2372,14 +2372,19 @@ int RPC_CLIENT::get_newer_version(std::string& version, std::string& version_dow
     RPC rpc(this);
 
     version = "";
+    version_download_url = "";
+
     retval = rpc.do_rpc("<get_newer_version/>\n");
     if (!retval) {
         while (rpc.fin.fgets(buf, 256)) {
+            if (!version.empty() && !version_download_url.empty()) {
+                break;
+            }
             if (parse_str(buf, "<newer_version>", version)) {
-                return ERR_XML_PARSE;
+                continue;
             }
             if (parse_str(buf, "<download_url>", version_download_url)) {
-                return ERR_XML_PARSE;
+                continue;
             }
         }
     }


### PR DESCRIPTION
Reused existing mechanism of version check.
Manager will check for new version during connection to the client.
Default message about new version will be shown in notices tab.
Added menu to check new version manually. In this case user will see the message with check result.
Fixed issue with new version response parse.