### PR TITLE
Drupal: Added patch to Views contrib module, 6.x-2.x-boinc-3-dev

### DIFF
--- a/drupal/sites/default/boinc/modules/contrib/views/handlers/views_handler_argument_many_to_one.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/handlers/views_handler_argument_many_to_one.inc
@@ -13,7 +13,7 @@
  * @ingroup views_argument_handlers
  */
 class views_handler_argument_many_to_one extends views_handler_argument {
-  function init(&$view, &$options) {
+  function init(&$view, $options) {
     parent::init($view, $options);
     $this->helper = new views_many_to_one_helper($this);
 

--- a/drupal/sites/default/boinc/modules/contrib/views/handlers/views_handler_field.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/handlers/views_handler_field.inc
@@ -454,7 +454,7 @@ If you would like to have the characters %5B and %5D please use the html entity 
    * @param $values
    *   An array of all objects returned from the query.
    */
-  function pre_render($values) { }
+  function pre_render(&$values) { }
 
   /**
    * Render the field.

--- a/drupal/sites/default/boinc/modules/contrib/views/handlers/views_handler_filter_date.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/handlers/views_handler_filter_date.inc
@@ -42,7 +42,7 @@ class views_handler_filter_date extends views_handler_filter_numeric {
     $this->validate_valid_time($form['value'], $form_state['values']['options']['operator'], $form_state['values']['options']['value']);
   }
 
-  function exposed_validate($form, &$form_state) {
+  function exposed_validate(&$form, &$form_state) {
     if (empty($this->options['exposed'])) {
       return;
     }

--- a/drupal/sites/default/boinc/modules/contrib/views/includes/base.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/includes/base.inc
@@ -42,7 +42,7 @@ class views_object {
    * Set default options on this object. Called by the constructor in a
    * complex chain to deal with backward compatibility.
    */
-  function options() { }
+  function options(&$options) { }
 
   /**
    * Set default options.

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/comment/views_handler_field_node_new_comments.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/comment/views_handler_field_node_new_comments.inc
@@ -45,7 +45,7 @@ class views_handler_field_node_new_comments extends views_handler_field_numeric 
     $this->field_alias = $this->table . '_' . $this->field;
   }
 
-  function pre_render($values) {
+  function pre_render(&$values) {
     global $user;
     if (!$user->uid || empty($values)) {
       return;

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/node/views_handler_filter_node_access.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/node/views_handler_filter_node_access.inc
@@ -4,7 +4,7 @@
  */
 class views_handler_filter_node_access extends views_handler_filter {
   function admin_summary() { }
-  function operator_form() { }
+  function operator_form(&$form, &$form_state) { }
   function can_expose() {
     return FALSE;
   }

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/node/views_handler_filter_node_status.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/node/views_handler_filter_node_status.inc
@@ -4,7 +4,7 @@
  */
 class views_handler_filter_node_status extends views_handler_filter {
   function admin_summary() { }
-  function operator_form() { }
+  function operator_form(&$form, &$form_state) { }
 
   function query() {
     $table = $this->ensure_my_table();

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/profile/views_handler_field_profile_list.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/profile/views_handler_field_profile_list.inc
@@ -6,7 +6,7 @@ class views_handler_field_profile_list extends views_handler_field_prerender_lis
   /**
    * Break up our field into a proper list.
    */
-  function pre_render($values) {
+  function pre_render(&$values) {
     $this->items = array();
     foreach ($values as $value) {
       $field = $value->{$this->field_alias};

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/system/views_handler_field_file.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/system/views_handler_field_file.inc
@@ -6,7 +6,7 @@ class views_handler_field_file extends views_handler_field {
   /**
    * Constructor to provide additional field to add.
    */
-  function init(&$view, &$options) {
+  function init(&$view, $options) {
     parent::init($view, $options);
     if (!empty($options['link_to_file'])) {
       $this->additional_fields['filepath'] = 'filepath';

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/taxonomy/views_handler_field_term_node_tid.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/taxonomy/views_handler_field_term_node_tid.inc
@@ -66,7 +66,7 @@ class views_handler_field_term_node_tid extends views_handler_field_prerender_li
     $this->add_additional_fields();
   }
 
-  function pre_render($values) {
+  function pre_render(&$values) {
     $this->field_alias = $this->aliases['vid'];
     $vids = array();
     foreach ($values as $result) {

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/taxonomy/views_handler_filter_term_node_tid_depth.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/taxonomy/views_handler_filter_term_node_tid_depth.inc
@@ -6,7 +6,7 @@
  * because it uses a subquery to find nodes with
  */
 class views_handler_filter_term_node_tid_depth extends views_handler_filter_term_node_tid {
-  function operator_options() {
+  function operator_options($which = 'title') {
     return array(
       'or' => t('Is one of'),
     );

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/upload/views_handler_field_upload_description.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/upload/views_handler_field_upload_description.inc
@@ -26,7 +26,7 @@ class views_handler_field_upload_description extends views_handler_field {
     );
   }
 
-  function pre_render($values) {
+  function pre_render(&$values) {
     if (empty($this->options['link_to_file'])) {
       return;
     }

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/upload/views_handler_field_upload_fid.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/upload/views_handler_field_upload_fid.inc
@@ -29,7 +29,7 @@ class views_handler_field_upload_fid extends views_handler_field_prerender_list 
     );
   }
 
-  function pre_render($values) {
+  function pre_render(&$values) {
     $vids = array();
     $this->items = array();
 

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/user/views_handler_field_user_name.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/user/views_handler_field_user_name.inc
@@ -6,7 +6,7 @@ class views_handler_field_user_name extends views_handler_field_user {
   /**
    * Add uid in the query so we can test for anonymous if needed.
    */
-  function init(&$view, &$data) {
+  function init(&$view, $data) {
     parent::init($view, $data);
     if (!empty($this->options['overwrite_anonymous'])) {
       $this->additional_fields['uid'] = 'uid';

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/user/views_handler_field_user_roles.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/user/views_handler_field_user_roles.inc
@@ -13,7 +13,7 @@ class views_handler_field_user_roles extends views_handler_field_prerender_list 
     $this->field_alias = $this->aliases['uid'];
   }
 
-  function pre_render($values) {
+  function pre_render(&$values) {
     $uids = array();
     $this->items = array();
 

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/user/views_handler_filter_user_name.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/user/views_handler_filter_user_name.inc
@@ -35,7 +35,7 @@ class views_handler_filter_user_name extends views_handler_filter_in_operator {
     }
   }
 
-  function value_validate(&$form, &$form_state) {
+  function value_validate($form, &$form_state) {
     $values = drupal_explode_tags($form_state['values']['options']['value']);
     $uids = $this->validate_user_strings($form['value'], $values);
 
@@ -114,7 +114,7 @@ class views_handler_filter_user_name extends views_handler_filter_in_operator {
     return $uids;
   }
 
-  function value_submit() {
+  function value_submit($form, &$form_state) {
     // prevent array filter from removing our anonymous user.
   }
 

--- a/drupal/sites/default/boinc/modules/contrib/views/views.info
+++ b/drupal/sites/default/boinc/modules/contrib/views/views.info
@@ -4,7 +4,7 @@ package = Views
 core = 6.x
 
 ; Information added by Drupal.org packaging script on 2015-02-11
-version = "6.x-2.18-boinc-2-dev"
+version = "6.x-2.18-boinc-3-dev"
 core = "6.x"
 project = "views"
 datestamp = "1494530273"

--- a/drupal/sites/default/boinc/modules/contrib/views/views.info
+++ b/drupal/sites/default/boinc/modules/contrib/views/views.info
@@ -7,5 +7,4 @@ core = 6.x
 version = "6.x-2.18-boinc-3-dev"
 core = "6.x"
 project = "views"
-datestamp = "1494530273"
-
+datestamp = "1497457987"


### PR DESCRIPTION
to eliminate E_STRICT PHP notices.

https://dev.gridrepublic.org/browse/DBOINCP-380

Drupal issue: https://www.drupal.org/node/893128