### PR TITLE
Adding user->id to be return with an e-mail lookup

### DIFF
--- a/html/user/lookup_account.php
+++ b/html/user/lookup_account.php
@@ -63,6 +63,7 @@ if (LDAP_HOST && $ldap_auth) {
     if (!$passwd_hash) {
         echo "<account_out>\n";
         echo "   <success/>\n";
+        echo "<id>$user->id</id>\n";
         echo "</account_out>\n";
         exit();
     }

--- a/html/user/lookup_account.php
+++ b/html/user/lookup_account.php
@@ -63,7 +63,7 @@ if (LDAP_HOST && $ldap_auth) {
     if (!$passwd_hash) {
         echo "<account_out>\n";
         echo "   <success/>\n";
-        echo "<id>$user->id</id>\n";
+        echo "   <id>$user->id</id>\n";
         echo "</account_out>\n";
         exit();
     }


### PR DESCRIPTION
For 3rd parties e-mail verification is the only way to verify users. This allows third parties to match a users id by his e-mail address, and thus securely identify their ownership of that account. 

Using this information we can access show_user.php?userid=id and be certain of an e-mails credit ownership.