### PR TITLE
plan classes: add workunit-related filters

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -201,13 +201,6 @@ bool PLAN_CLASS_SPEC::check(SCHEDULER_REQUEST& sreq, HOST_USAGE& hu, const WORKU
     //
     hu.sequential_app(sreq.host.p_fpops);
 
-    // disabled by configuration
-    if (disabled) {
-        if (config.debug_version_select)
-	    log_messages.printf(MSG_NORMAL, "[version] Plan class disabled\n");
-	return false;
-    }
-
     // WU restriction
     if (min_wu_id || max_wu_id || min_batch || max_batch) {
         if (wu_is_infeasible_for_plan_class(this, wu)) {
@@ -992,7 +985,6 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
             return 0;
         }
         if (xp.parse_str("name", name, sizeof(name))) continue;
-        if (xp.parse_bool("disabled", disabled)) continue;
         if (xp.parse_int("min_core_client_version", min_core_client_version)) continue;
         if (xp.parse_int("max_core_client_version", max_core_client_version)) continue;
         if (xp.parse_str("gpu_type", gpu_type, sizeof(gpu_type))) continue;

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -32,8 +32,6 @@
 
 using std::string;
 
-static bool wu_restricted_plan_class;
-
 // this returns a numerical OS version for Darwin/OSX and Windows,
 // letting us define numerical ranges for these OS versions
 //

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -32,6 +32,7 @@
 
 using std::string;
 
+static bool wu_restricted_plan_class;
 
 // this returns a numerical OS version for Darwin/OSX and Windows,
 // letting us define numerical ranges for these OS versions
@@ -77,6 +78,30 @@ static int android_version_num(HOST h) {
         return maj*10000 + min*100;
     }
     return 0;
+}
+
+static bool wu_is_infeasible_for_plan_class(const PLAN_CLASS_SPEC* pc, const WORKUNIT* wu) {
+    if (pc->min_wu_id && wu->id < pc->min_wu_id) {
+        if (config.debug_version_select)
+            log_messages.printf(MSG_NORMAL, "[version] WU#%ld too old for plan class '%s'\n", wu->id, pc->name);
+        return true;
+    }
+    if (pc->max_wu_id && wu->id > pc->max_wu_id) {
+        if (config.debug_version_select)
+            log_messages.printf(MSG_NORMAL, "[version] WU#%ld too new for plan class '%s'\n", wu->id, pc->name);
+        return true;
+    }
+    if (pc->min_batch && wu->batch < pc->min_batch) {
+        if (config.debug_version_select)
+            log_messages.printf(MSG_NORMAL, "[version] batch#%ld too old for plan class '%s'\n", wu->id, pc->name);
+        return true;
+    }
+    if (pc->max_batch && wu->batch > pc->max_batch) {
+        if (config.debug_version_select)
+            log_messages.printf(MSG_NORMAL, "[version] batch#%ld too new for plan class '%s'\n", wu->id, pc->name);
+        return true;
+    }
+    return false;
 }
 
 int PLAN_CLASS_SPECS::parse_file(const char* path) {
@@ -184,25 +209,10 @@ bool PLAN_CLASS_SPEC::check(SCHEDULER_REQUEST& sreq, HOST_USAGE& hu, const WORKU
     }
 
     // WU restriction
-    if (min_wu_id && wu->id < min_wu_id) {
-        if (config.debug_version_select)
-	    log_messages.printf(MSG_NORMAL, "[version] WU#%ld too old\n", wu->id);
-	return false;
-    }
-    if (max_wu_id && wu->id > max_wu_id) {
-        if (config.debug_version_select)
-	    log_messages.printf(MSG_NORMAL, "[version] WU#%ld too new\n", wu->id);
-	return false;
-    }
-    if (min_batch && wu->batch < min_batch) {
-        if (config.debug_version_select)
-	    log_messages.printf(MSG_NORMAL, "[version] batch#%ld too old\n", wu->id);
-	return false;
-    }
-    if (max_batch && wu->batch > max_batch) {
-        if (config.debug_version_select)
-	    log_messages.printf(MSG_NORMAL, "[version] batch#%ld too new\n", wu->id);
-	return false;
+    if (min_wu_id || max_wu_id || min_batch || max_batch) {
+        if (wu_is_infeasible_for_plan_class(this, wu)) {
+            return false;
+        }
     }
 
     // CPU features
@@ -963,30 +973,12 @@ bool PLAN_CLASS_SPECS::check(
     return false;
 }
 
-bool PLAN_CLASS_SPECS::wu_is_infeasible(char* plan_class, const WORKUNIT* wu) {
-    for (unsigned int i=0; i<classes.size(); i++) {
-        if(!strcmp(classes[i].name, plan_class)) {
-            if (classes[i].min_wu_id && wu->id < classes[i].min_wu_id) {
-                if (config.debug_version_select)
-                    log_messages.printf(MSG_NORMAL, "[version] WU#%ld too old for plan class '%s'\n", wu->id, plan_class);
-                return true;
+bool PLAN_CLASS_SPECS::wu_is_infeasible(char* plan_class_name, const WORKUNIT* wu) {
+    if(wu_restricted_plan_class) {
+        for (unsigned int i=0; i<classes.size(); i++) {
+            if(!strcmp(classes[i].name, plan_class_name)) {
+                return wu_is_infeasible_for_plan_class(&classes[i], wu);
             }
-            if (classes[i].max_wu_id && wu->id > classes[i].max_wu_id) {
-                if (config.debug_version_select)
-                    log_messages.printf(MSG_NORMAL, "[version] WU#%ld too new for plan class '%s'\n", wu->id, plan_class);
-                return true;
-            }
-            if (classes[i].min_batch && wu->batch < classes[i].min_batch) {
-                if (config.debug_version_select)
-                    log_messages.printf(MSG_NORMAL, "[version] batch#%ld too old for plan class '%s'\n", wu->id, plan_class);
-                return true;
-            }
-            if (classes[i].max_batch && wu->batch > classes[i].max_batch) {
-                if (config.debug_version_select)
-                    log_messages.printf(MSG_NORMAL, "[version] batch#%ld too new for plan class '%s'\n", wu->id, plan_class);
-                return true;
-            }
-            break;
         }
     }
     return false;
@@ -1085,10 +1077,10 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
         if (xp.parse_int("min_driver_version", min_driver_version)) continue;
         if (xp.parse_int("max_driver_version", max_driver_version)) continue;
         if (xp.parse_str("gpu_utilization_tag", gpu_utilization_tag, sizeof(gpu_utilization_tag))) continue;
-        if (xp.parse_int("min_wu_id", min_wu_id)) continue;
-        if (xp.parse_int("max_wu_id", max_wu_id)) continue;
-        if (xp.parse_int("min_batch", min_batch)) continue;
-        if (xp.parse_int("max_batch", max_batch)) continue;
+        if (xp.parse_int("min_wu_id", min_wu_id)) {wu_restricted_plan_class = true; continue;}
+        if (xp.parse_int("max_wu_id", max_wu_id)) {wu_restricted_plan_class = true; continue;}
+        if (xp.parse_int("min_batch", min_batch)) {wu_restricted_plan_class = true; continue;}
+        if (xp.parse_int("max_batch", max_batch)) {wu_restricted_plan_class = true; continue;}
 
         if (xp.parse_bool("need_ati_libs", need_ati_libs)) continue;
         if (xp.parse_bool("need_amd_libs", need_amd_libs)) continue;

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -26,6 +26,7 @@
 // if you add anything here, initialize if in the constructor
 //
 struct PLAN_CLASS_SPEC {
+    bool disabled;
     char name[256];
     char gpu_type[256];
     bool cuda;
@@ -63,6 +64,10 @@ struct PLAN_CLASS_SPEC {
     regex_t host_summary_regex;
     int user_id;
     double infeasible_random;
+    int min_wu_id;
+    int max_wu_id;
+    int min_batch;
+    int max_batch;
 
     // GPU apps
     //
@@ -115,7 +120,7 @@ struct PLAN_CLASS_SPEC {
 
     int parse(XML_PARSER&);
     bool opencl_check(OPENCL_DEVICE_PROP&);
-    bool check(SCHEDULER_REQUEST& sreq, HOST_USAGE& hu);
+    bool check(SCHEDULER_REQUEST& sreq, HOST_USAGE& hu, const WORKUNIT* wu);
     PLAN_CLASS_SPEC();
 };
 
@@ -123,6 +128,7 @@ struct PLAN_CLASS_SPECS {
     std::vector<PLAN_CLASS_SPEC> classes;
     int parse_file(const char*);
     int parse_specs(FILE*);
-    bool check(SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu);
+    bool check(SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu, const WORKUNIT* wu);
+    bool wu_is_infeasible(char* plan_class, const WORKUNIT* wu);
     PLAN_CLASS_SPECS(){};
 };

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -26,7 +26,6 @@
 // if you add anything here, initialize if in the constructor
 //
 struct PLAN_CLASS_SPEC {
-    bool disabled;
     char name[256];
     char gpu_type[256];
     bool cuda;

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -93,6 +93,9 @@ using std::string;
 
 PLAN_CLASS_SPECS plan_class_specs;
 
+/* is there a plan class spec that restricts the worunit (or batch) */
+bool wu_restricted_plan_class;
+
 GPU_REQUIREMENTS gpu_requirements[NPROC_TYPES];
 
 bool wu_is_infeasible_custom(
@@ -132,9 +135,11 @@ bool wu_is_infeasible_custom(
 #endif
 
     // WU restriction
-    if (plan_class_specs.classes.size() > 0) {
-        if (plan_class_specs.wu_is_infeasible(bav.avp->plan_class, &wu)) {
-            return true;
+    if (wu_restricted_plan_class) {
+        if (plan_class_specs.classes.size() > 0) {
+            if (plan_class_specs.wu_is_infeasible(bav.avp->plan_class, &wu)) {
+                return true;
+            }
         }
     }
 

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -91,12 +91,14 @@ using std::string;
 #define OPENCL_NVIDIA_MIN_RAM CUDA_MIN_RAM
 #endif
 
+PLAN_CLASS_SPECS plan_class_specs;
+
 GPU_REQUIREMENTS gpu_requirements[NPROC_TYPES];
 
 bool wu_is_infeasible_custom(
-    WORKUNIT& /*wu*/,
+    WORKUNIT& wu,
     APP& /*app*/,
-    BEST_APP_VERSION& /*bav*/
+    BEST_APP_VERSION& bav
 ) {
 #if 0
     // example 1: if WU name contains "_v1", don't use GPU apps.
@@ -128,6 +130,14 @@ bool wu_is_infeasible_custom(
         return true;
     }
 #endif
+
+    // WU restriction
+    if (plan_class_specs.classes.size() > 0) {
+        if (plan_class_specs.wu_is_infeasible(bav.avp->plan_class, &wu)) {
+            return true;
+        }
+    }
+
     return false;
 }
 
@@ -903,12 +913,10 @@ static inline bool app_plan_vbox(
     return true;
 }
 
-PLAN_CLASS_SPECS plan_class_specs;
-
 // app planning function.
 // See http://boinc.berkeley.edu/trac/wiki/AppPlan
 //
-bool app_plan(SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu) {
+bool app_plan(SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu, const WORKUNIT* wu) {
     char buf[256];
     static bool check_plan_class_spec = true;
     static bool have_plan_class_spec = false;
@@ -946,7 +954,7 @@ bool app_plan(SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu) {
         return false;
     }
     if (have_plan_class_spec) {
-        return plan_class_specs.check(sreq, plan_class, hu);
+        return plan_class_specs.check(sreq, plan_class, hu, wu);
     }
 
     if (!strcmp(plan_class, "mt")) {

--- a/sched/sched_customize.h
+++ b/sched/sched_customize.h
@@ -88,7 +88,7 @@ struct GPU_REQUIREMENTS {
 extern GPU_REQUIREMENTS gpu_requirements[NPROC_TYPES];
 
 extern bool wu_is_infeasible_custom(WORKUNIT&, APP&, BEST_APP_VERSION&);
-extern bool app_plan(SCHEDULER_REQUEST&, char* plan_class, HOST_USAGE&);
+extern bool app_plan(SCHEDULER_REQUEST&, char* plan_class, HOST_USAGE&, const WORKUNIT* wu);
 extern void handle_file_xfer_results();
 
 // Suppose we have a computation that uses two devices alternately.

--- a/sched/sched_customize.h
+++ b/sched/sched_customize.h
@@ -90,6 +90,7 @@ extern GPU_REQUIREMENTS gpu_requirements[NPROC_TYPES];
 extern bool wu_is_infeasible_custom(WORKUNIT&, APP&, BEST_APP_VERSION&);
 extern bool app_plan(SCHEDULER_REQUEST&, char* plan_class, HOST_USAGE&, const WORKUNIT* wu);
 extern void handle_file_xfer_results();
+extern bool wu_restricted_plan_class;
 
 // Suppose we have a computation that uses two devices alternately.
 // The devices have speeds s1 and s2.

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -522,7 +522,7 @@ static BEST_APP_VERSION* check_homogeneous_app_version(
     // and see if it supports the plan class
     //
     if (strlen(avp->plan_class)) {
-        if (!app_plan(*g_request, avp->plan_class, bav.host_usage)) {
+        if (!app_plan(*g_request, avp->plan_class, bav.host_usage, &wu)) {
             return NULL;
         }
     } else {
@@ -746,7 +746,7 @@ BEST_APP_VERSION* get_app_version(
             }
 
             if (strlen(av.plan_class)) {
-                if (!app_plan(*g_request, av.plan_class, host_usage)) {
+                if (!app_plan(*g_request, av.plan_class, host_usage, &wu)) {
                     if (config.debug_version_select) {
                         log_messages.printf(MSG_NORMAL,
                             "[version] [AV#%lu] app_plan() returned false\n",


### PR DESCRIPTION
filters <min_wu_id>, <max_wu_id>, <min_batch>, <max_batch> and <disabled>

This is a essentially a copy of #2000 which was merged prematurely (with an unfinished discussion) and later reverted in #2002 (without any discussion).

- WU information is passed from check_homogeneous_app_version() down to PLAN_CLASS::check()

- wu_is_infeasible_custom() is extended such that additional tasks also follow the plan class restrictions.
