### PR TITLE
Drupal: Remove project specific name from Feature user_profiles. 

### DIFF
--- a/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
@@ -492,9 +492,9 @@ Zimbabwe|Zimbabwe',
       'default_value_php' => NULL,
       'label' => 'Your opinions about this project',
       'weight' => '4',
-      'description' => 'Tell us your thoughts about Einstein@Home
+      'description' => 'Tell us your thoughts about ' . variable_get('site_name', '') . '
 
-   1. Why do you run Einstein@Home?
+   1. Why do you run '. variable_get('site_name', '') . '?
    2. What are your views about the project?
    3. Any suggestions? ',
       'type' => 'text_textarea',

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -416,7 +416,7 @@ function boincuser_request_pass_validate($form, &$form_state) {
  */
 function boincuser_authloginform() {
   $headers = apache_request_headers();
-  $project_name = variable_get('site_name', 'einsteinathome.org');
+  $project_name = variable_get('site_name', 'Drupal-BOINC');
   $project_domain = $headers['Host'];
   $form['heading'] = array(
     '#type' => 'markup',


### PR DESCRIPTION
Replaced with site_name variable.

Found as part of https://dev.gridrepublic.org/browse/DBOINCP-317
Similar change requested in PR #1834.