### PR TITLE
Drupal: Use BOINC username in place of Drupal username

### DIFF
--- a/drupal/sites/all/features/boinc_standard/boinc_standard.views_default.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.views_default.inc
@@ -85,6 +85,47 @@ function boinc_standard_views_default_views() {
       'field' => 'name',
       'relationship' => 'none',
     ),
+    'phpcode' => array(
+      'label' => 'BOINC user name',
+      'alter' => array(
+        'alter_text' => 0,
+        'text' => '',
+        'make_link' => 1,
+        'path' => 'account/[uid]',
+        'absolute' => 0,
+        'link_class' => '',
+        'alt' => '',
+        'rel' => '',
+        'prefix' => '',
+        'suffix' => '',
+        'target' => '',
+        'help' => '',
+        'trim' => 0,
+        'max_length' => '',
+        'word_boundary' => 1,
+        'ellipsis' => 1,
+        'html' => 0,
+        'strip_tags' => 0,
+      ),
+      'empty' => '',
+      'hide_empty' => 0,
+      'empty_zero' => 0,
+      'hide_alter_empty' => 1,
+      'value' => '<?php
+  $myuser = user_load($data->uid);
+  echo $myuser->boincuser_name;
+?>',
+      'exclude' => 0,
+      'id' => 'phpcode',
+      'table' => 'customfield',
+      'field' => 'phpcode',
+      'relationship' => 'none',
+    ),
+    'mail' => array(
+      'id' => 'mail',
+      'table' => 'users',
+      'field' => 'mail',
+    ),
     'rid' => array(
       'label' => 'Roles',
       'alter' => array(
@@ -345,10 +386,12 @@ function boinc_standard_views_default_views() {
     'columns' => array(
       'uid' => 'uid',
       'name' => 'name',
-      'status' => 'status',
+      'phpcode' => 'phpcode',
+      'mail' => 'mail',
       'rid' => 'rid',
-      'login' => 'login',
+      'status' => 'status',
       'access' => 'access',
+      'login' => 'login',
       'created' => 'created',
       'edit_node' => 'edit_node',
     ),
@@ -361,18 +404,25 @@ function boinc_standard_views_default_views() {
         'sortable' => 1,
         'separator' => '',
       ),
-      'status' => array(
+      'phpcode' => array(
+        'separator' => '',
+      ),
+      'mail' => array(
         'sortable' => 1,
         'separator' => '',
       ),
       'rid' => array(
         'separator' => '',
       ),
-      'login' => array(
+      'status' => array(
         'sortable' => 1,
         'separator' => '',
       ),
       'access' => array(
+        'sortable' => 1,
+        'separator' => '',
+      ),
+      'login' => array(
         'sortable' => 1,
         'separator' => '',
       ),

--- a/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
+++ b/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.views_default.inc
@@ -10089,7 +10089,7 @@ else {
   $uid = boincuser_lookup_uid($data->id);
   if ($uid) {
     $account = user_load($uid);
-    print l($account->name, "account/{$uid}");
+    print l($account->boincuser_name, "account/{$uid}");
   }
   else {
     // No Drupal account
@@ -10483,7 +10483,7 @@ else {
   $uid = boincuser_lookup_uid($data->id);
   if ($uid) {
     $account = user_load($uid);
-    print l($account->name, "account/{$uid}");
+    print l($account->boincuser_name, "account/{$uid}");
   }
   else {
     // No Drupal account

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1829,7 +1829,8 @@ function boincuser_get_user_profile_image($uid, $avatar = TRUE) {
     $user_image['image'] = $content_node_widget_settings['default_image'];
   }
   $user = user_load($uid);
-  $user_image['alt'] = $user->name;
+  // Use boinc username for image alt/title attributes
+  $user_image['alt'] = $user->boincuser_name;
   return $user_image;
 }
 

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -759,12 +759,15 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
     if ($reset_pass) {
       $_SESSION['reset_pass'] = 1;
     }
-    
+
+    // Adjust form elements already present
+    $form['account']['name']['#title'] = 'Drupal Username';
     $form['account']['name']['#size'] = 40;
     $form['account']['name']['#attributes']['autocomplete'] = 'off';
+    $form['account']['name']['#description'] .= '<p>This is the drupal (internal) username. The title above shows the BOINC username, which is the display name used publically that the user can change in Community Preferences.';
     $form['account']['mail']['#size'] = 40;
     $form['account']['pass']['#size'] = 17;
-    
+
     if (!$reset_pass AND ($user->uid == $account->uid OR !user_access('administer users'))) {
       // Add a password authenticator, required to change email or pw
       $form['account']['current_pass'] = array(
@@ -880,7 +883,7 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
         '#value' => 'user_account'
       )
     ));
-    
+
     break;
     
   case 'profile_node_form':

--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view-fields--boinc-friends--block-1.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view-fields--boinc-friends--block-1.tpl.php
@@ -1,3 +1,7 @@
-<a href="<?php echo url('account/' . $fields['uid']->content); ?>" title="<?php echo $fields['name']->content; ?>">
+<?php
+// Need to get BOINC user name from Drupal UID
+$user = user_load($fields['uid']->content);
+?>
+<a href="<?php echo url('account/' . $fields['uid']->content); ?>" alt="<?php echo $user->boincuser_name; ?>" title="<?php echo $user->boincuser_name; ?>">
   <?php echo $fields['field_image_fid']->content; ?>
 </a>


### PR DESCRIPTION
1. Community Stats: top users list uses boinc username.
1. Account dashboard, friends block: hover/alt/title text uses boinc username.
1. User profile images: hover/alt/title text uses boinc username.

https://dev.gridrepublic.org/browse/DBOINCP-254