### PR TITLE
back end: add feature for assigning WUs to a particular version num

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -902,7 +902,8 @@ void DB_WORKUNIT::db_print(char* buf){
         "app_version_id=%ld, "
         "transitioner_flags=%d, "
         "size_class=%d, "
-        "keywords='%s' ",
+        "keywords='%s', "
+        "app_version_num=%d ",
         create_time, appid,
         name, xml_doc, batch,
         rsc_fpops_est, rsc_fpops_bound, rsc_memory_bound, rsc_disk_bound,
@@ -923,7 +924,8 @@ void DB_WORKUNIT::db_print(char* buf){
         app_version_id,
         transitioner_flags,
         size_class,
-        keywords
+        keywords,
+        app_version_num
     );
 }
 
@@ -947,7 +949,8 @@ void DB_WORKUNIT::db_print_values(char* buf) {
         "%ld, "
         "%d, "
         "%d, "
-        "'%s')",
+        "'%s', "
+        "%d )",
         create_time, appid,
         name, xml_doc, batch,
         rsc_fpops_est, rsc_fpops_bound,
@@ -969,7 +972,8 @@ void DB_WORKUNIT::db_print_values(char* buf) {
         app_version_id,
         transitioner_flags,
         size_class,
-        keywords
+        keywords,
+        app_version_num
     );
 }
 
