### PR TITLE
SCHED_BATCH -> SCHED_IDLE

### DIFF
--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -1090,11 +1090,11 @@ int ACTIVE_TASK::start(bool test) {
                 }
             }
 #endif
-#if HAVE_SCHED_SETSCHEDULER && defined(SCHED_BATCH) && defined (__linux__)
+#if HAVE_SCHED_SETSCHEDULER && defined(SCHED_IDLE) && defined (__linux__)
             if (!high_priority) {
                 struct sched_param sp;
                 sp.sched_priority = 0;
-                if (sched_setscheduler(0, SCHED_BATCH, &sp)) {
+                if (sched_setscheduler(0, SCHED_IDLE, &sp)) {
                     perror("sched_setscheduler");
                 }
             }


### PR DESCRIPTION
It was a BOINC RasPi forum entry that made me revisit chrt and relearn about scheduler policies+priorities. BOINC executes the tasks (if !highpriority) under the SCHED_BATCH policy. This also let me unearth again that SCHED_IDLE is what in the very early UNIX days was reached by renicing to the highest values but today SCHED_IDLE is less of a priority than SCHED_BATCH with nicelevel 19.  I just executed the "chrt -i ..." manually and it seems just fine. Graphics still work. Communication with the BOINC servers is performed with a higher priority outside the task, which lets me think that we should expect any problem. So I suggest to have SCHED_IDLE the default for compute jobs.

Best,
Steffen