### PR TITLE
lib: Remove unused variables

### DIFF
--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -846,7 +846,6 @@ GR_PROXY_INFO::GR_PROXY_INFO() {
 }
 
 int GR_PROXY_INFO::parse(XML_PARSER& xp) {
-	std::string noproxy;
     use_http_proxy = false;
     use_socks_proxy = false;
     use_http_authentication = false;


### PR DESCRIPTION
From PVS Studio:
V808
'noproxy' object of 'basic_string' type was created but was not utilized.
https://www.viva64.com/en/w/V808/print

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>