### PR TITLE
Drupal: New account_finish landing page

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
@@ -312,17 +312,38 @@ function boincuser_admin_scheduler_submit($form, &$form_state) {
 
 
 /**
-  * Other BOINC options that don't fit elsewhere
+  * Drupal-BOINC Web site related options.
   */
-function boincuser_admin_other(&$form_state) {
+function boincuser_admin_weboptions(&$form_state) {
   $form = array();
 
   //form defaults
   $default = array(
-      'boinc_other_frontpage' => variable_get('boinc_other_frontpage', ''),
+    'boinc_weboptions_accountfinish' => variable_get('boinc_weboptions_accountfinish', ''),
+    'boinc_weboptions_moderationpage' => variable_get('boinc_weboptions_moderationpage', ''),
+    'boinc_weboptions_rulespolicies' => variable_get('boinc_weboptions_rulespolicies', ''),
+    'boinc_other_frontpage' => variable_get('boinc_other_frontpage', ''),
   );
   
   // Define the form
+  $form['boinc_weboptions_accountfinish'] = array (
+    '#type' => 'textfield',
+    '#title' => t('Path to a custom account_finish.php page, should be a path to a node'),
+    '#description' => t('Provide a path to a node which will serve as your site\'s landing page for users create an account using the BOINC client manager. They will be directed to this page after the account is created. If blank, a default account_finish page will be used.<br>Examples: account_finish, content/welcome, node/123'),
+    '#default_value' => $default['boinc_weboptions_accountfinish'],
+  );
+  $form['boinc_weboptions_moderate'] = array (
+    '#type' => 'textfield',
+    '#title' => t('Path to the site\'s content moderation info page, should be a path to a node'),
+    '#description' => t('Provide a path to a node which will serve as your site\'s page for account/content moderation information. This will be used on the default account_finish page. If blank, no link to a moderation page will be provided. If a path is provided to the custom account_finish.php page (above), this field will be ignored.<br>Examples: moderation, content/moderation, node/456'),
+    '#default_value' => $default['boinc_weboptions_moderationpage'],
+  );
+  $form['boinc_weboptions_rulespolicies'] = array (
+    '#type' => 'textfield',
+    '#title' => t('Path to the site\'s rule and policies page, should be a path to a node'),
+    '#description' => t('Provide a path to a node which will serve as your site\'s rules and policies page. This will be used on the Join page shown to new users. If blank, no link to a rules and policies page will be provided.<br>Examples: rules-and-policies, node/789'),
+    '#default_value' => $default['boinc_weboptions_rulespolicies'],
+  );
   $form['boinc_other_frontpage'] = array (
     '#type' => 'textarea',
     '#title' => bts('Message for site\'s Home Page', array(), NULL, 'boinc:admin-boinc-other-options'),
@@ -338,12 +359,28 @@ function boincuser_admin_other(&$form_state) {
 /**
   * Validate BOINC other form
   */
-function boincuser_admin_other_validate($form, &$form_state) {
+function boincuser_admin_weboptions_validate($form, &$form_state) {
+  $values = $form_state['values'];
+
+  $accountfinish = $values['boinc_weboptions_accountfinish'];
+  if ( ($accountfinish) AND (!drupal_lookup_path('source', $accountfinish)) ) {
+    form_set_error('boinc weboptions_accountfinish', t('Path to custom account finish page not found. Please provide a valid path, or leave blank to unset.'));
+  }
+
+  $moderationpage = $values['boinc_weboptions_moderationpage'];
+  if ( ($moderationpage) AND (!drupal_lookup_path('source', $moderationpage)) ) {
+    form_set_error('boinc weboptions_moderationpage', t('Path to moderation page not found. Please provide a valid path, or leave blank to unset.'));
+  }
+
+  $rulespolicies = $values['boinc_weboptions_rulespolicies'];
+  if ( ($rulespolicies) AND (!drupal_lookup_path('source', $rulespolicies)) ) {
+    form_set_error('boinc weboptions_rulespolicies', t('Path to rules and policies page not found. Please provide a valid path, or leave blank to unset.'));
+  }
 }
 
 /**
   * Submit BOINC other form
   */
-function boincuser_admin_other_submit($form, &$form_state) {
-  drupal_set_message( bts("Status: BOINC other settings have been updated", array(), NULL, 'boinc:admin-boinc-other-options') );
+function boincuser_admin_weboptions_submit($form, &$form_state) {
+  drupal_set_message( bts("Status: Drupa-BOINC Web site options have been updated", array(), NULL, 'boinc:admin-boinc-website-options') );
 }

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -163,11 +163,11 @@ function boincuser_menu() {
     'type' => MENU_NORMAL_ITEM,
     'file' => 'boincuser.admin.inc'
   );
-  $items['admin/boinc/other'] = array(
-    'title' => 'Other Options',
-    'description' => 'Set other BOINC options.',
+  $items['admin/boinc/weboptions'] = array(
+    'title' => 'Environment: Website Options',
+    'description' => 'Set options configuring this Drupal-BOINC Web site.',
     'page callback' => 'drupal_get_form',
-    'page arguments' => array('boincuser_admin_other'),
+    'page arguments' => array('boincuser_admin_weboptions'),
     'access arguments' => array('administer site configuration'),
     'type' => MENU_NORMAL_ITEM,
     'file' => 'boincuser.admin.inc'
@@ -1253,12 +1253,14 @@ function join_page($type = null) {
   case 'new':
   default:
     // Determine if there is a link to rules-and-policies
-    $ruleslink="";
-    if (drupal_lookup_path('source', $ruleslinkA)) {
-      $ruleslink = drupal_lookup_path('source', $ruleslinkA);
-    } else if (drupal_lookup_path('source', $ruleslinkB)) {
-      $ruleslink = drupal_lookup_path('source', $ruleslinkB);
-    }
+    //$ruleslink='';
+    //if (drupal_lookup_path('source', $ruleslinkA)) {
+    //  $ruleslink = drupal_lookup_path('source', $ruleslinkA);
+    //} else if (drupal_lookup_path('source', $ruleslinkB)) {
+    //  $ruleslink = drupal_lookup_path('source', $ruleslinkB);
+    //}
+
+    $ruleslink = drupal_lookup_path('source', variable_get('boinc_weboptions_rulespolicies', '') );
 
     // Join page output
     $output .= '<ol>';
@@ -1468,9 +1470,8 @@ function boincuser_account_finish() {
     drupal_goto();
   }
 
-  // Improvement: Have the path to the account_finish node be a path
-  // the admin can specify in the admin interface.
-  $customaccountfinishpath = drupal_lookup_path('source', 'account_finish');
+  // Lookup path to custom account finish page
+  $customaccountfinishpath = drupal_lookup_path('source', variable_get('boinc_weboptions_accountfinish', '') );
   if ( menu_valid_path(array('link_path' => $customaccountfinishpath)) ) {
     $node = menu_get_object('node', 1, $customaccountfinishpath);
     if ($node) {
@@ -1479,7 +1480,7 @@ function boincuser_account_finish() {
   }
 
   // Check moderation page exists
-  $moderationpath = drupal_lookup_path('source', 'moderation');
+  $moderationpath = drupal_lookup_path('source', variable_get('boinc_weboptions_moderationpage', '') );
   if ( menu_valid_path(array('link_path' => $moderationpath)) ) {
     $modsentence = bts('Please note: user profiles are subject to @moderation.', array('@moderation' => l(bts('moderation', array(), NULL, 'boinc:account-finish'), 'moderate')), NULL, 'boinc:account-finish');
   } else {

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -180,6 +180,13 @@ function boincuser_menu() {
     'access callback' => TRUE,
     'type' => MENU_CALLBACK
   );
+  $items['account_finish.php'] = array(
+    'title' => 'Welcome to ' . variable_get('site_name', 'Drupal-BOINC'),
+    'description' => 'RPC for after a user has created an account.',
+    'page callback' => 'boincuser_account_finish',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
   return $items;
 }
 
@@ -1426,6 +1433,138 @@ function boincuser_create_account() {
   echo " <account_out>\n";
   echo "   <authenticator>{$boinc_user->authenticator}</authenticator>\n";
   echo "</account_out>\n";
+}
+
+/**
+ * RPC for account_finish.php, the page user is sent to once an
+ * account is created using the BOINC clinet.
+ */
+function boincuser_account_finish() {
+  global $user;
+
+  $authtoken = isset($_GET['auth']) ? $_GET['auth'] : '';
+
+  // Ensure there is a authentication token before continuing
+  if (empty($authtoken)) {
+    drupal_not_found();
+    return ;
+  }
+
+  if (strlen($authtoken) != 32) {
+    drupal_set_message(bts('ERROR: There is no account with that authenticator.', array(), NULL, 'boinc:account-finish'), 'error');
+    drupal_goto();
+  }
+
+  require_boinc('boinc_db');
+  $boinc_user = BoincUser::lookup("authenticator='".addslashes($authtoken)."'");
+  if (!$boinc_user) {
+    drupal_set_message(bts('ERROR: There is no account with that authenticator.', array(), NULL, 'boinc:account-finish'), 'error');
+    drupal_goto();
+  }
+  $user = user_load(get_drupal_id($boinc_user->id));
+
+  if (!$user) {
+    drupal_set_message(bts('ERROR: There was a problem loading your account. Try logging in with your user name and password.', array(), NULL, 'boinc:account-finish'), 'error');
+    drupal_goto();
+  }
+
+  // Improvement: Have the path to the account_finish node be a path
+  // the admin can specify in the admin interface.
+  $customaccountfinishpath = drupal_lookup_path('source', 'account_finish');
+  if ( menu_valid_path(array('link_path' => $customaccountfinishpath)) ) {
+    $node = menu_get_object('node', 1, $customaccountfinishpath);
+    if ($node) {
+      return node_page_view($node);
+    }
+  }
+
+  // Check moderation page exists
+  $moderationpath = drupal_lookup_path('source', 'moderation');
+  if ( menu_valid_path(array('link_path' => $moderationpath)) ) {
+    $modsentence = bts('Please note: user profiles are subject to @moderation.', array('@moderation' => l(bts('moderation', array(), NULL, 'boinc:account-finish'), 'moderate')), NULL, 'boinc:account-finish');
+  } else {
+    $modsentence = bts('Please note: user profiles are subject to moderation.', array(), NULL, 'boinc:account-finish');
+  }
+
+  // @todo - add bts() function calls
+  $username = $user->boincuser_name;
+  $site_name = variable_get('site_name', 'Drupal-BOINC');
+  $output = "<p>" . bts('Thank you @user_name for joining @site_name. Your account has been created. Your BOINC client should start working on assigned tasks soon, without any additional action or configuration. Please visit the links below for what to do next. (Links will open in a new window.)',
+  array(
+    '@user_name' => $username,
+    '@site_name' => $site_name,
+  ), NULL, 'boinc:account-finish') . "</p>";
+
+  $options = array(
+    'attributes' => array( 'target' => '_blank' ),
+  );
+  $links = array(
+    array(
+      'data' => bts('Change your username at !community_preferences.', array(
+        '!community_preferences' => l(bts('Community Preferences', array(), NULL, 'boinc:account-fininsh'), 'account/prefs/community', $options),
+      ), NULL, 'boinc:account-finish'),
+      'children' => array(
+        bts('Your username is used to identify yourself to other volunteers on this Web site.', array(), NULL, 'boinc:account-finish'),
+        bts('In addition, you may set your account\'s default language and adjust notification settings.', array(), NULL, 'boinc:account-finish'),
+      ),
+    ),
+    array(
+      'data' => bts('Change your !computing_preferences.', array(
+        '!computing_preferences' => l(bts('Computing Preferences', array(), NULL, 'boinc:account-finish'), 'account/prefs', $options),
+      ), NULL, 'boinc:account-finish'),
+      'children' => array(
+        bts('You may adjust how much CPU, RAM, and Disk space the BOINC client is allowed to use for tasks on your computer.', array(), NULL, 'boinc:account-finish'),
+        bts('By default, you will run @site_name tasks without any additional configuration.', array(
+          '@site_name' => $site_name,
+        ), NULL, 'boinc:account-finish'),
+        bts('It is recommended new volunteers leave the default settings until they gain experience running some tasks. Ask questions in the !forums to get advice before making changes to a setting you don\'t understand.', array(
+          '!forums' => l(bts('forums', array(), NULL, 'boinc:account-finish'), 'community/forum', $options),
+        ), NULL, 'boinc:account-finish'),
+      ),
+    ),
+    array(
+        'data' => bts('Create a !user_profile.', array(
+          '!user_profile' => l(bts('User Profile', array(), NULL, 'boinc:account-finish'), '/account/profile/edit', $options),
+        ), NULL, 'boinc:account-finish'),
+      'children' => array(
+        bts('A user profile will inform other volunteers who you are and why you joined @site_name.', array(
+          '@site_name' => $site_name,
+        ), NULL, 'boinc:account-finish'),
+        $modsentence,
+      ),
+    ),
+    array(
+      'data' => bts('Join a !team.', array(
+        '!team' => l(bts('Team', array(), NULL, 'boinc:account-finish'), '/community/teams', $options),
+      ), NULL, 'boinc:account-finish'),
+      'children' => array(
+        bts('You may join a team, made up of other volunteers.', array(), NULL, 'boinc:account-finish'),
+      ),
+    ),
+    array(
+      'data' => bts('Go to your !account_dashboard.', array(
+        '!account_dashboard'=> l(bts('Account Dashboard', array(), NULL, 'boinc:account-finish'), 'account/dashboard', $options),
+      ), NULL, 'boinc:account-finish'),
+      'children' => array(
+        bts('Your account dashboard has information and links about your computer(s) and task(s) assigned.', array(), NULL, 'boinc:account-finish'),
+      ),
+    ),
+    array(
+      'data' => bts('Visit our !help pages.', array(
+        '!help' => l(bts('Help', array(), NULL, 'boinc:account-finish'), '/help', $options)
+      ), NULL, 'boinc:account-finish'),
+      'children' => array(
+        bts('Ask for help in our community\'s !forums.', array(
+          '!forums' => l(bts('forums', array(), NULL, 'boinc:account-finish'), 'community/forum', $options)
+        ), NULL, 'boinc:account-finish'),
+      ),
+    ),
+  );
+
+  //List of links
+  $output .= theme_item_list($links, $title = NULL, $type='ul');
+
+  return $output;
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1490,7 +1490,7 @@ function boincuser_account_finish() {
   // @todo - add bts() function calls
   $username = $user->boincuser_name;
   $site_name = variable_get('site_name', 'Drupal-BOINC');
-  $output = "<p>" . bts('Thank you @user_name for joining @site_name. Your account has been created. Your BOINC client should start working on assigned tasks soon, without any additional action or configuration. Please visit the links below for what to do next. (Links will open in a new window.)',
+  $output = "<p>" . bts('Thank you @user_name for joining @site_name. Your account has been created. Your BOINC client should start working on assigned tasks soon, without any additional action or configuration. Please visit the links below for more information and additional options. (Links will open in a new window.)',
   array(
     '@user_name' => $username,
     '@site_name' => $site_name,


### PR DESCRIPTION
New landing page for account_finish.php, used when user creates an account using BOINC client manager.

In addition, admin can supply a Drupal path to a custom one.

https://dev.gridrepublic.org/browse/DBOINCP-395