### PR TITLE
Drupal: Renamed moderation queue menu item as 'Queue'

### DIFF
--- a/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
@@ -31,7 +31,7 @@ function user_profiles_menu_default_menu_links() {
     'menu_name' => 'primary-links',
     'link_path' => 'moderate/profiles',
     'router_path' => 'moderate/profiles',
-    'link_title' => 'Moderation Queue',
+    'link_title' => 'Queue',
     'options' => array(
       'attributes' => array(
         'title' => '',
@@ -48,7 +48,7 @@ function user_profiles_menu_default_menu_links() {
   );
   // Translatables
   // Included for use with string extractors like potx.
-  t('Moderation Queue');
+  t('Queue');
   t('Profile');
 
 

--- a/drupal/sites/default/boinc/themes/boinc/css/html-reset.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/html-reset.css
@@ -125,8 +125,6 @@ h1 {
                            (relative to the base font), we have to divide that
                            length by the element's font-size:
                            1em / 2em = 0.5em */
-  border-bottom: 2px dotted #aaa;
-  padding-bottom: 7px;
 }
 
 h2 {

--- a/drupal/sites/default/boinc/themes/boinc/css/responsive-jswidth.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/responsive-jswidth.css
@@ -50,7 +50,7 @@
   /*right: 0;
   top: 0;*/
   padding: 1px 9px;
-  margin: 3px;
+  margin: 0 3px;
 }
 
 .has-js #mobile-menu-toggle {


### PR DESCRIPTION
Renamed the Moderation menu child item 'Moderation Menu' as 'Queue'.
Also, fixed BOINC theme CSS that was breaking mobile menu placement/layout.