### PR TITLE
Fix LDFLAGS for cross-compilation

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -43,18 +43,18 @@ endif
 
 lib_LTLIBRARIES = libboinc_api.la
 libboinc_api_la_SOURCES = $(api_files)
-libboinc_api_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION)
+libboinc_api_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 
 if BUILD_GRAPHICS_API
 lib_LTLIBRARIES += libboinc_graphics2.la
 libboinc_graphics2_la_SOURCES = $(graphics2_files)
 libboinc_graphics2_la_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_srcdir)/samples/image_libs
-libboinc_graphics2_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION) -ljpeg
+libboinc_graphics2_la_LDFLAGS = -version-number $(LIBBOINC_VERSION) -ljpeg
 endif #BUILD_GRAPHICS_API
 
 lib_LTLIBRARIES += libboinc_opencl.la
 libboinc_opencl_la_SOURCES = $(opencl_files)
-libboinc_opencl_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION)
+libboinc_opencl_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 
 if INSTALL_HEADERS
 ## install only headers that are meant for exporting the API !!

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -176,7 +176,7 @@ lib_LTLIBRARIES = libboinc.la
 libboinc_la_SOURCES = $(generic_sources) $(mac_sources) $(win_sources)
 libboinc_la_CFLAGS = $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
 libboinc_la_CXXFLAGS = $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
-libboinc_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -static -version-number $(LIBBOINC_VERSION)
+libboinc_la_LDFLAGS = -static -version-number $(LIBBOINC_VERSION)
 libboinc_la_LIBADD =
 
 if ENABLE_BOINCCRYPT
@@ -184,7 +184,7 @@ lib_LTLIBRARIES += libboinc_crypt.la
 libboinc_crypt_la_SOURCES = crypt.cpp
 libboinc_crypt_la_CFLAGS = $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(SSL_CFLAGS)
 libboinc_crypt_la_CXXFLAGS = $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(SSL_CXXFLAGS)
-libboinc_crypt_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -static -version-number $(LIBBOINC_VERSION)
+libboinc_crypt_la_LDFLAGS = -static -version-number $(LIBBOINC_VERSION)
 libboinc_crypt_la_LIBADD =
 endif
 
@@ -193,7 +193,7 @@ lib_LTLIBRARIES += libboinc_fcgi.la
 libboinc_fcgi_la_SOURCES = $(libfcgi_sources) $(mac_sources) $(win_sources)
 libboinc_fcgi_la_CFLAGS = -D_USING_FCGI_ $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
 libboinc_fcgi_la_CXXFLAGS = -D_USING_FCGI_ $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
-libboinc_fcgi_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION)
+libboinc_fcgi_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 libboinc_fcgi_la_LIBADD =
 endif 
 # end of "if ENABLE_FCGI"

--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -25,7 +25,7 @@ lib_LTLIBRARIES = libsched.la
 libsched_la_SOURCES = $(libsched_sources)
 libsched_la_CFLAGS = $(AM_CPPFLAGS)
 libsched_la_CXXFLAGS = $(AM_CPPFLAGS)
-libsched_la_LDFLAGS= -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION)
+libsched_la_LDFLAGS= -version-number $(LIBBOINC_VERSION)
 libsched_la_LIBADD= $(SSL_LIBS)
 
 ## install only headers that are meant for exporting the API !!
@@ -47,7 +47,7 @@ lib_LTLIBRARIES += libsched_fcgi.la
 libsched_fcgi_la_SOURCES = $(libsched_sources)
 libsched_fcgi_la_CFLAGS = -D_USING_FCGI_ $(AM_CPPFLAGS)
 libsched_fcgi_la_CXXFLAGS = -D_USING_FCGI_ $(AM_CPPFLAGS)
-libsched_fcgi_la_LDFLAGS= -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION)
+libsched_fcgi_la_LDFLAGS= -version-number $(LIBBOINC_VERSION)
 libsched_fcgi_la_LIBADD=
 
 endif

--- a/zip/Makefile.am
+++ b/zip/Makefile.am
@@ -61,7 +61,7 @@ endif
 
 lib_LTLIBRARIES = libboinc_zip.la
 libboinc_zip_la_SOURCES = $(libboinc_zip_sources)
-libboinc_zip_la_LDFLAGS = -L$(libdir) -rpath $(libdir) -version-number $(LIBBOINC_VERSION)
+libboinc_zip_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 libboinc_zip_la_LIBADD =
 
 # Some OSs may not prefix libraries with lib.


### PR DESCRIPTION
Remove "-L$(libdir)" from LDFLAGS of boinc libraries in Makefile.am of
api, lib, sched and zlib directories to be able to cross-compile boinc.

Indeed, libdir is not equal to the path where BOINC will be installed
but to exec_prefix/lib. The full installation path is
$(DESTDIR)/$(libdir).

To cross-compile boinc, exec_prefix will be set to the target path (for
example: /usr) and DESTDIR will be set (during make install) to the
staging or target directory on the host (for example /home/xxx/target).
The issue of adding -L$(libdir) is that it is not allowed by the
compiler, the error "unsafe header/library path used in
cross-compilation: '-L/usr/lib'" will be raised.

As a result, remove -L$(libdir)" from LDFLAGS, the default library
search paths are sufficient for "standard" compilation or can be updated
manually by passing the additional search path to LDFLAGS during the
configure call for cross-compilation.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>