### PR TITLE
job submission: don't error out if standard templates missing; change comment in transitioner

### DIFF
--- a/html/inc/submit.inc
+++ b/html/inc/submit.inc
@@ -340,7 +340,7 @@ if (0) {
     $req->project = "http://isaac.ssl.berkeley.edu/test/";
     $req->authenticator = trim(file_get_contents("test_auth"));
     $req->app_name = "uppercase";
-    $req->batch_name = "batch_name7";
+    $req->batch_name = "batch_name9";
     $req->app_version_num = 710;
     $req->jobs = array();
 
@@ -384,7 +384,7 @@ if (0) {
         <name><OUTFILE_0/></name>
         <generated_locally/>
         <upload_when_present/>
-        <max_nbytes>5000000</max_nbytes>
+        <max_nbytes>6000000</max_nbytes>
         <url><UPLOAD_URL/></url>
     </file_info>
     <result>

--- a/html/inc/submit.inc
+++ b/html/inc/submit.inc
@@ -57,6 +57,10 @@ function req_to_xml($req, $op) {
     foreach ($req->jobs as $job) {
         $x .= "    <job>
 ";
+        if (!empty($job->name)) {
+            $x .= "    <name>$job->name</name>
+";
+        }
         if (!empty($job->rsc_fpops_est)) {
             $x .= "    <rsc_fpops_est>$job->rsc_fpops_est</rsc_fpops_est>
 ";
@@ -340,24 +344,23 @@ if (0) {
     $req->project = "http://isaac.ssl.berkeley.edu/test/";
     $req->authenticator = trim(file_get_contents("test_auth"));
     $req->app_name = "uppercase";
-    $req->batch_name = "batch_name9";
+    $req->batch_name = "batch_name_11";
     $req->app_version_num = 710;
     $req->jobs = array();
 
-    $job = new StdClass;
-    $job->input_files = array();
 
     $f = new StdClass;
     $f->mode = "remote";
     $f->url = "http://isaac.ssl.berkeley.edu/validate_logic.txt";
     $f->md5 = "eec5a142cea5202c9ab2e4575a8aaaa7";
     $f->nbytes = 4250;
-    $job->input_files[] = $f;
 
+if (0) {
     $f = new StdClass;
     $f->mode = "local";
     $f->source = "foobar";
     //$job->input_files[] = $f;
+}
 
     $it = "
 <input_template>
@@ -396,6 +399,10 @@ if (0) {
 </output_template>
 ";
     for ($i=0; $i<2; $i++) {
+        $job = new StdClass;
+        $job->input_files = array();
+        $job->input_files[] = $f;
+        $job->name = $req->batch_name."_$i";
         //$job->rsc_fpops_est = $i*1e9;
         $job->command_line = "--t $i";
         $job->wu_template = $it;

--- a/lib/submit_api.py
+++ b/lib/submit_api.py
@@ -51,6 +51,8 @@ class JOB_DESC:
         return
     def to_xml(self):
         xml = '<job>\n'
+        if hasattr(self, 'name'):
+            xml += '<name>%s</name>\n'%self.name
         if hasattr(self, 'rsc_fpops_est'):
             xml += '<rsc_fpops_est>%f</rsc_fpops_est>\n'%self.rsc_fpops_est
         if hasattr(self, 'command_line'):

--- a/sched/transitioner.cpp
+++ b/sched/transitioner.cpp
@@ -719,6 +719,10 @@ bool do_pass() {
                 "[WU#%lu %s] handle_wu: %s; quitting\n",
                 wu_item.id, wu_item.name, boincerror(retval)
             );
+            // probably better to exit here.
+            // Whatever cause this WU to fail (and it could be temporary)
+            // might cause ALL WUs to fail
+            //
             exit(1);
         }
 

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -51,7 +51,8 @@
 
 using std::string;
 
-// the random part of output filenames needs to be hard to guess
+// Initialize RNG based on time and PID
+// (the random part of output filenames needs to be hard to guess)
 //
 static struct random_init {
     random_init() {
@@ -59,6 +60,8 @@ static struct random_init {
     }
 } random_init;
 
+// read file into buffer
+//
 int read_file(FILE* f, char* buf, int len) {
     int n = fread(buf, 1, len, f);
     buf[n] = 0;
@@ -268,7 +271,9 @@ int create_work2(
     DB_WORKUNIT& wu,
     const char* _wu_template,
     const char* result_template_filename,
-    const char* result_template_filepath,
+        // relative to project root; stored in DB
+    const char* /* result_template_filepath*/,
+        // deprecated
     vector<INFILE_DESC> &infiles,
     SCHED_CONFIG& config_loc,
     const char* command_line,
@@ -276,7 +281,6 @@ int create_work2(
     char* query_string
 ) {
     int retval;
-    char _result_template[BLOB_SIZE];
     char wu_template[BLOB_SIZE];
 
 #if 0
@@ -297,13 +301,13 @@ int create_work2(
         return retval;
     }
 
-    retval = read_filename(
-        result_template_filepath, _result_template, sizeof(_result_template)
-    );
-    if (retval) {
+    // check for presence of result template.
+    // we don't need to actually look at it.
+    //
+    const char* p = config.project_path(result_template_filename);
+    if (!boinc_file_exists(p)) {
         fprintf(stderr,
-            "create_work: can't read result template file %s\n",
-            result_template_filepath
+            "create_work: result template file %s doesn't exist\n", p
         );
         return retval;
     }

--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -15,7 +15,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// Create workunit(s).
+// Command-line program for creating jobs (workunits).
+// Used directly for local job submission;
+// run from PHP script for remote job submission.
+//
 // see http://boinc.berkeley.edu/trac/wiki/JobSubmission
 
 #include "config.h"


### PR DESCRIPTION
If you specify the input or output templates,
the standard ones (appname_in, appname_out) don't need to exist.

Also, in create_work():
- don't read the output template; just check that it exists.
- deprecate the result_template_filepath arg; redundant