### PR TITLE
Manager: Rename OK button to Save button

### DIFF
--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -159,14 +159,14 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
     m_panelButtons = new wxPanel( this, ID_DEFAULT, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
     wxBoxSizer* buttonSizer = new wxBoxSizer( wxHORIZONTAL );
 
-    m_btnOK = new wxButton( m_panelButtons, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_btnOK = new wxButton( m_panelButtons, wxID_OK, _("Save"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnOK->SetToolTip( _("Save all values and close the dialog.") );
-    m_btnOK->SetDefault();
     
     buttonSizer->Add( m_btnOK, 0, wxALL, 5 );
 
     m_btnCancel = new wxButton( m_panelButtons, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnCancel->SetToolTip( _("Close the dialog without saving.") );
+    m_btnCancel->SetDefault();
 
     buttonSizer->Add( m_btnCancel, 0, wxALL, 5 );
 

--- a/clientgui/DlgDiagnosticLogFlags.cpp
+++ b/clientgui/DlgDiagnosticLogFlags.cpp
@@ -118,7 +118,7 @@ CDlgDiagnosticLogFlags::CDlgDiagnosticLogFlags(wxWindow* parent) :
     
     wxBoxSizer* buttonSizer = new wxBoxSizer( wxHORIZONTAL );
 
-    wxButton* btnOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxButton* btnOK = new wxButton( this, wxID_OK, _("Save"), wxDefaultPosition, wxDefaultSize, 0 );
     btnOK->SetToolTip( _("Save all values and close the dialog") );
     buttonSizer->Add( btnOK, 0, wxALL, 5 );
 

--- a/clientgui/DlgExclusiveApps.cpp
+++ b/clientgui/DlgExclusiveApps.cpp
@@ -143,14 +143,14 @@ CDlgExclusiveApps::CDlgExclusiveApps(wxWindow* parent) :
     m_panelButtons = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
     wxBoxSizer* buttonSizer = new wxBoxSizer( wxHORIZONTAL );
 
-    m_btnOK = new wxButton( m_panelButtons, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_btnOK = new wxButton( m_panelButtons, wxID_OK, _("Save"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnOK->SetToolTip( _("save all values and close the dialog") );
-    m_btnOK->SetDefault();
     
     buttonSizer->Add( m_btnOK, 0, wxALL, 5 );
 
     m_btnCancel = new wxButton( m_panelButtons, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnCancel->SetToolTip( _("close the dialog without saving") );
+    m_btnCancel->SetDefault();
 
     buttonSizer->Add( m_btnCancel, 0, wxALL, 5 );
 

--- a/clientgui/DlgHiddenColumns.cpp
+++ b/clientgui/DlgHiddenColumns.cpp
@@ -97,7 +97,7 @@ CDlgHiddenColumns::CDlgHiddenColumns(wxWindow* parent) :
     
     wxBoxSizer* buttonSizer = new wxBoxSizer( wxHORIZONTAL );
 
-    m_btnOK = new wxButton( this, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_btnOK = new wxButton( this, wxID_OK, _("Save"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnOK->SetToolTip( _("Save all values and close the dialog") );
     buttonSizer->Add( m_btnOK, 0, wxALL, 5 );
 

--- a/clientgui/DlgOptions.cpp
+++ b/clientgui/DlgOptions.cpp
@@ -407,12 +407,12 @@ void CDlgOptions::CreateControls() {
     itemBoxSizer2->Add(itemBoxSizer59, 0, wxALIGN_RIGHT|wxALL, 5);
 
     wxButton* itemButton60 = new wxButton;
-    itemButton60->Create( itemDialog1, wxID_OK, _("&OK"), wxDefaultPosition, wxDefaultSize, 0 );
-    itemButton60->SetDefault();
+    itemButton60->Create( itemDialog1, wxID_OK, _("&Save"), wxDefaultPosition, wxDefaultSize, 0 );
     itemBoxSizer59->Add(itemButton60, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     wxButton* itemButton61 = new wxButton;
     itemButton61->Create( itemDialog1, wxID_CANCEL, _("&Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemButton61->SetDefault();
     itemBoxSizer59->Add(itemButton61, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     // Set validators

--- a/clientgui/sg_DlgPreferences.cpp
+++ b/clientgui/sg_DlgPreferences.cpp
@@ -350,11 +350,12 @@ void CPanelPreferences::CreateControls()
     wxBoxSizer* itemBoxSizer44 = new wxBoxSizer(wxHORIZONTAL);
     itemBoxSizer2->Add(itemBoxSizer44, 0, wxALIGN_RIGHT|wxALL, ADJUSTFORXDPI(5));
 
-    wxButton* itemButton44 = new wxButton( itemDialog1, wxID_OK, _("OK"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxButton* itemButton44 = new wxButton( itemDialog1, wxID_OK, _("Save"), wxDefaultPosition, wxDefaultSize, 0 );
 
     itemBoxSizer44->Add(itemButton44, 0, wxALIGN_CENTER_VERTICAL|wxALL, ADJUSTFORXDPI(5));
 
     wxButton* itemButton45 = new wxButton( itemDialog1, wxID_CANCEL, _("Cancel"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemButton45->SetDefault();
     itemBoxSizer44->Add(itemButton45, 0, wxALIGN_CENTER_VERTICAL|wxALL, ADJUSTFORXDPI(5));
     
 


### PR DESCRIPTION
Originally requested in #601: Change OK button on Advanced Preferences to Save button.
Button renamed in all dialogs with settings for consistency.
Also now 'Cancel' button is default button.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>