### PR TITLE
Client: Fix missed 'else' keyword.

### DIFF
--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -885,9 +885,9 @@ int get_os_information(
 
                 if ( lstrcmpi( "WINNT", szProductType) == 0 ) {
                     safe_strcpy( szSKU, "Workstation Edition" );
-                } if ( lstrcmpi( "LANMANNT", szProductType) == 0 ) {
+                } else if ( lstrcmpi( "LANMANNT", szProductType) == 0 ) {
                     safe_strcpy( szSKU, "Server Edition" );
-                } if ( lstrcmpi( "SERVERNT", szProductType) == 0 ) {
+                } else if ( lstrcmpi( "SERVERNT", szProductType) == 0 ) {
                     safe_strcpy( szSKU, "Advanced Server Edition" );
                 }
 


### PR DESCRIPTION
From PVS Studio:
V646
Consider inspecting the application's logic. It's possible that 'else' keyword is missing.
https://www.viva64.com/en/w/V646/print/

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>