### PR TITLE
Fix build with new glibc 2.26

### DIFF
--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -19,7 +19,7 @@
 #pragma implementation "AsyncRPC.h"
 #endif
 
-#if !(defined(_WIN32) || (defined(__WXMAC__) && (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_4)))
+#if HAVE_XLOCALE_H
 #include <xlocale.h>
 #endif
 

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -809,7 +809,9 @@ struct RPC {
 
 #elif defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_4)
 // uselocale() is not available in OS 10.3.9 so use weak linking
+#if HAVE_XLOCALE_H
 #include <xlocale.h>
+#endif
 extern int		freelocale(locale_t) __attribute__((weak_import));
 extern locale_t	newlocale(int, __const char *, locale_t) __attribute__((weak_import));
 extern locale_t	uselocale(locale_t) __attribute__((weak_import));


### PR DESCRIPTION
 * The nonstandard header <xlocale.h> has been removed.  Most programs should
   use <locale.h> instead.  If you have a specific need for the definition of
   locale_t with no other declarations, please contact
   libc-alpha@sourceware.org and explain.

the old glibc seems to still build correctly, build ongoing in
https://code.launchpad.net/~costamagnagianfranco/+recipe/boinc-upstream-daily