### PR TITLE
Manager: Remove unused function call.

### DIFF
--- a/clientgui/sg_ProjectWebSitesPopup.cpp
+++ b/clientgui/sg_ProjectWebSitesPopup.cpp
@@ -127,7 +127,6 @@ void CSimpleProjectWebSitesPopupButton::OnMenuLinkClicked(wxCommandEvent& event)
      } else{
          int menuId = menuIDevt - WEBSITE_URL_MENU_ID;
          PROJECT* project = pDoc->state.lookup_project(ctrl_url);
-         project->gui_urls[menuId].name.c_str();
      
          wxLaunchDefaultBrowser(wxString(project->gui_urls[menuId].url.c_str(),wxConvUTF8));
 	 }


### PR DESCRIPTION
From PVS Studio:
V530:
The return value of function 'c_str' is required to be utilized.
https://www.viva64.com/en/w/V530/print/

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>