### PR TITLE
Android: improved auto-versioning

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.application'
 
 import org.ajoberstar.grgit.Grgit
 
-// Use commit date as version code
+// Use commit date as version code (valid up to 07/18/2036)
 def buildVersionCode() {
     def repo = Grgit.open()
     def head = repo.head()
@@ -20,24 +20,30 @@ def buildVersionCode() {
 
 // Derive version name from release tag and add commit SHA1
 def buildVersionName() {
-    def pattern = /client_release\/\d+\.\d+\/(?<major>\d+)\.(?<minor>\d+)\.(?<revision>\d+)(?<suffix>[-_].*)/
-    def message = 'Invalid release tag encountered:'
+    def pattern = /client_release\/\d+\.\d+\/(?<major>\d+)\.(?<minor>\d+)\.(?<revision>\d+)(?<suffix>[-_\.].*)/
+    def version = ': DEVELOPMENT'
 
-    def tag = versionDetails().lastTag
+    def head = versionDetails()
+    def tag = head.lastTag
     def match = (tag =~ pattern)
 
     // Sanity checks for tag format
-    assert match.hasGroup() : "$message $tag"
-    assert 1 == match.size() : "$message $tag"
-    assert 5 == match[0].size() : "$message $tag"
+    if(match.hasGroup() && 1 == match.size() && 5 == match[0].size() && head.commitDistance == 0) {
+        def major = match.group('major')
+        def minor = match.group('minor')
+        def revision = match.group('revision')
+        def suffix = match.group('suffix')
+        version = "${major}.${minor}.${revision}${suffix}"
+        assert !suffix.endsWith('.dirty') : "Dirty working tree detected! Preventing release build!"
+    }
+    else {
+        println "Warning! Non-release tag or offset found: $tag (offset: $head.commitDistance)"
+        println "Flagging as DEVELOPMENT build..."
+    }
 
-    def major = match.group('major')
-    def minor = match.group('minor')
-    def revision = match.group('revision')
-    def suffix = match.group('suffix')
     def commit = versionDetails().gitHash
 
-    return "${major}.${minor}.${revision}${suffix} (${commit})"
+    return "${version} (${commit})"
 }
 
 android {


### PR DESCRIPTION
* Current version doesn't support development well enough
* Gradle seemingly doesn't support distinguishing build variants (debug/release) so I can't enforce proper release tagging
* Thus any non-matching tag will flag a build as DEVELOPMENT and a Gradle warning is displayed
* Also: release builds must be tagged directly (no commit offset)
* Also: release builds are not allowed to use a dirty working tree

This is a follow-up to PR #1866 that got merged prematurely.