### PR TITLE
Manager/Lib: fix 'New Manager window' function on Linux

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -721,6 +721,16 @@ void CBOINCGUIApp::DetectExecutableName() {
 
     // Store the root directory for later use.
     m_strBOINCMGRExecutableName = pszProg;
+#elif defined(__WXGTK__)
+    char path[PATH_MAX];
+    if (!get_real_executable_path(path, PATH_MAX)) {
+        // find filename component
+        char* name = strrchr(path, '/');
+        if (name) {
+            name++;
+            m_strBOINCMGRExecutableName = name;
+        }
+    }
 #endif
 }
 
@@ -742,6 +752,17 @@ void CBOINCGUIApp::DetectRootDirectory() {
 
     // Store the root directory for later use.
     m_strBOINCMGRRootDirectory = szPath;
+#elif defined(__WXGTK__)
+    char path[PATH_MAX];
+    if (!get_real_executable_path(path, PATH_MAX)) {
+        // find path component
+        char* name = strrchr(path, '/');
+        if (name) {
+            name++;
+            *name = '\0';
+            m_strBOINCMGRRootDirectory = path;
+        }
+    }
 #endif
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1017,6 +1017,11 @@ if test -e "/proc/self/stat"; then
     AC_DEFINE(HAVE__PROC_SELF_STAT, 1, [Define to 1 if /proc/self/stat exists])
 fi
 
+dnl Check for /proc/self/exe (Linux)
+if test -e "/proc/self/exe"; then
+    AC_DEFINE(HAVE__PROC_SELF_EXE, 1, [Define to 1 if /proc/self/exe exists])
+fi
+
 dnl Check for /proc/meminfo (Linux)
 if test -e "/proc/meminfo"; then
     AC_DEFINE(HAVE__PROC_MEMINFO, 1, [Define to 1 if /proc/meminfo exists])

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -625,3 +625,20 @@ double rand_normal() {
     cached = true;
     return z*cos(PI2*u2);
 }
+
+// determines the real path and filename of the current process
+// not the current working directory
+//
+int get_real_executable_path(char* path, size_t max_len) {
+#ifdef HAVE__PROC_SELF_EXE
+    int ret = readlink("/proc/self/exe", path, max_len);
+    if ( ret >= 0) {
+        path[ret] = '\0'; // readlink does not null terminate
+        return 0;
+    } else {
+        perror("readlink");
+        return ERR_PROC_PARSE;
+    }
+#endif
+    return ERR_NOT_IMPLEMENTED;
+}

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -636,7 +636,11 @@ int get_real_executable_path(char* path, size_t max_len) {
         path[ret] = '\0'; // readlink does not null terminate
         return 0;
     } else {
+#ifdef _USING_FCGI_
+        FCGI::perror("readlink");
+#else
         perror("readlink");
+#endif
         return ERR_PROC_PARSE;
     }
 #endif

--- a/lib/util.h
+++ b/lib/util.h
@@ -110,6 +110,8 @@ extern bool process_exists(int);
 
 extern int wait_client_mutex(const char* dir, double timeout);
 
+extern int get_real_executable_path(char* path, size_t max_len);
+
 #ifdef GCL_SIMULATOR
 extern double simtime;
 #define time(x) ((int)simtime)


### PR DESCRIPTION
This was not working because the manager was not detecting its own executable name and path so it couldn't start a new instance of itself. Windows and Mac use different codepaths so it worked there.
The new library function can be extended for Windows and Mac to avoid code duplication.

Fixes #1177 