### PR TITLE
Remote job submission: support app_version_num argument

### DIFF
--- a/html/inc/submit.inc
+++ b/html/inc/submit.inc
@@ -50,6 +50,10 @@ function req_to_xml($req, $op) {
         $x .= "    <workunit_template_file>$req->workunit_template_file</workunit_template_file>
 ";
     }
+    if ((isset($req->app_version_num)) && ($req->app_version_num)) {
+        $x .= "    <app_version_num>$req->app_version_num</app_version_num>
+";
+    }
     foreach ($req->jobs as $job) {
         $x .= "    <job>
         <rsc_fpops_est>$job->rsc_fpops_est</rsc_fpops_est>
@@ -332,7 +336,8 @@ if (0) {
     $req->project = "http://isaac.ssl.berkeley.edu/test/";
     $req->authenticator = trim(file_get_contents("test_auth"));
     $req->app_name = "uppercase";
-    $req->batch_name = "batch_name3";
+    $req->batch_name = "batch_name5";
+    $req->app_version_num = 710;
     $req->jobs = array();
 
     $job = new StdClass;

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -192,7 +192,7 @@ function stage_files(&$jobs) {
 // submit a list of jobs with a single create_work command.
 //
 function submit_jobs(
-    $jobs, $template, $app, $batch_id, $priority,
+    $jobs, $template, $app, $batch_id, $priority, $app_version_num,
     $result_template_file,      // batch-level; can also specify per job
     $workunit_template_file
 ) {
@@ -241,6 +241,9 @@ function submit_jobs(
     }
     if ($workunit_template_file) {
         $cmd .= " --wu_template templates/$workunit_template_file";
+    }
+    if ($app_version_num) {
+        $cmd .= " --app_version_num $app_version_num";
     }
     $cmd .= " --stdin >$errfile 2>&1";
     $h = popen($cmd, "w");
@@ -353,6 +356,8 @@ function xml_get_jobs($r) {
     return $jobs;
 }
 
+// $r is a simplexml object for the request message
+//
 function submit_batch($r) {
     xml_start_tag("submit_batch");
     $app = get_submit_app((string)($r->batch->app_name));
@@ -365,6 +370,7 @@ function submit_batch($r) {
     stage_files($jobs);
     $njobs = count($jobs);
     $now = time();
+    $app_version_num = (int)($r->batch->app_version_num);
     $batch_id = (int)($r->batch->batch_id);
     if ($batch_id) {
         $batch = BoincBatch::lookup_id($batch_id);
@@ -432,7 +438,7 @@ function submit_batch($r) {
     }
 
     submit_jobs(
-        $jobs, $template, $app, $batch_id, $let,
+        $jobs, $template, $app, $batch_id, $let, $app_version_num,
         $result_template_file, $workunit_template_file
     );
 

--- a/lib/remote_submit.cpp
+++ b/lib/remote_submit.cpp
@@ -395,7 +395,8 @@ int submit_jobs(
     char app_name[256],
     int batch_id,
     vector<JOB> jobs,
-    string& error_msg
+    string& error_msg,
+    int app_version_num
 ) {
     char buf[1024], url[1024];
     sprintf(buf,
@@ -403,10 +404,12 @@ int submit_jobs(
         "<authenticator>%s</authenticator>\n"
         "<batch>\n"
         "   <batch_id>%d</batch_id>\n"
-        "   <app_name>%s</app_name>\n",
+        "   <app_name>%s</app_name>\n"
+        "   <app_version_num>%d</app_version_num>\n",
         authenticator,
         batch_id,
-        app_name
+        app_name,
+        app_version_num
     );
     string request = buf;
     for (unsigned int i=0; i<jobs.size(); i++) {

--- a/lib/remote_submit.h
+++ b/lib/remote_submit.h
@@ -147,7 +147,8 @@ extern int submit_jobs(
     char app_name[256],
     int batch_id,
     std::vector<JOB> jobs,
-    std::string& error_msg
+    std::string& error_msg,
+    int app_version_num = 0
 );
 
 extern int estimate_batch(

--- a/lib/submit_api.py
+++ b/lib/submit_api.py
@@ -82,6 +82,10 @@ class BATCH_DESC:
             xml += '<batch_id>%s</batch_id>\n'%(self.batch_id)
         elif hasattr(self, 'batch_name'):
             xml += '<batch_name>%s</batch_name>\n'%(self.batch_name)
+
+        if hasattr(self, 'app_version_num'):
+            xml += '<app_version_num>%d</app_version_num>\n'%(self.app_version_num)
+
         for job in self.jobs:
             xml += job.to_xml()
         xml += '</batch>\n</%s>\n' %(op)

--- a/tools/submit_api_test.py
+++ b/tools/submit_api_test.py
@@ -46,6 +46,7 @@ def make_batch_desc(batch_name):
     [batch.project, batch.authenticator] = get_auth()
     batch.app_name = "uppercase"
     batch.batch_name = batch_name
+    batch.app_version_num = 710;
     batch.jobs = []
 
     for i in range(2):
@@ -191,5 +192,5 @@ def test_get_output_files():
     print(r)
 
 #test_query_batch(328)
-#test_submit_batch('batch_32')
-test_create_batch('batch_33')
+test_submit_batch('batch_35')
+#test_create_batch('batch_33')


### PR DESCRIPTION
Change the submit_batch RPC, and the various bindings of it (PHP, Python, C++)
to support an app_version_num arg,
specifying which app version number should be used to process the jobs in the batch.