### PR TITLE
XML parser: never use fgets(); don't require any tags to be on differ…

### DIFF
--- a/lib/parse.h
+++ b/lib/parse.h
@@ -351,7 +351,7 @@ extern int copy_stream(FILE* in, FILE* out);
 extern int strcatdup(char*& p, char* buf);
 extern int dup_element_contents(FILE* in, const char* end_tag, char** pp);
 extern int dup_element(FILE* in, const char* end_tag, char** pp);
-extern int copy_element_contents(FILE* in, const char* end_tag, char* p, int len);
+extern int copy_element_contents(FILE* in, const char* end_tag, char* p, size_t len);
 extern int copy_element_contents(FILE* in, const char* end_tag, std::string&);
 extern void replace_element_contents(
     char* buf, const char* start, const char* end, const char* replacement


### PR DESCRIPTION
…ent lines

There were a few places, like copy_element_contents() type functions,
that used fgets() and looked for end tag on that line.
The problem is this wipes out next tag if it's on same line.