### PR TITLE
client: only take global prefs from project when not attached to AM

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -676,9 +676,10 @@ int CLIENT_STATE::handle_scheduler_reply(
     }
 
     // if the scheduler reply includes global preferences,
+    // and we currently don't use an account manager
     // insert extra elements, write to disk, and parse
     //
-    if (sr.global_prefs_xml) {
+    if (!gstate.acct_mgr_info.using_am() && sr.global_prefs_xml) {
         // skip this if we have host-specific prefs
         // and we're talking to an old scheduler
         //


### PR DESCRIPTION
as the current scheduler take whatever global pref reply as is,
it should at least only take it if we didn't join any AM,

this is just a quick fix for #1777, 
there are room for further consideration about rewrite how we should take global pref.