### PR TITLE
Manager: Change OK button on Advanced Preferences to Save button

### DIFF
--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -104,7 +104,7 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
         if (!usingLocalPrefs) {
             legendSizer->Add(
                 new wxStaticText( topControlsStaticBox, ID_DEFAULT,
-                     _("Set values and click OK to use local preferences instead."),
+                     _("Set values and click Save to use local preferences instead."),
                      wxDefaultPosition, wxDefaultSize, 0 ),
                 0, wxALL, 1
             );

--- a/clientgui/sg_DlgPreferences.cpp
+++ b/clientgui/sg_DlgPreferences.cpp
@@ -186,7 +186,7 @@ void CPanelPreferences::CreateControls()
         if (!usingLocalPrefs) {
             legendSizer->Add(
                 new CTransparentStaticText( topSectionStaticBox, wxID_ANY,
-                     _("Set values and click OK to use local preferences instead."),
+                     _("Set values and click Save to use local preferences instead."),
                      wxDefaultPosition, wxDefaultSize, 0 ),
                 0, wxALL, 1
             );


### PR DESCRIPTION
Change text labels to remove inconsistency between them and button text as described in #601

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>