### PR TITLE
improved file_upload_handler

### DIFF
--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -314,10 +314,7 @@ int handle_file_upload(FILE* in, R_RSA_PUBLIC_KEY& key) {
     strcpy(xml_signature, "");
     bool found_data = false;
     while (fgets(buf, 256, in)) {
-        // intentionally set higher than debug as it may produce lots of output
-        if (config.fuh_debug_level > MSG_DEBUG) {
-            log_messages.printf(MSG_DEBUG, "got:%s\n", buf);
-        }
+        log_messages.printf(MSG_DETAIL, "got:%s\n", buf);
         if (match_tag(buf, "<file_info>")) continue;
         if (match_tag(buf, "</file_info>")) continue;
         if (match_tag(buf, "<signed_xml>")) continue;
@@ -562,7 +559,7 @@ int handle_request(FILE* in, R_RSA_PUBLIC_KEY& key) {
     log_messages.set_indent_level(1);
 #endif
     while (fgets(buf, 256, in)) {
-        log_messages.printf(MSG_DEBUG, "handle_request: %s", buf);
+        log_messages.printf(MSG_DETAIL, "handle_request: %s", buf);
         if (parse_int(buf, "<core_client_major_version>", major)) {
             continue;
         } else if (parse_int(buf, "<core_client_minor_version>", minor)) {

--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -289,7 +289,7 @@ int handle_file_upload(FILE* in, R_RSA_PUBLIC_KEY& key) {
     double max_nbytes=-1;
     char xml_signature[1024];
     int retval;
-    double offset=0, nbytes = -1, size;
+    double offset=0, nbytes = -1;
     bool is_valid, btemp;
 
     strcpy(name, "");
@@ -402,17 +402,6 @@ int handle_file_upload(FILE* in, R_RSA_PUBLIC_KEY& key) {
             name, boincerror(retval)
         );
     }
-
-    // if file already exists and is full size, don't upload again.
-    //
-    if (!file_size(path, size) && (size == nbytes)) {
-        log_messages.printf(MSG_NORMAL,
-            "file %s exists and is right size - skipping\n", name
-        );
-        copy_socket_to_null(in);
-        return return_success(0);
-    }
-
     log_messages.printf(MSG_NORMAL,
         "Starting upload of %s from %s [offset=%.0f, nbytes=%.0f]\n",
         name,

--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2016 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -16,7 +16,7 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // The BOINC file upload handler.
-// See doc/upload.php for protocol spec.
+// See http://boinc.berkeley.edu/trac/wiki/FileUpload for protocol spec.
 //
 
 #include "config.h"
@@ -236,7 +236,7 @@ int copy_socket_to_file(FILE* in, char* name, char* path, double offset, double 
                 }
             }
             if (sbuf.st_size > offset) {
-                log_messages.printf(MSG_CRITICAL,
+                log_messages.printf(MSG_NORMAL,
                     "file %s length on disk %d bytes; host upload starting at %.0f bytes.\n",
                      this_filename, (int)sbuf.st_size, offset
                 );
@@ -313,9 +313,10 @@ int handle_file_upload(FILE* in, R_RSA_PUBLIC_KEY& key) {
     strcpy(xml_signature, "");
     bool found_data = false;
     while (fgets(buf, 256, in)) {
-#if 1
-        log_messages.printf(MSG_NORMAL, "got:%s\n", buf);
-#endif
+        // intentionally set higher than debug as it may produce lots of output
+        if (config.fuh_debug_level > MSG_DEBUG) {
+            log_messages.printf(MSG_DEBUG, "got:%s\n", buf);
+        }
         if (match_tag(buf, "<file_info>")) continue;
         if (match_tag(buf, "</file_info>")) continue;
         if (match_tag(buf, "<signed_xml>")) continue;
@@ -341,7 +342,7 @@ int handle_file_upload(FILE* in, R_RSA_PUBLIC_KEY& key) {
             found_data = true;
             break;
         }
-        log_messages.printf(MSG_NORMAL, "unrecognized: %s", buf);
+        log_messages.printf(MSG_WARNING, "unrecognized: %s", buf);
     }
     if (strlen(name) == 0) {
         return return_error(ERR_PERMANENT, "Missing name");
@@ -585,7 +586,7 @@ int handle_request(FILE* in, R_RSA_PUBLIC_KEY& key) {
         }
     }
     if (!did_something) {
-        log_messages.printf(MSG_CRITICAL, "handle_request: no command\n");
+        log_messages.printf(MSG_WARNING, "handle_request: no command\n");
         return return_error(ERR_TRANSIENT, "no command");
     }
 

--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -475,7 +475,7 @@ int handle_get_file_size(char* file_name) {
         return return_error(ERR_TRANSIENT, "Server is out of disk space");
     }
 
-    fd = open(path, O_WRONLY|O_APPEND);
+    fd = open(path, O_RDONLY);
 
     if (fd<0 && ENOENT==errno) {
         // file does not exist: return zero length
@@ -495,8 +495,8 @@ int handle_get_file_size(char* file_name) {
         );
         return return_error(ERR_TRANSIENT, "can't open file");
     }
-
-    if ((pid = mylockf(fd))) {
+#ifdef LOCK_FILES
+    if ((pid = checklockf(fd))) {
         // file locked by another file_upload_handler: try again later
         //
         close(fd);
@@ -507,7 +507,8 @@ int handle_get_file_size(char* file_name) {
             "[%s] locked by file_upload_handler PID=%d", file_name, pid
         );
     }
-    // file exists, writable, not locked by anyone else, so return length.
+#endif
+    // file exists, readable, not locked by anyone else, so return length.
     //
     retval = stat(path, &sbuf);
     close(fd);

--- a/sched/sched_config.cpp
+++ b/sched/sched_config.cpp
@@ -88,6 +88,8 @@ int SCHED_CONFIG::parse(FILE* f) {
     default_disk_min_free_gb = .001;
     sched_debug_level = MSG_NORMAL;
     fuh_debug_level = MSG_NORMAL;
+    fuh_set_initial_permission = -1;
+    fuh_set_completed_permission = -1;
     strcpy(httpd_user, "apache");
     max_ncpus = MAX_NCPUS;
     scheduler_log_buffer = 32768;
@@ -150,6 +152,24 @@ int SCHED_CONFIG::parse(FILE* f) {
         if (xp.parse_int("uldl_dir_fanout", uldl_dir_fanout)) continue;
         if (xp.parse_bool("cache_md5_info", cache_md5_info)) continue;
         if (xp.parse_int("fuh_debug_level", fuh_debug_level)) continue;
+        if (xp.parse_str("fuh_set_completed_permission", buf, sizeof(buf))) {
+            long int l = strtol(buf, NULL, 8);
+            if (l > 0 && l < LONG_MAX) {
+                fuh_set_completed_permission = (int)l;
+            } else {
+                log_messages.printf(MSG_CRITICAL, "wrong fuh_set_completed_permission: %s\n", buf);
+            }
+            continue;
+        }
+        if (xp.parse_str("fuh_set_initial_permission", buf, sizeof(buf))) {
+            long int l = strtol(buf, NULL, 8);
+            if (l > 0 && l < LONG_MAX) {
+                fuh_set_initial_permission = (int)l;
+            } else {
+                log_messages.printf(MSG_CRITICAL, "wrong fuh_set_initial_permission: %s\n", buf);
+            }
+            continue;
+        }
         if (xp.parse_int("reliable_priority_on_over", reliable_priority_on_over)) continue;
         if (xp.parse_int("reliable_priority_on_over_except_error", reliable_priority_on_over_except_error)) continue;
         if (xp.parse_int("reliable_on_priority", reliable_on_priority)) continue;

--- a/sched/sched_config.h
+++ b/sched/sched_config.h
@@ -73,6 +73,8 @@ struct SCHED_CONFIG {
     int uldl_dir_fanout;        // fanout of ul/dl dirs; 0 if none
     bool cache_md5_info;
     int fuh_debug_level;
+    int fuh_set_completed_permission;
+    int fuh_set_initial_permission;
     int reliable_priority_on_over;
         // additional results generated after at least one result
         // is over will have their priority boosted by this amount    

--- a/sched/sched_util_basic.cpp
+++ b/sched/sched_util_basic.cpp
@@ -239,6 +239,24 @@ int mylockf(int fd) {
     return -1;
 }
 
+// check if there is a write lock on the given file with given fd.  Returns:
+// 0 if there is no write lock
+// PID (>0) of the process that has the lock
+// -1 if error
+//
+int checklockf(int fd) {
+    struct flock fl;
+    fl.l_type=F_RDLCK;
+    fl.l_whence=SEEK_SET;
+    fl.l_start=0;
+    fl.l_len=0;
+    if (-1 != fcntl(fd, F_GETLK, &fl)) {
+        if (fl.l_type == F_UNLCK) return 0;
+        if (fl.l_pid>0) return fl.l_pid;
+    }
+    return -1;
+}
+
 bool is_arg(const char* x, const char* y) {
     char buf[256];
     strcpy(buf, "--");

--- a/sched/sched_util_basic.h
+++ b/sched/sched_util_basic.h
@@ -60,6 +60,12 @@ extern int dir_hier_url(
 //
 extern int mylockf(int fd);
 
+// returns zero if there is no write lock on file with file descriptor fd.
+// returns < 0 if error
+// returns PID > 0 of the process that has the lock
+//
+extern int checklockf(int fd);
+
 // return true if x is -y or --y (for argv processing)
 //
 extern bool is_arg(const char*, const char*);


### PR DESCRIPTION
This is the file_upload_handler code which is running on Einstein@Home for the last year.
- fix `get_file_size()` to be read-only, it does not need to check if the existing file is writable
- fix `copy_socket_to_file()` to make completely uploaded files read-only and add a check if a subsequent upload happens (data will be discarded)
- reopen logfile on user defined signal so log rotation works properly when running as FCGI
- optional variety postfix for upload_dir and logfile when running as FCGI (we use this to split file uploads of small (O(100kB)) and large (O(3MB)) files to be stored in separate file systems for better speed and efficiency