### PR TITLE
MGR: support wxWidgets without webview

### DIFF
--- a/clientgui/NoticeListCtrl.h
+++ b/clientgui/NoticeListCtrl.h
@@ -45,8 +45,12 @@ public:
     
 ////@begin CNoticeListCtrl event handler declarations
 
+#if wxUSE_WEBVIEW
     void OnLinkClicked( wxWebViewEvent& event );
     void OnWebViewError( wxWebViewEvent& event );
+#else
+    void OnLinkClicked(wxHtmlLinkEvent &);
+#endif
 
 ////@end CNoticeListCtrl event handler declarations
 
@@ -56,7 +60,11 @@ public:
     bool        m_bDisplayFetchingNotices;
     bool        m_bDisplayEmptyNotice;
 private:
+#if wxUSE_WEBVIEW
     wxWebView*  m_browser;
+#else
+    wxHtmlWindow *m_browser;
+#endif
     bool        m_bNeedsReloading;
     int         m_itemCount;
     wxString    m_noticesBody;


### PR DESCRIPTION
If wxWidgets is built without the webview widget, make do with a
plain multiline text control.

--
openSUSE plans on removing webkitgtk. wxWidgets-3.0.X has it as an optional dependency but turning it off makes programs like boinc fail to build. Solve that in short order - the patch is not necessarily beautiful, though the resulting UI seems to do well, as most notices have very little markup (mostly just `<a>..</a>`).