### PR TITLE
Move 'strlen' function outside of the loop

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -1089,13 +1089,14 @@ static void handle_upload_file_status() {
     char path[MAXPATHLEN], buf[256], log_name[256], *p, log_buf[256];
     std::string filename;
     int status;
+    const size_t prefixLen = strlen(UPLOAD_FILE_STATUS_PREFIX);
 
     relative_to_absolute("", path);
     DirScanner dirscan(path);
     while (dirscan.scan(filename)) {
         strlcpy(buf, filename.c_str(), sizeof(buf));
         if (strstr(buf, UPLOAD_FILE_STATUS_PREFIX) != buf) continue;
-        strlcpy(log_name, buf+strlen(UPLOAD_FILE_STATUS_PREFIX), sizeof(log_name));
+        strlcpy(log_name, buf+prefixLen, sizeof(log_name));
         FILE* f = boinc_fopen(filename.c_str(), "r");
         if (!f) {
             fprintf(stderr,

--- a/client/app.cpp
+++ b/client/app.cpp
@@ -1047,12 +1047,13 @@ int ACTIVE_TASK::handle_upload_files() {
     std::string filename;
     char buf[MAXPATHLEN], path[MAXPATHLEN];
     int retval;
+    const size_t prefixLen = strlen(UPLOAD_FILE_REQ_PREFIX);
 
     DirScanner dirscan(slot_dir);
     while (dirscan.scan(filename)) {
         safe_strcpy(buf, filename.c_str());
         if (strstr(buf, UPLOAD_FILE_REQ_PREFIX) == buf) {
-            char* p = buf+strlen(UPLOAD_FILE_REQ_PREFIX);
+            char* p = buf+prefixLen;
             FILE_INFO* fip = result->lookup_file_logical(p);
             if (fip) {
                 get_pathname(fip, path, sizeof(path));

--- a/client/app_config.cpp
+++ b/client/app_config.cpp
@@ -245,12 +245,13 @@ int APP_CONFIGS::config_app_versions(PROJECT* p, bool show_warnings) {
             continue;
         }
         bool found = false;
+        const size_t cmdLineLen = strlen(avc.cmdline);
         for (unsigned int j=0; j<gstate.app_versions.size(); j++) {
             APP_VERSION* avp = gstate.app_versions[j];
             if (avp->app != app) continue;
             if (strcmp(avp->plan_class, avc.plan_class)) continue;
             found = true;
-            if (strlen(avc.cmdline)) {
+            if (cmdLineLen) {
                 safe_strcpy(avp->cmdline, avc.cmdline);
             }
             if (avc.avg_ncpus) {

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -544,14 +544,16 @@ int PROJECT::parse_preferences_for_user_files() {
 
     user_files.clear();
     size_t n=0, start, end;
+    const size_t app_fileOpenTagLen = strlen("<app_file>");
+    const size_t app_fileCloseTagLen = strlen("</app_file>");
     while (1) {
         start = project_specific_prefs.find("<app_file>", n);
         if (start == string::npos) break;
         end = project_specific_prefs.find("</app_file>", n);
         if (end == string::npos) break;
-        start += strlen("<app_file>");
+        start += app_fileOpenTagLen;
         string x = project_specific_prefs.substr(start, end);
-        n = end + strlen("</app_file>");
+        n = end + app_fileCloseTagLen;
 
         strlcpy(buf, x.c_str(), sizeof(buf));
         if (!parse_str(buf, "<timestamp>", timestamp)) break;

--- a/client/cs_trickle.cpp
+++ b/client/cs_trickle.cpp
@@ -59,10 +59,11 @@ int CLIENT_STATE::read_trickle_files(PROJECT* project, FILE* f) {
 
     // trickle-up filenames are of the form trickle_up_RESULTNAME_TIME[.sent]
     //
+    const size_t prefixLen = strlen("trickle_up_");
     while (ds.scan(fn)) {
         safe_strcpy(fname, fn.c_str());
         if (strstr(fname, "trickle_up_") != fname) continue;
-        q = fname + strlen("trickle_up_");
+        q = fname + prefixLen;
         p = strrchr(fname, '_');
         if (p <= q) continue;
         *p = 0;

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -331,6 +331,7 @@ int SCHEDULER_OP::parse_master_file(PROJECT* p, vector<string> &urls) {
     string str;
     FILE* f;
     int n;
+    const size_t schedulerCloseTagLen = strlen("</scheduler>");
 
     get_master_filename(*p, master_filename, sizeof(master_filename));
     f = boinc_fopen(master_filename, "r");
@@ -348,7 +349,7 @@ int SCHEDULER_OP::parse_master_file(PROJECT* p, vector<string> &urls) {
         while (q && parse_str(q, "<scheduler>", str)) {
             push_unique(str, urls);
             q = strstr(q, "</scheduler>");
-            if (q) q += strlen("</scheduler>");
+            if (q) q += schedulerCloseTagLen;
         }
 
         // check for new syntax: <link ...>

--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -1552,6 +1552,7 @@ UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID /* lpParameter */) {
     CONTEXT      c;
     BOINC_WINDOWCAPTURE window_info;
     BOINC_THREADLISTENTRY *pThreadEntry = NULL;
+    const size_t boinc_install_dirLen = strlen(diagnostics_get_boinc_install_dir());
 
     // We should not suspend our crash dump thread.
     diagnostics_set_thread_exempt_suspend();
@@ -1614,7 +1615,7 @@ UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID /* lpParameter */) {
                 // Kickstart the debugger extensions, look for the debugger files
                 //   in the install directory if it is defined, otherwise look
                 //   in the data directory.
-                if (0 != strlen(diagnostics_get_boinc_install_dir())) {
+                if (0 != boinc_install_dirLen) {
  	                bDebuggerInitialized = !DebuggerInitialize(
                         diagnostics_get_boinc_install_dir(),
                         diagnostics_get_symstore(),

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -321,6 +321,7 @@ void extract_venue(const char* in, const char* venue_name, char* out, int len) {
     const char* p, *q;
     char* wp;
     char buf[256];
+    const size_t venueCloseTagLen = strlen("</venue>");
     snprintf(buf, sizeof(buf), "<venue name=\"%s\">", venue_name);
     p = strstr(in, buf);
     if (p) {
@@ -344,7 +345,7 @@ void extract_venue(const char* in, const char* venue_name, char* out, int len) {
                strncat(out, q, p-q);
                q = strstr(p, "</venue>");
                if (!q) break;
-               q += strlen("</venue>");
+               q += venueCloseTagLen;
            }
     }
 }

--- a/samples/gfx_html/mongoose.cpp
+++ b/samples/gfx_html/mongoose.cpp
@@ -2570,6 +2570,7 @@ static int convert_uri_to_file_name(struct connection *conn, char *buf,
   const char *root = conn->server->config_options[DOCUMENT_ROOT];
 #ifndef MONGOOSE_NO_CGI
   const char *cgi_pat = conn->server->config_options[CGI_PATTERN];
+  const size_t cgi_patLen = strlen(cgi_pat);
   char *p;
 #endif
   const char *uri = conn->mg_conn.uri;
@@ -2611,7 +2612,7 @@ static int convert_uri_to_file_name(struct connection *conn, char *buf,
   for (p = buf + strlen(root) + 2; *p != '\0'; p++) {
     if (*p == '/') {
       *p = '\0';
-      if (mg_match_prefix(cgi_pat, strlen(cgi_pat), buf) > 0 &&
+      if (mg_match_prefix(cgi_pat, cgi_patLen, buf) > 0 &&
           !stat(buf, st)) {
       DBG(("!!!! [%s]", buf));
         *p = '/';

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -248,10 +248,11 @@ vector<TASK> daemons;
 //
 void str_replace_all(char* buf, const char* s1, const char* s2) {
     char buf2[64000];
+    const size_t s1Len = strlen(s1);
     while (1) {
         char* p = strstr(buf, s1);
         if (!p) break;
-        strcpy(buf2, p+strlen(s1));
+        strcpy(buf2, p+s1Len);
         strcpy(p, s2);
         strcat(p, buf2);
     }
@@ -705,6 +706,7 @@ int TASK::run(int argct, char** argvt) {
     }
 
     // resolve "boinc_resolve(...)" phrases in command-line
+    const size_t boinc_resolvePrefixLen = strlen("boinc_resolve(");
     while (1) {
         char lbuf[16384];
         char fname[1024];
@@ -722,7 +724,7 @@ int TASK::run(int argct, char** argvt) {
             exit(1);
         }
         *to = 0;
-        boinc_resolve_filename(from + strlen("boinc_resolve("), fname, sizeof(fname));
+        boinc_resolve_filename(from + boinc_resolvePrefixLen, fname, sizeof(fname));
 #ifdef _WIN32
         if(forward_slashes) {
             backslash_to_slash(fname);


### PR DESCRIPTION
From PVS Studio:
V814
Decreased performance. The 'strlen' function was called multiple times inside the body of a loop.
https://www.viva64.com/en/w/V814/print

Affected components:
api
client
lib
samples