### PR TITLE
Email address field removed from team founder list due to potential EU Anti-Spam law breach

### DIFF
--- a/html/user/team_email_list.php
+++ b/html/user/team_email_list.php
@@ -49,7 +49,7 @@ if ($xml) {
         xml_error(ERR_DB_NOT_FOUND);
     }
     echo "<users>\n";
-    $users = BoincUser::enum_fields("id, email_addr, send_email, name, total_credit, expavg_credit, expavg_time, has_profile, donated, country, cross_project_id, create_time, url", "teamid=$team->id");
+    $users = BoincUser::enum_fields("id, send_email, name, total_credit, expavg_credit, expavg_time, has_profile, donated, country, cross_project_id, create_time, url", "teamid=$team->id");
     foreach($users as $user) {
         show_team_member($user, $creditonly);
     }


### PR DESCRIPTION
Removed the email column as team founders extracting the email address for emailing via an external platform poses a potential breach of the EU anti-spam laws/regulation (potentially hundreds of Euros in fines per unsolicited email).