### PR TITLE
Drupal: Fixes for create account functions.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1351,20 +1351,32 @@ function boincuser_create_account() {
       xml_error(-137, 'account error');
     }
     // Create new account
-    $unrestricted_role = array_search('community member', user_roles(true)); 
+    $unrestricted_role = array_search('community member', user_roles(true));
+
+    // Make sure user_name is unique
+    $unique_name = find_unique_name($params['user_name']);
+
     $newUser = array(
-      'name' => $params['user_name'],
+      'name' => $unique_name,
       'pass' => null, // $params['passwd_hash'], // note: passing a hash here requires ALL passwords to be hashed via hook prior to interacting with the hash stored in the db
       'mail' => $params['email_addr'],
       'status' => 1,
       'init' => $params['email_addr'],
       'roles' => array($unrestricted_role => ''),
     );
+
+    // Create the drupal user
     $user = user_save(null, $newUser);
+    if (!$user) {
+      watchdog('boincuser', 'create_accout: Failed to create Drupal user account for @email', array('@email' => $params['email_addr']), WATCHDOG_WARNING);
+    }
+
+    // Create the BOINC user
     $boinc_user = make_user($params['email_addr'], $params['user_name'], $params['passwd_hash'], 'International');
     if (!$boinc_user) {
       xml_error(-137);
     }
+
     // Cross reference Drupal account with BOINC
     $reference = db_query("INSERT INTO {boincuser} SET uid=%d, boinc_id=%d", $user->uid, $boinc_user->id);
     if (!$reference) {

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -406,7 +406,11 @@ function boincuser_request_pass_validate($form, &$form_state) {
       boincuser_register_make_drupal_user($boinc_user);
     } else {
       // If there is no existing BOINC user either, show an error
-      form_set_error('name', bts('No account exists for @email -- select "Create new account" to register', array('@email' => $edit['name']), NULL, 'boinc:forgot-password'));
+      form_set_error('name', bts('No account exists for @email -- please create an account using a BOINC client -- !instructions',
+      array(
+          '@email' => $edit['name'],
+          '!instructions' => l(bts('Instructions', array(), NULL, 'boinc:forgot-password'), 'join')
+      ), NULL, 'boinc:forgot-password'));
     }
   }
 }


### PR DESCRIPTION
When create_account is called, check for uniqueness with the user_name when creating Drupal user account.
Fixed error message for Forgot Password form, which was incorrect and misleading.

https://dev.gridrepublic.org/browse/DBOINCP-379
https://dev.gridrepublic.org/browse/DBOINCP-376