### PR TITLE
Manager: Fix select computer dialog

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1434,36 +1434,26 @@ void CAdvancedFrame::OnSelectComputer(wxCommandEvent& WXUNUSED(event)) {
     wxString            password = wxEmptyString;
     CMainDocument*      pDoc = wxGetApp().GetDocument();
     long                lRetVal = -1;
+    bool                bRetrievePasswordFromFile = FALSE;
 
     wxASSERT(pDoc);
     wxASSERT(wxDynamicCast(pDoc, CMainDocument));
 
-    if (SelectComputer(hostName, portNum, password, false)) { 
-        if (pDoc->IsComputerNameLocal(hostName)) {
-            lRetVal = pDoc->Connect(
-                wxT("localhost"),
-                GUI_RPC_PORT,
-                wxEmptyString,
-                TRUE,
-                TRUE
-            );
-        } else {
-            // Connect to the remote machine
-            long lPort = GUI_RPC_PORT; 
-            int iPos = hostName.Find(wxT(":")); 
-            if (iPos != wxNOT_FOUND) { 
-                wxString sPort = hostName.substr(iPos + 1); 
-                if (!sPort.ToLong(&lPort)) lPort = GUI_RPC_PORT; 
-                hostName.erase(iPos); 
-            } 
-            lRetVal = pDoc->Connect(
-                hostName.c_str(),
-                portNum,
-                password.c_str(),
-                TRUE,
-                FALSE
-            );
+    if (SelectComputer(hostName, portNum, password, false)) {
+        // possibly read password from file if local computername AND no password was entered
+        if (pDoc->IsComputerNameLocal(hostName) && password == wxEmptyString) {
+            hostName = wxT("localhost");
+            bRetrievePasswordFromFile = TRUE;
         }
+        // Connect to the specified host
+        lRetVal = pDoc->Connect(
+            hostName.c_str(),
+            portNum,
+            password.c_str(),
+            TRUE,
+            bRetrievePasswordFromFile
+        );
+
         if (lRetVal) {
             ShowConnectionFailedAlert();
         }

--- a/clientgui/DlgSelectComputer.cpp
+++ b/clientgui/DlgSelectComputer.cpp
@@ -236,8 +236,9 @@ void CDlgSelectComputer::OnComputerNameUpdated( wxCommandEvent& WXUNUSED(event) 
 
     wxString name = m_ComputerNameCtrl->GetValue();
     if (pDoc->IsComputerNameLocal(name)) {
-        pDoc->m_pNetworkConnection->GetLocalPassword(strPassword);
-        m_ComputerPasswordCtrl->SetValue(strPassword);
+        if (pDoc->m_pNetworkConnection->GetLocalPassword(strPassword) == 0) {
+            m_ComputerPasswordCtrl->SetValue(strPassword);
+        }
     }
 }
 


### PR DESCRIPTION
The hostname "localhost" was recognized as a special name which always prompted the Manager to try to read contents of gui_rpc_auth.cfg. The Manager used an empty password if the file is not readable but then can't connect because the Client actually uses a password. Any user supplied password was overwritten which made the dialog not work when using "localhost" but work when used with "127.0.0.1".
Now the dialog checks if the user has entered an empty password which prompts reading gui_rpc_auth.cfg and uses the user supplied password otherwise.

Fixes #1306 