### PR TITLE
Drupal: Added hook to boinctranslate to update the URL/path for l10n_update

### DIFF
--- a/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
+++ b/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
@@ -1522,3 +1522,12 @@ function boinctranslate_parse_resources($resource_text) {
   }
   return $resources;
 }
+
+/*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
+ * Implementation of hooks for l10n_update
+ *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */
+function boinctranslate_l10n_update_projects_alter(&$projects) {
+  foreach ($projects as &$proj) {
+    $proj['info']['l10n path'] = 'https://ftp-origin.drupal.org/files/translations/%core/%project/%project-%release.%language.po';
+  }
+}


### PR DESCRIPTION
l10n_update module has buggy code which can't handle the new ftp-origin.drupal.org URL redirect.

https://dev.gridrepublic.org/browse/DBOINCP-363