### PR TITLE
Drupal: Fixed a few bugs in the project-pref XML code.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1292,12 +1292,6 @@ function boincwork_projectprefs_form_validate($form, &$form_state) {
           bts('At least one application must be selected', array(), NULL, 'boinc:account-preferences-project')
         );
       }
-      if ($apps_selected == count($validation_rules['apps']['list'])) {
-        foreach ($validation_rules['apps']['list'] as $app) {
-          unset($form_state['values']['applications'][$app]);
-        }
-        $form_state['storage']['all apps selected'] = TRUE;
-      }
     }
   }
 }
@@ -1339,12 +1333,6 @@ function boincwork_projectprefs_form_submit($form, &$form_state) {
     'project_specific' => boincwork_format_project_specific_prefs_data($edit)
   );
   $prefs = $updated_prefs + $prefs;
-  
-  // Don't specify apps if all are selected
-  if (isset($form_state['storage']['all apps selected'])) {
-    unset($prefs['project_specific']['app_id']);
-    unset($form_state['storage']['all apps selected']);
-  }
   
   // If this is a new preference set, be sure to unset the "cleared" attribute
   if (isset($prefs['@attributes']['cleared'])) {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -611,23 +611,19 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
       }
       if ($user_applications) {
         $checked = in_array($app_id, $user_applications);
+        // Even if the user_applications are defined, there is a case
+        // where we override: when the application is disabled but
+        // selected is true, meaning this is a 'mandatory'
+        // application.
+        if ( $app['@attributes']['enabled'] == 'false' AND $app['@attributes']['selected'] == 'true' ) {
+          $checked = TRUE;
+        }
       } else {
         // If user_applications is not defined, it means there are no
         // app_ids set in the user's project preferences payload
         // XML. Thus all Web form values should be determined by the
-        // app_overrides container. If the application is not enabled
-        // then the application is not selected. If the application is
-        // enabled but selected is set to false, then the application
-        // is not selected. If the override doesn't exist for that
-        // particular app, then the application is selected.
-
-        if ( ($app['@attributes']['enabled'] == 'false') OR
-        ( isset($app['@attributes']['enabled']) AND $app['@attributes']['selected'] == 'false' ) ) {
-          $checked = FALSE;
-        }
-        else {
-          $checked = TRUE;
-        }
+        // app_overrides container.
+        $checked = (isset($app['@attributes']['selected']) AND $app['@attributes']['selected'] == 'true') ? TRUE : FALSE;
       }
       $form['applications']["app_{$app_id}"] = array(
         '#title' => $app_name,

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -209,10 +209,7 @@ function boincwork_get_project_specific_config() {
   // applications are now queried from the database, and the content
   // of the XML upload is an override.
   if (!array_key_exists('app_overrides', $xml['project_specific_preferences'])) {
-    $simpleapps = array(
-      '@position' => 0,
-    );
-    $xml['project_specific_preferences']['app_overrides'] = $simpleapps;
+    $xml['project_specific_preferences']['app_overrides'] = array();
   }
   return $xml;
 }
@@ -617,8 +614,20 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
       } else {
         // If user_applications is not defined, it means there are no
         // app_ids set in the user's project preferences payload
-        // XML. Thus all Web form values should be checked.
-        $checked = TRUE;
+        // XML. Thus all Web form values should be determined by the
+        // app_overrides container. If the application is not enabled
+        // then the application is not selected. If the application is
+        // enabled but selected is set to false, then the application
+        // is not selected. If the override doesn't exist for that
+        // particular app, then the application is selected.
+
+        if ( ($app['@attributes']['enabled'] == 'false') OR
+        ( isset($app['@attributes']['enabled']) AND $app['@attributes']['selected'] == 'false' ) ) {
+          $checked = FALSE;
+        }
+        else {
+          $checked = TRUE;
+        }
       }
       $form['applications']["app_{$app_id}"] = array(
         '#title' => $app_name,


### PR DESCRIPTION
1. <app_overrides> container was replacing the first XML container in the project-specific XML upload.
2. Apps are selected based on <apps_overrides> if user has no <app_id>s in his/her payload XML.
3. If all applications are selected, all application ids are specified as <app_ids> elements in payload XML. (Before the lack of <app_ids> indicated all application selected.

https://dev.gridrepublic.org/browse/DBOINC-87