### PR TITLE
Give choice between COM and VboxManage interface

### DIFF
--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -149,7 +149,7 @@ int VBOX_BASE::run(bool do_restore_snapshot) {
 
     retval = is_registered();
     if (ERR_TIMEOUT == retval) {
-		vboxlog_msg("Error: Timeout");
+        vboxlog_msg("Error: Timeout");
 
         return VBOXWRAPPER_ERR_RECOVERABLE;
 
@@ -157,28 +157,27 @@ int VBOX_BASE::run(bool do_restore_snapshot) {
 
         if (is_vm_machine_configuration_available()) {
             retval = register_vm();
-			if (retval){
-				vboxlog_msg("Could not register");
-				return retval;
-			}
+            if (retval) {
+                vboxlog_msg("Could not register");
+                return retval;
+            }
         } else {
             if (is_disk_image_registered()) {
                 // Handle the case where a previous instance of the same projects VM
                 // was already initialized for the current slot directory but aborted
                 // while the task was suspended and unloaded from memory.
                 retval = deregister_stale_vm();
-				if (retval){
-					vboxlog_msg("Could not deregister stale VM");
-					return retval;
-				}
+                if (retval) {
+                    vboxlog_msg("Could not deregister stale VM");
+                    return retval;
+                }
             }
             retval = create_vm();
-			if (retval){
-				vboxlog_msg("Could not create VM");
-				return retval;
-			}
+            if (retval) {
+                vboxlog_msg("Could not create VM");
+                return retval;
+            }
         }
-
     }
 
     // The user has requested that we exit after registering the VM, so return an
@@ -193,27 +192,27 @@ int VBOX_BASE::run(bool do_restore_snapshot) {
     // Check to see if the VM is already in a running state, if so, poweroff.
     poll(false);
     if (online) {
-		vboxlog_msg("VM was running");
+        vboxlog_msg("VM was running");
         retval = poweroff();
-		if (retval){
-			vboxlog_msg("Could not stop running VM");
-			return ERR_NOT_EXITED;
-		}
+        if (retval) {
+            vboxlog_msg("Could not stop running VM");
+            return ERR_NOT_EXITED;
+        }
     }
 
     // If our last checkpoint time is greater than 0, restore from the previously
     // saved snapshot
     if (do_restore_snapshot) {
         retval = restore_snapshot();
-		if (retval){
-			vboxlog_msg("Could not restore from snapshot");
-			return retval;
-		}
+        if (retval) {
+            vboxlog_msg("Could not restore from snapshot");
+            return retval;
+        }
     }
 
     // Has BOINC signaled that we should quit?
     // Try to prevent starting the VM in an environment where we might be terminated any
-    // second.  This can happen if BOINC has been told to shutdown or the volunteer has 
+    // second.  This can happen if BOINC has been told to shutdown or the volunteer has
     // told BOINC to switch to a different project.
     //
     if (boinc_status.no_heartbeat || boinc_status.quit_request) {
@@ -222,10 +221,10 @@ int VBOX_BASE::run(bool do_restore_snapshot) {
 
     // Start the VM
     retval = start();
-	if (retval){
-		vboxlog_msg("Could not start ");
-		return retval;
-	}
+    if (retval) {
+        vboxlog_msg("Could not start ");
+        return retval;
+    }
 
     return 0;
 }
@@ -252,7 +251,7 @@ void VBOX_BASE::dump_hypervisor_logs(bool include_error_logs) {
     get_vm_exit_code(vm_exit_code);
 
     if (include_error_logs) {
-		dump_screenshot();
+        dump_screenshot();
         fprintf(
             stderr,
             "\n"
@@ -290,34 +289,34 @@ void VBOX_BASE::dump_vmguestlog_entries() {
     size_t line_pos;
     VBOX_TIMESTAMP current_timestamp;
     string msg;
-	string virtualbox_vm_log;
-	virtualbox_vm_log = vm_master_name + "/Logs/VBox.log";
+    string virtualbox_vm_log;
+    virtualbox_vm_log = vm_master_name + "/Logs/VBox.log";
 
-	if (boinc_file_exists(virtualbox_vm_log.c_str())) {
+    if (boinc_file_exists(virtualbox_vm_log.c_str())) {
 
-		std::ifstream  src(virtualbox_vm_log.c_str(), std::ios::binary);
-		while (std::getline(src, line))
-		{
-			line_pos = line.find("Guest Log:");
-			if (line_pos != string::npos) {
-				sscanf(
-					line.c_str(),
-					"%d:%d:%d.%d",
-					&current_timestamp.hours, &current_timestamp.minutes,
-					&current_timestamp.seconds, &current_timestamp.milliseconds
-					);
+        std::ifstream  src(virtualbox_vm_log.c_str(), std::ios::binary);
+        while (std::getline(src, line))
+        {
+            line_pos = line.find("Guest Log:");
+            if (line_pos != string::npos) {
+                sscanf(
+                    line.c_str(),
+                    "%d:%d:%d.%d",
+                    &current_timestamp.hours, &current_timestamp.minutes,
+                    &current_timestamp.seconds, &current_timestamp.milliseconds
+                );
 
-				if (is_timestamp_newer(current_timestamp, vm_log_timestamp)) {
-					vm_log_timestamp = current_timestamp;
-					msg = line.substr(line_pos, line.size() - line_pos);
+                if (is_timestamp_newer(current_timestamp, vm_log_timestamp)) {
+                    vm_log_timestamp = current_timestamp;
+                    msg = line.substr(line_pos, line.size() - line_pos);
 
-					sanitize_format(msg);
+                    sanitize_format(msg);
 
-					vboxlog_msg(msg.c_str());
-				}
-			}
-		}
-	}
+                    vboxlog_msg(msg.c_str());
+                }
+            }
+        }
+    }
 }
 
 int VBOX_BASE::dump_screenshot() {
@@ -329,13 +328,13 @@ int VBOX_BASE::dump_screenshot() {
     FILE*  f = NULL;
     string screenshot_encoded;
     string virtual_machine_slot_directory;
-	string screenshot_location;
+    string screenshot_location;
 
-	get_slot_directory(virtual_machine_slot_directory);
+    get_slot_directory(virtual_machine_slot_directory);
 
-	screenshot_location = virtual_machine_slot_directory;
-	screenshot_location += "/";
-	screenshot_location += SCREENSHOT_FILENAME;
+    screenshot_location = virtual_machine_slot_directory;
+    screenshot_location += "/";
+    screenshot_location += SCREENSHOT_FILENAME;
 
     if (boinc_file_exists(screenshot_location.c_str())) {
 
@@ -654,11 +653,11 @@ void VBOX_BASE::sanitize_format(std::string& output) {
     string::iterator iter = output.begin();
     while (iter != output.end()) {
         if (*iter == '%') {
-			// If we find '%', insert an additional '%' so that the we end up with
-			// "%%" in its place.  This with cause printf() type functions to print
-			// % within the formatted output.
-			//
-			iter = output.insert(iter+1, '%');
+            // If we find '%', insert an additional '%' so that the we end up with
+            // "%%" in its place.  This with cause printf() type functions to print
+            // % within the formatted output.
+            //
+            iter = output.insert(iter+1, '%');
             ++iter;
         } else {
             ++iter;
@@ -727,7 +726,7 @@ int VBOX_BASE::launch_vboxsvc() {
                 hVboxSvc = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, p.id);
                 if (hVboxSvc) break;
             }
-            
+
             if (pidVboxSvc && hVboxSvc) {
                 vboxlog_msg("Status Report: Detected vboxsvc.exe. (PID = '%d')", pidVboxSvc);
                 vboxsvc_pid = pidVboxSvc;
@@ -853,17 +852,17 @@ int VBOX_BASE::launch_vboxvm() {
 
     // Execute command
     if (!CreateProcess(
-        NULL, 
-        cmdline,
-        NULL,
-        NULL,
-        TRUE,
-        CREATE_NO_WINDOW,
-        NULL,
-        NULL,
-        &si,
-        &pi
-    )) {
+                NULL,
+                cmdline,
+                NULL,
+                NULL,
+                TRUE,
+                CREATE_NO_WINDOW,
+                NULL,
+                NULL,
+                &si,
+                &pi
+            )) {
         vboxlog_msg(
             "Status Report: Launching virtualbox.exe/vboxheadless.exe failed!."
         );
@@ -873,7 +872,7 @@ int VBOX_BASE::launch_vboxvm() {
             GetLastError()
         );
         goto CLEANUP;
-    } 
+    }
 
     while(1) {
         GetExitCodeProcess(pi.hProcess, &ulExitCode);
@@ -994,7 +993,7 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
             // lock is held by a previous instance of vboxmanage whos instance data hasn't been
             // cleaned up within vboxsvc yet.
             //
-            // Error Code: VBOX_E_INVALID_OBJECT_STATE (0x80bb0007) 
+            // Error Code: VBOX_E_INVALID_OBJECT_STATE (0x80bb0007)
             //
             if (VBOX_E_INVALID_OBJECT_STATE == (unsigned int)retval) {
                 if (retry_notes.find("Another VirtualBox management") == string::npos) {
@@ -1015,7 +1014,7 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
             // Experiments performed by jujube suggest changing the sleep interval to an exponential
             // style backoff would increase our chances of success.
             //
-            // Error Code: CO_E_SERVER_EXEC_FAILURE (0x80080005) 
+            // Error Code: CO_E_SERVER_EXEC_FAILURE (0x80080005)
             //
             if (CO_E_SERVER_EXEC_FAILURE == (unsigned int)retval) {
                 if (retry_notes.find("Unable to communicate with VirtualBox") == string::npos) {
@@ -1026,12 +1025,12 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
                     sleep_interval *= 2;
                 }
             }
-            
+
             // Retry?
-            if (!retry_failures && 
-                (VBOX_E_INVALID_OBJECT_STATE != (unsigned int)retval) && 
-                (CO_E_SERVER_EXEC_FAILURE != (unsigned int)retval)
-            ) {
+            if (!retry_failures &&
+                    (VBOX_E_INVALID_OBJECT_STATE != (unsigned int)retval) &&
+                    (CO_E_SERVER_EXEC_FAILURE != (unsigned int)retval)
+               ) {
                 break;
             }
 
@@ -1119,17 +1118,17 @@ int VBOX_BASE::vbm_popen_raw(
 
     // Execute command
     if (!CreateProcess(
-        NULL, 
-        (LPTSTR)command.c_str(),
-        NULL,
-        NULL,
-        TRUE,
-        CREATE_NO_WINDOW,
-        NULL,
-        NULL,
-        &si,
-        &pi
-    )) {
+                NULL,
+                (LPTSTR)command.c_str(),
+                NULL,
+                NULL,
+                TRUE,
+                CREATE_NO_WINDOW,
+                NULL,
+                NULL,
+                &si,
+                &pi
+            )) {
         vboxlog_msg("CreateProcess failed! (%d).", GetLastError());
         goto CLEANUP;
     }
@@ -1206,7 +1205,7 @@ CLEANUP:
 
     // Execute command
     fp = popen(modified_command.c_str(), "r");
-    if (fp == NULL){
+    if (fp == NULL) {
         vboxlog_msg("vbm_popen popen failed! (%d).", errno);
         retval = ERR_FOPEN;
     } else {
@@ -1289,4 +1288,3 @@ VBOX_VM::VBOX_VM() {
 
 VBOX_VM::~VBOX_VM() {
 }
-

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -208,7 +208,7 @@ int VBOX_VM::create_vm() {
     command += "--basefolder \"" + virtual_machine_slot_directory + "\" ";
     command += "--ostype \"" + os_name + "\" ";
     command += "--register";
-    
+
     retval = vbm_popen(command, output, "create");
     if (retval) return retval;
 
@@ -254,11 +254,11 @@ int VBOX_VM::create_vm() {
     command  = "modifyvm \"" + vm_name + "\" ";
     if (boot_iso) {
         command += "--boot1 dvd ";
-        command += "--boot2 disk ";        
+        command += "--boot2 disk ";
     } else {
         command += "--boot1 disk ";
         command += "--boot2 dvd ";
-    } 
+    }
     command += "--boot3 none ";
     command += "--boot4 none ";
 
@@ -418,9 +418,9 @@ int VBOX_VM::create_vm() {
     command += "--add \"" + vm_disk_controller_type + "\" ";
     command += "--controller \"" + vm_disk_controller_model + "\" ";
     if (
-         (vm_disk_controller_type == "sata") || (vm_disk_controller_type == "SATA") ||
-         (vm_disk_controller_type == "scsi") || (vm_disk_controller_type == "SCSI") ||
-         (vm_disk_controller_type == "sas") || (vm_disk_controller_type == "SAS")
+        (vm_disk_controller_type == "sata") || (vm_disk_controller_type == "SATA") ||
+        (vm_disk_controller_type == "scsi") || (vm_disk_controller_type == "SCSI") ||
+        (vm_disk_controller_type == "sas") || (vm_disk_controller_type == "SAS")
     ) {
         command += "--hostiocache off ";
     }
@@ -478,7 +478,7 @@ int VBOX_VM::create_vm() {
 
         // Add a virtual cache disk drive to VM
         //
-        if (enable_cache_disk){
+        if (enable_cache_disk) {
             vboxlog_msg("Adding virtual cache disk drive to VM. (%s)", cache_disk_filename.c_str());
             command  = "storageattach \"" + vm_name + "\" ";
             command += "--storagectl \"Hard Disk Controller\" ";
@@ -590,9 +590,9 @@ int VBOX_VM::create_vm() {
             // Add new firewall rule
             //
             sprintf(buf, ",tcp,%s,%d,,%d",
-                pf.is_remote?"":"127.0.0.1",
-                pf.host_port, pf.guest_port
-            );
+                    pf.is_remote?"":"127.0.0.1",
+                    pf.host_port, pf.guest_port
+                   );
             command  = "modifyvm \"" + vm_name + "\" ";
             command += "--natpf1 \"" + string(buf) + "\" ";
 
@@ -673,7 +673,7 @@ int VBOX_VM::register_vm() {
     //
     command  = "registervm ";
     command += "\"" + virtual_machine_slot_directory + "/" + vm_name + "/" + vm_name + ".vbox\" ";
-    
+
     retval = vbm_popen(command, output, "register");
     if (retval) return retval;
 
@@ -795,7 +795,7 @@ int VBOX_VM::deregister_stale_vm() {
     //   In use by VMs:        test2 (UUID: 000ab2be-1254-4c6a-9fdc-1536a478f601)
     //   Location:             C:\Users\romw\VirtualBox VMs\test2\test2.vdi
     //
-    if (enable_isocontextualization && enable_isocontextualization) {
+    if (enable_isocontextualization) {
         command  = "showhdinfo \"" + virtual_machine_slot_directory + "/" + cache_disk_filename + "\" ";
         retval = vbm_popen(command, output, "get HDD info");
         if (retval) return retval;
@@ -1182,10 +1182,10 @@ int VBOX_VM::capture_screenshot() {
 
             command = "controlvm \"" + vm_name + "\" ";
             command += "screenshotpng \"";
-	        command += virtual_machine_slot_directory;
-	        command += "/";
-	        command += SCREENSHOT_FILENAME;
-	        command += "\"";
+            command += virtual_machine_slot_directory;
+            command += "/";
+            command += SCREENSHOT_FILENAME;
+            command += "\"";
             retval = vbm_popen(command, output, "capture screenshot", true, true, 0);
             if (retval) return retval;
 
@@ -1193,7 +1193,7 @@ int VBOX_VM::capture_screenshot() {
 
         }
     }
-	return 0;
+    return 0;
 }
 
 int VBOX_VM::create_snapshot(double elapsed_time) {
@@ -1262,7 +1262,7 @@ int VBOX_VM::cleanup_snapshots(bool delete_active) {
     //
     // Traverse the list from newest to oldest.  Otherwise we end up with an error:
     //   VBoxManage.exe: error: Snapshot operation failed
-    //   VBoxManage.exe: error: Hard disk 'C:\ProgramData\BOINC\slots\23\vm_image.vdi' has 
+    //   VBoxManage.exe: error: Hard disk 'C:\ProgramData\BOINC\slots\23\vm_image.vdi' has
     //     more than one child hard disk (2)
     //
 
@@ -1298,7 +1298,7 @@ int VBOX_VM::cleanup_snapshots(bool delete_active) {
             command += "delete \"";
             command += uuid;
             command += "\" ";
-            
+
             // Only log the error if we are not attempting to deregister the VM.
             // delete_active is only set to true when we are deregistering the VM.
             retval = vbm_popen(command, output, "delete stale snapshot", !delete_active, false, 0);
@@ -1403,7 +1403,7 @@ bool VBOX_VM::is_system_ready(std::string& message) {
     if (
         (output.find("WARNING: The vboxdrv kernel module is not loaded.") != string::npos) ||
         (output.find("WARNING: The VirtualBox kernel modules are not loaded.") != string::npos)
-    ){
+    ) {
         vboxlog_msg("WARNING: The VirtualBox kernel modules are not loaded.");
         vboxlog_msg("WARNING: Please update/recompile VirtualBox kernel drivers.");
         message = "Please update/recompile VirtualBox kernel drivers.";
@@ -1413,7 +1413,7 @@ bool VBOX_VM::is_system_ready(std::string& message) {
     if (
         (output.find("Warning: program compiled against ") != string::npos) &&
         (output.find(" using older ") != string::npos)
-    ){
+    ) {
         vboxlog_msg("WARNING: VirtualBox incompatible dependencies detected.");
         message = "Please update/reinstall VirtualBox";
         rc = false;
@@ -1431,10 +1431,10 @@ bool VBOX_VM::is_disk_image_registered() {
 
     command = "showhdinfo \"" + virtual_machine_root_dir + "/" + image_filename + "\" ";
     if (vbm_popen(command, output, "hdd registration", false, false) == 0) {
-        if ((output.find("VBOX_E_FILE_ERROR") == string::npos) && 
-            (output.find("VBOX_E_OBJECT_NOT_FOUND") == string::npos) &&
-            (output.find("does not match the value") == string::npos)
-        ) {
+        if ((output.find("VBOX_E_FILE_ERROR") == string::npos) &&
+                (output.find("VBOX_E_OBJECT_NOT_FOUND") == string::npos) &&
+                (output.find("does not match the value") == string::npos)
+           ) {
             // Error message not found in text
             return true;
         }
@@ -1443,10 +1443,10 @@ bool VBOX_VM::is_disk_image_registered() {
     if (enable_isocontextualization && enable_cache_disk) {
         command = "showhdinfo \"" + virtual_machine_root_dir + "/" + cache_disk_filename + "\" ";
         if (vbm_popen(command, output, "hdd registration", false, false) == 0) {
-            if ((output.find("VBOX_E_FILE_ERROR") == string::npos) && 
-                (output.find("VBOX_E_OBJECT_NOT_FOUND") == string::npos) &&
-                (output.find("does not match the value") == string::npos)
-            ) {
+            if ((output.find("VBOX_E_FILE_ERROR") == string::npos) &&
+                    (output.find("VBOX_E_OBJECT_NOT_FOUND") == string::npos) &&
+                    (output.find("does not match the value") == string::npos)
+               ) {
                 // Error message not found in text
                 return true;
             }
@@ -1479,36 +1479,36 @@ int VBOX_VM::get_install_directory(string& install_directory) {
 
     // change the current directory to the boinc data directory if it exists
     lReturnValue = RegOpenKeyEx(
-        HKEY_LOCAL_MACHINE, 
-        _T("SOFTWARE\\Oracle\\VirtualBox"),  
-        0, 
-        KEY_READ,
-        &hkSetupHive
-    );
+                       HKEY_LOCAL_MACHINE,
+                       _T("SOFTWARE\\Oracle\\VirtualBox"),
+                       0,
+                       KEY_READ,
+                       &hkSetupHive
+                   );
     if (lReturnValue == ERROR_SUCCESS) {
         // How large does our buffer need to be?
         lReturnValue = RegQueryValueEx(
-            hkSetupHive,
-            _T("InstallDir"),
-            NULL,
-            NULL,
-            NULL,
-            &dwSize
-        );
+                           hkSetupHive,
+                           _T("InstallDir"),
+                           NULL,
+                           NULL,
+                           NULL,
+                           &dwSize
+                       );
         if (lReturnValue != ERROR_FILE_NOT_FOUND) {
             // Allocate the buffer space.
             lpszRegistryValue = (LPTSTR) malloc(dwSize);
             (*lpszRegistryValue) = NULL;
 
             // Now get the data
-            lReturnValue = RegQueryValueEx( 
-                hkSetupHive,
-                _T("InstallDir"),
-                NULL,
-                NULL,
-                (LPBYTE)lpszRegistryValue,
-                &dwSize
-            );
+            lReturnValue = RegQueryValueEx(
+                               hkSetupHive,
+                               _T("InstallDir"),
+                               NULL,
+                               NULL,
+                               (LPBYTE)lpszRegistryValue,
+                               &dwSize
+                           );
 
             install_directory = lpszRegistryValue;
         }
@@ -1549,20 +1549,20 @@ int VBOX_VM::get_version_information(std::string& version_raw, std::string& vers
         }
 
         if (3 == sscanf(output.c_str(), "%d.%d.%d", &vbox_major, &vbox_minor, &vbox_release)) {
-			snprintf(
+            snprintf(
                 buf, sizeof(buf),
                 "%d.%d.%d",
                 vbox_major, vbox_minor, vbox_release
             );
             version_raw = buf;
-			snprintf(
+            snprintf(
                 buf, sizeof(buf),
                 "VirtualBox VboxManage Interface (Version: %d.%d.%d)",
                 vbox_major, vbox_minor, vbox_release
             );
             version_display = buf;
         } else {
-			version_raw = "Unknown";
+            version_raw = "Unknown";
             version_display = "VirtualBox VboxManage Interface (Version: Unknown)";
         }
     }
@@ -1723,48 +1723,48 @@ int VBOX_VM::get_vm_network_bytes_received(double& received) {
 }
 
 int VBOX_VM::get_vm_process_id() {
-	string virtualbox_vm_log;
-	string::iterator iter;
-	int retval = BOINC_SUCCESS;
-	string line;
-	string comp = "Process ID";
-	string pid;
-	size_t pid_start;
-	size_t pid_end;
-	std::size_t found;
+    string virtualbox_vm_log;
+    string::iterator iter;
+    int retval = BOINC_SUCCESS;
+    string line;
+    string comp = "Process ID";
+    string pid;
+    size_t pid_start;
+    size_t pid_end;
+    std::size_t found;
 
 
-	virtualbox_vm_log = vm_master_name + "/Logs/VBox.log";
+    virtualbox_vm_log = vm_master_name + "/Logs/VBox.log";
 
-	if (boinc_file_exists(virtualbox_vm_log.c_str())) {
+    if (boinc_file_exists(virtualbox_vm_log.c_str())) {
 
-		std::ifstream  src(virtualbox_vm_log.c_str(), std::ios::binary);
-		while (std::getline(src, line))
-		{
+        std::ifstream  src(virtualbox_vm_log.c_str(), std::ios::binary);
+        while (std::getline(src, line))
+        {
 
-			found = line.find(comp);
-			if (found != string::npos){
+            found = line.find(comp);
+            if (found != string::npos) {
 
-				pid_start = line.find("Process ID: ");
-				if (pid_start == string::npos) {
-					vboxlog_msg("Something wrong with the process ID finding\n %s ", line.c_str());
-					return ERR_NOT_FOUND;
-				}
-				pid_start += strlen("Process ID: ");
-				pid_end = line.find("\n", pid_start);
-				pid = line.substr(pid_start, pid_end - pid_start);
-				strip_whitespace(pid);
-				if (pid.size() <= 0) {
-					return ERR_NOT_FOUND;
-				}
+                pid_start = line.find("Process ID: ");
+                if (pid_start == string::npos) {
+                    vboxlog_msg("Something wrong with the process ID finding\n %s ", line.c_str());
+                    return ERR_NOT_FOUND;
+                }
+                pid_start += strlen("Process ID: ");
+                pid_end = line.find("\n", pid_start);
+                pid = line.substr(pid_start, pid_end - pid_start);
+                strip_whitespace(pid);
+                if (pid.size() <= 0) {
+                    return ERR_NOT_FOUND;
+                }
 
-				vm_pid = atol(pid.c_str());
-				break;
-			}
-		}
-	}
+                vm_pid = atol(pid.c_str());
+                break;
+            }
+        }
+    }
 
-	return retval;
+    return retval;
 }
 
 int VBOX_VM::get_vm_exit_code(unsigned long& exit_code) {
@@ -1789,7 +1789,7 @@ double VBOX_VM::get_vm_cpu_time() {
 }
 
 // Enable the network adapter if a network connection is required.
-// NOTE: Network access should never be allowed if the code running in a 
+// NOTE: Network access should never be allowed if the code running in a
 //   shared directory or the VM image itself is NOT signed.  Doing so
 //   opens up the network behind the company firewall to attack.
 //
@@ -1921,6 +1921,4 @@ void VBOX_VM::reset_vm_process_priority() {
     }
 #endif
 }
-
 }
-

--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -80,11 +80,17 @@
 #include "vboxcheckpoint.h"
 #include "vboxwrapper.h"
 #include "vbox_common.h"
+//Use of COM_OFF to choose between COM 
+//and VboxManage interfaces
+//
+//Default is COM
 #ifdef _WIN32
+#ifndef COM_OFF
 #include "vbox_mscom42.h"
 #include "vbox_mscom43.h"
 #include "vbox_mscom50.h"
 #include "vbox_mscom51.h"
+#endif
 #endif
 #include "vbox_vboxmanage.h"
 
@@ -423,7 +429,9 @@ int main(int argc, char** argv) {
     // Initialize system services
     // 
 #ifdef _WIN32
+#ifndef COM_OFF
     CoInitialize(NULL);
+#endif
 #ifdef USE_WINSOCK
     WSADATA wsdata;
     retval = WSAStartup( MAKEWORD( 1, 1 ), &wsdata);
@@ -439,7 +447,9 @@ int main(int argc, char** argv) {
     boinc_parse_init_data_file();
     boinc_get_init_data(aid);
 
+	//Use COM_OFF to choose how we initialize() the VM
 #ifdef _WIN32
+#ifndef COM_OFF
     // Determine what version of VirtualBox we are using via the registry. Use a
     // namespace specific version of the function because VirtualBox has been known
     // to change the registry location from time to time.
@@ -481,6 +491,7 @@ int main(int argc, char** argv) {
             }
 		}
     }
+#endif
 #endif
     // Initialize VM Hypervisor
     //
@@ -1383,7 +1394,9 @@ int main(int argc, char** argv) {
     }
 
 #ifdef _WIN32
+#ifndef COM_OFF
     CoUninitialize();
+#endif
 #ifdef USE_WINSOCK
     WSACleanup();
 #endif
@@ -1391,3 +1404,4 @@ int main(int argc, char** argv) {
 
     return 0;
 }
+

--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -31,7 +31,7 @@
 // --register_only  Register the VM but don't run it.
 //                  Useful for debugging; see the wiki page
 // --memory_size_mb How much memory (in MB) to give the VM. Overrides the
-//                  value in vbox_job.xml if its present. 
+//                  value in vbox_job.xml if its present.
 //
 // Handles:
 // - suspend/resume/quit/abort
@@ -80,7 +80,7 @@
 #include "vboxcheckpoint.h"
 #include "vboxwrapper.h"
 #include "vbox_common.h"
-//Use of COM_OFF to choose between COM 
+//Use of COM_OFF to choose between COM
 //and VboxManage interfaces
 //
 //Default is COM
@@ -145,7 +145,7 @@ bool read_fraction_done(double& frac_done, VBOX_VM& vm) {
     }
 
     frac_done = frac;
-	return true;
+    return true;
 }
 
 void read_completion_file_info(unsigned long& exit_code, bool& is_notice, string& message, VBOX_VM& vm) {
@@ -311,8 +311,8 @@ void check_trickle_triggers(VBOX_VM& vm) {
             vboxlog_msg("ERROR: can't read trickle trigger file %s", filename);
         } else {
             retval = boinc_send_trickle_up(
-                filename, const_cast<char*>(text.c_str())
-            );
+                         filename, const_cast<char*>(text.c_str())
+                     );
             if (retval) {
                 vboxlog_msg("boinc_send_trickle_up() failed: %s (%d)", boincerror(retval), retval);
             }
@@ -361,11 +361,11 @@ void check_trickle_period(double& elapsed_time, double& trickle_period) {
     last_trickle_report_time = elapsed_time;
     vboxlog_msg("Status Report: Trickle-Up Event.");
     sprintf(buf,
-        "<cpu_time>%f</cpu_time>", last_trickle_report_time
-    );
+            "<cpu_time>%f</cpu_time>", last_trickle_report_time
+           );
     int retval = boinc_send_trickle_up(
-        const_cast<char*>("cpu_time"), buf
-    );
+                     const_cast<char*>("cpu_time"), buf
+                 );
     if (retval) {
         vboxlog_msg("Sending Trickle-Up Event failed (%d).", retval);
     }
@@ -401,7 +401,7 @@ int main(int argc, char** argv) {
     bool report_net_usage = false;
     bool initial_heartbeat_check = true;
     double net_usage_timer = 600;
-	int vm_image = 0;
+    int vm_image = 0;
     unsigned long vm_exit_code = 0;
     bool is_notice = false;
     int temp_delay = 86400;
@@ -427,7 +427,7 @@ int main(int argc, char** argv) {
     vboxlog_msg("vboxwrapper (%d.%d.%d): starting", BOINC_MAJOR_VERSION, BOINC_MINOR_VERSION, VBOXWRAPPER_RELEASE);
 
     // Initialize system services
-    // 
+    //
 #ifdef _WIN32
 #ifndef COM_OFF
     CoInitialize(NULL);
@@ -447,7 +447,7 @@ int main(int argc, char** argv) {
     boinc_parse_init_data_file();
     boinc_get_init_data(aid);
 
-	//Use COM_OFF to choose how we initialize() the VM
+    //Use COM_OFF to choose how we initialize() the VM
 #ifdef _WIN32
 #ifndef COM_OFF
     // Determine what version of VirtualBox we are using via the registry. Use a
@@ -465,8 +465,8 @@ int main(int argc, char** argv) {
     if (BOINC_SUCCESS != vbox42::VBOX_VM::get_version_information(vbox_version_raw, vbox_version_display)) {
         if (BOINC_SUCCESS != vbox43::VBOX_VM::get_version_information(vbox_version_raw, vbox_version_display)) {
             if (BOINC_SUCCESS != vbox50::VBOX_VM::get_version_information(vbox_version_raw, vbox_version_display)) {
-				vbox51::VBOX_VM::get_version_information(vbox_version_raw, vbox_version_display);
-			}
+                vbox51::VBOX_VM::get_version_information(vbox_version_raw, vbox_version_display);
+            }
         }
     }
     if (!vbox_version_raw.empty()) {
@@ -483,13 +483,13 @@ int main(int argc, char** argv) {
         if ((5 == vbox_major) && (1 <= vbox_minor)) {
             pVM = (VBOX_VM*) new vbox51::VBOX_VM();
         }
-		if (pVM) {
+        if (pVM) {
             retval = pVM->initialize();
             if (retval) {
                 delete pVM;
                 pVM = NULL;
             }
-		}
+        }
     }
 #endif
 #endif
@@ -527,7 +527,7 @@ int main(int argc, char** argv) {
 
     // Choose a random interleave value for checkpoint intervals
     // to stagger disk I/O.
-    // 
+    //
     srand((int)getpid());
     random_checkpoint_factor = drand() * 600;
 
@@ -545,7 +545,7 @@ int main(int argc, char** argv) {
     }
 
     // Check for architecture incompatibilities
-    // 
+    //
 #if defined(_WIN32) && defined(_M_IX86)
     if (strstr(aid.host_info.os_version, "x64")) {
         vboxlog_msg("64-bit version of BOINC is required, please upgrade. Rescheduling execution for a later date.");
@@ -554,13 +554,13 @@ int main(int argc, char** argv) {
 #endif
 
     // Record what version of VirtualBox was used.
-    // 
+    //
     if (!pVM->virtualbox_version_display.empty()) {
         vboxlog_msg("Detected: %s", pVM->virtualbox_version_display.c_str());
     }
 
     // Record if anonymous platform was used.
-    // 
+    //
     if (boinc_file_exists((std::string(aid.project_dir) + std::string("/app_info.xml")).c_str())) {
         vboxlog_msg("Detected: Anonymous Platform Enabled");
     }
@@ -586,18 +586,18 @@ int main(int argc, char** argv) {
         boinc_temporary_exit(86400, "Incompatible configuration detected.");
     }
 
-    // Check against known incompatible versions of VirtualBox.  
+    // Check against known incompatible versions of VirtualBox.
     // VirtualBox 4.2.6 crashes during snapshot operations
     // and 4.2.18 fails to restore from snapshots properly.
     //
-    if ((pVM->virtualbox_version_raw.find("4.2.6") != std::string::npos) || 
-        (pVM->virtualbox_version_raw.find("4.2.18") != std::string::npos) || 
-        (pVM->virtualbox_version_raw.find("4.3.0") != std::string::npos) ) {
+    if ((pVM->virtualbox_version_raw.find("4.2.6") != std::string::npos) ||
+            (pVM->virtualbox_version_raw.find("4.2.18") != std::string::npos) ||
+            (pVM->virtualbox_version_raw.find("4.3.0") != std::string::npos) ) {
         vboxlog_msg("Incompatible version of VirtualBox detected. Please upgrade to a later version.");
         boinc_temporary_exit(86400,
-            "Incompatible version of VirtualBox detected; please upgrade.",
-            true
-        );
+                             "Incompatible version of VirtualBox detected; please upgrade.",
+                             true
+                            );
     }
 
     // Check to see if the system is in a state in which
@@ -691,24 +691,24 @@ int main(int argc, char** argv) {
         pVM->vm_master_description = "standalone";
         if (pVM->enable_floppyio) {
             sprintf(buf, "%s.%s",
-                FLOPPY_IMAGE_FILENAME, FLOPPY_IMAGE_FILENAME_EXTENSION
-            );
+                    FLOPPY_IMAGE_FILENAME, FLOPPY_IMAGE_FILENAME_EXTENSION
+                   );
             pVM->floppy_image_filename = buf;
         }
     } else {
         pVM->vm_master_name += md5_string(std::string(aid.result_name)).substr(0, 16);
         pVM->vm_master_description = aid.result_name;
-		if (vm_image) {
+        if (vm_image) {
             sprintf(buf, "%s_%d.%s",
-                IMAGE_FILENAME, vm_image, IMAGE_FILENAME_EXTENSION
-            );
+                    IMAGE_FILENAME, vm_image, IMAGE_FILENAME_EXTENSION
+                   );
             pVM->image_filename = buf;
-		}
+        }
         if (pVM->enable_floppyio) {
             sprintf(buf, "%s_%d.%s",
-                FLOPPY_IMAGE_FILENAME, aid.slot,
-                FLOPPY_IMAGE_FILENAME_EXTENSION
-            );
+                    FLOPPY_IMAGE_FILENAME, aid.slot,
+                    FLOPPY_IMAGE_FILENAME_EXTENSION
+                   );
             pVM->floppy_image_filename = buf;
         }
     }
@@ -722,10 +722,10 @@ int main(int argc, char** argv) {
     // cpu count: cmdline arg overrides config file
     //
     if (aid.ncpus > 1.0 || ncpus > 1.0) {
-		if (ncpus > 32.0) {
+        if (ncpus > 32.0) {
             vboxlog_msg("WARNING: Virtualbox only allows up to 32 processors to be allocated to a VM, resetting to 32.  (%f allocated)", ncpus);
-			ncpus = 32.0;
-		}
+            ncpus = 32.0;
+        }
         if (ncpus) {
             sprintf(buf, "%d", (int)ceil(ncpus));
         } else {
@@ -839,15 +839,15 @@ int main(int argc, char** argv) {
             //
             if (pVM->vm_pid) {
                 retval = boinc_report_app_status_aux(
-                    current_cpu_time,
-                    last_checkpoint_cpu_time,
-                    fraction_done,
-                    pVM->vm_pid,
-                    bytes_sent,
-                    bytes_received
-                );
+                             current_cpu_time,
+                             last_checkpoint_cpu_time,
+                             fraction_done,
+                             pVM->vm_pid,
+                             bytes_sent,
+                             bytes_received
+                         );
             }
- 
+
             // Give the BOINC API time to report the pid to BOINC.
             //
             boinc_sleep(5.0);
@@ -870,13 +870,13 @@ int main(int argc, char** argv) {
     //
     vboxlog_msg("Reporting VM Process ID to BOINC.");
     retval = boinc_report_app_status_aux(
-        current_cpu_time,
-        last_checkpoint_cpu_time,
-        fraction_done,
-        pVM->vm_pid,
-        bytes_sent,
-        bytes_received
-    );
+                 current_cpu_time,
+                 last_checkpoint_cpu_time,
+                 fraction_done,
+                 pVM->vm_pid,
+                 bytes_sent,
+                 bytes_received
+             );
 
     // Wait for up to 5 minutes for the VM to switch states.
     // A system under load can take a while.
@@ -895,7 +895,7 @@ int main(int argc, char** argv) {
     //
     pVM->lower_vm_process_priority();
 
-    // Log our current state 
+    // Log our current state
     pVM->poll(true);
 
     // Is the VM still running? If not, why not?
@@ -970,15 +970,15 @@ int main(int argc, char** argv) {
             //
             if (pVM->vm_pid) {
                 retval = boinc_report_app_status_aux(
-                    current_cpu_time,
-                    last_checkpoint_cpu_time,
-                    fraction_done,
-                    pVM->vm_pid,
-                    bytes_sent,
-                    bytes_received
-                );
+                             current_cpu_time,
+                             last_checkpoint_cpu_time,
+                             fraction_done,
+                             pVM->vm_pid,
+                             bytes_sent,
+                             bytes_received
+                         );
             }
- 
+
             // Give the BOINC API time to report the pid to BOINC.
             //
             boinc_sleep(5.0);
@@ -1051,7 +1051,7 @@ int main(int argc, char** argv) {
             if (
                 (initial_heartbeat_check && (elapsed_time >= (last_heartbeat_elapsed_time + 600.0))) ||
                 (!initial_heartbeat_check && (elapsed_time >= (last_heartbeat_elapsed_time + pVM->minimum_heartbeat_interval)))
-            ){
+            ) {
                 bool should_exit = false;
                 struct stat heartbeat_stat;
 
@@ -1168,7 +1168,7 @@ int main(int argc, char** argv) {
                     vboxlog_msg("ERROR: VM task failed to pause, rescheduling task for a later time.");
                     pVM->poweroff();
                     boinc_temporary_exit(86400, "VM job unmanageable, restarting later.");
-               }
+                }
             }
         } else {
             if (pVM->suspended) {
@@ -1177,7 +1177,7 @@ int main(int argc, char** argv) {
                     vboxlog_msg("ERROR: VM task failed to resume, rescheduling task for a later time.");
                     pVM->poweroff();
                     boinc_temporary_exit(86400, "VM job unmanageable, restarting later.");
-               }
+                }
             }
 
             // stuff to do every 10 secs (everything else is 1/sec)
@@ -1192,12 +1192,12 @@ int main(int argc, char** argv) {
                 fraction_done = elapsed_time / pVM->job_duration;
             } else if (pVM->fraction_done_filename.size() > 0) {
                 if (!read_fraction_done(fraction_done, *pVM)) {
-					// Report a non-zero fraction done so that BOINC will not attempt to use CPU Time and
-					// deadline as a means to calculate fraction done when a fraction done file is
-					// specified.
-					//
-					fraction_done = 0.001;
-				}
+                    // Report a non-zero fraction done so that BOINC will not attempt to use CPU Time and
+                    // deadline as a means to calculate fraction done when a fraction done file is
+                    // specified.
+                    //
+                    fraction_done = 0.001;
+                }
             }
             if (fraction_done > 1.0) {
                 fraction_done = 1.0;
@@ -1228,7 +1228,7 @@ int main(int argc, char** argv) {
             }
 
             // Real VM checkpoints (snapshots) are expensive, don't do them very often.
-            // 
+            //
             // If the project has disabled automatic checkpoints, just report that we have
             // successfully completed the checkpoint as soon as the API reports that we should
             // checkpoint.
@@ -1329,9 +1329,9 @@ int main(int argc, char** argv) {
         // report network usage every 10 min so the client can enforce quota
         //
         if (aid.global_prefs.daily_xfer_limit_mb
-            && pVM->enable_network
-            && !pVM->suspended
-        ) {
+                && pVM->enable_network
+                && !pVM->suspended
+           ) {
             net_usage_timer -= POLL_PERIOD;
             if (net_usage_timer <= 0) {
                 net_usage_timer = 600;
@@ -1351,13 +1351,13 @@ int main(int argc, char** argv) {
 
         if (report_net_usage) {
             retval = boinc_report_app_status_aux(
-                elapsed_time,
-                last_checkpoint_cpu_time,
-                fraction_done,
-                pVM->vm_pid,
-                bytes_sent,
-                bytes_received
-            );
+                         elapsed_time,
+                         last_checkpoint_cpu_time,
+                         fraction_done,
+                         pVM->vm_pid,
+                         bytes_sent,
+                         bytes_received
+                     );
             if (!retval) {
                 report_net_usage = false;
             }
@@ -1404,4 +1404,3 @@ int main(int argc, char** argv) {
 
     return 0;
 }
-


### PR DESCRIPTION
Give the option to Windows users to choose between the COM interface and the VboxManage interface using a preprocessor flag (COM_OFF). Change the way logs are parsed to get the process ID and to get the guest vm log entries. Add some more detailed logging.