### PR TITLE
lib: fix uninitialized class members in constructor

### DIFF
--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -787,14 +787,16 @@ int boinc_make_dirs(const char* dirpath, const char* filepath) {
 
 
 FILE_LOCK::FILE_LOCK() {
-#ifndef _WIN32
+#if defined(_WIN32) && !defined(__CYGWIN32__)
+  handle = INVALID_HANDLE_VALUE;
+#else
     fd = -1;
 #endif
     locked = false;
 }
 
 FILE_LOCK::~FILE_LOCK() {
-#ifndef _WIN32
+#if !defined(_WIN32) || defined(__CYGWIN32__)
     if (fd >= 0) close(fd);
 #endif
 }

--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -94,7 +94,7 @@ struct TIME_SPAN {
         Between
     };
     TIME_SPAN() : present(false), start_hour(0), end_hour(0) {}
-    TIME_SPAN(double start, double end) : start_hour(start), end_hour(end) {}
+    TIME_SPAN(double start, double end) : present(false), start_hour(start), end_hour(end) {}
 
     bool suspended(double hour) const;
     TimeMode mode() const;


### PR DESCRIPTION
From PVS Studio:
V730
Not all members of a class are initialized inside the constructor.
Consider inspecting: present.
Consider inspecting: handle.
https://www.viva64.com/en/w/V730/print/

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>