### PR TITLE
client: eliminate possible buffer overflow in reporting result errors

### DIFF
--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -439,6 +439,7 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
         );
     }
 #endif
+    char err_msg[4096];
     bool will_restart = false;
 
     get_app_status_msg();
@@ -491,12 +492,12 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
         default:
             char szError[1024];
             set_task_state(PROCESS_EXITED, "handle_exited_app");
-            gstate.report_result_error(
-                *result,
+            sprintf(err_msg,
                 "%s - exit code %d (0x%x)",
                 windows_format_error_string(exit_code, szError, sizeof(szError)),
                 exit_code, exit_code
             );
+            gstate.report_result_error(*result, err_msg);
             if (log_flags.task_debug) {
                 msg_printf(result->project, MSG_INFO,
                     "[task] Process for %s exited",
@@ -528,12 +529,12 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
                 }
                 if (result->exit_status) {
                     set_task_state(PROCESS_EXITED, "handle_exited_app");
-                    gstate.report_result_error(
-                        *result,
+                    sprintf(err_msg,
                         "process exited with code %d (0x%x, %d)",
                         result->exit_status, result->exit_status,
                         (-1<<8)|result->exit_status
                     );
+                    gstate.report_result_error(*result, err_msg);
                 } else {
                     if (finish_file_present()) {
                         set_task_state(PROCESS_EXITED, "handle_exited_app");
@@ -567,9 +568,8 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
                 result->exit_status = stat;
                 set_task_state(PROCESS_WAS_SIGNALED, "handle_exited_app");
                 signal = got_signal;
-                gstate.report_result_error(
-                    *result, "process got signal %d", signal
-                );
+                sprintf(err_msg, "process got signal %d", signal);
+                gstate.report_result_error(*result, err_msg);
             }
         } else {
             result->exit_status = EXIT_UNKNOWN;

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -492,7 +492,7 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
         default:
             char szError[1024];
             set_task_state(PROCESS_EXITED, "handle_exited_app");
-            sprintf(err_msg,
+            snprintf(err_msg, sizeof(err_msg),
                 "%s - exit code %d (0x%x)",
                 windows_format_error_string(exit_code, szError, sizeof(szError)),
                 exit_code, exit_code
@@ -529,7 +529,7 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
                 }
                 if (result->exit_status) {
                     set_task_state(PROCESS_EXITED, "handle_exited_app");
-                    sprintf(err_msg,
+                    snprintf(err_msg, sizeof(err_msg),
                         "process exited with code %d (0x%x, %d)",
                         result->exit_status, result->exit_status,
                         (-1<<8)|result->exit_status
@@ -568,7 +568,9 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
                 result->exit_status = stat;
                 set_task_state(PROCESS_WAS_SIGNALED, "handle_exited_app");
                 signal = got_signal;
-                sprintf(err_msg, "process got signal %d", signal);
+                snprintf(err_msg, sizeof(err_msg),
+                    "process got signal %d", signal
+                );
                 gstate.report_result_error(*result, err_msg);
             }
         } else {

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -1166,7 +1166,9 @@ error:
     // Verify it to trigger another download.
     //
     gstate.input_files_available(result, true);
-    gstate.report_result_error(*result, "couldn't start app: %s", buf);
+    char err_msg[4096];
+    sprintf(err_msg, "couldn't start app: %s", buf);
+    gstate.report_result_error(*result, err_msg);
     if (log_flags.task_debug) {
         msg_printf(wup->project, MSG_INFO,
             "[task] couldn't start app: %s", buf

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -1167,7 +1167,7 @@ error:
     //
     gstate.input_files_available(result, true);
     char err_msg[4096];
-    sprintf(err_msg, "couldn't start app: %s", buf);
+    snprintf(err_msg, sizeof(err_msg), "couldn't start app: %s", buf);
     gstate.report_result_error(*result, err_msg);
     if (log_flags.task_debug) {
         msg_printf(wup->project, MSG_INFO,

--- a/client/async_file.cpp
+++ b/client/async_file.cpp
@@ -160,7 +160,9 @@ int ASYNC_COPY::copy_chunk() {
 void ASYNC_COPY::error(int retval) {
     char err_msg[4096];
     atp->set_task_state(PROCESS_COULDNT_START, "ASYNC_COPY::error");
-    sprintf(err_msg, "Couldn't copy file: %s", boincerror(retval));
+    snprintf(err_msg, sizeof(err_msg),
+        "Couldn't copy file: %s", boincerror(retval)
+    );
     gstate.report_result_error(*(atp->result), err_msg);
     gstate.request_schedule_cpus("start failed");
 }

--- a/client/async_file.cpp
+++ b/client/async_file.cpp
@@ -158,10 +158,10 @@ int ASYNC_COPY::copy_chunk() {
 // handle the failure of a copy; error out the result
 //
 void ASYNC_COPY::error(int retval) {
+    char err_msg[4096];
     atp->set_task_state(PROCESS_COULDNT_START, "ASYNC_COPY::error");
-    gstate.report_result_error(
-        *(atp->result), "Couldn't copy file: %s", boincerror(retval)
-    );
+    sprintf(err_msg, "Couldn't copy file: %s", boincerror(retval));
+    gstate.report_result_error(*(atp->result), err_msg);
     gstate.request_schedule_cpus("start failed");
 }
 

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1565,14 +1565,12 @@ bool CLIENT_STATE::garbage_collect_always() {
             wup = rp->wup;
             if (wup->had_download_failure(failnum)) {
                 wup->get_file_errors(error_msgs);
-                report_result_error(
-                    *rp, "WU download error: %s", error_msgs.c_str()
-                );
+                string err_msg = "WU download error: " + error_msgs;
+                report_result_error(*rp, err_msg.c_str());
             } else if (rp->avp && rp->avp->had_download_failure(failnum)) {
                 rp->avp->get_file_errors(error_msgs);
-                report_result_error(
-                    *rp, "app_version download error: %s", error_msgs.c_str()
-                );
+                string err_msg = "app_version download error: " + error_msgs;
+                report_result_error(*rp, err_msg.c_str());
             }
         }
         bool found_error = false;
@@ -1605,7 +1603,8 @@ bool CLIENT_STATE::garbage_collect_always() {
                     atp->abort_task(ERR_RESULT_UPLOAD, "upload failure");
                 }
             }
-            report_result_error(*rp, "upload failure: %s", error_str.c_str());
+            string err_msg = "upload failure: " + error_str;
+            report_result_error(*rp, err_msg.c_str());
         }
 #endif
         rp->avp->ref_cnt++;
@@ -1855,10 +1854,8 @@ bool CLIENT_STATE::time_to_exit() {
 // - If result state is FILES_DOWNLOADED, change it to COMPUTE_ERROR
 //   so that we don't try to run it again.
 //
-int CLIENT_STATE::report_result_error(RESULT& res, const char* format, ...) {
-    char buf[4096],  err_msg[4096];
-        // The above store 1-line messages and short XML snippets.
-        // Shouldn't exceed a few hundred bytes.
+int CLIENT_STATE::report_result_error(RESULT& res, const char* err_msg) {
+    char buf[1024];
     unsigned int i;
     int failnum;
 
@@ -1871,18 +1868,14 @@ int CLIENT_STATE::report_result_error(RESULT& res, const char* format, ...) {
     res.set_ready_to_report();
     res.completed_time = now;
 
-    va_list va;
-    va_start(va, format);
-    vsnprintf(err_msg, sizeof(err_msg), format, va);
-    va_end(va);
-
     sprintf(buf, "Unrecoverable error for task %s", res.name);
 #ifndef SIM
     scheduler_op->project_rpc_backoff(res.project, buf);
 #endif
 
-    sprintf( buf, "<message>\n%s\n</message>\n", err_msg);
-    res.stderr_out.append(buf);
+    res.stderr_out.append("<message>\n");
+    res.stderr_out.append(err_msg);
+    res.stderr_out.append("</message>\n");
 
     switch(res.state()) {
     case RESULT_NEW:

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -265,7 +265,7 @@ struct CLIENT_STATE {
         APP*, char* platform, int ver, char* plan_class
     );
     int detach_project(PROJECT*);
-    int report_result_error(RESULT&, const char *format, ...);
+    int report_result_error(RESULT&, const char* err_msg);
     int reset_project(PROJECT*, bool detaching);
     bool no_gui_rpc;
     bool gui_rpc_unix_domain;

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1442,9 +1442,9 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
                 continue;
             }
             if (retval) {
-                report_result_error(
-                    *(atp->result), "Couldn't start or resume: %d", retval
-                );
+                char err_msg[4096];
+                sprintf(err_msg, "Couldn't start or resume: %d", retval);
+                report_result_error(*(atp->result), err_msg);
                 request_schedule_cpus("start failed");
                 continue;
             }

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1443,7 +1443,9 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
             }
             if (retval) {
                 char err_msg[4096];
-                sprintf(err_msg, "Couldn't start or resume: %d", retval);
+                snprintf(err_msg, sizeof(err_msg),
+                    "Couldn't start or resume: %d", retval
+                );
                 report_result_error(*(atp->result), err_msg);
                 request_schedule_cpus("start failed");
                 continue;


### PR DESCRIPTION
A result with a lot of failed uploads could overflow a 4K buffer.
Change report_result_error() so you just pass it the error message,
rather than va_args nonsense.