### PR TITLE
validator: raise the quorum for 'suspicious' results to ensure validation

### DIFF
--- a/sched/validate_util2.cpp
+++ b/sched/validate_util2.cpp
@@ -116,6 +116,16 @@ int check_set(
         good_results += suspicious_results;
     }
 
+    // if there are "suspicious" results and min_quorum < g_app->target_nresults
+    // (i.e. adaptive replication), raise min_quorum to g_app->target_nresults
+    // the abs() is there for Einstein@Home-specific use of app->target_nresults,
+    // please leave it in there.
+    //
+    if (suspicious_results && wu.min_quorum < abs(g_app->target_nresults)) {
+        log_messages.printf(MSG_NORMAL, "suspicious result - raising quorum\n");
+        wu.min_quorum = abs(g_app->target_nresults);
+    }
+
     if (good_results < wu.min_quorum) goto cleanup;
 
     // Compare results

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -91,6 +91,7 @@ typedef enum {
 
 char app_name[256];
 DB_APP app;
+DB_APP* g_app = &app;
 int wu_id_modulus=0;
 int wu_id_remainder=0;
 int wu_id_min=0;

--- a/sched/validator.h
+++ b/sched/validator.h
@@ -24,3 +24,6 @@ extern WORKUNIT* g_wup;
     // A pointer to the WU currently being processed;
     // you can access this in your init_result() etc. functions
     // (which are passed RESULT but not WORKUNIT)
+
+extern DB_APP* g_app;
+    // a pointer to the app (similar to above)


### PR DESCRIPTION
If a validator (in init_result()) marks a result as 'suspicious', it is replicated. However with the the quorum still being '1' (as it is in 'adaptive replication'), the replication by itself doesn't ensure that the result really gets successfully verified by another result. So in the presence of a 'suspicious' result, raise the quorum to ensure that.