### PR TITLE
web: fix beta app version handling in apps.php page

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -619,9 +619,7 @@ function latest_avs_app_platform($appid, $platformid) {
     foreach ($avs as $av) {
         foreach ($avs as $av2) {
             if ($av->id == $av2->id) continue;
-            if ($av->plan_class == $av2->plan_class && $av->version_num > $av2->version_num) {
-                $av2->deprecated = 1;
-            } else if ($av2->beta) {
+            if ($av->plan_class == $av2->plan_class && $av->beta == $av2->beta && $av->version_num > $av2->version_num) {
                 $av2->deprecated = 1;
             }
         }


### PR DESCRIPTION
In apps.php treat beta app versions independently of non-beta app versions, even if these have the same plan class. This is consistent with what the (array) scheduler does (try 'beta' apps first (with highest version number per plan class), then 'non-beta' (dito)).