### PR TITLE
Build: use default sysconfdir instead of /etc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -538,16 +538,6 @@ if test "x${libdir}" = "xNONE" -o -z "${libdir}" ; then
   bindir="${exec_prefix}/lib"
 fi
 
-dnl if --sysconfdir was not specified, default ${sysconfdir} to '/etc/'.
-dnl this is done to preserve the behaviour of previous BOINC versions
-dnl which always installed to /etc/ in client/scripts/. Now we install
-dnl to ${sysconfdir}/.
-dnl the default value for ${sysconfdir} set by automake is '${prefix}/etc',
-dnl but we also test for an empty string
-if test "${sysconfdir}" = '${prefix}/etc' -o "x${sysconfdir}" = "x"; then
-  sysconfdir=/etc
-fi
-
 AC_DEFINE_UNQUOTED(BOINC_PREFIX,"`eval echo ${prefix}`",[Directory tree where BOINC will be installed])
 AC_DEFINE_UNQUOTED(BOINC_EXECPREFIX,"`eval echo ${bindir}`",[Directory where BOINC executables will be installed])
 AC_DEFINE_UNQUOTED(BOINC_LIBDIR,"`eval echo ${libdir}`",[Directory where BOINC libraries will be installed])


### PR DESCRIPTION
When using --prefix this override tries to install files from client/scripts to /etc instead of ${prefix}/etc. This is against what the user wants and leads to an error message as normally only root can install files to /etc. There is no need to be backwards compatible in this place as installs are usually done via repository packages.
This still uses /etc to determine where the config file should be copied to which is ok because the user most likely wants to use the Client on the machine it was built on.

Note: The startup scripts and config files in client/scripts are outdated and might not work on recent Linux distributions. Newer ones can be found in the Debian/Fedora packages.

fixes #1227 