### PR TITLE
Drupal: Forum top links are now placed into two columns.

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/css/comments.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/comments.css
@@ -80,7 +80,6 @@ div.node-type-forum.not-first-page {
   padding-bottom: 4px;
 }
 .node-type-forum h2.title {
-  margin: 14px 0 24px;
 }
 .node-type-forum.not-first-page h2.title {
   margin-bottom: 0;

--- a/drupal/sites/default/boinc/themes/boinc/css/pages.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/pages.css
@@ -125,9 +125,13 @@ div#site-name /* The name of the website */ {
 
 .breadcrumb /* The path to the current page in the form of a list of links */ {
   padding-bottom: 0; /* Undo system.css */
+  display: inline-block;
+  float: left;
+  width: 60%;
 }
 .breadcrumb.bottom-breadcrumb {
-  margin-top: 25px
+  margin-top: 39px;
+  width: 100%;
 }
 
 a:link, a:visited {
@@ -894,6 +898,10 @@ table.user-projects {
   text-transform: uppercase;
   color: #808080;
   letter-spacing: 1px; 
+}
+
+.forum-links {
+  width: 100%;
 }
 
 /* Join */

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
@@ -75,13 +75,6 @@
 ?>
 <div id="top"></div>
 
-<?php if ($subscribe_link): ?>
-  <div class="subscribe">
-    <a href="#block-comment_form_block-comment_form">Post new comment</a> |&nbsp;
-    <?php print $subscribe_link; ?>
-  </div>
-<?php endif; ?>
-
 <div id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?> clearfix<?php echo ($first_page) ? '' : ' not-first-page'; ?>">
   
   <?php 
@@ -100,9 +93,18 @@
       $subtitle = implode(' &rsaquo; ', $subtitle);
     }
   ?>
-  
-  <div class="breadcrumb">
-    <h2 class="title"><?php print $subtitle; ?></h2>
+
+  <div class="forum-links">
+    <div class="breadcrumb">
+      <h2 class="title"><?php print $subtitle; ?></h2>
+    </div>
+    <div class="subscribe">
+      <?php if ($subscribe_link): ?>
+        <a href="#block-comment_form_block-comment_form">Post new comment</a> |&nbsp;
+        <?php print $subscribe_link; ?>
+      <?php endif; ?>
+    </div>
+    <div class="clearfix"></div>
   </div>
 
   <?php if ($unpublished): ?>

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
@@ -75,13 +75,6 @@
 ?>
 <?php $first_page = (!isset($_GET['page']) OR ($_GET['page'] < 1)); ?>
 
-<?php if ($subscribe_link): ?>
-  <div class="subscribe">
-    <a href="#block-comment_form_block-comment_form">Post new comment</a> |&nbsp;
-    <?php print $subscribe_link; ?>
-  </div>
-<?php endif; ?>
-
 <div id="node-<?php print $node->nid; ?>" class="<?php print $classes; ?> clearfix<?php echo ($first_page) ? '' : ' not-first-page'; ?>">
   
   <?php 
@@ -117,8 +110,17 @@
     }
   ?>
   
-  <div class="breadcrumb">
-    <h2 class="title"><?php print $subtitle; ?></h2>
+  <div class="forum-links">
+    <div class="breadcrumb">
+      <h2 class="title"><?php print $subtitle; ?></h2>
+    </div>
+    <div class="subscribe">
+      <?php if ($subscribe_link): ?>
+        <a href="#block-comment_form_block-comment_form">Post new comment</a> |&nbsp;
+        <?php print $subscribe_link; ?>
+      <?php endif; ?>
+    </div>
+    <div class="clearfix"></div>
   </div>
   
   <?php if ($unpublished): ?>


### PR DESCRIPTION
Breadcrumb, post new comment, and subscribe links are placed into a single div with separate sub-divs. CSS changed to placed these sub-divs into two columns.

https://dev.gridrepublic.org/browse/DBOINCP-309