### PR TITLE
Assign app version num to WUs

### DIFF
--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -390,12 +390,12 @@ void ACTIVE_TASK::handle_temporary_exit(
     } else {
         if (is_notice) {
             msg_printf(result->project, MSG_USER_ALERT,
-                "Task postponed: %s", reason
+                "Task %s postponed for %.f seconds: %s", result->name, backoff, reason
             );
         } else {
             if (log_flags.task) {
                 msg_printf(result->project, MSG_INFO,
-                    "task postponed %f sec: %s", backoff, reason
+                    "Task %s postponed for %.f seconds: %s", result->name, backoff, reason
                 );
             }
         }

--- a/client/client_msgs.cpp
+++ b/client/client_msgs.cpp
@@ -125,6 +125,11 @@ void show_message(
     // print message to the console
     printf("%s", evt_message);
 
+#ifdef _MSC_VER
+    // MSVCRT doesn't support line buffered streams
+    fflush(stdout);
+#endif
+
     // print message to the debugger view port
     diagnostics_trace_to_debugger(evt_message);  
 }

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -83,6 +83,10 @@ void log_message_startup(const char* msg) {
     );
     if (!gstate.executing_as_daemon) {
         fprintf(stdout, "%s", evt_msg);
+#ifdef _MSC_VER
+        // MSVCRT doesn't support line buffered streams
+        fflush(stdout);
+#endif
     } else {
 #ifdef _WIN32
         LogEventInfoMessage(evt_msg);
@@ -373,8 +377,6 @@ int boinc_main_loop() {
         if (!gstate.poll_slow_events()) {
             gstate.do_io_or_sleep(POLL_INTERVAL);
         }
-        fflush(stderr);
-        fflush(stdout);
 
         if (gstate.time_to_exit()) {
             msg_printf(NULL, MSG_INFO, "Time to exit");

--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -59,20 +59,11 @@ CDlgItemProperties::CDlgItemProperties(wxWindow* parent) :
     
     m_bSizer1 = new wxBoxSizer( wxVERTICAL );
     
-    m_scrolledWindow = new wxScrolledWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHSCROLL|wxVSCROLL );
-    m_scrolledWindow->SetScrollRate( 5, 5 );
-    wxBoxSizer* m_bSizer2;
-    m_bSizer2 = new wxBoxSizer( wxVERTICAL );
-    
     const long style = wxBORDER_NONE;
-    m_txtInformation = new wxHtmlWindow( m_scrolledWindow, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, "" );
+    m_txtInformation = wxWebView::New( this, wxID_ANY, wxWebViewDefaultURLStr, wxDefaultPosition, wxDefaultSize, wxWebViewBackendDefault, style );
+    m_txtInformation->EnableContextMenu( false );
 
-    m_bSizer2->Add( m_txtInformation, 1, wxEXPAND, 5 );
-
-    m_scrolledWindow->SetSizer( m_bSizer2 );
-    m_scrolledWindow->Layout();
-    m_bSizer2->Fit( m_scrolledWindow );
-    m_bSizer1->Add( m_scrolledWindow, 1, wxEXPAND | wxALL, 5 );
+    m_bSizer1->Add( m_txtInformation, 1, wxEXPAND | wxALL, 5 );
     
     m_btnClose = new wxButton( this, wxID_OK, _("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnClose->SetDefault(); 
@@ -357,7 +348,6 @@ void CDlgItemProperties::renderInfos(PROJECT* project_in) {
         addProperty(_("Last scheduler reply"), dt.Format());
     }
     renderInfos();
-    m_scrolledWindow->FitInside();
 }
 
 // show task properties
@@ -445,7 +435,6 @@ void CDlgItemProperties::renderInfos(RESULT* result) {
         addProperty(_("Executable"), wxString(avp->exec_filename, wxConvUTF8));
     }
     renderInfos();
-    m_scrolledWindow->FitInside();
 }
 
 //
@@ -520,26 +509,55 @@ wxString CDlgItemProperties::FormatApplicationName(RESULT* result ) {
 
 
 void CDlgItemProperties::renderInfos() {
+    wxString str_bg;
+    str_bg.Printf(wxT("#%x"), this->GetBackgroundColour().GetRGB());
+    wxFont font = this->GetFont();
+    wxString font_name = font.GetFaceName();
+    wxString font_size;
+    font_size.Printf(wxT("%d"), font.GetPointSize());
+
     std::string content;
     content += "<html>";
+    content += "<head>";
+    content += "<style>";
+    content += " body { ";
+    content += " background-color: " + str_bg + "; ";
+    content += " overflow : auto; ";
+    content += " } ";
+    content += " table { ";
+    content += " width: 100%; ";
+    content += " } ";
+    content += " span { ";
+    content += " white-space: nowrap; ";
+    content += " font-family: '" + font_name + "'; ";
+    content += " font-size: " + font_size + "pt; ";
+    content += " } ";
+    content += "</style>";
+    content += "</head>";
     content += "<body>";
-    content += "<table style='width:100%'>";
+    content += "<table>";
     for (size_t i = 0; i < m_items.size(); ++i) {
         if (m_items[i].item_type == ItemTypeSection) {
             content += "<tr>";
             content += "<td colspan='2'>";
+            content += "<span>";
             content += "<b>";
             content += m_items[i].name;
             content += "</b>";
+            content += "</span>";
             content += "</td>";
             content += "</tr>";
         } else if (m_items[i].item_type == ItemTypeProperty) {
             content += "<tr>";
             content += "<td>";
+            content += "<span>";
             content += m_items[i].name;
+            content += "</span>";
             content += "</td>";
             content += "<td>";
+            content += "<span>";
             content += m_items[i].value;
+            content += "</span>";
             content += "</td>";
             content += "</tr>";
         }        
@@ -547,7 +565,7 @@ void CDlgItemProperties::renderInfos() {
     content += "</table>";
     content += "</body>";
     content += "</html>";
-    m_txtInformation->SetPage(content);
+    m_txtInformation->SetPage(wxString(content), "");
 }
 
 

--- a/clientgui/DlgItemProperties.h
+++ b/clientgui/DlgItemProperties.h
@@ -62,10 +62,9 @@ private:
 	void addProperty(const wxString& name, const wxString& value);
 protected:
         wxBoxSizer* m_bSizer1;
-        wxScrolledWindow* m_scrolledWindow;
         wxButton* m_btnClose;
         wxString m_strBaseConfigLocation;
-        wxHtmlWindow* m_txtInformation;
+        wxWebView* m_txtInformation;
 };
 
 #endif

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1201,7 +1201,12 @@ function boincuser_edit_profile($account = null) {
   */
 function join_page($type = null) {
   global $base_url;
-  $ruleslink = '/content/rules-and-policies';
+  /* The paths/links to the rules-and-policies page is hardcoded
+   * here. An improvement would be admin settings for the Join Page
+   * where this path could be set.
+   */
+  $ruleslinkA = 'rules-and-policies';
+  $ruleslinkB = 'content/rules-and-policies';
   $site_name = variable_get('site_name', 'Drupal-BOINC');
   $registration_enabled = variable_get('user_register', 0);
   $output = '<div class="join">';
@@ -1240,8 +1245,17 @@ function join_page($type = null) {
     break;
   case 'new':
   default:
+    // Determine if there is a link to rules-and-policies
+    $ruleslink="";
+    if (drupal_lookup_path('source', $ruleslinkA)) {
+      $ruleslink = drupal_lookup_path('source', $ruleslinkA);
+    } else if (drupal_lookup_path('source', $ruleslinkB)) {
+      $ruleslink = drupal_lookup_path('source', $ruleslinkB);
+    }
+
+    // Join page output
     $output .= '<ol>';
-    if (menu_valid_path(array('link_path' => $ruleslink))) {
+    if ( menu_valid_path(array('link_path' => $ruleslink)) ) {
       $output .= '  <li>' . bts("Read our !rules_and_policies.", array(
         '!rules_and_policies' => l(bts('Rules and Policies', array(), NULL, 'boinc:join-page'), $ruleslink),
       ), NULL, 'boinc:join-page') . '</li>';

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -352,6 +352,7 @@ int diagnostics_init(
         if (!stdout_file) {
             return ERR_FOPEN;
         }
+        setvbuf(stdout_file, NULL, _IOLBF, BUFSIZ);
     }
 
     if (flags & BOINC_DIAG_REDIRECTSTDOUTOVERWRITE) {
@@ -359,6 +360,7 @@ int diagnostics_init(
         if (!stdout_file) {
             return ERR_FOPEN;
         }
+        setvbuf(stdout_file, NULL, _IOLBF, BUFSIZ);
     }
 
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -631,7 +631,7 @@ double rand_normal() {
 //
 #ifdef HAVE__PROC_SELF_EXE
 int get_real_executable_path(char* path, size_t max_len) {
-    int ret = readlink("/proc/self/exe", path, max_len);
+    int ret = readlink("/proc/self/exe", path, max_len - 1);
     if ( ret >= 0) {
         path[ret] = '\0'; // readlink does not null terminate
         return 0;


### PR DESCRIPTION
Allow projects to specify that a WU should be processed by app versions with a particular version #.
To do this:
pass --app_version_num arg to create_work
set app.min_version to the lowest version num for which there are outstanding jobs
   (can use xadd for this)

The goal is to smooth the transition between versions with incompatible input files