### PR TITLE
Drupal: Removed another line in user_profiles feature to remove overrides.

### DIFF
--- a/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
@@ -35,7 +35,6 @@ function user_profiles_menu_default_menu_links() {
       'attributes' => array(
         'title' => '',
       ),
-      'alter' => TRUE,
     ),
     'module' => 'menu',
     'hidden' => '0',


### PR DESCRIPTION
Similar to #1803 