### PR TITLE
Drupal: Fix boinc theme css

### DIFF
--- a/drupal/sites/default/boinc/themes/boinc/css/comments.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/comments.css
@@ -215,7 +215,10 @@ div.node-type-forum.not-first-page {
 .comment-body .moderator-links li.first,
 .node-type-forum .node-body .moderator-links .links li.first,
 .node-type-team-forum .node-body .moderator-links .links li.first,
-.comment-body .links li.comment_forbidden.first.last {
+.comment-body .links li.comment_forbidden.first.last,
+.comment-body .links li.comment_forbidden.last,
+.node-type-forum .node-body .links li.comment_forbidden.last,
+.node-type-team-forum .node-body .links li.comment_forbidden.last {
   border-width: 0;
   margin-left: 0;
   padding-left: 0;


### PR DESCRIPTION
Removes extra border from comment link when user cannot post comments to the Web site.

Found by Tristan in PR #2080.