### PR TITLE
[WIP] Manager: Use wxHtmlWindow in DlgItemProperties.

### DIFF
--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -62,9 +62,10 @@ CDlgItemProperties::CDlgItemProperties(wxWindow* parent) :
     m_bSizer1 = new wxBoxSizer( wxVERTICAL );
     
     const long style = wxBORDER_NONE;
-    m_txtInformation = wxWebView::New( this, wxID_ANY, wxWebViewDefaultURLStr, wxDefaultPosition, wxDefaultSize, wxWebViewBackendDefault, style );
-    m_txtInformation->EnableContextMenu( false );
-
+    m_txtInformation = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, wxEmptyString );
+    m_txtInformation->Bind(wxEVT_LEFT_DOWN, &CDlgItemProperties::OnMouseButtonEvent, this);
+    m_txtInformation->Bind(wxEVT_LEFT_UP, &CDlgItemProperties::OnMouseButtonEvent, this);
+    
     m_bSizer1->Add( m_txtInformation, 1, wxEXPAND | wxALL, 5 );
     
     wxBoxSizer *bSizer2 = new wxBoxSizer(wxHORIZONTAL);
@@ -75,6 +76,7 @@ CDlgItemProperties::CDlgItemProperties(wxWindow* parent) :
 
     m_pCopySelectedButton = new wxButton(this, ID_COPYSELECTED, _("Copy &Selected"), wxDefaultPosition, wxDefaultSize);
     bSizer2->Add(m_pCopySelectedButton, 0, wxALIGN_BOTTOM | wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
+    m_pCopySelectedButton->Enable(false);
 
     m_btnClose = new wxButton( this, wxID_OK, _("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnClose->SetDefault(); 
@@ -522,53 +524,27 @@ wxString CDlgItemProperties::FormatApplicationName(RESULT* result ) {
 void CDlgItemProperties::renderInfos() {
     wxString str_bg;
     str_bg.Printf(wxT("#%x"), this->GetBackgroundColour().GetRGB());
-    wxFont font = this->GetFont();
-    wxString font_name = font.GetFaceName();
-    wxString font_size;
-    font_size.Printf(wxT("%d"), font.GetPointSize());
 
     std::string content;
     content += "<html>";
-    content += "<head>";
-    content += "<style>";
-    content += " body { ";
-    content += " background-color: " + str_bg + "; ";
-    content += " overflow : auto; ";
-    content += " } ";
-    content += " table { ";
-    content += " width: 100%; ";
-    content += " } ";
-    content += " span { ";
-    content += " white-space: nowrap; ";
-    content += " font-family: '" + font_name + "'; ";
-    content += " font-size: " + font_size + "pt; ";
-    content += " } ";
-    content += "</style>";
-    content += "</head>";
-    content += "<body>";
-    content += "<table>";
+    content += "<body bgcolor='" + str_bg + "'>";
+    content += "<table width='100%'>";
     for (size_t i = 0; i < m_items.size(); ++i) {
         if (m_items[i].item_type == ItemTypeSection) {
             content += "<tr>";
-            content += "<td colspan='2'>";
-            content += "<span>";
+            content += "<td colspan='2' nowrap>";
             content += "<b>";
             content += m_items[i].name;
             content += "</b>";
-            content += "</span>";
             content += "</td>";
             content += "</tr>";
         } else if (m_items[i].item_type == ItemTypeProperty) {
             content += "<tr>";
-            content += "<td>";
-            content += "<span>";
+            content += "<td nowrap>";
             content += m_items[i].name;
-            content += "</span>";
             content += "</td>";
-            content += "<td>";
-            content += "<span>";
+            content += "<td nowrap>";
             content += m_items[i].value;
-            content += "</span>";
             content += "</td>";
             content += "</tr>";
         }        
@@ -576,7 +552,7 @@ void CDlgItemProperties::renderInfos() {
     content += "</table>";
     content += "</body>";
     content += "</html>";
-    m_txtInformation->SetPage(wxString(content), "");
+    m_txtInformation->SetPage(content);
 }
 
 
@@ -590,20 +566,23 @@ void CDlgItemProperties::addProperty(const wxString& name, const wxString& value
     m_items.push_back(ITEM(ItemTypeProperty, name, value));
 }
 
-void CDlgItemProperties::OnCopySelected( wxCommandEvent& ) {
-    if (m_txtInformation->HasSelection()) {
-        m_txtInformation->Copy();
-    } else {
-        if (wxTheClipboard->Open()) {
-            wxTheClipboard->Clear();
-            wxTheClipboard->SetData(new wxTextDataObject(wxEmptyString));
-            wxTheClipboard->Close();
-        }
+void CDlgItemProperties::copyTextToClipboard(const wxString& text) {
+    if (wxTheClipboard->Open()) {
+        wxTheClipboard->Clear();
+        wxTheClipboard->SetData(new wxTextDataObject(text));
+        wxTheClipboard->Close();
     }
 }
 
+void CDlgItemProperties::OnMouseButtonEvent(wxMouseEvent& event) {
+    m_pCopySelectedButton->Enable(m_txtInformation->SelectionToText() != wxEmptyString);
+    event.Skip();
+}
+
+void CDlgItemProperties::OnCopySelected( wxCommandEvent& ) {
+    copyTextToClipboard(m_txtInformation->SelectionToText());
+}
+
 void CDlgItemProperties::OnCopyAll( wxCommandEvent& ) {
-    m_txtInformation->SelectAll();
-    m_txtInformation->Copy();
-    m_txtInformation->ClearSelection();
+    copyTextToClipboard(m_txtInformation->ToText());
 }

--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -524,10 +524,16 @@ wxString CDlgItemProperties::FormatApplicationName(RESULT* result ) {
 void CDlgItemProperties::renderInfos() {
     wxString str_bg;
     str_bg.Printf(wxT("#%x"), this->GetBackgroundColour().GetRGB());
+    wxString str_fg;
+    str_fg.Printf(wxT("#%x"), this->GetForegroundColour().GetRGB());
 
     std::string content;
     content += "<html>";
     content += "<body bgcolor='" + str_bg + "'>";
+    content += "<font";
+    content += " color='" + str_fg + "' ";
+    content += " face='" + this->GetFont().GetFaceName() + "' ";
+    content += ">";
     content += "<table width='100%'>";
     for (size_t i = 0; i < m_items.size(); ++i) {
         if (m_items[i].item_type == ItemTypeSection) {
@@ -550,6 +556,7 @@ void CDlgItemProperties::renderInfos() {
         }        
     }
     content += "</table>";
+    content += "</font>";
     content += "</body>";
     content += "</html>";
     m_txtInformation->SetPage(content);

--- a/clientgui/DlgItemProperties.h
+++ b/clientgui/DlgItemProperties.h
@@ -23,19 +23,11 @@
 #pragma interface "DlgItemProperties.cpp"
 #endif
 
-#include <wx/intl.h>
-
-#include <wx/gdicmn.h>
-#include <wx/gbsizer.h>
 #include <wx/sizer.h>
-#include <wx/scrolwin.h>
-#include <wx/font.h>
-#include <wx/colour.h>
-#include <wx/settings.h>
 #include <wx/string.h>
 #include <wx/button.h>
 #include <wx/dialog.h>
-#include <wx/wxhtml.h>
+#include <wx/html/htmlwin.h>
 
 #include "MainDocument.h"
 
@@ -68,13 +60,15 @@ private:
        void renderInfos();
 	void addSection(const wxString& title);
 	void addProperty(const wxString& name, const wxString& value);
+    void copyTextToClipboard(const wxString& text);
+    void OnMouseButtonEvent(wxMouseEvent& event);
 protected:
         wxBoxSizer* m_bSizer1;
         wxButton* m_btnClose;
         wxButton* m_pCopySelectedButton;
         wxButton* m_pCopyAllButton;
         wxString m_strBaseConfigLocation;
-        wxWebView* m_txtInformation;
+        wxHtmlWindow* m_txtInformation;
 };
 
 #endif


### PR DESCRIPTION
Use wxHtmlWindow instead of wxWebView.
Handle mouse events to show the correct state of the 'Copy selected' button.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>