@@ -1010,6 +1014,7 @@ void DB_WORKUNIT::db_parse(MYSQL_ROW &r) {
     transitioner_flags = atoi(r[i++]);
     size_class = atoi(r[i++]);
     strcpy2(keywords, r[i++]);
+    app_version_num = atoi(r[i++]);
 }
 
 void DB_CREDITED_JOB::db_print(char* buf){
@@ -2026,6 +2031,7 @@ void WORK_ITEM::parse(MYSQL_ROW& r) {
     wu.transitioner_flags = atoi(r[i++]);
     wu.size_class = atoi(r[i++]);
     strcpy2(wu.keywords, r[i++]);
+    wu.app_version_num = atoi(r[i++]);
 }
 
 int DB_WORK_ITEM::enumerate(

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -145,7 +145,7 @@ struct APP_VERSION {
     double expavg_time;
     bool beta;
 
-    // the following used by scheduler, not in DB
+    // the following used by scheduler (add_wu_to_reply()), not in DB
     //
     BEST_APP_VERSION* bavp;
 
@@ -482,6 +482,8 @@ struct WORKUNIT {
         // doesn't have to look up app
     char keywords[256];
         // keywords, as space-separated integers
+    int app_version_num;
+        // if nonzero, use only this version num
 
     void clear();
     WORKUNIT(){clear();}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -257,6 +257,7 @@ create table workunit (
     transitioner_flags      tinyint         not null,
     size_class              smallint        not null default -1,
     keywords                varchar(254)    not null,
+    app_version_num         integer         not null,
     primary key (id)
 ) engine=InnoDB;
 

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1055,6 +1055,12 @@ function update_7_21_2017() {
     ");
 }
 
+function update_8_9_2017() {
+    do_query("alter table workunit
+        add column app_version_num integer not null
+    ");
+}
+
 // Updates are done automatically if you use "upgrade".
 //
 // If you need to do updates manually,
@@ -1105,6 +1111,7 @@ $db_updates = array (
     array(27016, "update_3_17_2017"),
     array(27017, "update_6_13_2017"),
     array(27018, "update_7_21_2017"),
+    array(27019, "update_8_9_2017"),
 );
 
 ?>

--- a/sched/sched_shmem.cpp
+++ b/sched/sched_shmem.cpp
@@ -182,6 +182,10 @@ int SCHED_SHMEM::scan_tables() {
     // for each (app, platform) pair,
     // get all versions with numbers maximal in their plan class.
     //
+    // If the app is using version-specific WUs,
+    // get all versions >= min_version,
+    // and flag the latest ones
+    //
     for (i=0; i<nplatforms; i++) {
         PLATFORM& splatform = platforms[i];
         for (j=0; j<napps; j++) {
@@ -195,6 +199,9 @@ int SCHED_SHMEM::scan_tables() {
             while (!app_version.enumerate(query)) {
                 avs.push_back(app_version);
             }
+
+            // flag non-latest versions as deprecated
+            //
             for (unsigned int k=0; k<avs.size(); k++) {
                 APP_VERSION& av1 = avs[k];
                 for (unsigned int kk=0; kk<avs.size(); kk++) {
@@ -207,7 +214,16 @@ int SCHED_SHMEM::scan_tables() {
             }
             for (unsigned int k=0; k<avs.size(); k++) {
                 APP_VERSION& av1 = avs[k];
-                if (av1.deprecated) continue;
+                if (sapp.min_version) {
+                    if (av1.version_num < sapp.min_version) {
+                        fprintf(stderr, "version too small %d < %d\n",
+                            av1.version_num, sapp.min_version
+                        );
+                        continue;
+                    }
+                } else {
+                    if (av1.deprecated) continue;
+                }
                 if (av1.min_core_version && av1.min_core_version < 10000) {
                     fprintf(stderr, "min core version too small - multiplying by 100\n");
                     av1.min_core_version *= 100;
@@ -379,7 +395,7 @@ void SCHED_SHMEM::show(FILE* f) {
     for (int i=0; i<max_wu_results; i++) {
         if (i%24 == 0) {
             fprintf(f,
-                "%4s %12s %10s %10s %10s %8s %10s %8s %12s %12s %9s\n",
+                "%4s %12s %10s %10s %10s %8s %10s %8s %12s %12s %9s %9s\n",
                 "slot",
                 "app",
                 "WU ID",
@@ -390,7 +406,8 @@ void SCHED_SHMEM::show(FILE* f) {
                 "in shmem",
                 "size class",
                 "need reliable",
-                "inf count"
+                "inf count",
+                "version"
             );
         }
         WU_RESULT& wu_result = wu_results[i];
@@ -403,7 +420,7 @@ void SCHED_SHMEM::show(FILE* f) {
             appname = app?app->name:"missing";
             delta_t = dtime() - wu_result.time_added_to_shared_memory;
             fprintf(f,
-                "%4d %12.12s %10lu %10lu %10d %8d %10d %7ds %9d %12s %9d\n",
+                "%4d %12.12s %10lu %10lu %10d %8d %10d %7ds %9d %12s %9d %9d\n",
                 i,
                 appname,
                 wu_result.workunit.id,
@@ -414,7 +431,8 @@ void SCHED_SHMEM::show(FILE* f) {
                 delta_t,
                 wu_result.workunit.size_class,
                 wu_result.need_reliable?"yes":"no",
-                wu_result.infeasible_count
+                wu_result.infeasible_count,
+                wu_result.workunit.app_version_num
             );
             break;
         case WR_STATE_EMPTY:

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -631,6 +631,12 @@ BEST_APP_VERSION* get_app_version(
                 }
             }
 
+            if (wu.app_version_num) {
+                if (bavp->avp->version_num != wu.app_version_num) {
+                    break;
+                }
+            }
+
             if (config.debug_version_select) {
                 app_version_desc(*bavp, buf);
                 log_messages.printf(MSG_NORMAL,
@@ -698,6 +704,17 @@ BEST_APP_VERSION* get_app_version(
             APP_VERSION& av = ssp->app_versions[j];
             if (av.appid != wu.appid) continue;
             if (av.platformid != p->id) continue;
+
+            if (wu.app_version_num) {
+                if (av.version_num != wu.app_version_num) {
+                    continue;
+                }
+            } else {
+                if (av.deprecated) {
+                    continue;
+                }
+            }
+
             if (av.beta) {
                 if (!g_wreq->project_prefs.allow_beta_work) {
                     continue;

--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -53,6 +53,7 @@ void usage() {
         "Options:\n"
         "   --appname name\n"
         "   [ --additional_xml x ]\n"
+        "   [ --app_version_num N ]\n"
         "   [ --batch n ]\n"
         "   [ --broadcast ]\n"
         "   [ --broadcast_user ID ]\n"
@@ -266,6 +267,8 @@ int main(int argc, char** argv) {
             jd.wu.rsc_memory_bound = atof(argv[++i]);
         } else if (arg(argv, i, "size_class")) {
             jd.wu.size_class = atoi(argv[++i]);
+        } else if (arg(argv, i, "app_version_num")) {
+            jd.wu.app_version_num = atoi(argv[++i]);
         } else if (arg(argv, i, "rsc_disk_bound")) {
             jd.wu.rsc_disk_bound = atof(argv[++i]);
         } else if (arg(argv, i, "delay_bound")) {

--- a/tools/xadd
+++ b/tools/xadd
@@ -47,11 +47,15 @@ foreach ($x->platform as $platform) {
 foreach ($x->app as $app) {
     $n = (string)$app->name;
     $ufn = (string)$app->user_friendly_name;
+    $min_version = (int)$app->min_version;
     $a = BoincApp::lookup("name='$n'");
     if ($a) {
         if ($a->user_friendly_name != $ufn) {
             $a->update("user_friendly_name='$ufn'");
             echo "updated user friendly name of app $n\n";
+        } else if ($a->min_version != $min_version) {
+            $a->update("min_version = $min_version");
+            echo "updated min_version of app $n\n";
         } else {
             echo "app $n already in DB\n";
         }


### PR DESCRIPTION
Allow projects to specify that WUs should be processed by particular version nums.
Add --app_version_num arg to create_work
Set app.min_version to lowest version with outstanding jobs
  (can used xadd to do this)