### PR TITLE
Drupal: Fixed bug in moved (forum) topic link.

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -370,6 +370,11 @@ function boinc_preprocess_forum_topic_list(&$variables) {
           $topic->new_replies = NULL;
         }
       }
+      // Use same logic in forum.module to change message if topic has
+      // moved. Changed link to match boinc path-added "community".
+      if ($topic->forum_tid != $variables['tid']) {
+        $variables['topics'][$id]->message = l(t('This topic has been moved'), "community/forum/$topic->forum_tid");
+      }
     }
   }
 }

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
@@ -88,7 +88,7 @@
       drupal_set_title($title);
       $subtitle = array();
       // Get vocabulary name and taxonomy name for subtitle breadcrumbs
-      $taxonomy = reset($node->taxonomy);
+      $taxonomy = taxonomy_get_term($node->forum_tid);
       if ($forum_vocab = taxonomy_vocabulary_load($taxonomy->vid)) {
         $subtitle[] = l($forum_vocab->name, 'community/forum');
       }


### PR DESCRIPTION
A moved forum topic's shadow topic message had wrong link. Added path "community" to link.

Also, I updated this PR to fix a second bug: the breadcrumbs of topics where a shadow copy is created were incorrect, and needed a minor fix.

https://dev.gridrepublic.org/browse/DBOINCP-366
https://dev.gridrepublic.org/browse/DBOINCP-372