### PR TITLE
Drupal: Fix user_profiles Feature to eliminate Feature override

### DIFF
--- a/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
@@ -16,7 +16,6 @@ function user_profiles_menu_default_menu_links() {
       'attributes' => array(
         'title' => '',
       ),
-      'alter' => TRUE,
     ),
     'module' => 'menu',
     'hidden' => '0',


### PR DESCRIPTION
Drupal: Removed alter=>TRUE from user_profile menu_links, which was causing a permanent override.

part of https://dev.gridrepublic.org/browse/DBOINCP-274