### PR TITLE
These updates address issue #1850 - Random seg faults on Android ARM

### DIFF
--- a/lib/diagnostics.h
+++ b/lib/diagnostics.h
@@ -21,7 +21,7 @@
 
 #ifdef _WIN32
 #include "boinc_win.h"
-#else 
+#else
 #include <signal.h>
 #ifdef __cplusplus
 #include <cassert>
@@ -146,7 +146,7 @@ extern void set_signal_exit_code(int);
 }
 #endif
 
-#ifdef ANDROID
+#if defined(ANDROID) && !defined(AVOID_ANDROID_VOODOO)
 // Yes, these are undocumented android functions located
 // libcorkscrew.so .  They may not always be there, but it's better than
 // nothing.  And we've got source so we could reimplement them if necessary.
@@ -181,8 +181,8 @@ typedef struct {
 
 
 typedef ssize_t (*unwind_backtrace_signal_arch_t)(
-        siginfo_t *, void *, const map_info_t *, backtrace_frame_t *, 
-        size_t , size_t 
+        siginfo_t *, void *, const map_info_t *, backtrace_frame_t *,
+        size_t , size_t
     );
 extern unwind_backtrace_signal_arch_t unwind_backtrace_signal_arch;
 
@@ -198,7 +198,7 @@ typedef void (*get_backtrace_symbols_t)(
 extern get_backtrace_symbols_t get_backtrace_symbols;
 
 typedef void (*free_backtrace_symbols_t)(backtrace_symbol_t* symbols,
-size_t frames);    
+size_t frames);
 extern free_backtrace_symbols_t free_backtrace_symbols;
 
 typedef symbol_table_t *(*load_symbol_table_t)(const char *);
@@ -271,7 +271,7 @@ extern format_backtrace_line_t format_backtrace_line;
 
 #else  // _DEBUG
 
-#define BOINCASSERT(expr)         
+#define BOINCASSERT(expr)
 #ifndef IRIX
 #if defined(__MINGW32__) || defined(__CYGWIN32__)
 #define BOINCTRACE
@@ -295,7 +295,7 @@ extern format_backtrace_line_t format_backtrace_line;
 #endif
 
 #ifndef BOINCTRACE
-#define BOINCTRACE			
+#define BOINCTRACE
 #endif
 
 #ifndef BOINCINFO


### PR DESCRIPTION
    For some android devices, setitimer can cause random seg faults
    so this update addresses this by avoiding setitimer for ANDROID
    builds. Signal handlers were also added to help debug/test kill,
    abort, suspend, and resume logic.

The changes in diagnostics.cpp and .h also helped.

    Added the option to avoid android voodoo in the diagnostics stuff.

    The voodoo didn't seem to work on the local devices we tested and
    caused segfaults on some devices from our test project.

These changes significantly stabilized our Rosetta@home android arm
application.