### PR TITLE
lib: Fix missed parameters from 'throw' statements.

### DIFF
--- a/lib/run_app_windows.cpp
+++ b/lib/run_app_windows.cpp
@@ -71,7 +71,7 @@ GetAccountSid(
         //
         *Sid = (PSID)HeapAlloc(GetProcessHeap(), 0, cbSid);
 
-        if(*Sid == NULL) throw;
+        if(*Sid == NULL) throw 0;
 
         ReferencedDomain = (LPSTR)HeapAlloc(
                         GetProcessHeap(),
@@ -79,7 +79,7 @@ GetAccountSid(
                         cchReferencedDomain * sizeof(CHAR)
                         );
 
-        if(ReferencedDomain == NULL) throw;
+        if(ReferencedDomain == NULL) throw 0;
 
         //
         // Obtain the SID of the specified account on the specified system.
@@ -103,7 +103,7 @@ GetAccountSid(
                             *Sid,
                             cbSid
                             );
-                if(*Sid == NULL) throw;
+                if(*Sid == NULL) throw 0;
 
                 ReferencedDomain = (LPSTR)HeapReAlloc(
                             GetProcessHeap(),
@@ -111,9 +111,9 @@ GetAccountSid(
                             ReferencedDomain,
                             cchReferencedDomain * sizeof(CHAR)
                             );
-                if(ReferencedDomain == NULL) throw;
+                if(ReferencedDomain == NULL) throw 0;
             }
-            else throw;
+            else throw 0;
         }
 
         //
@@ -296,17 +296,17 @@ void get_sandbox_account_service_token() {
                     dwSize + 1);
 
                 if (pszUserName == NULL)
-                    throw;
+                    throw 0;
 
                 if (!GetUserNameEx(
                         NameSamCompatible,
                         pszUserName,
                         &dwSize)
                 )
-                    throw;
+                    throw 0;
             }
             else
-                throw;
+                throw 0;
 
             // Obtain the SID for the current user name.
 
@@ -315,7 +315,7 @@ void get_sandbox_account_service_token() {
                     pszUserName,
                     &pBOINCMasterSID)
             )
-                throw;
+                throw 0;
 
             // Obtain the DACL for the service token.
 
@@ -336,7 +336,7 @@ void get_sandbox_account_service_token() {
                     dwSizeNeeded);
 
                 if (pTokenDefaultDACL == NULL)
-                    throw;
+                    throw 0;
 
                 dwSize = dwSizeNeeded;
 
@@ -347,10 +347,10 @@ void get_sandbox_account_service_token() {
                         dwSize,
                         &dwSizeNeeded)
                 )
-                    throw;
+                    throw 0;
             }
             else
-                throw;
+                throw 0;
 
             //
             pOldAcl = pTokenDefaultDACL->DefaultDacl;
@@ -371,7 +371,7 @@ void get_sandbox_account_service_token() {
                     sizeof(ACL_SIZE_INFORMATION),
                     AclSizeInformation)
                 )
-                   throw;
+                   throw 0;
             }
 
             // Compute the size of the new ACL.
@@ -389,12 +389,12 @@ void get_sandbox_account_service_token() {
                 dwNewAclSize);
 
             if (pNewAcl == NULL)
-                throw;
+                throw 0;
 
             // Initialize the new DACL.
 
             if (!InitializeAcl(pNewAcl, dwNewAclSize, ACL_REVISION))
-                throw;
+                throw 0;
 
             // If DACL is present, copy it to a new DACL.
 
@@ -407,7 +407,7 @@ void get_sandbox_account_service_token() {
                     {
                         // Get an ACE.
                         if (!GetAce(pOldAcl, i, &pTempAce))
-                            throw;
+                            throw 0;
 
                         // Add the ACE to the new ACL.
                         if (!AddAce(
@@ -417,7 +417,7 @@ void get_sandbox_account_service_token() {
                                 pTempAce,
                             ((PACE_HEADER)pTempAce)->AceSize)
                         )
-                            throw;
+                            throw 0;
                     }
                 }
             }
@@ -431,7 +431,7 @@ void get_sandbox_account_service_token() {
             );
 
             if (pace1 == NULL)
-                throw;
+                throw 0;
 
             pace1->Header.AceType  = ACCESS_ALLOWED_ACE_TYPE;
             pace1->Header.AceFlags = CONTAINER_INHERIT_ACE |
@@ -443,7 +443,7 @@ void get_sandbox_account_service_token() {
             pace1->Mask            = PROCESS_ALL_ACCESS;
 
             if (!CopySid(GetLengthSid(pBOINCProjectSID), &pace1->SidStart, pBOINCProjectSID))
-                throw;
+                throw 0;
 
             // Add an ACE to the process.
 
@@ -454,7 +454,7 @@ void get_sandbox_account_service_token() {
                 (LPVOID)pace1,
                 pace1->Header.AceSize)
             )
-                throw;
+                throw 0;
 
             // Add the second ACE to the process.
 
@@ -465,7 +465,7 @@ void get_sandbox_account_service_token() {
             );
 
             if (pace2 == NULL)
-                throw;
+                throw 0;
 
             pace2->Header.AceType  = ACCESS_ALLOWED_ACE_TYPE;
             pace2->Header.AceFlags = CONTAINER_INHERIT_ACE |
@@ -477,7 +477,7 @@ void get_sandbox_account_service_token() {
             pace2->Mask            = PROCESS_ALL_ACCESS;
 
             if (!CopySid(GetLengthSid(pBOINCMasterSID), &pace2->SidStart, pBOINCMasterSID))
-                throw;
+                throw 0;
 
             // Add an ACE to the process.
 
@@ -488,7 +488,7 @@ void get_sandbox_account_service_token() {
                 (LPVOID)pace2,
                 pace2->Header.AceSize)
             )
-                throw;
+                throw 0;
 
             // Set a new Default DACL for the token.
             pTokenDefaultDACL->DefaultDacl = pNewAcl;
@@ -499,7 +499,7 @@ void get_sandbox_account_service_token() {
                 pTokenDefaultDACL,
                 dwNewAclSize)
             )
-                throw;
+                throw 0;
 
             // Indicate success.
             fprintf(stderr, "New Token ACL Success!!!\n");


### PR DESCRIPTION
From PVS Studio:
V667:
The 'throw' operator does not possess any arguments and is not situated within the 'catch' block.
https://www.viva64.com/en/w/V667/print/

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>