### PR TITLE
Drupal: Fix respdes header and menu

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/boinc.info
+++ b/drupal/sites/default/boinc/themes/boinc/boinc.info
@@ -57,6 +57,7 @@ scripts[] = js/fancy-radios.js
 scripts[] = js/jquery.equalheights.js
 scripts[] = js/script.js
 scripts[] = js/jquery.detectwidths.js
+scripts[] = js/jquery.headerwidth.js
 
   ; The regions defined in Zen's default page.tpl.php file.  The name in
   ; brackets is the name of the variable in the page.tpl.php file, (e.g.

--- a/drupal/sites/default/boinc/themes/boinc/css/responsive-jswidth.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/responsive-jswidth.css
@@ -2,6 +2,7 @@
 
 /**
  * @file
+ * Responsive Javascript Styling
  *
  * Contains CSS styles to handle different screen sizes. This CSS file is used
  * for the responsive Javascript width theme. 
@@ -12,7 +13,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 /* Hide the mobile menu icon. */
-
 .has-js #block-mobile_menu_toggle-0.usenavbar {
   display: none;
 }
@@ -39,18 +39,14 @@
   min-height: 31px;
 }
 
-
 /* Show the hamburger menu and the menu block. */
 .has-js #block-mobile_menu_toggle-0.usehamburger {
   display: block;
-  position: absolute;
-  /* Place icon in lower-left. */
-  left: 0;
-  /* Place icon in upper-right. */
-  /*right: 0;
-  top: 0;*/
-  padding: 1px 9px;
-  margin: 0 3px;
+  position: relative;
+  padding-top: 3px;
+  margin: 0 auto;
+  max-width: 980px;
+  padding-left: 20px;
 }
 
 .has-js #mobile-menu-toggle {
@@ -90,18 +86,12 @@
   padding: 0 20px;
 }
   
-/* Remove height style for navigation <a> links, 
-   Remove padding as well. */
-.has-js #navigation.usehamburger li a {
-  height: auto;
-  padding: 0;
-}
-
 /* Set base mobile menu font color and size. */
 .has-js #navigation.usehamburger .block .menu li a {
   color: #faa341;
   font-size: 14px;
   height: auto;
+  padding: 0;
 }
 
 /* Add active and hover color for links in mobile menu. */

--- a/drupal/sites/default/boinc/themes/boinc/css/responsive-media.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/responsive-media.css
@@ -36,6 +36,11 @@
     margin: 16px 12px 12px;
   }
 
+  /* Header adjustment when hamburger menu is onscreen. */
+  #header {
+    max-width: none;
+  }
+
   /* Hide the mobile menu icon. Hide the mobile navigation menu. */
   #navigation-mmt {
     display: none;
@@ -71,6 +76,11 @@
   #sub-menu ul,
   #action-links ul {
     display: none;
+  }
+
+  /* Header adjustment when hamburger menu is onscreen. */
+  #header {
+    max-width: none;
   }
 
   /* Set the navigation bar space for the mobile menu.*/
@@ -109,13 +119,6 @@
     padding: 0 20px;
   }
   
-  /* Remove height style for navigation <a> links, 
-   Remove padding as well. */
-  #navigation li a {
-    height: auto;
-    padding: 0;
-  }
-
   /* Set base mobile menu font color and size. */
   #navigation .block .menu li a {
     color: #faa341;

--- a/drupal/sites/default/boinc/themes/boinc/js/jquery.detectwidths.js
+++ b/drupal/sites/default/boinc/themes/boinc/js/jquery.detectwidths.js
@@ -7,6 +7,13 @@
  * text width is too wide for the screen, inject CSS to toggle between
  * using a hamburger menu (usehamburger) or a navigation bar
  * (usenavbar).
