### PR TITLE
Manager: Implement feature 'Do not show this message again' in 'Shut …

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1465,6 +1465,7 @@ void CAdvancedFrame::OnClientShutdown(wxCommandEvent& WXUNUSED(event)) {
     wxCommandEvent     evtSelectNewComputer(wxEVT_COMMAND_MENU_SELECTED, ID_SELECTCOMPUTER);
     CMainDocument*     pDoc = wxGetApp().GetDocument();
     CSkinAdvanced*     pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
+    int                showDialog = wxGetApp().GetBOINCMGRDisplayShutdownConnectedClientMessage();
     CDlgGenericMessage dlg(this);
     wxString           strDialogTitle = wxEmptyString;
     wxString           strDialogMessage = wxEmptyString;
@@ -1479,29 +1480,31 @@ void CAdvancedFrame::OnClientShutdown(wxCommandEvent& WXUNUSED(event)) {
     // Stop all timers
     StopTimers();
 
+    if (showDialog) {
+        // %s is the application name
+        //    i.e. 'BOINC Manager', 'GridRepublic Manager'
+        strDialogTitle.Printf(
+            _("%s - Shut down the current client..."),
+            pSkinAdvanced->GetApplicationName().c_str()
+        );
 
-    // %s is the application name
-    //    i.e. 'BOINC Manager', 'GridRepublic Manager'
-    strDialogTitle.Printf(
-        _("%s - Shut down the current client..."),
-        pSkinAdvanced->GetApplicationName().c_str()
-    );
+        // 1st %s is the application name
+        //    i.e. 'BOINC Manager', 'GridRepublic Manager'
+        // 2nd %s is the project name
+        //    i.e. 'BOINC', 'GridRepublic'
+        strDialogMessage.Printf(
+            _("%s will shut down the current client\nand prompt you for another host to connect to."),
+            pSkinAdvanced->GetApplicationName().c_str()
+        );
 
-    // 1st %s is the application name
-    //    i.e. 'BOINC Manager', 'GridRepublic Manager'
-    // 2nd %s is the project name
-    //    i.e. 'BOINC', 'GridRepublic'
-    strDialogMessage.Printf(
-        _("%s will shut down the current client\nand prompt you for another host to connect to."),
-        pSkinAdvanced->GetApplicationName().c_str()
-    );
+        dlg.SetTitle(strDialogTitle);
+        dlg.m_DialogMessage->SetLabel(strDialogMessage);
+        dlg.Fit();
+        dlg.Centre();
+    }
 
-    dlg.SetTitle(strDialogTitle);
-    dlg.m_DialogMessage->SetLabel(strDialogMessage);
-    dlg.Fit();
-    dlg.Centre();
-
-    if (wxID_OK == dlg.ShowModal()) {
+    if (!showDialog || wxID_OK == dlg.ShowModal()) {
+        wxGetApp().SetBOINCMGRDisplayShutdownConnectedClientMessage(!dlg.m_DialogDisableMessage->GetValue());
         pDoc->CoreClientQuit();
         pDoc->ForceDisconnect();
         

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -106,6 +106,7 @@ bool CBOINCGUIApp::OnInit() {
     m_iBOINCMGRDisableAutoStart = 0;
     m_iShutdownCoreClient = 0;
     m_iDisplayExitDialog = 1;
+    m_iDisplayShutdownConnectedClientDialog = 1;
     m_iGUISelected = BOINC_SIMPLEGUI;
     m_bSafeMessageBoxDisplayed = 0;
     m_bRunDaemon = true;
@@ -163,6 +164,7 @@ bool CBOINCGUIApp::OnInit() {
     m_pConfig->SetPath(wxT("/"));
     m_pConfig->Read(wxT("AutomaticallyShutdownClient"), &m_iShutdownCoreClient, 0L);
     m_pConfig->Read(wxT("DisplayShutdownClientDialog"), &m_iDisplayExitDialog, 1L);
+    m_pConfig->Read(wxT("DisplayShutdownConnectedClientDialog"), &m_iDisplayShutdownConnectedClientDialog, 1L);
     m_pConfig->Read(wxT("DisableAutoStart"), &m_iBOINCMGRDisableAutoStart, 0L);
     m_pConfig->Read(wxT("LanguageISO"), &m_strISOLanguageCode, wxT(""));
     m_pConfig->Read(wxT("GUISelection"), &m_iGUISelected, BOINC_SIMPLEGUI);
@@ -567,6 +569,7 @@ void CBOINCGUIApp::SaveState() {
     m_pConfig->Write(wxT("LanguageISO"), m_strISOLanguageCode);
     m_pConfig->Write(wxT("AutomaticallyShutdownClient"), m_iShutdownCoreClient);
     m_pConfig->Write(wxT("DisplayShutdownClientDialog"), m_iDisplayExitDialog);
+    m_pConfig->Write(wxT("DisplayShutdownConnectedClientDialog"), m_iDisplayShutdownConnectedClientDialog);
     m_pConfig->Write(wxT("DisableAutoStart"), m_iBOINCMGRDisableAutoStart);
     m_pConfig->Write(wxT("RunDaemon"), m_bRunDaemon);
 }

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -97,6 +97,7 @@ protected:
     int                 m_iBOINCMGRDisableAutoStart;
     int                 m_iShutdownCoreClient;
     int                 m_iDisplayExitDialog;
+    int                 m_iDisplayShutdownConnectedClientDialog;
 
     bool                m_bGUIVisible;
     
@@ -154,6 +155,11 @@ public:
                                                     { return m_iDisplayExitDialog; }
     void                SetBOINCMGRDisplayExitMessage(int iDisplayExitMessage)
                                                     { m_iDisplayExitDialog = iDisplayExitMessage; }
+
+    int                 GetBOINCMGRDisplayShutdownConnectedClientMessage()
+                                                    { return m_iDisplayShutdownConnectedClientDialog; }
+    void                SetBOINCMGRDisplayShutdownConnectedClientMessage(int iDisplayShutdownConnectedClientDialog)
+                                                    { m_iDisplayShutdownConnectedClientDialog = iDisplayShutdownConnectedClientDialog; }
 
     bool                GetRunDaemon()
                                                     { return m_bRunDaemon; }  


### PR DESCRIPTION
…Down Connected Client' dialog.

This fixes #1193: "Shut Down Connected Client" dialog doesn't work right
New option 'DisplayShutdownConnectedClientDialog' added.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>