### PR TITLE
Fix inconsistency between uploaded files and queried ones in boinc_gahp

### DIFF
--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -245,7 +245,7 @@ int process_input_files(SUBMIT_REQ& req, string& error_msg) {
             INFILE& infile = job.infiles[j];
             map<string, LOCAL_FILE>::iterator iter = local_files.find(infile.src_path);
             LOCAL_FILE& lf = iter->second;
-            sprintf(infile.physical_name, "jf_%s", lf.boinc_name);
+            sprintf(infile.physical_name, "%s", lf.boinc_name);
         }
     }
 


### PR DESCRIPTION
When uploaded the files just get the md5 as their name but are then submitted with the "jf_" in front of the name. Thus the batch submission fails due to non existent input file. 