### PR TITLE
lib: fix boinc_file_exists() on Windows

### DIFF
--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -547,9 +547,7 @@ int boinc_file_exists(const char* path) {
 #ifdef _WIN32
     // don't use _stat64 because it doesn't work with VS2015, XP client
     DWORD dwAttrib = GetFileAttributesA(path);
-    return (dwAttrib != INVALID_FILE_ATTRIBUTES
-        && !(dwAttrib & FILE_ATTRIBUTE_DIRECTORY)
-    );
+    return dwAttrib != INVALID_FILE_ATTRIBUTES;
 #else
     struct stat buf;
     if (stat(path, &buf)) {


### PR DESCRIPTION
The function is documented to check if anything exists at the given path. The client depends on this behavior. If the function checks only for regular files the client will fail to clean up slot directories before using them for another task.

Fix the function to match the documentation.