### PR TITLE
Drupal: Fix link to use url function

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -98,7 +98,7 @@ function boinc_links__system_main_menu($links, $menu, $element) {
       if ($link['href'] == 'dashboard') {
         $item_count = privatemsg_unread_count();
         if ($item_count) {
-          $link['title'] .= '</a> <a href="/messages" class="compound secondary"><div class="item-count-wrapper"><span class="item-count">' . $item_count . '</span></div>';
+          $link['title'] .= '</a> <a href="' . url('messages') . '" class="compound secondary"><div class="item-count-wrapper"><span class="item-count">' . $item_count . '</span></div>';
           $link['html'] = TRUE;
           $link['attributes']['class'] = 'compound';
         }


### PR DESCRIPTION
Fix link to use `url()` function.

https://dev.gridrepublic.org/browse/DBOINCP-317