### PR TITLE
vboxwrapper: Fix vboxwrapper_vs2013.vcxproj build.

### DIFF
--- a/win_build/vboxwrapper_vs2013.vcxproj
+++ b/win_build/vboxwrapper_vs2013.vcxproj
@@ -312,6 +312,7 @@
     <ClCompile Include="..\samples\vboxwrapper\vbox_mscom42.cpp" />
     <ClCompile Include="..\samples\vboxwrapper\vbox_mscom43.cpp" />
     <ClCompile Include="..\samples\vboxwrapper\vbox_mscom50.cpp" />
+    <ClCompile Include="..\samples\vboxwrapper\vbox_mscom51.cpp" />
     <ClCompile Include="..\samples\vboxwrapper\vbox_mscom_impl.cpp" />
     <ClCompile Include="..\samples\vboxwrapper\vbox_vboxmanage.cpp" />
   </ItemGroup>
@@ -326,6 +327,7 @@
     <ClInclude Include="..\samples\vboxwrapper\vbox_mscom42.h" />
     <ClInclude Include="..\samples\vboxwrapper\vbox_mscom43.h" />
     <ClInclude Include="..\samples\vboxwrapper\vbox_mscom50.h" />
+    <ClInclude Include="..\samples\vboxwrapper\vbox_mscom51.h" />
     <ClInclude Include="..\samples\vboxwrapper\vbox_mscom_impl.h" />
     <ClInclude Include="..\samples\vboxwrapper\vbox_vboxmanage.h" />
   </ItemGroup>


### PR DESCRIPTION
Add missed vbox_mscom51.cpp and vbox_mscom51.h files to the project.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>