### PR TITLE
Drupal: Added ability to add context to other-boinc-translation-strings text file.

### DIFF
--- a/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
+++ b/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
@@ -861,10 +861,17 @@ function boinctranslate_refresh_translations() {
           $line = explode("|", $string);
           if ($line) {
             if (count($line)==1) {
-              bts($line[0]);
+              $tl0 = trim($line[0]);
+              if ($tl0) {
+                bts($tl0);
+              }
             }
             elseif (count($line)>1) {
-              bts($line[0], array(), NULL, $line[1]);
+              $tl0 = trim($line[0]);
+              $tl1 = trim($line[1]);
+              if ($tl0 and $tl1) {
+                bts($tl0, array(), NULL, $tl1);
+              }
             }
           }// if ($line)
 

--- a/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
+++ b/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
@@ -853,10 +853,24 @@ function boinctranslate_refresh_translations() {
       foreach ($other_strings as $string) {
         $string = trim($string);
         if ($string) {
-          bts($string);
-        }
-      }
-    }
+          // Ignore lines starting with '#' i.e., comments.
+          if ($string[0] === "#")
+            continue;
+
+          // Use '|' as delimiter to split string and context info.
+          $line = explode("|", $string);
+          if ($line) {
+            if (count($line)==1) {
+              bts($line[0]);
+            }
+            elseif (count($line)>1) {
+              bts($line[0], array(), NULL, $line[1]);
+            }
+          }// if ($line)
+
+        }// if ($string)
+      }// foreach
+    }// if ($other_strings)
   }
   
   foreach ($languages as $langcode => $language) {

--- a/drupal/sites/default/boinc/modules/boinctranslate/includes/other-boinc-translation-strings.txt
+++ b/drupal/sites/default/boinc/modules/boinctranslate/includes/other-boinc-translation-strings.txt
@@ -1,11 +1,34 @@
+# Format: Each line should one one string and (optionally) one context detail.
+# Lines starting with '#' are ignored as comments.
+# STRING|CONTEXT
+#
+# Use the pipe '|' character as the delimiter to separate the two items. You
+# cannot use the '|' pipe character in your string. If the '|' delimiter is not
+# present, no context details will be passed. If additional '|' delimiters are
+# found, they and the subsequent text will be ignored.
+#
+# Context details are of the format textgroup:type:objectid:property.
+#
+# The textgroup determines the category of the string and the type is where
+# the string originates. You can further denote a specific object ID (e.g. node
+# ID), if appropriate, and then the final property item can be used if more
+# specificity is still required. Generally, a simple textgroup:type context is
+# sufficient.
+#
 Password
 Enter the password that accompanies your username.
 Request new password
-Mark all topics read
-Mark all forums read
+Mark all topics read|boinc:forum
+Mark all forums read|boinc:forum
 CAPTCHA validation error: unknown CAPTCHA session ID. Contact the site administrator if this problem persists.
 The answer you entered for the CAPTCHA was not correct.
 Access denied. You must login to view this page.
 You are not authorized to access this page.
-Disable rich-text
-Enable rich-text
+Disable rich-text|boinc:forum
+Enable rich-text|boinc:forum
+subscribe|boinc:forum-thread-subscribe
+unsubscribe|boinc:forum-thread-subscribe
+Report|boinc:forum
+Cancel report|boinc:forum
+Reset flags|boinc:forum
+Ignore user|boinc:forum


### PR DESCRIPTION
boinctranslate module will read file and use '|' as delimiter to separate the string from its context.
Added context to a number of strings in the other-boinc-translation-strings file.

https://dev.gridrepublic.org/browse/DBOINCP-361