### PR TITLE
Drupal: Use boinc username in Solr searches.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1815,6 +1815,23 @@ function boincuser_apachesolr_index_documents_alter(array &$documents, $entity, 
       $node = node_load($nid);
       $account = user_load($node->uid);
 
+      // Use boincuser name and not drupal user name
+      $document->label = apachesolr_clean_text($account->boincuser_name);
+      // Author information
+      if ($node->uid == 0 || strlen($node->name) == 0) {
+        // @see user_validate_name(). !'0' === TRUE.
+        $document->ss_name = '0';
+      }
+      else {
+        $document->ss_name = $account->boincuser_name;
+        // We want the name to be searchable for keywords.
+        $document->tos_name = $account->boincuser_name;
+      }
+
+      // Rename "Profle" to "User"
+      $document->bundle = "User";
+      $document->bundle_name = "User";
+
       // Replace the Solr document's created field with the date the user 
       // account was created. This replaces the node creation date typically 
       // used for indexing nodes.

--- a/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
@@ -53,14 +53,16 @@
 <?php
   case 'Profile':
   case 'profile':
+  case 'User':
+  case 'user':
     $nid = $result['fields']['entity_id'];
     $node = node_load($nid);
     $account = user_load($node->uid);
     if (isset($account)) {
-      $user_image = boincuser_get_user_profile_image($account->uid, FALSE);
+      $user_image = boincuser_get_user_profile_image($account->uid);
       $url = "{$base_path}account/{$account->uid}";
       if (empty($title)) {
-        $title = $account->name;
+        $title = $account->boincuser_name;
       }
     }
   ?>


### PR DESCRIPTION
Changed bundle name from "Profile" to "User".
Boinc username is used in Solr index (replaces drupal username).
Search template updated to use bundle name "User" and to use boinc username.

https://dev.gridrepublic.org/browse/DBOINCP-357