### PR TITLE
Manager: Remove unused variables

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -913,7 +913,6 @@ bool CAdvancedFrame::SaveState() {
     CBOINCBaseView* pView = NULL;
     wxString        strConfigLocation;
     wxString        strPreviousLocation;
-    wxString        strBuffer;
     int             iIndex = 0;
     int             iItemCount = 0;
 
@@ -975,8 +974,6 @@ bool CAdvancedFrame::RestoreState() {
     CBOINCBaseView* pView = NULL;
     wxString        strConfigLocation;
     wxString        strPreviousLocation;
-    wxString        strBuffer;
-    wxString        strValue;
     long            iIndex;
     long            iPageCount;
     long            iCurrentPage;
@@ -1749,9 +1746,6 @@ void CAdvancedFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
     CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     CWizardAttach* pWizard = NULL;
     wxString strComputer = wxEmptyString;
-    wxString strName = wxEmptyString;
-    wxString strURL = wxEmptyString;
-    wxString strTeamName = wxEmptyString;
     wxString strDialogTitle = wxEmptyString;
     wxString strDialogDescription = wxEmptyString;
     std::string strProjectName;
@@ -2015,7 +2009,6 @@ void CAdvancedFrame::OnFrameRender(wxTimerEvent& WXUNUSED(event)) {
                     m_pStatusbar->m_pbmpDisconnect->Hide();
                     m_pStatusbar->m_ptxtDisconnect->Hide();
 
-                    wxString strBuffer = wxEmptyString;
                     wxString strComputerName = wxEmptyString;
                     wxString strComputerVersion = wxEmptyString;
                     wxString strStatusText = wxEmptyString;

--- a/clientgui/BOINCDialupManager.cpp
+++ b/clientgui/BOINCDialupManager.cpp
@@ -97,7 +97,6 @@ void CBOINCDialUpManager::OnPoll() {
     bool                bIsOnline = false;
     bool                bWantConnection = false;
     bool                bWantDisconnect = false;
-    wxString            strDialogMessage = wxEmptyString;
     CC_STATUS           cc_status;
 
 

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -117,8 +117,9 @@ bool CBOINCGUIApp::OnInit() {
     int      iDesiredLanguageCode = 0;
     bool     bOpenEventLog = false;
     wxString strDesiredSkinName = wxEmptyString;
+#ifdef SANDBOX
     wxString strDialogMessage = wxEmptyString;
-    wxString strOldLanguageCode = wxEmptyString;
+#endif
     bool     success = false;
 
 

--- a/clientgui/BOINCTaskBar.cpp
+++ b/clientgui/BOINCTaskBar.cpp
@@ -698,7 +698,6 @@ void CTaskBarIcon::UpdateTaskbarStatus() {
 #else
     wxString       strMachineName       = wxEmptyString;
     wxString       strMessage           = wxEmptyString;
-    wxString       strBuffer            = wxEmptyString;
     wxIcon         icnIcon;
 
     pDoc->GetConnectedComputerName(strMachineName);

--- a/clientgui/DlgHiddenColumns.cpp
+++ b/clientgui/DlgHiddenColumns.cpp
@@ -184,7 +184,6 @@ void CDlgHiddenColumns::CreateCheckboxes() {
 
         CBOINCListCtrl* listCtrl = pView->GetListCtrl();
         wxInt32 iShownColumnCount = listCtrl->GetColumnCount();
-        wxString strHiddenColumns;
         wxArrayInt aOrder(iShownColumnCount);
 
 #ifdef wxHAS_LISTCTRL_COLUMN_ORDER

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -521,7 +521,6 @@ int CMainDocument::OnInit() {
 
 
 int CMainDocument::OnExit() {
-    wxString         strConnectedCompter = wxEmptyString;
     int              iRetVal = 0;
 
     if (m_pClientManager) {
@@ -2374,7 +2373,6 @@ int CMainDocument::GetStatisticsCount() {
 
 int CMainDocument::GetProxyConfiguration() {
     int     iRetVal = 0;
-    wxString    strEmpty = wxEmptyString;
 
     iRetVal = rpc.get_proxy_settings(proxy_info);
     if (iRetVal) {

--- a/clientgui/browser.cpp
+++ b/clientgui/browser.cpp
@@ -800,7 +800,6 @@ bool detect_cookie_ie_supported_uac(std::string& project_url, std::string& name,
     std::string  domainname;
     std::wstring domainname_w;
     std::wstring name_w;
-    std::wstring value_w;
     size_t       uiDelimeterLocation;
 
     if (!ieframelib) {

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -754,9 +754,6 @@ void CSimpleFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
     CMainDocument*     pDoc = wxGetApp().GetDocument();
     CWizardAttach*     pWizard = NULL;
     wxString strComputer = wxEmptyString;
-    wxString strName = wxEmptyString;
-    wxString strURL = wxEmptyString;
-    wxString strTeamName = wxEmptyString;
     std::string strProjectName;
     std::string strProjectURL;
     std::string strProjectAuthenticator;

--- a/clientgui/sg_TaskPanel.cpp
+++ b/clientgui/sg_TaskPanel.cpp
@@ -791,7 +791,6 @@ void CSimpleTaskPanel::GetApplicationAndProjectNames(RESULT* result, wxString* a
     RESULT*        state_result = NULL;
     wxString       strAppBuffer = wxEmptyString;
     wxString       strGPUBuffer = wxEmptyString;
-    wxString pct_done_str = wxEmptyString;
 
     wxASSERT(pDoc);
     wxASSERT(wxDynamicCast(pDoc, CMainDocument));

--- a/clientgui/wizardex.cpp
+++ b/clientgui/wizardex.cpp
@@ -482,9 +482,6 @@ bool wxWizardEx::ShowPage(wxWizardPageEx *page, bool goingForward)
     // button or not (initially the label is "Next")
     bool btnLabelWasNext = true;
 
-    // remember the old bitmap (if any) to compare with the new one later
-    wxBitmap bmpPrev;
-
     // check for previous page
     if ( m_page )
     {


### PR DESCRIPTION
From PVS Studio:
V808
'strBuffer' object of 'wxString' type was created but was not utilized.
'strValue' object of 'wxString' type was created but was not utilized.
'strName' object of 'wxString' type was created but was not utilized.
'strURL' object of 'wxString' type was created but was not utilized.
'strTeamName' object of 'wxString' type was created but was not utilized.
'strDialogMessage' object of 'wxString' type was created but was not utilized.
'strOldLanguageCode' object of 'wxString' type was created but was not utilized.
'strHiddenColumns' object of 'wxString' type was created but was not utilized.
'strConnectedCompter' object of 'wxString' type was created but was not utilized.
'strEmpty' object of 'wxString' type was created but was not utilized.
'value_w' object of 'basic_string' type was created but was not utilized.
'pct_done_str' object of 'wxString' type was created but was not utilized.
'bmpPrev' object of 'wxBitmap' type was created but was not utilized.
https://www.viva64.com/en/w/V808/print

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>