### PR TITLE
web: team-related fixes

### DIFF
--- a/html/inc/team_types.inc
+++ b/html/inc/team_types.inc
@@ -18,10 +18,9 @@
 
 include_once("../inc/translation.inc");
 
-global $team_types;
 $team_types = array(
     "",
-    tra("None"),
+    tra("Other"),
     tra("Company"),
     tra("Primary school"),
     tra("Secondary school"),

--- a/html/user/custom.css
+++ b/html/user/custom.css
@@ -11,3 +11,8 @@ table a:hover, .table a:hover, a:hover {
 blockquote {
     font-size: 15px;
 }
+
+.bg-primary a {
+    color: white;
+    text-decoration: underline;
+}

--- a/html/user/team.php
+++ b/html/user/team.php
@@ -49,7 +49,7 @@ echo "
     <li> <a href=\"top_teams.php\">" . tra("All teams") . "</a>
 ";
 
-for ($i=1; $i<8; $i++) {
+for ($i=1; $i<count($team_types); $i++) {
     echo "<li> <a href=\"top_teams.php?type=".$i."\">".tra("%1 teams", team_type_name($i))."</a>
     ";
 }

--- a/html/user/top_teams.php
+++ b/html/user/top_teams.php
@@ -57,7 +57,7 @@ default:
 }
 
 $type = get_int("type", true);
-if ($type < 1 || $type > 7) {
+if ($type < 0 || $type >= count($team_types)) {
     $type = 0;
 }
 $type_url="";


### PR DESCRIPTION
At some point we added several team categories (national, computer type, etc.)
but there were a couple of places in the code where the # of categories
was hardwired, so the new categories weren't shown.

Also, for white-backbround color schemes,
in table headers with bg-default,
links were invisible because the text color was same as background.
Fix this in custom.css.