### PR TITLE
client: fix writing log messages

### DIFF
--- a/client/client_msgs.cpp
+++ b/client/client_msgs.cpp
@@ -125,7 +125,7 @@ void show_message(
     // print message to the console
     printf("%s", evt_message);
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     // MSVCRT doesn't support line buffered streams
     fflush(stdout);
 #endif

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -83,7 +83,7 @@ void log_message_startup(const char* msg) {
     );
     if (!gstate.executing_as_daemon) {
         fprintf(stdout, "%s", evt_msg);
-#ifdef _MSC_VER
+#ifdef _WIN32
         // MSVCRT doesn't support line buffered streams
         fflush(stdout);
 #endif

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -666,8 +666,8 @@ int diagnostics_cycle_logs() {
             boinc_copy(stderr_log, stderr_archive);
             stderr_file_size = 0;
             stderr_file = freopen(stderr_log, "w", stderr);
-            setbuf(stderr_file, 0);
             if (NULL == stderr_file) return ERR_FOPEN;
+            setbuf(stderr_file, 0);
         }
     }
 
@@ -679,6 +679,7 @@ int diagnostics_cycle_logs() {
             boinc_copy(stdout_log, stdout_archive);
             stdout_file = freopen(stdout_log, "w", stdout);
             if (NULL == stdout_file) return ERR_FOPEN;
+            setvbuf(stdout_file, NULL, _IOLBF, BUFSIZ);
         }
     }
     return BOINC_SUCCESS;


### PR DESCRIPTION
**lib: set correct buffering mode after cycling logs**

After freopen() stream is fully buffered. In this mode client's log messages are written to stdoutdae.txt BUFSIZ (typically 512) bytes at a time.

Set stdout to line buffered mode after freopen() so that messages are written one line at a time.

Set stderr's buffering mode after making sure freopen() succeeded.


**client: explicitly flush stdout on all Windows builds**

stdout is set to line buffered mode but MSVCRT doesn't support this mode and uses fully buffered mode instead. MinGW uses MSVCRT but the code doesn't take this into account and as a result stdoutdae.txt is 
written BUFSIZ (typically 512) bytes at a time on MinGW builds.

Correct this by flushing stdout after every message regardless of which Windows compiler is used.


Fixes #2141.