### PR TITLE
Travis: use Trusty image and use apg-get to install dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ branches:
 #    on_success: always
 #    on_failure: always
 
-# This switches to the container-based infrastructure and allows caching
-sudo: false
+# Use Trusty image and enable sudo to install apt dependencies
+dist: trusty
+sudo: required
 
 cache:
-  apt: true
   directories:
   - 3rdParty/buildCache
 
@@ -32,28 +32,6 @@ addons:
     build_command_prepend: "./configure --enable-apps"
     build_command:   "make -j 4"
     branch_pattern: coverity_scan
-  apt_packages:
-    - freeglut3-dev
-    - libxmu-dev
-    - libxi-dev
-    #- python-mysqldb
-    - libfcgi-dev
-    #- libcurl4-openssl-dev
-    - libxss-dev
-    - libnotify-dev
-    - libxcb-util0-dev
-    - libsqlite3-dev
-    - libgtk2.0-dev
-    - libwebkitgtk-dev
-    - mingw-w64
-    - binutils-mingw-w64-i686
-    - binutils-mingw-w64-x86-64
-    - gcc-mingw-w64
-    - gcc-mingw-w64-i686
-    - gcc-mingw-w64-x86-64
-    - g++-mingw-w64
-    - g++-mingw-w64-i686
-    - g++-mingw-w64-x86-64
 
 env:
   global:
@@ -72,6 +50,10 @@ env:
 
 matrix:
   fast_finish: true
+
+before_install:
+   - sudo apt-get -qq update
+   - sudo apt-get install freeglut3-dev libxmu-dev libxi-dev libfcgi-dev libxss-dev libnotify-dev libxcb-util0-dev libsqlite3-dev libgtk2.0-dev libwebkitgtk-dev mingw-w64 binutils-mingw-w64-i686 binutils-mingw-w64-x86-64 gcc-mingw-w64 gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 g++-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64
 
 before_script:
 - ./_autosetup


### PR DESCRIPTION
The container-based Trusty does not allow all the packages we need.