### PR TITLE
Drupal: Modified db_set_active() functions so drupal database is correctly queries by bts() function.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -886,11 +886,14 @@ function boincwork_host_set_venue($host_id = NULL, $venue = NULL) {
     "SELECT userid FROM {host} WHERE id = '%d'",
     $host_id
   ));
+  db_set_active('default');
   if ($host_owner AND $host_owner == $account->boincuser_id) {
+    db_set_active('boinc');
     $updated = db_query(
       "UPDATE {host} SET venue = '%s' WHERE id = '%d'",
       $venue, $host_id
     );
+    db_set_active('default');
     if ($updated) {
       drupal_set_message(
         bts('The location for this host has been updated.', array(), NULL, 'boinc:account-host-details')
@@ -910,7 +913,6 @@ function boincwork_host_set_venue($host_id = NULL, $venue = NULL) {
       'warning'
     );
   }
-  db_set_active('default');
   drupal_goto("host/{$host_id}");
 }
 


### PR DESCRIPTION
bts() functions may query the drupal DB. Use `db_set_active()` to make sure boinc/drupal DB queries are being handled correctly.

https://dev.gridrepublic.org/browse/DBOINCP-383