### PR TITLE
Drupal: Changed order of if-statements to change logic of account_create.php

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1371,21 +1371,22 @@ function boincuser_create_account() {
     if ($user) {
       // Create the BOINC user.
       $boinc_user = make_user($params['email_addr'], $params['user_name'], $params['passwd_hash'], 'International');
-      if (!$boinc_user) {
+      if ($boinc_user) {
+        // Cross reference Drupal account with BOINC.
+        $reference = db_query("INSERT INTO {boincuser} SET uid=%d, boinc_id=%d", $user->uid, $boinc_user->id);
+        if (!$reference) {
+          xml_error(-1, 'error connecting BOINC account to Drupal');
+        }
+      }
+      else {
         xml_error(-137);
-      }
-
-      // Cross reference Drupal account with BOINC.
-      $reference = db_query("INSERT INTO {boincuser} SET uid=%d, boinc_id=%d", $user->uid, $boinc_user->id);
-      if (!$reference) {
-        xml_error(-1, 'error connecting BOINC account to Drupal');
-      }
+      }// if boinc user created.
     }
     else {
       watchdog('boincuser', 'create_accout: Failed to create Drupal user account for @email', array('@email' => $params['email_addr']), WATCHDOG_WARNING);
       xml_error(-1, 'error creating Drupal user account');
-    }// if drupal user created
-  }// if existing user found
+    }// if drupal user created.
+  }// if existing user found.
   echo " <account_out>\n";
   echo "   <authenticator>{$boinc_user->authenticator}</authenticator>\n";
   echo "</account_out>\n";

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1345,7 +1345,8 @@ function boincuser_create_account() {
     } else {
       xml_error(-137);
     }
-  } else {
+  }
+  else {
     // Verify that there isn't somehow a Drupal user already (not possible with proper function)
     if ($existing_user = user_load(array('mail' => $params['email_addr']))) {
       xml_error(-137, 'account error');
@@ -1365,24 +1366,26 @@ function boincuser_create_account() {
       'roles' => array($unrestricted_role => ''),
     );
 
-    // Create the drupal user
+    // Create the drupal user. If the drupal user cannot be created, then stop with error message.
     $user = user_save(null, $newUser);
-    if (!$user) {
+    if ($user) {
+      // Create the BOINC user.
+      $boinc_user = make_user($params['email_addr'], $params['user_name'], $params['passwd_hash'], 'International');
+      if (!$boinc_user) {
+        xml_error(-137);
+      }
+
+      // Cross reference Drupal account with BOINC.
+      $reference = db_query("INSERT INTO {boincuser} SET uid=%d, boinc_id=%d", $user->uid, $boinc_user->id);
+      if (!$reference) {
+        xml_error(-1, 'error connecting BOINC account to Drupal');
+      }
+    }
+    else {
       watchdog('boincuser', 'create_accout: Failed to create Drupal user account for @email', array('@email' => $params['email_addr']), WATCHDOG_WARNING);
-    }
-
-    // Create the BOINC user
-    $boinc_user = make_user($params['email_addr'], $params['user_name'], $params['passwd_hash'], 'International');
-    if (!$boinc_user) {
-      xml_error(-137);
-    }
-
-    // Cross reference Drupal account with BOINC
-    $reference = db_query("INSERT INTO {boincuser} SET uid=%d, boinc_id=%d", $user->uid, $boinc_user->id);
-    if (!$reference) {
-      xml_error(-1, 'error connecting BOINC account to Drupal');
-    }
-  }
+      xml_error(-1, 'error creating Drupal user account');
+    }// if drupal user created
+  }// if existing user found
   echo " <account_out>\n";
   echo "   <authenticator>{$boinc_user->authenticator}</authenticator>\n";
   echo "</account_out>\n";


### PR DESCRIPTION
If a Drupal user account cannot be created, a BOINC user account is NOT created, and no link between the two is made.
Then
If a BOINC account cannot be created, no link between the BOINC and Drupal user accounts is made.

https://dev.gridrepublic.org/browse/DBOINCP-379