### PR TITLE
Drupal: fix i18n add missing strings

### DIFF
--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.menu_custom.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.menu_custom.inc
@@ -13,7 +13,7 @@ function boinc_standard_menu_default_menu_custom() {
     'description' => 'Auxiliary menu, typically at the bottom of the page in the footer, that includes links to content such as "about us" or "privacy policy" etc.',
   );
   // Translatables
-  // Included for use with string extractors like potx.
+  // Title and description for footer menu appears in admin menu: Admin> Site Building> Menus
   t('Auxiliary menu, typically at the bottom of the page in the footer, that includes links to content such as "about us" or "privacy policy" etc.');
   t('Footer links');
 

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.menu_links.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.menu_links.inc
@@ -82,11 +82,10 @@ function boinc_standard_menu_default_menu_links() {
   );
   // Translatables
   // Included for use with string extractors like potx.
-  t('BOINC');
-  t('Credentials');
-  t('Dashboard');
-  t('Home');
-
+  bts('Home', array(), NULL, 'boinc:menu-link');
+  bts('Credentials', array(), NULL, 'boinc:menu-link');
+  bts('Dashboard', array(), NULL, 'boinc:menu-link');
+  bts('BOINC', array(), NULL, 'boinc:footer-link');
 
   return $menu_links;
 }

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.menu_links.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.menu_links.inc
@@ -81,7 +81,7 @@ function boinc_standard_menu_default_menu_links() {
     'parent_path' => 'dashboard',
   );
   // Translatables
