### PR TITLE
Manager: Fix menu item description.

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -677,8 +677,8 @@ bool CAdvancedFrame::CreateMenu() {
         pSkinAdvanced->GetApplicationShortName().c_str()
     );
     strMenuDescription.Printf(
-        _("Show information about BOINC and %s"),
-        pSkinAdvanced->GetApplicationName().c_str()
+        _("See more information about %s on the web"),
+        pSkinAdvanced->GetApplicationShortName().c_str()
     );
     menuHelp->Append(
         ID_HELPBOINCWEBSITE,


### PR DESCRIPTION
Fix menu item description as requested in #1033.
Also this fixes #770 because now it shows correct branded product link that should be opened.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>