### PR TITLE
Drupal: Modified date and time strings to be consistent.

### DIFF
--- a/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
+++ b/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
@@ -196,7 +196,7 @@ function work_and_host_stats_views_default_views() {
       'hide_empty' => 0,
       'empty_zero' => 0,
       'date_format' => 'custom',
-      'custom_date_format' => 'j M Y G:i:s e',
+      'custom_date_format' => 'j M Y G:i:s T',
       'exclude' => 1,
       'id' => 'sent_time',
       'table' => 'result',
@@ -272,8 +272,10 @@ function work_and_host_stats_views_default_views() {
         'text' => '',
         'make_link' => 0,
         'path' => '',
+        'absolute' => 0,
         'link_class' => '',
         'alt' => '',
+        'rel' => '',
         'prefix' => '',
         'suffix' => '',
         'target' => '',
@@ -288,9 +290,10 @@ function work_and_host_stats_views_default_views() {
       'empty' => '',
       'hide_empty' => 0,
       'empty_zero' => 0,
+      'hide_alter_empty' => 1,
       'value' => '<?php
   require_boinc(\'util\');
-  echo time_str($data->result_sent_time);
+  echo date(\'j M Y G:i:s T\', $data->result_sent_time);
 ?>',
       'exclude' => 0,
       'id' => 'phpcode_3',
@@ -7602,8 +7605,10 @@ else {
         'text' => '',
         'make_link' => 0,
         'path' => '',
+        'absolute' => 0,
         'link_class' => '',
         'alt' => '',
+        'rel' => '',
         'prefix' => '',
         'suffix' => '',
         'target' => '',
@@ -7618,9 +7623,10 @@ else {
       'empty' => '',
       'hide_empty' => 0,
       'empty_zero' => 0,
+      'hide_alter_empty' => 1,
       'value' => '<?php
   require_boinc(\'util\');
-  echo time_str($data->result_sent_time);
+  echo date(\'j M Y G:i:s T\', $data->result_sent_time);
 ?>',
       'exclude' => 0,
       'id' => 'phpcode_3',
@@ -11779,8 +11785,10 @@ else {
         'text' => '',
         'make_link' => 0,
         'path' => '',
+        'absolute' => 0,
         'link_class' => '',
         'alt' => '',
+        'rel' => '',
         'prefix' => '',
         'suffix' => '',
         'target' => '',
@@ -11795,9 +11803,10 @@ else {
       'empty' => '',
       'hide_empty' => 0,
       'empty_zero' => 0,
+      'hide_alter_empty' => 1,
       'value' => '<?php
   require_boinc(\'util\');
-  echo time_str($data->result_sent_time);
+  echo date(\'j M Y G:i:s T\', $data->result_sent_time);
 ?>',
       'exclude' => 0,
       'id' => 'phpcode_3',

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -861,7 +861,7 @@ function boincwork_host_merge_form(&$form_state, $host_id) {
         array(
           '@name' => $current_host->domain_name,
           '@date' => date('j M Y', $current_host->create_time),
-          '@time' => date('H:i:s T', $current_host->create_time),
+          '@time' => date('G:i:s T', $current_host->create_time),
           '@id' => $current_host->id,
         ),
         NULL, 'boinc:account-host-merge') . '</p>',
@@ -871,7 +871,7 @@ function boincwork_host_merge_form(&$form_state, $host_id) {
   foreach ($hosts as $host) {
     $options[$host->id] = array(
       $host->domain_name,
-      date('j M Y H:i:s T', $host->create_time),
+      date('j M Y G:i:s T', $host->create_time),
       $host->id,
     );
   }

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -1410,7 +1410,7 @@ function boincwork_host_last_contact($timestamp, $host_id = NULL, $context = NUL
   $root_log_dir = variable_get('boinc_host_sched_logs_dir', '');
   $log = '';
   if ($timestamp) {
-    $output = gmdate('j M Y | G:i:s', $timestamp) . ' UTC';
+    $output = date('j M Y G:i:s T', $timestamp);
   }
   if ($root_log_dir AND $host_id) {
     $subdir = substr($host_id, 0, -3) OR $subdir = 0;
@@ -1457,7 +1457,7 @@ function boincwork_task_time_reported($received_time = NULL, $deadline = NULL, $
   $output = '---';
   if ($received_time OR $deadline) {
     $timestamp = ($received_time) ? $received_time : $deadline;
-    $output = gmdate('j M Y, G:i:s', $timestamp) . ' UTC';
+    $output = date('j M Y G:i:s T', $timestamp);
     // Add a wrapper to deadline text
     if (!$received_time) {
       if (time() < $deadline) {
@@ -1738,7 +1738,7 @@ function boincwork_tasktable($category = 0, $queryid = 1, $tselect = NULL, $app_
           ),
           l($result->workunitid, "workunit/{$result->workunitid}"),
           l($result->hostid, "host/{$result->hostid}"),
-          time_str($result->sent_time),
+          date('j M Y G:i:s T', $result->sent_time),
           boincwork_task_time_reported($result->received_time, $result->report_deadline),
           state_string($result),
           $nf->format($result->elapsed_time),

--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -495,7 +495,7 @@ function boinc_preprocess_privatemsg_view(&$vars, $hook) {
   }
   $author_picture .= '</div>';
   $vars['author_picture'] = $author_picture;
-  $vars['message_timestamp'] = date('j M Y H:i:s T', $vars['message']['timestamp']);
+  $vars['message_timestamp'] = date('j M Y G:i:s T', $vars['message']['timestamp']);
 }
 // */
 

--- a/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
@@ -143,7 +143,7 @@
     <?php endif; ?>
 
     <div class="submitted">
-      <?php print date('j M Y H:i:s T', $comment->timestamp); ?>
+      <?php print date('j M Y G:i:s T', $comment->timestamp); ?>
     </div>
     <div class="comment-id">
       <?php echo l(bts('Message @id', array('@id' => $comment->cid), NULL, 'boinc:message-header'),

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
@@ -176,7 +176,7 @@
       
       <?php if ($display_submitted): ?>
         <div class="submitted">
-          <?php print date('j M Y H:i:s T', $node->created); ?>
+          <?php print date('j M Y G:i:s T', $node->created); ?>
         </div>
       <?php endif; ?>
       <div class="topic-id">

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
@@ -193,7 +193,7 @@
       
       <?php if ($display_submitted): ?>
         <div class="submitted">
-          <?php print date('j M Y H:i:s T', $node->created); ?>
+          <?php print date('j M Y G:i:s T', $node->created); ?>
         </div>
       <?php endif; ?>
       <div class="topic-id">

--- a/drupal/sites/default/boinc/themes/boinc/templates/node.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node.tpl.php
@@ -97,11 +97,11 @@
         <span class="submitted">
           <?php
             if ($type == 'news') {
-              print bts('Submitted on !datetime', array('!datetime' => date('j M Y H:i:s T', $node->created)), NULL, 'boinc:news-submitted-info');
+              print bts('Submitted on !datetime', array('!datetime' => date('j M Y G:i:s T', $node->created)), NULL, 'boinc:news-submitted-info');
             }
             else {
               print bts('Submitted by !username on !datetime',
-                array('!username' => $name, '!datetime' => date('j M Y H:i:s T', $node->created)), NULL, 'boinc:page-submitted-info');
+                array('!username' => $name, '!datetime' => date('j M Y G:i:s T', $node->created)), NULL, 'boinc:page-submitted-info');
             }
           ?>
         </span>


### PR DESCRIPTION
Changed all timezone strings to 'T'. Made all time strings consisent, hour is 'G', no comma or other separator(s) between date and time.

https://dev.gridrepublic.org/browse/DBOINCP-312