### PR TITLE
Lib: fix escape_url() for UTF8 encoded strings

### DIFF
--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -162,7 +162,8 @@ void escape_url(const char *in, char*out, int out_size) {
     char buf[256];
     int x, y;
     for (x=0, y=0; in[x] && (y<out_size-3); ++x) {
-        if (isalnum(in[x])) {
+        unsigned char c = (unsigned char)in[x];
+        if (c < 0x80 && isalnum(c)) {
             out[y] = in[x];
             ++y;
         } else {

--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -117,9 +117,9 @@ static char x2c(char *what) {
 
 void c2x(char *what) {
     char buf[3];
-    char num = atoi(what);
-    char d1 = num / 16;
-    char d2 = num % 16;
+    unsigned char num = atoi(what);
+    unsigned char d1 = num / 16;
+    unsigned char d2 = num % 16;
     int abase1, abase2;
     if (d1 < 10) abase1 = 48;
     else abase1 = 55;
@@ -169,7 +169,7 @@ void escape_url(const char *in, char*out, int out_size) {
             out[y] = '%';
             ++y;
             out[y] = 0;
-            snprintf(buf, sizeof(buf), "%d", (char)in[x]);
+            snprintf(buf, sizeof(buf), "%u", (unsigned char)in[x]);
             c2x(buf);
             strlcat(out, buf, out_size);
             y += 2;


### PR DESCRIPTION
The default modifier for char with GCC is signed but for character encoding we always need to use unsigned as the code tables only have positive values.

fixes #1951