### PR TITLE
update_versions: handle multiple API_VERSION strings

### DIFF
--- a/tools/update_versions
+++ b/tools/update_versions
@@ -195,7 +195,7 @@ function get_api_version($a, $v, $p, $fds) {
     foreach ($fds as $fd) {
         if ($fd->main_program) {
             $path = "apps/$a/$v/$p/$fd->physical_name";
-            $handle = popen("strings $path | grep API_VERSION", "r");
+            $handle = popen("strings $path | egrep --max-count=1 '^API_VERSION_[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'", "r");
             $x = fread($handle, 8192);
             pclose($handle);
             $x = strstr($x, "API_VERSION_");


### PR DESCRIPTION
An executable may have more than one string that contains
"API_VERSION" such as:

API_VERSION_7.7.0
API_VERSION
LPAPI_VERSION

If there is more than one string update_versions extracts the
version number from the first one and then puts the version number
and the rest of the strings into <api_version>:

    <api_version>7.7.0
API_VERSION
LPAPI_VERSION</api_version>

Change update_versions to extract only those strings that look like
BOINC's API_VERSION and only the first one if there for some reason
is more than one such string.

Fixes #2121.

This commit adapts 7a35b69c642677d048329c0cff56bce8627df55b to the
new PHP version of update_versions.