### PR TITLE
vboxwrapper: Remove unused variables

### DIFF
--- a/samples/vboxwrapper/vbox_mscom_impl.cpp
+++ b/samples/vboxwrapper/vbox_mscom_impl.cpp
@@ -290,7 +290,6 @@ int VBOX_VM::create_vm() {
     HRESULT rc;
     char buf[256];
     APP_INIT_DATA aid;
-    CComBSTR vm_machine_uuid;
     CComPtr<IMachine> pMachineRO;
     CComPtr<IMachine> pMachine;
     CComPtr<ISession> pSession;
@@ -907,7 +906,6 @@ int VBOX_VM::deregister_vm(bool delete_media) {
     CComPtr<IProgress> pProgress;
     CComPtr<IBandwidthControl> pBandwidthControl;
     CComPtr<ISnapshot> pRootSnapshot;
-    std::vector<CComPtr<IMedium>> clean_mediums;
     std::vector<CComPtr<IMedium>> mediums;
     std::vector<std::string> snapshots;
     DeviceType device_type; 


### PR DESCRIPTION
From PVS Studio:
V808
'vm_machine_uuid' object of 'CComBSTR' type was created but was not utilized.
'clean_mediums' object of 'vector' type was created but was not utilized.
https://www.viva64.com/en/w/V808/print

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>