### PR TITLE
Manager: fix uninitialized class members in constructor

### DIFF
--- a/clientgui/BOINCBaseWizard.cpp
+++ b/clientgui/BOINCBaseWizard.cpp
@@ -47,11 +47,13 @@ IMPLEMENT_DYNAMIC_CLASS( CBOINCBaseWizard, wxWizardEx )
 CBOINCBaseWizard::CBOINCBaseWizard() :
     wxWizardEx()
 {
+  m_bCancelInProgress = false;
 }
 
 CBOINCBaseWizard::CBOINCBaseWizard(wxWindow *parent, int id, const wxString& title, const wxPoint& pos, long style) :
     wxWizardEx(parent, id, title, pos, style)
 {
+  m_bCancelInProgress = false;
 }
 
 /*!

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -112,6 +112,7 @@ CNetworkConnection::CNetworkConnection(CMainDocument* pDocument) :
     m_bForceReconnect = false;
     m_bReconnectOnError = false;
     m_bNewConnection = false;
+    m_bUseDefaultPassword = false;
     m_bUsedDefaultPassword = false;
     m_iPort = GUI_RPC_PORT,
     m_iReadGUIRPCAuthFailure = 0;


### PR DESCRIPTION
From PVS Studio:
V730
Not all members of a class are initialized inside the constructor.
Consider inspecting: m_bCancelInProgress.
Consider inspecting: m_bUseDefaultPassword.
https://www.viva64.com/en/w/V730/print/

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>