### PR TITLE
Client: normalize whitespace in p_model and p_vendor entries

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -839,14 +839,6 @@ static void get_cpu_info_mac(HOST_INFO& host) {
 #endif
 
     host.p_model[p_model_size-1] = 0;
-    char *in = host.p_model + 1;
-    char *out = in;
-    // Strip out runs of multiple spaces
-    do {
-        if ((!isspace(*(in-1))) || (!isspace(*in))) {
-            *out++ = *in;
-        }
-    } while (*in++);
 
     // This returns an Apple hardware model designation such as "MacPro3,1".
     // One source for converting this to a common model name is:
@@ -1069,7 +1061,6 @@ int get_network_usage_totals(
         total_sent += ifmsg->ifm_data.ifi_obytes;
 #endif
     }
-        
     return 0;
 }
 
@@ -1400,14 +1391,6 @@ int HOST_INFO::get_cpu_info() {
 #elif HAVE_SYS_SYSTEMINFO_H
     sysinfo(SI_PLATFORM, p_vendor, sizeof(p_vendor));
     sysinfo(SI_ISALIST, p_model, sizeof(p_model));
-    for (unsigned int i=0; i<sizeof(p_model); i++) {
-        if (p_model[i]==' ') {
-            p_model[i]=0;
-        }
-        if (p_model[i]==0) {
-            i=sizeof(p_model);
-        }
-    }
 #else
 #error Need to specify a method to get p_vendor, p_model
 #endif
@@ -1802,7 +1785,8 @@ int HOST_INFO::get_host_info(bool init) {
     get_memory_info();
     timezone = get_timezone();
     get_os_info();
-
+    collapse_whitespace(p_model);
+    collapse_whitespace(p_vendor);
     if (!strlen(host_cpid)) {
         generate_host_cpid();
     }

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -1442,6 +1442,8 @@ int HOST_INFO::get_host_info(bool init) {
         m_cache,
         p_ncpus
     );
+    collapse_whitespace(p_model);
+    collapse_whitespace(p_vendor);
     if (!strlen(host_cpid)) {
         generate_host_cpid();
     }

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -385,6 +385,25 @@ void unescape_os_release(char* buf) {
     *out = 0;
 }
 
+// collapse multiple whitespace into one (will not strip_whitespace)
+//
+void collapse_whitespace(string& str) {
+    int n = (int) str.length();
+    if (n<2) return;
+    for (int i=1; i<n; i++) {
+        if (isspace(str[i-1]) && isspace(str[i])) {
+            str.erase(i, 1);
+            n--; i--;
+        }
+    }
+}
+
+void collapse_whitespace(char *str) {
+    string s = str;
+    collapse_whitespace(s);
+    strcpy(str, s.c_str());
+}
+
 char* time_to_string(double t) {
     static char buf[100];
     if (!t) {

--- a/lib/str_util.h
+++ b/lib/str_util.h
@@ -35,6 +35,8 @@ extern void strip_whitespace(std::string&);
 extern void strip_quotes(char *str);
 extern void strip_quotes(std::string&);
 extern void unescape_os_release(char *str);
+extern void collapse_whitespace(char *str);
+extern void collapse_whitespace(std::string&);
 extern char* time_to_string(double);
 extern char* precision_time_to_string(double);
 extern void secs_to_hmsf(double, char*);


### PR DESCRIPTION
This was already done for Mac but not Linux and Windows. It collapses multiple consecutive blanks into one blank which is then send to the server.