### PR TITLE
client: Remove unused variables

### DIFF
--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1109,7 +1109,6 @@ void CLIENT_STATE::append_unfinished_time_slice(vector<RESULT*> &run_list) {
 //
 bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
     unsigned int i;
-    vector<ACTIVE_TASK*> preemptable_tasks;
     int retval;
     double ncpus_used=0;
     ACTIVE_TASK* atp;


### PR DESCRIPTION
From PVS Studio:
V808
'preemptable_tasks' object of 'vector' type was created but was not utilized.
https://www.viva64.com/en/w/V808/print

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>