### PR TITLE
client/lib: don't flush stdout and stderr in main loop

### DIFF
--- a/client/client_msgs.cpp
+++ b/client/client_msgs.cpp
@@ -125,6 +125,11 @@ void show_message(
     // print message to the console
     printf("%s", evt_message);
 
+#ifdef _MSC_VER
+    // MSVCRT doesn't support line buffered streams
+    fflush(stdout);
+#endif
+
     // print message to the debugger view port
     diagnostics_trace_to_debugger(evt_message);  
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -83,6 +83,10 @@ void log_message_startup(const char* msg) {
     );
     if (!gstate.executing_as_daemon) {
         fprintf(stdout, "%s", evt_msg);
+#ifdef _MSC_VER
+        // MSVCRT doesn't support line buffered streams
+        fflush(stdout);
+#endif
     } else {
 #ifdef _WIN32
         LogEventInfoMessage(evt_msg);
@@ -373,8 +377,6 @@ int boinc_main_loop() {
         if (!gstate.poll_slow_events()) {
             gstate.do_io_or_sleep(POLL_INTERVAL);
         }
-        fflush(stderr);
-        fflush(stdout);
 
         if (gstate.time_to_exit()) {
             msg_printf(NULL, MSG_INFO, "Time to exit");

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -352,6 +352,7 @@ int diagnostics_init(
         if (!stdout_file) {
             return ERR_FOPEN;
         }
+        setvbuf(stdout_file, NULL, _IOLBF, BUFSIZ);
     }
 
     if (flags & BOINC_DIAG_REDIRECTSTDOUTOVERWRITE) {
@@ -359,6 +360,7 @@ int diagnostics_init(
         if (!stdout_file) {
             return ERR_FOPEN;
         }
+        setvbuf(stdout_file, NULL, _IOLBF, BUFSIZ);
     }
 
 


### PR DESCRIPTION
The client flushes stdout and stderr at every iteration of the main loop. On Windows, stderr is opened in commit mode and this results in a write to NTFS $Log every time the stream is flushed even if nothing was written to the stream since last flush. These unnecessary writes totals to several hundred megabytes per day. Some users are concerned that this shortens the lifespan of their hardware.

Fix this by removing the flushes from main loop. stderr is unbuffered so it never needed the flush. After freopen() in diagnostics_init() stdout is fully buffered. Change stdout to line buffered mode so that log messages are visible in log files immediately.

MSVCRT doesn't support line buffered streams. It treats them as fully buffered. Emulate line buffered stream by flushing stdout in logging functions when compiling with Visual C++.