### PR TITLE
Fix cross-compile from ubuntu with mingw

### DIFF
--- a/lib/boinc_win.h
+++ b/lib/boinc_win.h
@@ -40,6 +40,11 @@
 #endif
 #endif
 
+#ifdef __MINGW32__
+#define strdate     _strdate
+#define strtime     _strtime
+#endif
+
 #ifndef HAVE_CONFIG_H
 
 // Windows C Runtime Library

--- a/lib/str_replace.h
+++ b/lib/str_replace.h
@@ -20,8 +20,11 @@
 #ifndef STR_REPLACE_H
 #define STR_REPLACE_H
 
-#ifndef _WIN32
+#ifdef HAVE_CONFIG_H
 #include "config.h"
+#endif
+
+#ifndef _WIN32
 #include <sys/types.h>
 #endif
 


### PR DESCRIPTION
I was cross compiling from ubuntu xenial with mingw for windows.
A few error occurred because current code failed to recognize mingw.
There might be better ways(that I don't know) to fix it.