### PR TITLE
Drupal: Modified default value for site_name variable.

### DIFF
--- a/drupal/sites/all/features/news/news.views_default.inc
+++ b/drupal/sites/all/features/news/news.views_default.inc
@@ -431,7 +431,7 @@ function news_views_default_views() {
       'default_argument_fixed' => '',
       'default_argument_php' => '// Use this to set a custom feed title that works both in the feed and
 // in the auto discovery link in the page header
-return variable_get(\'site_name\', \'BOINC\');
+return variable_get(\'site_name\', \'Drupal-BOINC\');
 ',
       'validate_argument_node_type' => array(
         'page' => 0,

--- a/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
+++ b/drupal/sites/all/features/stats_charts/stats_charts.panels_default.inc
@@ -40,7 +40,7 @@ function stats_charts_default_panels_mini() {
     $pane->access = array();
     $pane->configuration = array(
       'admin_title' => 'Project stats overview',
-      'title' => bts('@this_project Progress', array('@this_project' => variable_get('site_name', '')), NULL, 'boinc:frontpage'),
+      'title' => bts('@this_project Progress', array('@this_project' => variable_get('site_name', 'Drupal-BOINC')), NULL, 'boinc:frontpage'),
       'body' => '<?php echo boincstats_get_project_stats_overview(); ?>',
       'format' => '3',
       'substitute' => TRUE,

--- a/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.features.content.inc
@@ -496,7 +496,7 @@ Zimbabwe|Zimbabwe',
    1. Why do you run @this_project?
    2. What are your views about the project?
    3. Any suggestions?',
-      array('@this_project' => variable_get('site_name','')), NULL, 'boinc:account-profile-edit'),
+      array('@this_project' => variable_get('site_name', 'Drupal-BOINC')), NULL, 'boinc:account-profile-edit'),
       'type' => 'text_textarea',
       'module' => 'text',
     ),

--- a/drupal/sites/default/boinc/modules/boincstats/boincstats.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincstats/boincstats.admin.inc
@@ -39,7 +39,7 @@ function boincstats_admin_stats_system(&$form_state) {
   $form['boinc_stats_remote_project_id'] = array(
     '#type' => 'textfield',
     '#title' => t('Stats ID for @project', array(
-      '@project' => variable_get('site_name', t('this project')))),
+      '@project' => variable_get('site_name', 'Drupal-BOINC'))),
     '#default_value' => $default['boinc_stats_remote_project_id'], 
     '#description' => t('This project must be registered with a stats system in
       order for some statistics to be available. Currently only one system is

--- a/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
+++ b/drupal/sites/default/boinc/modules/boinctranslate/boinctranslate.module
@@ -719,8 +719,8 @@ function boinctranslate_export_po_generate($language = NULL, $strings = array(),
 
   if (!isset($header)) {
     if (isset($type) && $type == "project") {
-      $header = "# ".variable_get('site_name', 'Drupal')." drupal localization template\n";
-      $header .= "# Copyright (C) ".date("Y")." ".variable_get('site_name', 'Drupal')."\n";
+      $header = "# ".variable_get('site_name', 'Drupal-BOINC')." drupal localization template\n";
+      $header .= "# Copyright (C) ".date("Y")." ".variable_get('site_name', 'Drupal-BOINC')."\n";
     } else {
       $header = "# BOINC drupal localization template\n";
       $header .= "# Copyright (C) ".date("Y")." University of California\n";
@@ -732,7 +732,7 @@ function boinctranslate_export_po_generate($language = NULL, $strings = array(),
     $header .= "msgid \"\"\n";
     $header .= "msgstr \"\"\n";
     if (isset($type) && $type == "project") {
-      $header .= "\"Project-Id-Version: ".variable_get('site_name', 'Drupal')." ".date("Y-m-d-H:iO")."\\n\"\n";
+      $header .= "\"Project-Id-Version: ".variable_get('site_name', 'Drupal-BOINC')." ".date("Y-m-d-H:iO")."\\n\"\n";
     } else {
       $header .= "\"Project-Id-Version: BOINC unknown\\n\"\n"; // TODO: add SHA1 of source checkout here
     }

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1564,7 +1564,7 @@ function boincuser_moderate_user_ban($uid, $reason = '', $duration = '') {
       global $user;
       global $base_url;
       global $base_path;
-      $site_name = variable_get('site_name',  'Drupal-BOINC');
+      $site_name = variable_get('site_name', 'Drupal-BOINC');
       $site_url = $base_url . $base_path;
       $moderator = user_load($user->uid);
       $settings = array(

--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -630,7 +630,7 @@ function boinc_flag_friend_message_email($status, $flag, $recipient, $sender) {
       // Sender accepted recipient's friend request
       $email['subject'] = bts('!name accepted your friend request [!site]', array(
         '!name' => $sender->boincuser_name,
-        '!site' => variable_get('site_name', ''),
+        '!site' => variable_get('site_name', 'Drupal-BOINC'),
         ), NULL, 'boinc:friend-request-email');
       $email['body'] = bts('!name confirmed you as a friend on !site.
 
@@ -642,7 +642,7 @@ Follow this link to view his or her profile:
 Thanks,
 The !site team', array(
         '!name' => isset($sender->boincuser_name) ? $sender->boincuser_name : $sender->name,
-        '!site' => variable_get('site_name', ''),
+        '!site' => variable_get('site_name', 'Drupal-BOINC'),
         '!message' => $flag->friend_message ? bts('Message', array(), NULL, 'boinc:friend-request-email:-1:a-private-message') . ': ' . $flag->friend_message : '',
         '!link' => url('account/'. $sender->uid, array('absolute' => TRUE)),
         ), array(), NULL, 'boinc:friend-request-email');
@@ -650,7 +650,7 @@ The !site team', array(
 
     case FLAG_FRIEND_PENDING:
       // Sender is requesting to be recipient's friend
-      $email['subject'] = bts('Friend request from !name [!site]', array('!name' => $sender->boincuser_name, '!site' => variable_get('site_name', '')), NULL, 'boinc:friend-request-email');
+      $email['subject'] = bts('Friend request from !name [!site]', array('!name' => $sender->boincuser_name, '!site' => variable_get('site_name', 'Drupal-BOINC')), NULL, 'boinc:friend-request-email');
       $email['body'] = bts('!name added you as a friend on !site. You can approve or deny this request. Denying a request will not send a notification, but will remove the request from both of your accounts.
 
 Follow the link below to view this request:
@@ -661,7 +661,7 @@ Follow the link below to view this request:
 Thanks,
 The !site team', array(
         '!name' => isset($sender->boincuser_name) ? $sender->boincuser_name : $sender->name,
-        '!site' => variable_get('site_name', ''),
+        '!site' => variable_get('site_name', 'Drupal-BOINC'),
         '!message' => $flag->friend_message ? bts('Message', array(), NULL, 'boinc:friend-request-email:-1:a-private-message') . ': ' . $flag->friend_message : '',
         '!link' => url('goto/friend-requests', array('absolute' => TRUE)),
         ),

--- a/drupal/sites/default/boinc/themes/boinc/templates/forum-list.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/forum-list.tpl.php
@@ -114,7 +114,7 @@
   </p>
   <p>
     <?php print bts('We also ask that you keep all discussion on the message boards related to @project or BOINC with the small exception of the Science message board where you are free to discuss anything relevant to the underlying science. Participants interested in broader discussions should post to unofficial forums for @project.',
-      array('@project' => variable_get('site_name', bts('this project'))), NULL, 'boinc:forum-fine-print'); ?>
+      array('@project' => variable_get('site_name', 'Drupal-BOINC')), NULL, 'boinc:forum-fine-print'); ?>
   </p>
   <p>
     <?php print bts('These message boards now support BBCode tags only.', array(), NULL, 'boinc:forum-fine-print'); ?>

--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view-rss--news.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view-rss--news.tpl.php
@@ -10,7 +10,7 @@
  // that works there, this works here. Setting title here does not set the
  // title in the RSS auto discovery link on the front page, and setting the
  // description in the view does not allow the site_name variable.
- $site_name = variable_get('site_name', 'BOINC');
+ $site_name = variable_get('site_name', 'Drupal-BOINC');
  $description = bts('The latest news from the @site_name project',
     array('@site_name' => $site_name), NULL, 'boinc:rss-feed-description');
   


### PR DESCRIPTION
Changed instances of variable_get('site_name') to use string 'Drupal-BOINC' as default, if site_name system variable is not set. This default string is not translated as the variable should be set by the site admin.

part of:
https://dev.gridrepublic.org/browse/DBOINCP-336