### PR TITLE
Check execinfo.h availability in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -676,7 +676,7 @@ AC_TYPE_SIGNAL
 if test "${isWIN32}" = "yes" ; then
   AC_CHECK_HEADERS(winsock2.h winsock.h windows.h ws2tcpip.h winternl.h crtdbg.h)
 fi
-AC_CHECK_HEADERS(sys/types.h sys/un.h arpa/inet.h dirent.h grp.h fcntl.h inttypes.h stdint.h memory.h netdb.h netinet/in.h netinet/tcp.h netinet/ether.h net/if.h net/if_arp.h signal.h strings.h sys/auxv.h sys/file.h sys/fcntl.h sys/ipc.h sys/ioctl.h sys/msg.h sys/param.h sys/resource.h sys/select.h sys/sem.h sys/shm.h sys/sockio.h sys/socket.h sys/stat.h sys/statvfs.h sys/statfs.h sys/systeminfo.h sys/time.h sys/types.h sys/utsname.h sys/vmmeter.h sys/wait.h unistd.h utmp.h errno.h procfs.h ieeefp.h setjmp.h float.h sal.h)
+AC_CHECK_HEADERS(sys/types.h sys/un.h arpa/inet.h dirent.h grp.h fcntl.h inttypes.h stdint.h memory.h netdb.h netinet/in.h netinet/tcp.h netinet/ether.h net/if.h net/if_arp.h signal.h strings.h sys/auxv.h sys/file.h sys/fcntl.h sys/ipc.h sys/ioctl.h sys/msg.h sys/param.h sys/resource.h sys/select.h sys/sem.h sys/shm.h sys/sockio.h sys/socket.h sys/stat.h sys/statvfs.h sys/statfs.h sys/systeminfo.h sys/time.h sys/types.h sys/utsname.h sys/vmmeter.h sys/wait.h unistd.h utmp.h errno.h procfs.h ieeefp.h setjmp.h float.h sal.h execinfo.h)
 
 save_cxxflags="${CXXFLAGS}"
 save_cppflags="${CPPFLAGS}"

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -46,7 +46,7 @@
 #include "mac_backtrace.h"
 #endif
 
-#ifdef __GLIBC__
+#ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
 #endif
 
@@ -775,7 +775,7 @@ void boinc_catch_signal(int signal) {
     default: fprintf(stderr, "unknown signal %d\n", signal); break;
     }
 
-#ifdef __GLIBC__
+#ifdef HAVE_EXECINFO_H
     void *array[64];
     size_t size;
     size = backtrace (array, 64);


### PR DESCRIPTION
Currently, execinfo.h is included in lib/diagnostics.cpp if `__GLIBC__` is
defined. However, this does not work when cross-compiling boinc with
uclibc-ng. So, instead, check the presence of execinfo.h in configure.ac
and update lib/diagnostics.cpp accordingly.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>