### PR TITLE
client: fix report_result_error buffer overflow

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1836,9 +1836,10 @@ bool CLIENT_STATE::time_to_exit() {
 //   so that we don't try to run it again.
 //
 int CLIENT_STATE::report_result_error(RESULT& res, const char* format, ...) {
-    char buf[4096],  err_msg[4096];
+    char buf[4160],  err_msg[4096];
         // The above store 1-line messages and short XML snippets.
         // Shouldn't exceed a few hundred bytes.
+        // buf has to be larger in case err_msg max out
     unsigned int i;
     int failnum;
 


### PR DESCRIPTION
this is just a quick fix, I need someone with insight to review is this a proper fix,

tl;dr
CLIENT_STATE::report_result_error made an assumption that err_msg  won't get too large,
unfortunately, it will get really large due to this line

https://github.com/BOINC/boinc/blob/08c5b3b276b079c1433ed8f1e569314d9df88168/client/client_state.cpp#L1570

full detail and related log
http://boinc.berkeley.edu/dev/forum_thread.php?id=11772