### PR TITLE
Set character set explicitly at database creation

### DIFF
--- a/py/Boinc/database.py
+++ b/py/Boinc/database.py
@@ -284,7 +284,7 @@ def create_database(srcdir, config = None, drop_first = False):
     cursor = get_dbconnection().cursor()
     if drop_first:
         cursor.execute("drop database if exists %s"%config.db_name)
-    cursor.execute("create database %s"%config.db_name)
+    cursor.execute("create database %s character set latin1 collate latin1_swedish_ci"%config.db_name)
     cursor.execute("use %s"%config.db_name)
     for file in ['schema.sql', 'constraints.sql']:
         _execute_sql_script(cursor, os.path.join(srcdir, 'db', file))

--- a/py/Boinc/database.py
+++ b/py/Boinc/database.py
@@ -284,7 +284,7 @@ def create_database(srcdir, config = None, drop_first = False):
     cursor = get_dbconnection().cursor()
     if drop_first:
         cursor.execute("drop database if exists %s"%config.db_name)
-    cursor.execute("create database %s character set latin1 collate latin1_swedish_ci"%config.db_name)
+    cursor.execute("create database %s character set utf8 collate utf8_general_ci"%config.db_name)
     cursor.execute("use %s"%config.db_name)
     for file in ['schema.sql', 'constraints.sql']:
         _execute_sql_script(cursor, os.path.join(srcdir, 'db', file))


### PR DESCRIPTION
By default, Debian installs of MariaDB set the character set to utf8mb4. This causes the various ALTER TABLE commands from db/constraints.sql called by tools/make_project to fail with an error of "specified key was too long". The proposed change here forces the project database to the one-character-wide latin1 set, which is in line with the char arrays in db/boinc_db_types.h.