-  // Included for use with string extractors like potx.
+  // Use bts() function to translate additional strings.
   bts('Home', array(), NULL, 'boinc:menu-link');
   bts('Credentials', array(), NULL, 'boinc:menu-link');
   bts('Dashboard', array(), NULL, 'boinc:menu-link');

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.pages_default.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.pages_default.inc
@@ -118,7 +118,7 @@ function boinc_standard_default_page_manager_pages() {
     $pane->access = array();
     $pane->configuration = array(
       'override_title' => 1,
-      'override_title_text' => 'My stats',
+      'override_title_text' => bts('My stats', array(), NULL, 'boinc:account-dashboard'),
     );
     $pane->cache = array();
     $pane->style = array(

--- a/drupal/sites/all/features/friends/friends.views_default.inc
+++ b/drupal/sites/all/features/friends/friends.views_default.inc
@@ -95,7 +95,7 @@ function friends_views_default_views() {
   $handler->override_option('cache', array(
     'type' => 'none',
   ));
-  $handler->override_option('empty', 'No Friends have been added.');
+  $handler->override_option('empty', bts('No Friends have been added.', array(), NULL, 'boinc:friends-page'));
   $handler->override_option('empty_format', '5');
   $handler->override_option('use_pager', '1');
   $handler->override_option('distinct', 1);
@@ -294,7 +294,7 @@ function friends_views_default_views() {
   $handler->override_option('path', 'account/%/friends/all');
   $handler->override_option('menu', array(
     'type' => 'default tab',
-    'title' => 'View All Friends',
+    'title' => bts('View All Friends', array(), NULL, 'boinc:friends-page'),
     'description' => '',
     'weight' => '-10',
     'name' => 'navigation',
@@ -523,7 +523,7 @@ function friends_views_default_views() {
   $handler->override_option('path', 'account/%/friends/pending');
   $handler->override_option('menu', array(
     'type' => 'tab',
-    'title' => 'Friend Requests',
+    'title' => bts('Friend Requests', array(), NULL, 'boinc:friends-page'),
     'description' => '',
     'weight' => '0',
     'name' => 'navigation',
@@ -718,7 +718,7 @@ function friends_views_default_views() {
   $handler->override_option('path', 'account/%/friends/flagged');
   $handler->override_option('menu', array(
     'type' => 'tab',
-    'title' => 'Awaiting Friend Approvals',
+    'title' => bts('Awaiting Friend Approvals', array(), NULL, 'boinc:friends-page'),
     'description' => '',
     'weight' => '0',
     'name' => 'navigation',

--- a/drupal/sites/all/features/global_search_solr/global_search_solr.apachesolr_search_defaults.inc
+++ b/drupal/sites/all/features/global_search_solr/global_search_solr.apachesolr_search_defaults.inc
@@ -13,7 +13,7 @@ function global_search_solr_apachesolr_search_default_searchers() {
   $searcher->label = 'Core Search';
   $searcher->description = 'Core Search';
   $searcher->search_path = 'search/site';
-  $searcher->page_title = 'Search site';
+  $searcher->page_title = bts('Search site', array(), NULL, 'boinc:search-page');
   $searcher->env_id = 'solr';
   $searcher->settings = array(
     'fq' => array(),

--- a/drupal/sites/all/features/news/news.features.menu_links.inc
+++ b/drupal/sites/all/features/news/news.features.menu_links.inc
@@ -26,7 +26,7 @@ function news_menu_default_menu_links() {
     'weight' => '-48',
   );
   // Translatables
-  // Included for use with string extractors like potx.
+  // Use bts() function to translate additional strings.
   bts('News', array(), NULL, 'boinc:menu-link');
 
 

--- a/drupal/sites/all/features/news/news.features.menu_links.inc
+++ b/drupal/sites/all/features/news/news.features.menu_links.inc
@@ -27,7 +27,7 @@ function news_menu_default_menu_links() {
   );
   // Translatables
   // Included for use with string extractors like potx.
-  t('News');
+  bts('News', array(), NULL, 'boinc:menu-link');
 
 
   return $menu_links;

--- a/drupal/sites/all/features/private_messages/private_messages.panels_default.inc
+++ b/drupal/sites/all/features/private_messages/private_messages.panels_default.inc
@@ -39,12 +39,15 @@ function private_messages_default_panels_mini() {
     $pane->configuration = array(
       'admin_title' => 'Mail summary',
       'title' => 'Messages',
-      'body' => '<?php global $base_path; ?>
+      'body' => '<?php 
+  $l1 = url(\'messages\');
+  $l2 = url(\'messages/new\');
+?>
 <ul class="tab-list">
   <li class="first tab"><div>
-    <a href="<?php echo $base_path; ?>messages"><?php print bts(\'Inbox\'); ?></a><div class="item-count-wrapper"><span class="item-count"><?php echo privatemsg_unread_count(); ?></span></div></div>
+    <a href="<?php echo $l1;?>"><?php print bts(\'Inbox\', array(), NULL, \'boinc:account-dashboard\'); ?></a><div class="item-count-wrapper"><span class="item-count"><?php echo privatemsg_unread_count(); ?></span></div></div>
   </li>
-  <li class="last tab"><a href="<?php echo $base_path; ?>messages/new"><?php print bts(\'Compose new\'); ?></a></li>
+  <li class="last tab"><a href="<?php echo $l2?>"><?php print bts(\'Compose new\', array(), NULL, \'boinc:account-dashboard\'); ?></a></li>
 </ul>',
       'format' => '3',
       'substitute' => TRUE,

--- a/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
+++ b/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
@@ -38,7 +38,7 @@ function stats_charts_default_panels_mini() {
     $pane->access = array();
     $pane->configuration = array(
       'admin_title' => 'Project stats overview',
-      'title' => 'Einstein@Home Progress',
+      'title' => bts('Einstein@Home Progress', array(), NULL, 'boinc:frontpage'),
       'body' => '<?php echo boincstats_get_project_stats_overview(); ?>',
       'format' => '3',
       'substitute' => TRUE,

--- a/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
+++ b/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
@@ -38,7 +38,7 @@ function stats_charts_default_panels_mini() {
     $pane->access = array();
     $pane->configuration = array(
       'admin_title' => 'Project stats overview',
-      'title' => variable_get('site_name', '') . " " . bts("Progress", array(), NULL, 'boinc:frontpage'),
+      'title' => bts('@this_project Progress', array('@this_project' => variable_get('site_name', '')), NULL, 'boinc:frontpage'),
       'body' => '<?php echo boincstats_get_project_stats_overview(); ?>',
       'format' => '3',
       'substitute' => TRUE,

--- a/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
+++ b/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
@@ -38,7 +38,7 @@ function stats_charts_default_panels_mini() {
     $pane->access = array();
     $pane->configuration = array(
       'admin_title' => 'Project stats overview',
-      'title' => bts('Einstein@Home Progress', array(), NULL, 'boinc:frontpage'),
+      'title' => variable_get('site_name', '') . " " . bts("Progress", array(), NULL, 'boinc:frontpage'),
       'body' => '<?php echo boincstats_get_project_stats_overview(); ?>',
       'format' => '3',
       'substitute' => TRUE,

--- a/drupal/sites/all/features/stats_charts/stats_charts.views_default.inc
+++ b/drupal/sites/all/features/stats_charts/stats_charts.views_default.inc
@@ -527,7 +527,7 @@ function stats_charts_views_default_views() {
     'nothing' => array(
       'label' => '',
       'alter' => array(
-        'text' => 'Certificates',
+        'text' => bts('Certificates', array(), NULL, 'boinc:account-dashboard'),
         'make_link' => 1,
         'path' => 'account/certs',
         'absolute' => 0,
@@ -834,7 +834,7 @@ function stats_charts_views_default_views() {
       'hide_alter_empty' => 1,
       'value' => '<?php
 
-echo l(t(\'Show computers\'), \'account/\' . get_drupal_id($data->id) . \'/computers\');
+echo l(bts(\'Show computers\', array(), NULL, \'boinc:accountpage\'), \'account/\' . get_drupal_id($data->id) . \'/computers\');
 
 ?>',
       'exclude' => 0,

--- a/drupal/sites/all/features/user_account_host_list/user_account_host_list.views_default.inc
+++ b/drupal/sites/all/features/user_account_host_list/user_account_host_list.views_default.inc
@@ -830,7 +830,7 @@ function user_account_host_list_views_default_views() {
   $handler->override_option('path', 'account/computers/all');
   $handler->override_option('menu', array(
     'type' => 'tab',
-    'title' => 'All computers',
+    'title' => bts('All computers', array(), NULL, 'boinc:account-host-list'),
     'description' => 'Show all computers associated with the account',
     'weight' => '1',
     'name' => 'navigation',
@@ -870,7 +870,7 @@ function user_account_host_list_views_default_views() {
   $handler->override_option('path', 'account/computers/active');
   $handler->override_option('menu', array(
     'type' => 'default tab',
-    'title' => 'Computers active in past 30 days',
+    'title' => bts('Computers active in past 30 days', array(), NULL, 'boinc:account-host-list'),
     'description' => '',
     'weight' => '0',
     'name' => 'navigation',

--- a/drupal/sites/all/features/user_account_project_list/user_account_project_list.panels_default.inc
+++ b/drupal/sites/all/features/user_account_project_list/user_account_project_list.panels_default.inc
@@ -38,7 +38,7 @@ function user_account_project_list_default_panels_mini() {
     $pane->access = array();
     $pane->configuration = array(
       'admin_title' => 'Dashboard project table',
-      'title' => 'Projects',
+      'title' => bts('Projects', array(), NULL, 'boinc:account-dashboard'),
       'body' => '<?php echo boincuser_get_projects_table(); ?>',
       'format' => '3',
       'substitute' => TRUE,

--- a/drupal/sites/all/features/user_preferences/user_preferences.features.menu_links.inc
+++ b/drupal/sites/all/features/user_preferences/user_preferences.features.menu_links.inc
@@ -27,8 +27,10 @@ function user_preferences_menu_default_menu_links() {
   );
   // Translatables
   // Included for use with string extractors like potx.
-  t('Preferences');
-
+  bts('Preferences', array(), NULL, 'boinc:menu-link');
+  bts('Community', array(), NULL, 'boinc:menu-link');
+  bts('Privacy', array(), NULL, 'boinc:menu-link');
+  bts('Subscriptions', array(), NULL, 'boinc:menu-link');
 
   return $menu_links;
 }

--- a/drupal/sites/all/features/user_preferences/user_preferences.features.menu_links.inc
+++ b/drupal/sites/all/features/user_preferences/user_preferences.features.menu_links.inc
@@ -26,7 +26,7 @@ function user_preferences_menu_default_menu_links() {
     'parent_path' => 'dashboard',
   );
   // Translatables
-  // Included for use with string extractors like potx.
+  // Use bts() function to translate additional strings.
   bts('Preferences', array(), NULL, 'boinc:menu-link');
   bts('Community', array(), NULL, 'boinc:menu-link');
   bts('Privacy', array(), NULL, 'boinc:menu-link');

--- a/drupal/sites/all/features/user_preferences/user_preferences.views_default.inc
+++ b/drupal/sites/all/features/user_preferences/user_preferences.views_default.inc
@@ -448,7 +448,7 @@ elseif ($data->node_type == \'news\') {
   $handler->override_option('path', 'account/prefs/subscriptions');
   $handler->override_option('menu', array(
     'type' => 'tab',
-    'title' => 'Subscriptions',
+    'title' => bts('Subscriptions', array(), NULL, 'boinc:account-dashboard'),
     'description' => '',
     'weight' => '20',
     'name' => 'primary-links',
@@ -778,7 +778,7 @@ elseif ($data->node_type == \'news\') {
       'relationship' => 'none',
     ),
     'last_updated' => array(
-      'label' => 'Updated',
+      'label' => bts('Updated', array(), NULL, 'boinc:account-dashboard'),
       'alter' => array(
         'alter_text' => 0,
         'text' => '',

--- a/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
@@ -695,7 +695,7 @@ Zimbabwe|Zimbabwe',
         ),
       ),
       'default_value_php' => NULL,
-      'label' => 'Postal code',
+      'label' => bts('Postal code', array(), NULL, 'boinc:account-profile-edit'),
       'weight' => '6',
       'description' => '',
       'type' => 'text_textfield',
@@ -704,7 +704,7 @@ Zimbabwe|Zimbabwe',
   );
 
   // Translatables
-  // Included for use with string extractors like potx.
+  // Use bts() function to translate additional strings.
   bts('Avatar', array(), NULL, 'boinc:account-profile-edit');
   bts('Country', array(), NULL, 'boinc:account-profile-edit');
   bts('Profile image', array(), NULL, 'boinc:account-profile-edit');

--- a/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
@@ -60,9 +60,9 @@ function user_profiles_content_default_fields() {
         ),
       ),
       'default_value_php' => NULL,
-      'label' => 'Your personal background',
+      'label' => bts('Your personal background', array(), NULL, 'boinc:account-profile-edit'),
       'weight' => '3',
-      'description' => 'Tell us about yourself. You could tell us where you\'re from, your age, occupation, hobbies, or anything else about yourself. ',
+      'description' => bts('Tell us about yourself. You could tell us where you\'re from, your age, occupation, hobbies, or anything else about yourself.', array(), NULL, 'boinc:account-profile-edit'),
       'type' => 'text_textarea',
       'module' => 'text',
     ),
@@ -490,13 +490,13 @@ Zimbabwe|Zimbabwe',
         ),
       ),
       'default_value_php' => NULL,
-      'label' => 'Your opinions about this project',
+      'label' => bts('Your opinions about this project', array(), NULL, 'boinc:account-profile-edit'),
       'weight' => '4',
-      'description' => 'Tell us your thoughts about Einstein@Home
-
-   1. Why do you run Einstein@Home?
+      'description' => bts('Tell us your thoughts about @this_project
+   1. Why do you run @this_project?
    2. What are your views about the project?
-   3. Any suggestions? ',
+   3. Any suggestions?',
+      array('@this_project' => variable_get('site_name','')), NULL, 'boinc:account-profile-edit'),
       'type' => 'text_textarea',
       'module' => 'text',
     ),
@@ -695,7 +695,7 @@ Zimbabwe|Zimbabwe',
         ),
       ),
       'default_value_php' => NULL,
-      'label' => 'Zip code',
+      'label' => 'Postal code',
       'weight' => '6',
       'description' => '',
       'type' => 'text_textfield',
@@ -705,13 +705,13 @@ Zimbabwe|Zimbabwe',
 
   // Translatables
   // Included for use with string extractors like potx.
-  t('Avatar');
-  t('Country');
-  t('Profile image');
-  t('Website URL');
-  t('Your opinions about this project');
-  t('Your personal background');
-  t('Zip code');
+  bts('Avatar', array(), NULL, 'boinc:account-profile-edit');
+  bts('Country', array(), NULL, 'boinc:account-profile-edit');
+  bts('Profile image', array(), NULL, 'boinc:account-profile-edit');
+  bts('Website URL', array(), NULL, 'boinc:account-profile-edit');
+  bts('Your opinions about this project', array(), NULL, 'boinc:account-profile-edit');
+  bts('Your personal background', array(), NULL, 'boinc:account-profile-edit');
+  bts('Postal code', array(), NULL, 'boinc:account-profile-edit');
 
   return $fields;
 }

--- a/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
@@ -45,7 +45,7 @@ function user_profiles_menu_default_menu_links() {
     'parent_path' => 'moderate',
   );
   // Translatables
-  // Included for use with string extractors like potx.
+  // Use bts() function to translate additional strings.
   bts('Queue', array(), NULL, 'boinc:menu-link');
   bts('Profile', array(), NULL, 'boinc:menu-link');
 

--- a/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.menu_links.inc
@@ -46,9 +46,8 @@ function user_profiles_menu_default_menu_links() {
   );
   // Translatables
   // Included for use with string extractors like potx.
-  t('Queue');
-  t('Profile');
-
+  bts('Queue', array(), NULL, 'boinc:menu-link');
+  bts('Profile', array(), NULL, 'boinc:menu-link');
 
   return $menu_links;
 }

--- a/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
+++ b/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
@@ -5665,7 +5665,7 @@ Cross-project stats:
   $handler->override_option('path', 'account/%/computers/active');
   $handler->override_option('menu', array(
     'type' => 'default tab',
-    'title' => 'Active in past 30 days',
+    'title' => bts('Active in past 30 days', array(), NULL, 'boinc:user-host-list'),
     'description' => 'Show only computers that have been active in the past month',
     'weight' => '0',
     'name' => 'navigation',
@@ -5681,7 +5681,7 @@ Cross-project stats:
   $handler->override_option('path', 'account/%/computers/all');
   $handler->override_option('menu', array(
     'type' => 'tab',
-    'title' => 'All computers',
+    'title' => bts('All computers', array(), NULL, 'boinc:user-host-list'),
     'description' => 'Show all computers associated with the account',
     'weight' => '1',
     'name' => 'navigation',
@@ -7415,7 +7415,7 @@ else {
       'relationship' => 'none',
     ),
     'workunitid' => array(
-      'label' => 'Work unit ID',
+      'label' => 'Workunit ID',
       'alter' => array(
         'alter_text' => 0,
         'text' => '',
@@ -8841,7 +8841,7 @@ else {
       'relationship' => 'none',
     ),
     'workunitid' => array(
-      'label' => 'Work unit ID',
+      'label' => 'Workunit ID',
       'alter' => array(
         'alter_text' => 0,
         'text' => '',

--- a/drupal/sites/default/boinc/modules/boinctranslate/includes/other-boinc-translation-strings.txt
+++ b/drupal/sites/default/boinc/modules/boinctranslate/includes/other-boinc-translation-strings.txt
@@ -32,3 +32,11 @@ Report|boinc:forum
 Cancel report|boinc:forum
 Reset flags|boinc:forum
 Ignore user|boinc:forum
+All tasks|boinc:workunit-and-host-lists
+Time reported or deadline|boinc:workunit-and-host-lists
+Run time (sec)|boinc:task-deatils
+CPU time (sec)|boinc:task-deatils
+Canonical result|boinc:workunit-details
+Minimum quorum|boinc:workunit-details
+Initial replication|boinc:workunit-details
+Max # of error/total/success tasks|boinc:workunit-details

--- a/drupal/sites/default/boinc/modules/boinctranslate/includes/other-boinc-translation-strings.txt
+++ b/drupal/sites/default/boinc/modules/boinctranslate/includes/other-boinc-translation-strings.txt
@@ -34,8 +34,8 @@ Reset flags|boinc:forum
 Ignore user|boinc:forum
 All tasks|boinc:workunit-and-host-lists
 Time reported or deadline|boinc:workunit-and-host-lists
-Run time (sec)|boinc:task-deatils
-CPU time (sec)|boinc:task-deatils
+Run time (sec)|boinc:task-details
+CPU time (sec)|boinc:task-details
 Canonical result|boinc:workunit-details
 Minimum quorum|boinc:workunit-details
 Initial replication|boinc:workunit-details

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -416,7 +416,7 @@ function boincuser_request_pass_validate($form, &$form_state) {
  */
 function boincuser_authloginform() {
   $headers = apache_request_headers();
-  $project_name = variable_get('site_name', 'einsteinathome.org');
+  $project_name = variable_get('site_name', 'Drupal-BOINC');
   $project_domain = $headers['Host'];
   $form['heading'] = array(
     '#type' => 'markup',

--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -487,9 +487,8 @@ function boinc_preprocess_search_result(&$variables) {
   $type = strtolower($variables['result']['type']);
   switch ($type) {
   case 'team':
-    global $base_url;
     $node = $variables['result']['node'];
-    $variables['url'] = $base_url .'/community/teams/' . $node->entity_id;
+    $variables['url'] = url('/community/teams/' . $node->entity_id);;
     break;
   default:
   }
@@ -774,13 +773,13 @@ function _boinc_action_links() {
 
   $output = '<ul class="menu"><li class="first">';
   if ($user->uid) {
-    $output .= '<a href="' . $base_path . 'logout">' . bts('Logout') . '</a>';
+    $output .= '<a href="' . url('logout') . '">' . bts('Logout') . '</a>';
   } else {
-    $output .= '<a href="' . $base_path . 'user/login?' . drupal_get_destination() . '">' . bts('Login') . '</a>';
+    $output .= '<a href="' . url('user/login', array('query' => drupal_get_destination()) ) . '">' . bts('Login') . '</a>';
   }
   $output .= '</li>';
   if (module_exists('global_search') OR module_exists('global_search_solr')) {
-    $output .= '<li class="last"> <a class="search" href="' . $base_path . 'search/site">' . bts('search') . '</a> </li>';
+    $output .= '<li class="last"> <a class="search" href="' . url('search/site') . '">' . bts('search') .'</a> </l1>';
   }
   $output .= '</ul>';
   return $output;

--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -484,12 +484,42 @@ function boinc_preprocess_block(&$vars, $hook) {
 // */ 
 
 function boinc_preprocess_search_result(&$variables) {
-  $type = strtolower($variables['result']['type']);
+  $type = strtolower($variables['result']['bundle']);
   switch ($type) {
+  case 'profile':
+  case 'user':
+    $node = $variables['result']['node'];
+    $variables['url'] = url('account/' . $node->is_uid);
+    $variables['title'] = $node->tos_name;
+    $variables['user_image'] = boincuser_get_user_profile_image($node->is_uid);
+    break;
   case 'team':
     $node = $variables['result']['node'];
     $variables['url'] = url('/community/teams/' . $node->entity_id);;
     break;
+  case 'forum':
+    $node = $variables['result']['node'];
+    $drupalnode = node_load($node->entity_id);
+    // Get the taxonomy for the node, creates a link to the parent forum
+    $taxonomy = reset($drupalnode->taxonomy);
+    if ($vocab = taxonomy_vocabulary_load($taxonomy->vid)) {
+      $variables['parent_forum'] = l($taxonomy->name, "community/forum/{$taxonomy->tid}");
+    }
+    break;
+  case 'comment':
+    // Get the node id for this comment
+    $nid = $variables['result']['fields']['tos_content_extra'];
+    $drupalnode = node_load($nid);
+    // Parent forum topic title
+    $variables['parent_title'] = $drupalnode->title;
+    // Link to the parent forum topic
+    $variables['parent_topic'] = l($drupalnode->title, drupal_get_path_alias('node/' . $nid) );
+    // Get the taxonomy for the node, creates a link to the parent forum
+    $taxonomy = reset($drupalnode->taxonomy);
+    if ($vocab = taxonomy_vocabulary_load($taxonomy->vid)) {
+      $variables['parent_forum'] = l($taxonomy->name, "community/forum/{$taxonomy->tid}");
+    }
+  break;
   default:
   }
 }

--- a/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
@@ -101,11 +101,11 @@
     ?>
     <div class="name"><?php print $author; ?></div>
     <?php if ($account->uid): ?>
-      <div class="join-date">Joined: <?php print date('j M y', $account->created); ?></div>
-      <div class="post-count">Posts: <?php print $account->post_count; ?></div>
-      <div class="credit">Credit: <?php print $account->boincuser_total_credit; ?></div>
-      <div class="rac">RAC: <?php print $account->boincuser_expavg_credit; ?></div>
-      
+      <div class="join-date"><?php print bts('Joined', array(), NULL, 'boinc:user-info') . ': ' . date('j M y', $account->created); ?></div>
+      <div class="post-count"><?php print bts('Posts', array(), NULL, 'boinc:user-info') . ': ' . $account->post_count; ?></div>
+      <div class="credit"><?php print bts('Credit', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_total_credit; ?></div>
+      <div class="rac"><?php print bts('RAC', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_expavg_credit; ?></div>
+
       <div class="user-links">
         <div class="ignore-link"><?php print l($ignore_link['ignore_user']['title'],
           $ignore_link['ignore_user']['href'],

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
@@ -144,11 +144,11 @@
       ?>
       <div class="name"><?php print $name; ?></div>
       <?php if ($account->uid): ?>
-        <div class="join-date">Joined: <?php print date('j M y', $account->created); ?></div>
-        <div class="post-count">Posts: <?php print $account->post_count; ?></div>
-        <div class="credit">Credit: <?php print $account->boincuser_total_credit; ?></div>
-        <div class="rac">RAC: <?php print $account->boincuser_expavg_credit; ?></div>
-        
+        <div class="join-date"><?php print bts('Joined', array(), NULL, 'boinc:user-info') . ': ' . date('j M y', $account->created); ?></div>
+        <div class="post-count"><?php print bts('Posts', array(), NULL, 'boinc:user-info') . ': ' . $account->post_count; ?></div>
+        <div class="credit"><?php print bts('Credit', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_total_credit; ?></div>
+        <div class="rac"><?php print bts('RAC', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_expavg_credit; ?></div>
+
         <div class="user-links">
           <div class="ignore-link"><?php print l($ignore_link['ignore_user']['title'],
             $ignore_link['ignore_user']['href'],

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
@@ -161,11 +161,11 @@
       ?>
       <div class="name"><?php print $name; ?></div>
       <?php if ($account->uid): ?>
-        <div class="join-date">Joined: <?php print date('j M y', $account->created); ?></div>
-        <div class="post-count">Posts: <?php print $account->post_count; ?></div>
-        <div class="credit">Credit: <?php print $account->boincuser_total_credit; ?></div>
-        <div class="rac">RAC: <?php print $account->boincuser_expavg_credit; ?></div>
-        
+        <div class="join-date"><?php print bts('Joined', array(), NULL, 'boinc:user-info') . ': ' . date('j M y', $account->created); ?></div>
+        <div class="post-count"><?php print bts('Posts', array(), NULL, 'boinc:user-info') . ': ' . $account->post_count; ?></div>
+        <div class="credit"><?php print bts('Credit', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_total_credit; ?></div>
+        <div class="rac"><?php print bts('RAC', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_expavg_credit; ?></div>
+1        
         <div class="user-links">
           <div class="ignore-link"><?php print l($ignore_link['ignore_user']['title'],
             $ignore_link['ignore_user']['href'],

--- a/drupal/sites/default/boinc/themes/boinc/templates/page.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/page.tpl.php
@@ -201,16 +201,15 @@
           <ul><li class="first">
             <?php 
               global $user;
-              global $base_path;
               if ($user->uid):
-                echo '<a href="' . $base_path . 'logout"><span class="secondary-link tab">' . bts('Logout') . '</span></a>';
+                echo '<a href="' . url('logout') . '"><span class="secondary-link tab">' . bts('Logout') . '</span></a>';
               else:
-                echo '<a href="' . $base_path . 'user/login?' . drupal_get_destination() . '"><span class="secondary-link tab">' . bts('Login') . '</span></a>';
+                echo '<a href="' . url('user/login', array('query' => drupal_get_destination()) ) . '"><span class="secondary-link tab">' . bts('Login') . '</span></a>';
               endif;
             ?>
             </li>
             <?php if (module_exists('global_search') OR module_exists('global_search_solr')): ?>
-              <li class="last"><a class="search" href="<?php print $base_path; ?>search/site"><span class="tab"><?php print bts('search'); ?></span></a></li>
+              <li class="last"><a class="search" href="<?php print url('search/site') ?>"><span class="tab"><?php print bts('search'); ?></span></a></li>
             <?php endif; ?>
           </ul>
         </div>

--- a/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
@@ -46,22 +46,12 @@
  * @see template_preprocess_search_result()
  */
 ?>
-<?php switch ($info_split['type']): ?>
+<?php switch ($result['bundle']): ?>
 <?php
   case 'Profile':
   case 'profile':
   case 'User':
   case 'user':
-    $nid = $result['fields']['entity_id'];
-    $node = node_load($nid);
-    $account = user_load($node->uid);
-    if (isset($account)) {
-      $user_image = boincuser_get_user_profile_image($account->uid);
-      $url = url('account/' . $account->uid);
-      if (empty($title)) {
-        $title = $account->boincuser_name;
-      }
-    }
   ?>
   <div class="result user">
     <?php if ($user_image['image']['filepath']): ?>
@@ -86,14 +76,8 @@
   <?php break; ?>
   
 <?php
-  case 'Forum topic':
-    $nid = $result['fields']['entity_id'];
-    $node = node_load($nid);
-    // Get the taxonomy for the node, creates a link to the parent forum
-    $taxonomy = reset($node->taxonomy);
-    if ($vocab = taxonomy_vocabulary_load($taxonomy->vid)) {
-      $parent_forum = l($taxonomy->name, "community/forum/{$taxonomy->tid}");
-    }
+  case 'Forum':
+  case 'forum':
   ?>
   <div class="result forum">
     <dt class="title">
@@ -115,23 +99,14 @@
 
 <?php
   case 'Comment':
-    // Get the node if for this comment
-    $nid = $result['fields']['tos_content_extra'];
-    $node = node_load($nid);
-    // Link to the parent forum topic
-    $parent_topic = l($node->title, drupal_get_path_alias('node/' . $nid) );
-    // Get the taxonomy for the node, creates a link to the parent forum
-    $taxonomy = reset($node->taxonomy);
-    if ($vocab = taxonomy_vocabulary_load($taxonomy->vid)) {
-      $parent_forum = l($taxonomy->name, "community/forum/{$taxonomy->tid}");
-    }
+  case 'comment':
   ?>
   <div class="result">
     <dt class="title">
       <?php if ($parent_forum): ?>
         <?php print $parent_forum . " : "; ?>
       <?php endif; ?>
-      <a href="<?php print $url; ?>"><?php print $node->title; ?></a>
+      <a href="<?php print $url; ?>"><?php print $parent_title; ?></a>
     </dt>
     <dd>
       <?php if ($snippet) : ?>
@@ -139,7 +114,6 @@
       <?php endif; ?>
       <?php if ($info) : ?>
         <p class="search-info"><?php print $info; ?>
-<?php //print " - " . $parent_forum . " : " . $parent_topic; ?>
         </p>
       <?php endif; ?>
     </dd>

--- a/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
@@ -75,10 +75,10 @@
     <div class="name"><a href="<?php print $url; ?>"><?php print $title; ?></a></div>
     <div class="details">
       <div class="user-stats">
-        <div class="join-date"><?php print bts('Joined') . ': ' . date('j M y', $account->created); ?></div>
-        <div class="post-count"><?php print bts('Posts') . ': ' . $account->post_count; ?></div>
-        <div class="credit"><?php print bts('Credit') . ': ' . $account->boincuser_total_credit; ?></div>
-        <div class="rac"><?php print bts('RAC') . ': ' . $account->boincuser_expavg_credit; ?></div>
+        <div class="join-date"><?php print bts('Joined', array(), NULL, 'boinc:user-info') . ': ' . date('j M y', $account->created); ?></div>
+        <div class="post-count"><?php print bts('Posts', array(), NULL, 'boinc:user-info') . ': ' . $account->post_count; ?></div>
+        <div class="credit"><?php print bts('Credit', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_total_credit; ?></div>
+        <div class="rac"><?php print bts('RAC', array(), NULL, 'boinc:user-info') . ': ' . $account->boincuser_expavg_credit; ?></div>
       </div>
     </div>
     <?php if ($snippet) : ?>

--- a/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/search-result.tpl.php
@@ -45,9 +45,6 @@
  *
  * @see template_preprocess_search_result()
  */
- 
- global $base_path;
- 
 ?>
 <?php switch ($info_split['type']): ?>
 <?php
@@ -60,7 +57,7 @@
     $account = user_load($node->uid);
     if (isset($account)) {
       $user_image = boincuser_get_user_profile_image($account->uid);
-      $url = "{$base_path}account/{$account->uid}";
+      $url = url('account/' . $account->uid);
       if (empty($title)) {
         $title = $account->boincuser_name;
       }

--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view-fields--boinc-friends--block-1.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view-fields--boinc-friends--block-1.tpl.php
@@ -1,5 +1,3 @@
-<?php global $base_path; ?>
-
-<a href="<?php echo "{$base_path}account/{$fields['uid']->content}"; ?>" title="<?php echo $fields['name']->content; ?>">
+<a href="<?php echo url('account/' . $fields['uid']->content); ?>" title="<?php echo $fields['name']->content; ?>">
   <?php echo $fields['field_image_fid']->content; ?>
 </a>


### PR DESCRIPTION
Changed links in menubar to use `url()` function so language code is properly inserted into URL.
Added a number strings to the boinc textgroup, with context details.
