### PR TITLE
lib: fix out of bounds write in get_real_executable_path

### DIFF
--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -631,7 +631,7 @@ double rand_normal() {
 //
 #ifdef HAVE__PROC_SELF_EXE
 int get_real_executable_path(char* path, size_t max_len) {
-    int ret = readlink("/proc/self/exe", path, max_len);
+    int ret = readlink("/proc/self/exe", path, max_len - 1);
     if ( ret >= 0) {
         path[ret] = '\0'; // readlink does not null terminate
         return 0;


### PR DESCRIPTION
If the link were max_len bytes long or longer, the null terminator would have been written one past the end of path.