+ *
+ * If the menubar text is so wide it will not fit on the desktop width
+ * site (980 px), then the CSS class (oversizemenubar) will be
+ * used. In addition, the oversize flag will be set. This flag informs
+ * the resize function not to swap out the hamburger menu
+ * (userhamburger) for the navigation bar, as the latter will be too
+ * wide for the layout.
  */
 
 /* 
@@ -19,32 +26,106 @@
 var padding = 30;
 var mobile_bp = 750;
 var desktop_min = 980;
+var oversize = 0;
+
+/*
+ * jQuery plugin from http://www.foliotek.com/devblog/getting-the-width-of-a-hidden-element-with-jquery-using-width/
+ * Obtains the width of the hidden item.
+ * Returns a dim object containing the items heights and widths.
+ */
+(function ($) {
+$.fn.getHiddenDimensions = function (includeMargin) {
+    var $item = this,
+    props = { display: 'block' },
+    dim = { width: 0, height: 0, innerWidth: 0, innerHeight: 0, outerWidth: 0, outerHeight: 0 },
+    $hiddenParents = $item.parents().andSelf().not(':visible'),
+    includeMargin = (includeMargin == null) ? false : includeMargin;
+
+    var oldProps = [];
+    $hiddenParents.each(function () {
+        var old = {};
+
+        for (var name in props) {
+            old[name] = this.style[name];
+            this.style[name] = props[name];
+        }
+
+        oldProps.push(old);
+    });
+
+    dim.width = $item.width();
+    dim.outerWidth = $item.outerWidth(includeMargin);
+    dim.innerWidth = $item.innerWidth();
+    dim.height = $item.height();
+    dim.innerHeight = $item.innerHeight();
+    dim.outerHeight = $item.outerHeight(includeMargin);
+
+    $hiddenParents.each(function (i) {
+        var old = oldProps[i];
+        for (var name in props) {
+            this.style[name] = old[name];
+        }
+    });
+
+    return dim;
+}
+}(jQuery));
+
+
+/**
+ * Helper function to obtain the width of the navigation bar elements,
+ * regardless of its visibility.
+ *
+ * Returns the total width of the two menu items plus padding.
+ */
+function getNavWidth() {
+  var maindims   = $('#main-menu ul').getHiddenDimensions();
+  var actiondims = $('#action-links ul').getHiddenDimensions();
+  var total_width = maindims.outerWidth + actiondims.outerWidth + padding;
+  return total_width;
+}
 
 $(document).ready(function() {
   var window_width = $(window).width();
-  var total_width = $('#main-menu ul').width() + $('#action-links ul').width();
-    if ( ((total_width+padding) > window_width) || window_width <= mobile_bp ) {
+  var total_width = getNavWidth();
+  if ( ((total_width) > Math.min(window_width, desktop_min)) || window_width <= mobile_bp ) {
     $('#header-wrapper div').addClass('usehamburger');
   } else {
     $('#header-wrapper div').addClass('usenavbar');
   }
-
+  if (total_width > desktop_min) {
+    oversize = 1;
+    if (window_width > desktop_min) {
+      $('#header-wrapper div').addClass('oversizemenubar');
+    }
+  }
 });
 
 
 $(window).resize(function() {
   var window_width = $(window).width();
+  var total_width = getNavWidth();
+
+  if (total_width > desktop_min) {
+    oversize = 1;
+    if (window_width > desktop_min) {
+      $('#header-wrapper div').addClass('oversizemenubar');
+    } else {
+      $('#header-wrapper div').removeClass('oversizemenubar');
+    }
+  }
+
   if ($('#header-wrapper div').hasClass('usenavbar')) {
-    var total_width = $('#main-menu ul').width() + $('#action-links ul').width();
-    if ((total_width+padding) > window_width || window_width <= mobile_bp ) {
+    if ( total_width > Math.min(window_width, desktop_min) || window_width <= mobile_bp ) {
       $('#header-wrapper div').removeClass('usenavbar');
       $('#header-wrapper div').addClass('usehamburger');
     }
-  }	
-  if ($('#header-wrapper div').hasClass('usehamburger') && (window_width >= desktop_min)) {
-    $('#header-wrapper div').removeClass('usehamburger');
-    $('#header-wrapper div').addClass('usenavbar');
-
+  }
+  if ($('#header-wrapper div').hasClass('usehamburger')) {
+    if ( (window_width >= desktop_min) && !oversize ) {
+      $('#header-wrapper div').removeClass('usehamburger');
+      $('#header-wrapper div').addClass('usenavbar');
+    }
     // Set CSS of mobile menu to display: none when window is resized.
     document.getElementById("navigation-mmt").style.display = "none";
   }

--- a/drupal/sites/default/boinc/themes/boinc/js/jquery.headerwidth.js
+++ b/drupal/sites/default/boinc/themes/boinc/js/jquery.headerwidth.js
@@ -1,0 +1,32 @@
+/**
+ * Jquery function to change the header width dependning on whether or
+ * not the document elements are too wide for the screen. Uses
+ * clientWidth and scrollWidth, if the scrollWidth is larger than
+ * clientWidth, then some element is too wide for the screen. The
+ * header width is set to the scrollWidth.
+ *
+ * The actual HTML element set is div id=page. The CSS width is set to
+ * the scrollWidth.
+ */
+function setheaderwidth() {
+  var cw  = document.documentElement["clientWidth"];
+  var swh = document.documentElement["scrollWidth"];
+  var swb = document.body["scrollWidth"];
+  var sw = Math.max(swh, swb);
+
+  if (cw < sw) {
+    $('#page').css('width', sw+'px');
+  }
+  else {
+    $('#page').css('width', '');
+  }
+}
+
+$(document).ready(function() {
+  setheaderwidth();
+});
+
+
+$(window).resize(function() {
+  setheaderwidth();
+})


### PR DESCRIPTION
Use javascript to set the width of the header to the width of the content of the page.

Fixed bug where navigation menu bar which is wider than the width of the 980px desktop layout, and breaks the layout. If the whole navigation bar is larger that 980px, use the mobile menu instead.

https://dev.gridrepublic.org/browse/DBOINCP-250