### PR TITLE
Mac os10 3 screensaver fix

### DIFF
--- a/api/MultiGPUMig.defs
+++ b/api/MultiGPUMig.defs
@@ -1,0 +1,19 @@
+#include <mach/mach_types.defs>
+
+subsystem MGSServer 29000;
+userprefix      _MGC;         /* Routine prefixes for user access. */
+serverprefix    _MGS;         /* Routine prefixes for internal server access. */
+
+/* Client -> Server */
+routine CheckinClient(
+		server_port	: mach_port_t;
+	in	client_port	: mach_port_t;
+	out	client_index	: int32_t
+);
+
+/* Master -> Slave */
+routine DisplayFrame(
+		server_port	: mach_port_t;
+		frame_index	: int32_t;
+		iosurface_port    : mach_port_t
+);

--- a/api/graphics2.cpp
+++ b/api/graphics2.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2017 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -31,6 +31,9 @@
 #include "shmem.h"
 #include "boinc_api.h"
 #include "graphics2.h"
+#ifdef __APPLE__
+#include "x_opengl.h"
+#endif
 
 double boinc_max_fps = 30.;
 double boinc_max_gfx_cpu_frac = 0.2;
@@ -84,7 +87,23 @@ bool throttled_app_render(int x, int y, double t) {
         if (boinc_max_gfx_cpu_frac) {
             boinc_calling_thread_cpu_time(t0);
         }
+        
+#ifdef __APPLE__
+        if (UseSharedOffscreenBuffer()) {
+            MacPrepareOffscreenBuffer();
+        }
+#endif
         app_graphics_render(x, y, t);
+
+#ifdef __APPLE__
+        if (UseSharedOffscreenBuffer()) {
+            MacPassOffscreenBufferToScreenSaver();
+
+//app_graphics_render(x, y, t); // For testing only
+        }
+
+#endif
+
         if (boinc_max_gfx_cpu_frac) {
             boinc_calling_thread_cpu_time(t1);
             total_render_time += t1 - t0;

--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -1,6 +1,6 @@
 // Berkeley Open Infrastructure for Network Computing
 // http://boinc.berkeley.edu
-// Copyright (C) 2005 University of California
+// Copyright (C) 2017 University of California
 //
 // This is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -21,13 +21,32 @@
 //  macglutfix.m
 //
 
+#define CREATE_LOG 0    // Set to 1 for debugging
+
+#define GL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED
+
 #include <Cocoa/Cocoa.h>
+#include <mach/mach_time.h>
+#include <pthread.h>
+#include "x_opengl.h"
+#import <OpenGL/CGLIOSurface.h>
+#import <GLKit/GLKit.h>
+#include <servers/bootstrap.h>
+#import "MultiGPUMig.h"
+#import "MultiGPUMigServer.h"
+
+#include "diagnostics.h"
+#include "boinc_gl.h"
+#include "boinc_glut.h"
+
+extern bool fullscreen; // set in graphics2_unix.cpp
 
 // For unknown reason, "boinc_api.h" gets a compile 
 // error here so just declare boinc_is_standalone()
 //#include "boinc_api.h"
 extern int boinc_is_standalone(void);
 
+// int set_realtime(int period, int computation, int constraint);
 void MacGLUTFix(bool isScreenSaver);
 void BringAppToFront(void);
 
@@ -54,11 +73,6 @@ void MacGLUTFix(bool isScreenSaver) {
         }
     }
 
-    // In screensaver mode, set our window's level just above 
-    // our BOINC screensaver's window level so it can appear 
-    // over it.  This doesn't interfere with the screensaver 
-    // password dialog because the dialog appears only after 
-    // our screensaver is closed.
     myContext = [ NSOpenGLContext currentContext ];
     if (myContext)
         myView = [ myContext view ];
@@ -66,17 +80,57 @@ void MacGLUTFix(bool isScreenSaver) {
         myWindow = [ myView window ];
     if (myWindow == nil)
         return;
-        
+    
     if (!isScreenSaver) {
         NSButton *closeButton = [myWindow standardWindowButton:NSWindowCloseButton ];
         [closeButton setEnabled:YES];
         [myWindow setDocumentEdited: NO];
         return;
     }
-        
-    if ([ myWindow level ] == GlutFullScreenWindowLevel)
-        [ myWindow setLevel:RealSaverLevel+20 ];
+
+    // As of OS 10.13, app windows can no longer appear on top of screensaver
+    // window, but we still use this method on older versions of OS X for
+    // compatibility with older project graphics apps.
+    if (!UseSharedOffscreenBuffer()) {
+        // In screensaver mode, set our window's level just above
+        // our BOINC screensaver's window level so it can appear
+        // over it.  This doesn't interfere with the screensaver
+        // password dialog because the dialog appears only after
+        // our screensaver is closed.
+        if ([ myWindow level ] == GlutFullScreenWindowLevel) {
+            [ myWindow setLevel:RealSaverLevel+20 ];
+        }
+    }
 }
+
+#if 0
+// NOT USED: See comments in animateOneFrame in Mac_Saver_ModuleView.m
+// <https://developer.apple.com/library/content/technotes/tn2169>
+int set_realtime(int period, int computation, int constraint) {
+    mach_timebase_info_data_t timebase_info;
+    mach_timebase_info(&timebase_info);
+ 
+    const uint64_t NANOS_PER_MSEC = 1000000ULL;
+    double clock2abs = ((double)timebase_info.denom / (double)timebase_info.numer) * NANOS_PER_MSEC;
+ 
+    thread_time_constraint_policy_data_t policy;
+    policy.period      = period;
+    policy.computation = (uint32_t)(computation * clock2abs); // computation ms of work
+    policy.constraint  = (uint32_t)(constraint * clock2abs);
+//    policy.preemptible = FALSE;
+    policy.preemptible = TRUE;
+
+    int kr = thread_policy_set(pthread_mach_thread_np(pthread_self()),
+                   THREAD_TIME_CONSTRAINT_POLICY,
+                   (thread_policy_t)&policy,
+                   THREAD_TIME_CONSTRAINT_POLICY_COUNT);
+    if (kr != KERN_SUCCESS) {
+        fprintf(stderr, "set_realtime() failed.\n");
+        return 0;
+    }
+    return 1;
+}
+#endif
 
 void BringAppToFront() {
     [ NSApp activateIgnoringOtherApps:YES ];
@@ -84,5 +138,288 @@ void BringAppToFront() {
 
 void HideThisApp() {
     [ NSApp hide:NSApp ];
+}
+
+// On OS 10.13 or later, use MachO comunication and IOSurfaceBuffer to
+// display the graphics output of our child graphics apps in our window.
+
+// Code adapted from Apple Developer Tech Support Sample Code MutiGPUIOSurface:
+// <https://developer.apple.com/library/content/samplecode/MultiGPUIOSurface>
+
+#define NUM_IOSURFACE_BUFFERS 2
+
+@interface ServerController : NSObject <NSMachPortDelegate>
+{
+    NSMachPort *serverPort;
+	NSMachPort *localPort;
+    
+	uint32_t serverPortName;
+	uint32_t localPortName;
+    
+	NSMachPort *clientPort[16];
+	uint32_t clientPortNames[16];
+	uint32_t clientPortCount;
+}
+- (ServerController *)init;
+- (kern_return_t)checkInClient:(mach_port_t)client_port index:(int32_t *)client_index;
+- (void)portDied:(NSNotification *)notification;
+- (void)sendIOSurfaceMachPortToClients: (uint32_t)index withMachPort:(mach_port_t) iosurface_port;
+
+@end
+
+static ServerController *myserverController;
+
+static uint32_t nextFrameIndex;
+static uint32_t currentFrameIndex;
+
+static IOSurfaceRef ioSurfaceBuffers[NUM_IOSURFACE_BUFFERS];
+static mach_port_t ioSurfaceMachPorts[NUM_IOSURFACE_BUFFERS];
+static GLuint textureNames[NUM_IOSURFACE_BUFFERS];
+static GLuint fboNames[NUM_IOSURFACE_BUFFERS];
+static GLuint depthBufferName;
+
+@implementation ServerController
+
+- (ServerController *)init
+{
+	[[NSNotificationCenter defaultCenter] addObserver:self
+	    selector:@selector(portDied:) name:NSPortDidBecomeInvalidNotification object:nil];
+	
+    mach_port_t servicePortNum = MACH_PORT_NULL;
+    kern_return_t machErr;
+    char *portName = "edu.berkeley.boincsaver";
+    
+// NSMachBootstrapServer is deprecated in OS 10.13, so use bootstrap_look_up
+//	serverPort = [(NSMachPort *)([[NSMachBootstrapServer sharedInstance] servicePortWithName:@"edu.berkeley.boincsaver"]) retain];
+    machErr = bootstrap_check_in(bootstrap_port, portName, &servicePortNum);
+    if (machErr != KERN_SUCCESS) {
+        		[NSApp terminate:self];
+    }
+    serverPort = (NSMachPort*)[NSMachPort portWithMachPort:servicePortNum];
+	
+	// Create a local dummy reply port to use with the mig reply stuff
+	localPort = [[NSMachPort alloc] init];
+	
+	// Retrieve raw mach port names.
+	serverPortName = [serverPort machPort];
+	localPortName  = [localPort machPort];
+
+	[serverPort setDelegate:self];
+	[serverPort scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+
+    // NOT USED: See comments in animateOneFrame in Mac_Saver_ModuleView.m
+#if 0
+    // This is an alternate method to get enough CPU cycles when we
+    // are running in the background behind ScreensaverEngine.app
+    set_realtime(0, 5, 33);
+    //set_realtime(0, 5, 10);
+    //set_realtime(33, 5, 33);
+    //set_realtime(30, 3, 6);
+    //set_realtime(30, 10, 20);
+#endif
+
+    return self;
+}
+
+- (void)portDied:(NSNotification *)notification
+{
+	NSPort *port = [notification object];
+	if(port == serverPort)
+	{
+		[NSApp terminate:self];
+	}
+	else
+	{		
+		int i;
+		for(i = 0; i < clientPortCount+1; i++)
+		{
+			if([clientPort[i] isEqual:port])
+			{
+				[clientPort[i] release];
+				clientPort[i] = nil;
+				clientPortNames[i] = 0;
+			}
+		}
+	}
+}
+
+- (void)handleMachMessage:(void *)msg
+{
+	union __ReplyUnion___MGCMGSServer_subsystem reply;
+	
+	mach_msg_header_t *reply_header = (void *)&reply;
+	kern_return_t kr;
+	
+	if(MGSServer_server(msg, reply_header) && reply_header->msgh_remote_port != MACH_PORT_NULL)
+	{
+		kr = mach_msg(reply_header, MACH_SEND_MSG, reply_header->msgh_size, 0, MACH_PORT_NULL,
+			     0, MACH_PORT_NULL);
+        if(kr != 0)
+			[NSApp terminate:nil];
+	}
+}
+
+- (kern_return_t)checkInClient:(mach_port_t)client_port index:(int32_t *)client_index
+{	
+	clientPortCount++;			// clients always start at index 1
+	clientPortNames[clientPortCount] = client_port;
+	clientPort[clientPortCount] = [[NSMachPort alloc] initWithMachPort:client_port];
+	
+	*client_index = clientPortCount;
+	return 0;
+}
+
+kern_return_t _MGSCheckinClient(mach_port_t server_port, mach_port_t client_port,
+			       int32_t *client_index)
+{
+	return [myserverController checkInClient:client_port index:client_index];
+}
+
+// For the MachO server, this is a no-op
+kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, uint32_t iosurface_port)
+{
+	return 0;
+}
+
+- (void)sendIOSurfaceMachPortToClients:(uint32_t)index withMachPort:(mach_port_t)iosurface_port
+{
+	int i;
+	for(i = 0; i < clientPortCount+1; i++)
+	{
+		if(clientPortNames[i])
+		{
+            // print_to_log_file("BOINCSCR: about to call _MGCDisplayFrame  with iosurface_port %d, IOSurfaceGetID %d and frameIndex %d", (int)iosurface_port, IOSurfaceGetID(ioSurfaceBuffers[index]), (int)index);
+			_MGCDisplayFrame(clientPortNames[i], index, iosurface_port);
+		}
+	}
+}
+@end
+
+
+void MacPrepareOffscreenBuffer() {
+	GLuint name, namef;
+
+    if (!myserverController) {
+        myserverController = [[[ServerController alloc] init] retain];
+    }
+
+    if (!ioSurfaceBuffers[0]) {
+        NSOpenGLContext * myContext = [ NSOpenGLContext currentContext ];
+        NSView *myView = [ myContext view ];
+        GLsizei w = myView.bounds.size.width;
+        GLsizei h = myView.bounds.size.height;
+
+        // Set up all of our iosurface buffers
+        for(int i = 0; i < NUM_IOSURFACE_BUFFERS; i++) {
+            ioSurfaceBuffers[i] = IOSurfaceCreate((CFDictionaryRef)@{
+                (id)kIOSurfaceWidth: [NSNumber numberWithInt: w],
+                (id)kIOSurfaceHeight: [NSNumber numberWithInt: h],
+                (id)kIOSurfaceBytesPerElement: @4
+                });
+            ioSurfaceMachPorts[i] = IOSurfaceCreateMachPort(ioSurfaceBuffers[i]);
+        }
+    }
+    
+	if(!textureNames[nextFrameIndex])
+	{
+        NSOpenGLContext * myContext = [ NSOpenGLContext currentContext ];
+        NSView *myView = [ myContext view ];
+        GLsizei w = myView.bounds.size.width;
+        GLsizei h = myView.bounds.size.height;
+
+        CGLContextObj cgl_ctx = (CGLContextObj)[myContext CGLContextObj];
+        
+        glGenTextures(1, &name);
+        
+        glBindTexture(GL_TEXTURE_RECTANGLE, name);
+        // At the moment, CGLTexImageIOSurface2D requires the GL_TEXTURE_RECTANGLE target
+        CGLTexImageIOSurface2D(cgl_ctx, GL_TEXTURE_RECTANGLE, GL_RGBA, w, h, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                        ioSurfaceBuffers[nextFrameIndex], 0);
+        glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);	
+        
+        // Generate an FBO and bind the texture to it as a render target.
+        glBindTexture(GL_TEXTURE_RECTANGLE, 0);
+        
+        glGenFramebuffers(1, &namef);
+        glBindFramebuffer(GL_FRAMEBUFFER, namef);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE, name, 0);
+
+        if(!depthBufferName)
+        {
+            glGenRenderbuffers(1, &depthBufferName);
+            glRenderbufferStorage(GL_TEXTURE_RECTANGLE, GL_DEPTH, w, h);
+        }
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_RECTANGLE, depthBufferName);
+
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        
+        fboNames[nextFrameIndex] = namef;
+        textureNames[nextFrameIndex] = name;
+	}
+    currentFrameIndex = nextFrameIndex;
+	nextFrameIndex = (nextFrameIndex + 1) % NUM_IOSURFACE_BUFFERS;
+
+    glBindFramebuffer(GL_FRAMEBUFFER, fboNames[currentFrameIndex]);
+}
+
+void MacPassOffscreenBufferToScreenSaver() {
+    glutSwapBuffers();
+    [myserverController sendIOSurfaceMachPortToClients: currentFrameIndex
+                        withMachPort:ioSurfaceMachPorts[currentFrameIndex]];
+    glFlush();
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+// Code for debugging:
+
+#if CREATE_LOG
+void strip_cr(char *buf)
+{
+    char *theCR;
+
+    theCR = strrchr(buf, '\n');
+    if (theCR)
+        *theCR = '\0';
+    theCR = strrchr(buf, '\r');
+    if (theCR)
+        *theCR = '\0';
+}
+#endif
+
+void print_to_log_file(const char *format, ...) {
+#if CREATE_LOG
+    va_list args;
+    char buf[256];
+    time_t t;
+    FILE *f;
+    if (fullscreen) {
+        // We can't write to our home directory if running as user / group boinc_project
+        f = fopen("/Users/Shared/test_log.txt", "a");
+    } else {
+        strlcpy(buf, getenv("HOME"), sizeof(buf));
+        strlcat(buf, "/Documents/test_log.txt", sizeof(buf));
+        f = fopen(buf, "a");
+        // freopen(buf, "a", stdout);
+        //freopen(buf, "a", stderr);
+    }
+    if (!f) return;
+    time(&t);
+    strcpy(buf, asctime(localtime(&t)));
+    strip_cr(buf);
+
+    fputs(buf, f);
+    fputs("   ", f);
+
+    va_start(args, format);
+    vfprintf(f, format, args);
+    va_end(args);
+    
+    fputs("\n", f);
+    fflush(f);
+    fclose(f);
+#endif
 }
 

--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -28,14 +28,12 @@
 #include <Cocoa/Cocoa.h>
 #include <mach/mach_time.h>
 #include <pthread.h>
-#include "x_opengl.h"
 #import <OpenGL/CGLIOSurface.h>
 #import <GLKit/GLKit.h>
 #include <servers/bootstrap.h>
 #import "MultiGPUMig.h"
 #import "MultiGPUMigServer.h"
-
-#include "diagnostics.h"
+#include "x_opengl.h"
 #include "boinc_gl.h"
 #include "boinc_glut.h"
 

--- a/api/x_opengl.h
+++ b/api/x_opengl.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2017 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -25,9 +25,15 @@ extern "C" {
 extern int xwin_glut_is_initialized();  
 
 #ifdef __APPLE__
-extern void MacGLUTFix(bool isScreenSaver);  
+extern void MacGLUTFix(bool isScreenSaver);
+extern void MacPrepareOffscreenBuffer(void);
+extern void MacPassOffscreenBufferToScreenSaver(void);
 extern void BringAppToFront(void);
 extern void HideThisApp(void);
+extern bool UseSharedOffscreenBuffer(void);
+
+extern void print_to_log_file(const char *format, ...);
+
 #endif
 
 #ifdef __cplusplus

--- a/clientscr/Mac_Saver_ModuleView.h
+++ b/clientscr/Mac_Saver_ModuleView.h
@@ -20,6 +20,7 @@
 //
 
 #import <ScreenSaver/ScreenSaver.h>
+#import <Cocoa/Cocoa.h>
 
 
 @interface BOINC_Saver_ModuleView : ScreenSaverView 
@@ -43,19 +44,54 @@
 
 @end
 
+@interface SharedGraphicsController : NSObject <NSMachPortDelegate>
+
+@property (NS_NONATOMIC_IOSONLY, readonly) GLuint currentTextureName;
+- (instancetype)init:(NSView*)saverView;
+- (void)portDied:(NSNotification *)notification;
+- (void)testConnection;
+
+@end
+
+@interface saverOpenGLView : NSOpenGLView
+
+- (GLuint)setupIOSurfaceTexture:(IOSurfaceRef)ioSurfaceBuffer;
+
+@end
+
+// The declarations below must be kept in sync with
+// the corresponding ones in Mac_Saver_Module.h
+#ifdef _DEBUG
+    #define _T(x) x
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void            initBOINCSaver(void);
 int             startBOINCSaver(void);
 int             getSSMessage(char **theMessage, int* coveredFreq);
 void            windowIsCovered();
 void            drawPreview(CGContextRef myContext);
 void            closeBOINCSaver(void);
+void            setDefaultDisplayPeriods(void);
+bool            getShow_default_ss_first();
 double          getGFXDefaultPeriod();
 double          getGFXSciencePeriod();
 double          getGGFXChangePeriod();
+void            incompatibleGfxApp(char * appPath, pid_t pid, int slot);
+void            setShow_default_ss_first(bool value);
 void            setGFXDefaultPeriod(double value);
 void            setGFXSciencePeriod(double value);
 void            setGGFXChangePeriod(double value);
-bool            validateNumericString(CFStringRef s);
 double          getDTime();
 void            doBoinc_Sleep(double seconds);
-extern void     print_to_log_file(const char *format, ...);
+void            launchedGfxApp(char * appPath, pid_t thePID, int slot);
+void            print_to_log_file(const char *format, ...);
+void            strip_cr(char *buf);
+void            PrintBacktrace(void);
+
+#ifdef __cplusplus
+}    // extern "C"
+#endif

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -20,14 +20,24 @@
 //  BOINC_Saver_Module
 //
 
+#define GL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED 1
+
 #import "Mac_Saver_ModuleView.h"
 #include <Carbon/Carbon.h>
 #include <AppKit/AppKit.h>
-#include <QTKit/QTKitDefines.h> // For NSInteger
 #include <IOKit/hidsystem/IOHIDLib.h>
 #include <IOKit/hidsystem/IOHIDParameter.h>
 #include <IOKit/hidsystem/event_status_driver.h>
+#import <OpenGL/gl.h>
+#import <GLKit/GLKit.h>
+#include <servers/bootstrap.h>
+//#import <IOSurface/IOSurface.h>
+//#import <OpenGL/gl3.h>
+//#import <OpenGL/CGLIOSurface.h>
+
 #include "mac_util.h"
+#import "MultiGPUMig.h"
+#import "MultiGPUMigServer.h"
 
 #ifndef NSInteger
 #if __LP64__ || NS_BUILD_32_LIKE_64
@@ -59,9 +69,6 @@ typedef float CGFloat;
 #define NSAlertStyleCritical NSCriticalAlertStyle
 #endif
 
-void print_to_log_file(const char *format, ...);
-void strip_cr(char *buf);
-
 static double gSS_StartTime = 0.0;
 mach_port_t gEventHandle = 0;
 
@@ -85,6 +92,16 @@ NSPoint gCurrentDelta;
 CGContextRef myContext;
 bool isErased;
 
+static SharedGraphicsController *mySharedGraphicsController;
+static bool runningSharedGraphics;
+static pid_t childPid;
+static char gfxAppPath[MAXPATHLEN];
+static int taskSlot;
+static NSRunningApplication *childApp;
+static double gfxAppStartTime;
+static bool UseSharedOffscreenBuffer(void);
+
+
 #define TEXTBOXMINWIDTH 400.0
 #define MINTEXTBOXHEIGHT 40.0
 #define MAXTEXTBOXHEIGHT 300.0
@@ -93,8 +110,18 @@ bool isErased;
 #define MINDELTA 8
 #define MAXDELTA 16
 
+// On OS 10.13+, assume graphics app is not compatible if no MachO connection after 5 seconds
+#define MAXWAITFORCONNECTION 5.0
+
 int signof(float x) {
     return (x > 0.0 ? 1 : -1);
+}
+
+void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
+    strlcpy(gfxAppPath, appPath, sizeof(gfxAppPath));
+    childPid = thePID;
+    taskSlot = slot;
+    gfxAppStartTime = getDTime();
 }
 
 @implementation BOINC_Saver_ModuleView
@@ -284,6 +311,16 @@ int signof(float x) {
         [ self setAnimationTimeInterval:1/30.0 ];
 #endif
         return;
+    } else {
+        NSWindow *myWindow = [ self window ];
+        NSRect windowFrame = [ myWindow frame ];
+        if ( (windowFrame.origin.x == 0) && (windowFrame.origin.y == 0) ) { // Main screen
+            // On OS 10.13 or later, use MachO comunication and IOSurfaceBuffer to
+            // display the graphics output of our child graphics apps in our window.
+            if (UseSharedOffscreenBuffer() && !mySharedGraphicsController) {
+                mySharedGraphicsController = [[SharedGraphicsController alloc] init:self] ;
+            }
+        }
     }
 
     // For unkown reasons, OS 10.7 Lion screensaver and later delay several seconds
@@ -304,59 +341,108 @@ int signof(float x) {
     if ( (windowFrame.origin.x != 0) || (windowFrame.origin.y != 0) ) {
         // Hide window on second display to aid in debugging
 #ifdef _DEBUG
+        // This technique no longer works on newer versions of OS X
         [ myWindow setLevel:kCGMinimumWindowLevel ];
         NSInteger alpha = 0;
         [ myWindow setAlphaValue:alpha ];   // For OS 10.6
+        [ myWindow orderOut:self];
 #endif
         return;         // We draw only to main screen
+    }
+
+	// On OS 10.13 or later, use MachO comunication and IOSurfaceBuffer to
+	// display the graphics output of our child graphics apps in our window.
+    if (runningSharedGraphics) {
+        // Since ScreensaverEngine.app is running in the foreground, our child
+        // graphics app may not get enough CPU cycles for good animation.
+        // Calling [ NSApp activateIgnoringOtherApps:YES ] frequently from the
+        // child doesn't help. But activating our child frequently from the
+        // front process (this screensaver plugin) does appear to guarantee
+        // good animation.
+        //
+        // An alternate approach that also works is to have the child process
+        // tell the kernel it has real time constraints by calling
+        // thread_policy_set() with thread_policy_flavor_t set to
+        // THREAD_TIME_CONSTRAINT_POLICY as described in
+        // <https://developer.apple.com/library/content/technotes/tn2169>.
+        //
+        // But different graphics apps may have different time requirements,
+        // so it is difficult to know the best values to set in the
+        // thread_time_constraint_policy_data_t struct. If the graphics app asks
+        // for too much time, the worker apps will get less time, and if it asks
+        // for too little time the animation won't be smooth.
+        //
+        // So frequently activating the child app here seems to be best.
+        //
+        if (childApp) {
+             [ childApp activateWithOptions:NSApplicationActivateIgnoringOtherApps ];\
+        }
+        isErased = false;
+        return;
     }
 
     NSRect viewBounds = [self bounds];
 
     newFrequency = getSSMessage(&msg, &coveredFreq);
 
-    // NOTE: My tests seem to confirm that the top window is always the first
-    // window returned by [NSWindow windowNumbersWithOptions:] However, Apple's
-    // documentation is unclear whether we can depend on this.  So I have 
-    // added some safety by doing two things:
-    // [1] Only use the windowNumbersWithOptions test when we have started
-    //     project graphics.
-    // [2] Assume that our window is covered 45 seconds after starting project 
-    //     graphics even if the windowNumbersWithOptions test did not indicate
-    //     that is so.
-    //
-    // getSSMessage() returns a non-zero value for coveredFreq only if we have started 
-    // project graphics.
-    //
-    // If we should use a different frequency when our window is covered by another 
-    // window, then check whether there is a window at a higher z-level than ours.
-
-    // Assuming our window(s) are initially the top window(s), determine our position
-    // in the window list when no graphics applications have covered us.
-    if (gTopWindowListIndex < 0) {
-        NSArray *theWindowList = [NSWindow windowNumbersWithOptions:NSWindowNumberListAllApplications];
-        myWindowNumber = [ myWindow windowNumber ];
-        gTopWindowListIndex = [theWindowList indexOfObjectIdenticalTo:[NSNumber numberWithInt:myWindowNumber]];
-    }
-
-    if (coveredFreq) {
-        if ( (msg != NULL) && (msg[0] != '\0') ) {
-            NSArray *theWindowList = [NSWindow windowNumbersWithOptions:NSWindowNumberListAllApplications];
-            n = [theWindowList count];
-            if (gTopWindowListIndex < n) {
-                if ([(NSNumber*)[theWindowList objectAtIndex:gTopWindowListIndex] integerValue] != myWindowNumber) {
-                    // Project graphics application has a window open above ours
-                    // Don't waste CPU cycles since our window is obscured by application graphics
-                    newFrequency = coveredFreq;
-                    msg = NULL;
-                    windowIsCovered();
-                }
+    if (UseSharedOffscreenBuffer()) {
+        // If runningSharedGraphics is still false after MAXWAITFORCONNECTION,
+        // assume graphics app is not compatible with OS 10.13+ and kill it.
+        if (gfxAppStartTime) {
+            if ((getDTime() - gfxAppStartTime)> MAXWAITFORCONNECTION) {
+                incompatibleGfxApp(gfxAppPath, childPid, taskSlot);
             }
-        } else {
-            newFrequency = coveredFreq;
+        }
+    // As of OS 10.13, app windows can no longer appear on top of screensaver
+    // window, but we still use this method on older versions of OS X for
+    // compatibility with older project graphics apps (those which have not
+    // yet been relinked with the updated libboinc_graphics2.a.)
+    } else {
+        // NOTE: My tests seem to confirm that the top window is always the first
+        // window returned by [NSWindow windowNumbersWithOptions:] However, Apple's
+        // documentation is unclear whether we can depend on this.  So I have
+        // added some safety by doing two things:
+        // [1] Only use the windowNumbersWithOptions test when we have started
+        //     project graphics.
+        // [2] Assume that our window is covered 45 seconds after starting project
+        //     graphics even if the windowNumbersWithOptions test did not indicate
+        //     that is so.
+        //
+        // getSSMessage() returns a non-zero value for coveredFreq only if we have started
+        // project graphics.
+        //
+        // If we should use a different frequency when our window is covered by another
+        // window, then check whether there is a window at a higher z-level than ours.
+
+        // Assuming our window(s) are initially the top window(s), determine our position
+        // in the window list when no graphics applications have covered us.
+        if (gTopWindowListIndex < 0) {
+            NSArray *theWindowList = [NSWindow windowNumbersWithOptions:NSWindowNumberListAllApplications];
+            myWindowNumber = [ myWindow windowNumber ];
+            gTopWindowListIndex = [theWindowList indexOfObjectIdenticalTo:[NSNumber numberWithInt:myWindowNumber]];
+        }
+
+        if (coveredFreq) {
+            if ( (msg != NULL) && (msg[0] != '\0') ) {
+                NSArray *theWindowList = [NSWindow windowNumbersWithOptions:NSWindowNumberListAllApplications];
+                n = [theWindowList count];
+                if (gTopWindowListIndex < n) {
+                    if ([(NSNumber*)[theWindowList objectAtIndex:gTopWindowListIndex] integerValue] != myWindowNumber) {
+                        // Project graphics application has a window open above ours
+                        // Don't waste CPU cycles since our window is obscured by application graphics
+                        newFrequency = coveredFreq;
+                        msg = NULL;
+                        windowIsCovered();
+                    }
+                }
+            } else {
+                newFrequency = coveredFreq;
+            }
         }
     }
-
+    
+    // Draw our moving BOINC logo and screensaver status text
+    
     // Clear the previous drawing area
     currentDrawingRect = gMovingRect;
     currentDrawingRect.origin.x = (float) ((int)gCurrentPosition.x);
@@ -464,10 +550,6 @@ int signof(float x) {
             HIThemeGetTextDimensions(cf_msg, (float)gMovingRect.size.width, &textInfo, NULL, &gActualTextBoxHeight, NULL);
             gActualTextBoxHeight += TEXTBOXTOPBORDER;
             
-            // Use only APIs available in Mac OS 10.3.9
-//            HIThemeSetTextFill(kThemeTextColorWhite, NULL, myContext, kHIThemeOrientationNormal);
-//            SetThemeTextColor(kThemeTextColorWhite, 32, true);
-
             CGFloat myWhiteComponents[] = {1.0, 1.0, 1.0, 1.0};
             CGColorSpaceRef myColorSpace = CGColorSpaceCreateDeviceRGB ();
             CGColorRef myTextColor = CGColorCreate(myColorSpace, myWhiteComponents);
@@ -506,6 +588,11 @@ int signof(float x) {
         if (timeToBlock > 0.0) {
             doBoinc_Sleep(timeToBlock);
         }
+    }
+    
+    // Check for a new graphics app sending us data
+    if (UseSharedOffscreenBuffer()) {
+        [mySharedGraphicsController testConnection];
     }
 }
 
@@ -649,3 +736,356 @@ Bad:
 }
 
 @end
+
+// On OS 10.13 or later, use MachO comunication and IOSurfaceBuffer to
+// display the graphics output of our child graphics apps in our window.
+// All code past this point is for that implementation.
+
+// Adapted from Apple Developer Tech Support Sample Code MutiGPUIOSurface:
+// <https://developer.apple.com/library/content/samplecode/MultiGPUIOSurface>
+
+#define NUM_IOSURFACE_BUFFERS 2
+
+@interface SharedGraphicsController()
+{
+	NSMachPort *serverPort;
+	NSMachPort *localPort;
+    
+	uint32_t serverPortName;
+	uint32_t localPortName;
+    
+	int32_t clientIndex;
+	uint32_t nextFrameIndex;
+	
+    NSView *screenSaverView;
+    saverOpenGLView *openGLView;
+    
+	IOSurfaceRef _ioSurfaceBuffers[NUM_IOSURFACE_BUFFERS];
+    mach_port_t _ioSurfaceMachPorts[NUM_IOSURFACE_BUFFERS];
+	GLuint _textureNames[NUM_IOSURFACE_BUFFERS];
+}
+@end
+
+static bool okToDraw;
+
+@implementation SharedGraphicsController
+
+- (instancetype)init:(NSView*)saverView {
+    screenSaverView = saverView;
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self 
+	    selector:@selector(portDied:) name:NSPortDidBecomeInvalidNotification object:nil];
+	
+    [self testConnection];
+    
+    return self;
+}
+
+
+- (void) testConnection
+{
+    mach_port_t servicePortNum = MACH_PORT_NULL;
+    kern_return_t machErr;
+    char *portName = "edu.berkeley.boincsaver";
+    
+	// Try to check in with master.
+// NSMachBootstrapServer is deprecated in OS 10.13, so use bootstrap_look_up
+//	serverPort = [(NSMachPort *)([[NSMachBootstrapServer sharedInstance] portForName:@"edu.berkeley.boincsaver"]) retain];
+	machErr = bootstrap_look_up(bootstrap_port, portName, &servicePortNum);
+    if (machErr == KERN_SUCCESS) {
+        serverPort = (NSMachPort*)[NSMachPort portWithMachPort:servicePortNum];
+    } else {
+        serverPort = MACH_PORT_NULL;
+    }
+
+	if(serverPort != MACH_PORT_NULL)
+	{
+		// Create our own local port.
+		localPort = [[NSMachPort alloc] init];
+		
+		// Retrieve raw mach port names.
+		serverPortName = [serverPort machPort];
+		localPortName  = [localPort machPort];
+		
+		// Register our local port with the current runloop.
+		[localPort setDelegate:self];
+		[localPort scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+		 
+		// Check in with server.
+		int kr;
+		kr = _MGCCheckinClient(serverPortName, localPortName, &clientIndex);
+		if(kr != 0)
+			[NSApp terminate:nil];
+
+        openGLView = [[saverOpenGLView alloc] initWithFrame:[screenSaverView frame]];
+        
+        [screenSaverView addSubview:openGLView];
+
+        runningSharedGraphics = true;
+
+        if (childPid) {
+            gfxAppStartTime = 0.0;
+            childApp = [NSRunningApplication runningApplicationWithProcessIdentifier:childPid];
+        }
+    }
+}
+
+- (void)portDied:(NSNotification *)notification
+{
+	NSPort *port = [notification object];
+	if(port == serverPort) {
+        childApp = nil;
+        gfxAppStartTime = 0.0;
+        gfxAppPath[0] = '\0';
+
+        if ([serverPort isValid]) {
+            [serverPort invalidate];
+//            [serverPort release];
+        }
+        serverPort = nil;
+		[localPort removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+
+        if ([localPort isValid]) {
+            [localPort invalidate];
+        }
+//        [localPort release];
+        localPort = nil;
+
+        int i;
+        for(i = 0; i < NUM_IOSURFACE_BUFFERS; i++) {
+            if (_ioSurfaceBuffers[i]) {
+                CFRelease(_ioSurfaceBuffers[i]);
+                _ioSurfaceBuffers[i] = nil;
+            }
+
+            // if (glIsTexture(_textureNames[i])) {
+                // glDeleteTextures(1, _textureNames[i]);
+            // }
+            _textureNames[i] = 0;
+            
+            if (_ioSurfaceMachPorts[i] != MACH_PORT_NULL) {
+                mach_port_deallocate(mach_task_self(), _ioSurfaceMachPorts[i]);
+                _ioSurfaceMachPorts[i] = MACH_PORT_NULL;
+            }
+        }
+
+        if ((serverPort == nil) && (localPort == nil)) {
+            runningSharedGraphics = false;
+            [openGLView removeFromSuperview];   // Releases openGLView
+        }
+	}
+}
+- (void)handleMachMessage:(void *)msg
+{
+	union __ReplyUnion___MGCMGSServer_subsystem reply;
+	
+	mach_msg_header_t *reply_header = (void *)&reply;
+	kern_return_t kr;
+	
+	if(MGSServer_server(msg, reply_header) && reply_header->msgh_remote_port != MACH_PORT_NULL)
+	{
+		kr = mach_msg(reply_header, MACH_SEND_MSG, reply_header->msgh_size, 0, MACH_PORT_NULL, 
+			     0, MACH_PORT_NULL);
+        if(kr != 0)
+			[NSApp terminate:nil];
+	}
+}
+
+- (kern_return_t)displayFrame:(int32_t)frameIndex surfacemachport:(mach_port_t)iosurface_port
+{
+	nextFrameIndex = frameIndex;
+
+	if(!_ioSurfaceBuffers[frameIndex])
+	{
+		_ioSurfaceBuffers[frameIndex] = IOSurfaceLookupFromMachPort(iosurface_port);
+        _ioSurfaceMachPorts[frameIndex] = iosurface_port;
+	}
+	if(!_textureNames[frameIndex])
+    {
+		_textureNames[frameIndex] = [openGLView setupIOSurfaceTexture:_ioSurfaceBuffers[frameIndex]];
+    }
+
+    okToDraw = true;    // Tell drawRect that we have real data to display
+
+	[openGLView setNeedsDisplay:YES];
+	[openGLView display];
+
+	return 0;
+}
+
+// For the MachO client, this is a no-op.
+kern_return_t _MGSCheckinClient(mach_port_t server_port, mach_port_t client_port,
+			       int32_t *client_index)
+{
+	return 0;
+}
+
+kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, mach_port_t iosurface_port)
+{
+	return [mySharedGraphicsController displayFrame:frame_index surfacemachport:iosurface_port];
+}
+
+- (GLuint)currentTextureName
+{
+	return _textureNames[nextFrameIndex];
+}
+
+@end
+
+@implementation saverOpenGLView
+
+- (instancetype)initWithFrame:(NSRect)frame {
+    NSOpenGLPixelFormatAttribute	attribs []	=
+    {
+//		NSOpenGLPFAWindow,
+		NSOpenGLPFADoubleBuffer,
+		NSOpenGLPFAAccelerated,
+		NSOpenGLPFANoRecovery,
+		NSOpenGLPFAColorSize,		(NSOpenGLPixelFormatAttribute)32,
+		NSOpenGLPFAAlphaSize,		(NSOpenGLPixelFormatAttribute)8,
+		NSOpenGLPFADepthSize,		(NSOpenGLPixelFormatAttribute)24,
+		(NSOpenGLPixelFormatAttribute) 0
+	};
+
+    NSOpenGLPixelFormat *pix_fmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:attribs];
+
+    if(!pix_fmt)
+       [ NSApp terminate:nil];
+
+	self = [super initWithFrame:frame pixelFormat:pix_fmt];
+
+
+	[[self openGLContext] makeCurrentContext];
+
+    // drawRect is apparently called due to the above code, causing the
+    // screen to flash unless we prevent any actual drawing, so tell
+    // drawRect that we do not yet have real data to display
+    okToDraw = false;
+
+	return self;
+}
+
+- (void)prepareOpenGL
+{
+    [super prepareOpenGL];
+}
+
+- (void)update
+{
+	// Override to do nothing.
+}
+
+// Create an IOSurface backed texture
+- (GLuint)setupIOSurfaceTexture:(IOSurfaceRef)ioSurfaceBuffer
+{
+	GLuint name;
+	CGLContextObj cgl_ctx = (CGLContextObj)[[self openGLContext] CGLContextObj];
+
+	glGenTextures(1, &name);
+	
+	glBindTexture(GL_TEXTURE_RECTANGLE, name);
+    // At the moment, CGLTexImageIOSurface2D requires the GL_TEXTURE_RECTANGLE target
+	CGLTexImageIOSurface2D(cgl_ctx, GL_TEXTURE_RECTANGLE, GL_RGBA, (GLsizei)self.bounds.size.width, (GLsizei)self.bounds.size.height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+					ioSurfaceBuffer, 0);
+
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);	
+
+	return name;
+}
+
+- (BOOL)isOpaque
+{
+	return YES;
+}
+
+// Render a quad with the the IOSurface backed texture
+- (void)renderTextureFromIOSurfaceWithWidth:(GLsizei)logoWidth height:(GLsizei)logoHeight
+{
+    GLfloat quad[] = {
+        //x, y            s, t
+        (GLfloat)logoWidth, 0.0f,    0.0f, 0.0f,
+        0.0f, (GLfloat)logoHeight,   0.0f, 0.0f,
+        0.0f,  0.0f,     1.0f, 0.0f,
+        0.0f,  0.0f,     0.0f, 1.0f
+    };
+    
+    GLint		saveMatrixMode;
+
+    glGetIntegerv(GL_MATRIX_MODE, &saveMatrixMode);
+    glMatrixMode(GL_TEXTURE);
+    glPushMatrix();
+    glLoadMatrixf(quad);
+    glMatrixMode(saveMatrixMode);
+    
+    glBindTexture(GL_TEXTURE_RECTANGLE, [mySharedGraphicsController currentTextureName]);
+    glEnable(GL_TEXTURE_RECTANGLE);
+    
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+
+	//Draw textured quad
+	glBegin(GL_QUADS);
+		glTexCoord2f(0.0, 0.0);
+		glVertex3f(-1.0, -1.0, 0.0);
+		glTexCoord2f(1.0, 0.0);
+		glVertex3f(1.0, -1.0, 0.0);
+		glTexCoord2f(1.0, 1.0);
+		glVertex3f(1.0, 1.0, 0.0);
+		glTexCoord2f(0.0, 1.0);
+		glVertex3f(-1.0, 1.0, 0.0);
+	glEnd();
+    
+		glDisable(GL_TEXTURE_RECTANGLE);
+		
+		glGetIntegerv(GL_MATRIX_MODE, &saveMatrixMode);
+		glMatrixMode(GL_TEXTURE);
+		glPopMatrix();
+		glMatrixMode(saveMatrixMode);
+
+}
+
+- (void)drawRect:(NSRect)theRect
+{
+    glViewport(0, 0, (GLint)theRect.size.width, (GLint)theRect.size.height);
+
+    glClearColor(0.0, 0.0, 0.0, 0.0);
+
+    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+
+    // drawRect is apparently called before we have real data to display,
+    // causing the screen to flash unless we prevent any actual drawing.
+    if (!okToDraw) {
+        [[self openGLContext] flushBuffer];
+    return;
+}
+
+    // MachO client draws with current IO surface contents as texture
+    [self renderTextureFromIOSurfaceWithWidth:(GLsizei)self.bounds.size.width height:(GLsizei)self.bounds.size.height];
+
+    [[self openGLContext] flushBuffer];
+}
+
+@end
+
+
+// On OS 10.13 or later, use MachO comunication and IOSurfaceBuffer to
+// display the graphics output of our child graphics apps in our window.
+static bool UseSharedOffscreenBuffer() {
+    static bool alreadyTested = false;
+    static bool needSharedGfxBuffer = false;
+
+//return true;    // FOR TESTING ONLY
+    if (alreadyTested) {
+        return needSharedGfxBuffer;
+    }
+    alreadyTested = true;
+    if (compareOSVersionTo(10, 13) >= 0) {
+        needSharedGfxBuffer = true;
+        return true;
+    }
+    return false;
+}
+
+

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2017 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -28,6 +28,8 @@
 #ifdef __APPLE__
 #include <Carbon/Carbon.h>
 #include <sys/wait.h>
+#include <app_ipc.h>
+#include <malloc/malloc.h>
 #endif
 
 // Common application includes
@@ -83,22 +85,35 @@ bool CScreensaver::is_same_task(RESULT* taska, RESULT* taskb) {
 }
 
 int CScreensaver::count_active_graphic_apps(RESULTS& res, RESULT* exclude) {
-    unsigned int i = 0;
+    int i = 0;
     unsigned int graphics_app_count = 0;
 
     // Count the number of active graphics-capable apps excluding the specified result.
     // If exclude is NULL, don't exclude any results.
     //
-    for (i = 0; i < res.results.size(); i++) {
-        BOINCTRACE(_T("get_random_graphics_app -- active task detected\n"));
+    for (i = res.results.size()-1; i >=0 ; i--) {
+        BOINCTRACE(_T("count_active_graphic_apps -- active task detected\n"));
         BOINCTRACE(
-            _T("get_random_graphics_app -- name = '%s', path = '%s'\n"),
+            _T("count_active_graphic_apps -- name = '%s', path = '%s'\n"),
             res.results[i]->name, res.results[i]->graphics_exec_path
         );
 
         if (!strlen(res.results[i]->graphics_exec_path)) continue;
         if (is_same_task(res.results[i], exclude)) continue;
-        BOINCTRACE(_T("get_random_graphics_app -- active task detected w/graphics\n"));
+#ifdef __APPLE__
+        // Remove it from the vector if incompatible with current version of OS X
+        if (isIncompatible(res.results[i]->graphics_exec_path)) {
+            BOINCTRACE(
+                _T("count_active_graphic_apps -- removing incompatible name = '%s', path = '%s'\n"),
+                res.results[i]->name, res.results[i]->graphics_exec_path
+            );
+            RESULT *rp = res.results[i];
+            res.results.erase(res.results.begin()+i);
+            delete rp;
+            continue;
+        }
+#endif
+        BOINCTRACE(_T("count_active_graphic_apps -- active task detected w/graphics\n"));
 
         graphics_app_count++;
     }
@@ -161,10 +176,38 @@ CLEANUP:
 }
 
 
+#ifdef __APPLE__
+void CScreensaver::markAsIncompatible(char *gfxAppPath) {
+    char *buf = (char *)malloc(strlen(gfxAppPath)+1);
+    if (buf) {
+        strlcpy(buf, gfxAppPath, malloc_size(buf));
+        m_vIncompatibleGfxApps.push_back(buf);
+       BOINCTRACE(_T("markAsIncompatible -- path = '%s'\n"), gfxAppPath);
+    }
+}
+
+bool CScreensaver::isIncompatible(char *appPath) {
+    unsigned int i = 0;
+    for (i = 0; i < m_vIncompatibleGfxApps.size(); i++) {
+        BOINCTRACE(
+            _T("isIncompatible -- comparing incompatible path '%s' to candidate path %s\n"),
+            m_vIncompatibleGfxApps[i], appPath
+        );
+        if (strcmp(m_vIncompatibleGfxApps[i], appPath) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+#endif
+
+
 // Launch a project (science) graphics application
 //
 int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application) {
     int retval = 0;
+    
     if (strlen(rp->graphics_exec_path)) {
         // V6 Graphics
 #ifdef __APPLE__
@@ -191,6 +234,10 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
             0,
             graphics_application
         );
+
+    if (graphics_application) {
+        launchedGfxApp(rp->graphics_exec_path, graphics_application, rp->slot);
+    }
 #else
         char* argv[3];
         argv[0] = "app_graphics";   // not used
@@ -244,6 +291,10 @@ int CScreensaver::terminate_v6_screensaver(GFXAPP_ID& graphics_application) {
         0,
         thePID
     );
+    
+    if (graphics_application) {
+        launchedGfxApp("", 0, -1);
+    }
     
     for (i=0; i<200; i++) {
         boinc_sleep(0.01);      // Wait 2 seconds max
@@ -321,6 +372,10 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
         0,
         graphics_application
     );
+
+    if (graphics_application) {
+        launchedGfxApp("boincscr", graphics_application, -1);
+    }
 
     BOINCTRACE(_T("launch_default_screensaver returned %d\n"), retval);
     
@@ -427,6 +482,7 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
     m_bShow_default_ss_first = false;
 
 #ifdef __APPLE__
+    m_vIncompatibleGfxApps.clear();
     default_ss_dir_path = "/Library/Application Support/BOINC Data";
 #else
     default_ss_dir_path = (char*)m_strBOINCInstallDirectory.c_str();

--- a/clientscr/screensaver.h
+++ b/clientscr/screensaver.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2017 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -57,6 +57,7 @@ enum SS_PHASE {
 #define SCRAPPERR_CANTLAUNCHDEFAULTGFXAPP                   0x82000014
 #define SCRAPPERR_DEFAULTGFXAPPCANTCONNECT                  0x82000015
 #define SCRAPPERR_DEFAULTGFXAPPCRASHED                      0x82000016
+#define SCRAPPERR_GFXAPPINCOMPATIBLE                        0x82000017
 
 
 #endif

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		DD01B6790C16723C0023A806 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20286C33FDCF999611CA2CEA /* Carbon.framework */; };
 		DD08648D19E0BE6D00994039 /* ProjectWelcomePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD08648B19E0BE6D00994039 /* ProjectWelcomePage.cpp */; };
 		DD0A06F50869A2D2007CD86E /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DD0BB7A21F62B105000151B2 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
 		DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD0C5A8A0816711400CEC5D7 /* boinc.jpg */; };
 		DD0D32DD1E0ABEEE00A0FBAB /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DD11E5B617D1A89700947975 /* MacAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = DD1907FA17D1A2F100596F03 /* MacAccessiblity.mm */; };
@@ -180,6 +181,7 @@
 		DD55AF6D1916248200259439 /* coproc_sched.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD55AF6B1916248200259439 /* coproc_sched.cpp */; };
 		DD5BF77D0D4F3D0C00EDF980 /* mac_icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6381450870DB78007A2F8E /* mac_icon.cpp */; };
 		DD5FE1B517828887003339DF /* translate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF9350F176B0D0C00A2793C /* translate.cpp */; };
+		DD64D8011F6BE5BA00FEEAAA /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
 		DD6617880A3FFD8C00FFEBEB /* check_security.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6617870A3FFD8C00FFEBEB /* check_security.cpp */; };
 		DD67F8140ADB9DD000B0015E /* wxPieCtrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD40E75D0ADB87BC00214518 /* wxPieCtrl.cpp */; };
 		DD6802310E701ACD0067D009 /* cert_sig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD68022E0E701ACD0067D009 /* cert_sig.cpp */; };
@@ -330,8 +332,7 @@
 		DDA1F1EE126D105B005EFFEB /* current_version.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA1F1EC126D105B005EFFEB /* current_version.cpp */; };
 		DDA45500140F7DE200D97676 /* synch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD407AED07D2FE7200163EF5 /* synch.cpp */; };
 		DDA45501140F7E7900D97676 /* reduce_main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD40825807D3076400163EF5 /* reduce_main.cpp */; };
-		DDA674851F1C70C800C95646 /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA674831F1C70C800C95646 /* keyword.cpp */; };
-		DDA674861F1C70C800C95646 /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA674831F1C70C800C95646 /* keyword.cpp */; };
+		DDA5ED9C1F7D0AAE002EADC8 /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
 		DDA6BD120BD4551F008F7921 /* mac_backtrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA6BD040BD4551F008F7921 /* mac_backtrace.cpp */; };
 		DDA6BD130BD4551F008F7921 /* QBacktrace.c in Sources */ = {isa = PBXBuildFile; fileRef = DDA6BD060BD4551F008F7921 /* QBacktrace.c */; };
 		DDA6BD140BD4551F008F7921 /* QCrashReport.c in Sources */ = {isa = PBXBuildFile; fileRef = DDA6BD080BD4551F008F7921 /* QCrashReport.c */; };
@@ -391,6 +392,7 @@
 		DDC55A70136013F800D79903 /* procinfo_mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDB6934F0ABFE9C600689FD8 /* procinfo_mac.cpp */; };
 		DDC82FA31A35BB68005FA808 /* DlgHiddenColumns.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC82FA11A35BB68005FA808 /* DlgHiddenColumns.cpp */; };
 		DDC836E60EDEA5DB001C2EF9 /* TermsOfUsePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC836E50EDEA5DB001C2EF9 /* TermsOfUsePage.cpp */; };
+		DDC8FB2A1F6D393C00BE55B8 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
 		DDC988FE0F3BD44100EE8D0E /* gui_rpc_client_ops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD73E34E08A0694000656EB1 /* gui_rpc_client_ops.cpp */; };
 		DDCF84080E1B7C0A005EDC45 /* DlgItemProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDCF84060E1B7C0A005EDC45 /* DlgItemProperties.cpp */; };
 		DDD0697312D70C9400120920 /* sg_TaskPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD0697112D70C9400120920 /* sg_TaskPanel.cpp */; };
@@ -458,9 +460,6 @@
 		DDDC2055183B560B00CB5845 /* mac_address.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDDC2053183B560B00CB5845 /* mac_address.cpp */; };
 		DDDD6D8012E4611300C258A0 /* sg_ProjectPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDDD6D7E12E4611300C258A0 /* sg_ProjectPanel.cpp */; };
 		DDDE43B10EC04C1800083520 /* DlgExitMessage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDDE43B00EC04C1800083520 /* DlgExitMessage.cpp */; };
-		DDDEDF6F1F2F353B00614748 /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA674831F1C70C800C95646 /* keyword.cpp */; };
-		DDDEDF701F2F354000614748 /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA674831F1C70C800C95646 /* keyword.cpp */; };
-		DDDEDF711F2F354C00614748 /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA674831F1C70C800C95646 /* keyword.cpp */; };
 		DDE1372A10DC5E5300161D6B /* cs_notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372810DC5E5300161D6B /* cs_notice.cpp */; };
 		DDE1372F10DC5E8D00161D6B /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
 		DDE1373210DC5EA400161D6B /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
@@ -489,6 +488,9 @@
 		DDE900251E643DFF003728F2 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DDE900261E643E39003728F2 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
 		DDE900271E643E3C003728F2 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
+		DDEEAA991F73D3D70051E8C5 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
+		DDEEAA9A1F73E8630051E8C5 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
+		DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
 		DDF5E23318B8673E005DEA6E /* uninstall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4688590C1661970089F500 /* uninstall.cpp */; };
 		DDF5E23418B86803005DEA6E /* AddRemoveUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD33709106224E800867C7D /* AddRemoveUser.cpp */; };
 		DDF5F85A10DD05DB006A50CD /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
@@ -748,6 +750,7 @@
 		DD04BE1A0EDD836A006D5603 /* TermsOfUsePage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TermsOfUsePage.h; path = ../clientgui/TermsOfUsePage.h; sourceTree = SOURCE_ROOT; };
 		DD08648B19E0BE6D00994039 /* ProjectWelcomePage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProjectWelcomePage.cpp; sourceTree = "<group>"; };
 		DD08648C19E0BE6D00994039 /* ProjectWelcomePage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProjectWelcomePage.h; sourceTree = "<group>"; };
+		DD0BB7A11F62B105000151B2 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = /System/Library/Frameworks/IOSurface.framework; sourceTree = "<absolute>"; };
 		DD0C5A8A0816711400CEC5D7 /* boinc.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; name = boinc.jpg; path = ../clientscr/res/boinc.jpg; sourceTree = SOURCE_ROOT; };
 		DD1277B3081F3D67007B5DE1 /* PostInstall.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PostInstall.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD1277B5081F3D67007B5DE1 /* PostInstall-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PostInstall-Info.plist"; sourceTree = "<group>"; };
@@ -900,6 +903,7 @@
 		DD5EF08807C5B7C7007CCE8D /* version.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = version.h; path = ../version.h; sourceTree = SOURCE_ROOT; };
 		DD6381450870DB78007A2F8E /* mac_icon.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = mac_icon.cpp; sourceTree = "<group>"; };
 		DD6381F80870DD83007A2F8E /* make_app_icon_h.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = make_app_icon_h.cpp; sourceTree = "<group>"; };
+		DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.mig; path = MultiGPUMig.defs; sourceTree = "<group>"; };
 		DD64DF0409DCC5E000668B3A /* gutil_text.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = gutil_text.cpp; sourceTree = "<group>"; };
 		DD64E7D507D89DB800B176C8 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		DD6617870A3FFD8C00FFEBEB /* check_security.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = check_security.cpp; sourceTree = "<group>"; };
@@ -1061,8 +1065,6 @@
 		DDA1F1ED126D105B005EFFEB /* current_version.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = current_version.h; path = ../client/current_version.h; sourceTree = SOURCE_ROOT; };
 		DDA290360CB5D80E00512BD8 /* Mac_Saver_Module.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = Mac_Saver_Module.h; path = ../clientscr/Mac_Saver_Module.h; sourceTree = SOURCE_ROOT; };
 		DDA45502140F85DD00D97676 /* str_replace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = str_replace.h; sourceTree = "<group>"; };
-		DDA674831F1C70C800C95646 /* keyword.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = keyword.cpp; sourceTree = "<group>"; };
-		DDA674841F1C70C800C95646 /* keyword.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = keyword.h; sourceTree = "<group>"; };
 		DDA6BD030BD4551F008F7921 /* dyld_gdb.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = dyld_gdb.h; path = ../lib/mac/dyld_gdb.h; sourceTree = SOURCE_ROOT; };
 		DDA6BD040BD4551F008F7921 /* mac_backtrace.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = mac_backtrace.cpp; path = ../lib/mac/mac_backtrace.cpp; sourceTree = SOURCE_ROOT; };
 		DDA6BD050BD4551F008F7921 /* mac_backtrace.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = mac_backtrace.h; path = ../lib/mac/mac_backtrace.h; sourceTree = SOURCE_ROOT; };
@@ -1175,6 +1177,7 @@
 		DDF9350F176B0D0C00A2793C /* translate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = translate.cpp; path = ../lib/translate.cpp; sourceTree = "<group>"; };
 		DDF93510176B0D0C00A2793C /* translate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = translate.h; path = ../lib/translate.h; sourceTree = "<group>"; };
 		DDF9385407E28906004DC076 /* checkin_notes */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; name = checkin_notes; path = ../checkin_notes; sourceTree = SOURCE_ROOT; };
+		DDF9B4D01F680006008BC9B7 /* x_opengl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x_opengl.h; sourceTree = "<group>"; };
 		DDF9EC03144EB14B005D6144 /* libboinc_opencl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboinc_opencl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF9EC08144EB2BB005D6144 /* boinc_opencl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = boinc_opencl.cpp; sourceTree = "<group>"; };
 		DDF9EC09144EB2BB005D6144 /* boinc_opencl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boinc_opencl.h; sourceTree = "<group>"; };
@@ -1311,6 +1314,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD0BB7A21F62B105000151B2 /* IOSurface.framework in Frameworks */,
 				DD89165A0F3B1B9000DE5B1C /* AppKit.framework in Frameworks */,
 				DD89165F0F3B1BC200DE5B1C /* GLUT.framework in Frameworks */,
 				DD8916600F3B1BC200DE5B1C /* OpenGL.framework in Frameworks */,
@@ -1322,7 +1326,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD130E740820C422001A0291 /* ScreenSaver.framework in Frameworks */,
+				DDEEAA9A1F73E8630051E8C5 /* IOSurface.framework in Frameworks */,
 				DDB6E3EF0D5B27AA00ED12B8 /* Carbon.framework in Frameworks */,
+				DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */,
 				DDB74A6C0D74259E00E97A40 /* AppKit.framework in Frameworks */,
 				DDD93E7313E017B600B92D0F /* IOKit.framework in Frameworks */,
 			);
@@ -1474,6 +1480,7 @@
 				DD9E560E182D0D40002AF0F8 /* WebKit.framework */,
 				DD89165D0F3B1BC200DE5B1C /* GLUT.framework */,
 				DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */,
+				DD0BB7A11F62B105000151B2 /* IOSurface.framework */,
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = SOURCE_ROOT;
@@ -1522,6 +1529,7 @@
 				DDC3D55D0D507D1700BE6D23 /* BOINCClientManager.h */,
 				DD8DD4A509D9432F0043019E /* BOINCDialupManager.cpp */,
 				DD8DD4A609D9432F0043019E /* BOINCDialupManager.h */,
+				DD81C40507C5D1020098A04D /* BOINCGUIApp.cpp */,
 				DD81C43B07C5D2240098A04D /* BOINCGUIApp.h */,
 				DD81C40407C5D1020098A04D /* BOINCListCtrl.cpp */,
 				DD81C43A07C5D2240098A04D /* BOINCListCtrl.h */,
@@ -1808,8 +1816,6 @@
 				DD81C60307C5D8630098A04D /* gui_rpc_client.h */,
 				DD344BB607C5AEEE0043025C /* hostinfo.cpp */,
 				DD344BB707C5AEEE0043025C /* hostinfo.h */,
-				DDA674831F1C70C800C95646 /* keyword.cpp */,
-				DDA674841F1C70C800C95646 /* keyword.h */,
 				DDA6BCED0BD4546D008F7921 /* mac */,
 				F5159562029EB02001F5651B /* md5.cpp */,
 				F5159563029EB02001F5651B /* md5.h */,
@@ -1977,9 +1983,11 @@
 				DD6D82DA08131AB1008F7200 /* macglutfix.m */,
 				DD6381450870DB78007A2F8E /* mac_icon.cpp */,
 				DD6381F80870DD83007A2F8E /* make_app_icon_h.cpp */,
+				DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */,
 				DD40825707D3076400163EF5 /* reduce_lib.cpp */,
 				DD40825807D3076400163EF5 /* reduce_main.cpp */,
 				DD40825907D3076400163EF5 /* reduce.h */,
+				DDF9B4D01F680006008BC9B7 /* x_opengl.h */,
 			);
 			name = api;
 			path = ../api;
@@ -2001,7 +2009,6 @@
 				DD7748B40A356D6C0025D05E /* SetupSecurity.cpp */,
 				DDA12A910A369AB500FBDD12 /* SetupSecurity.h */,
 				DDAEC9E707FA58A000A7BC36 /* SetVersion.cpp */,
-				DD81C40507C5D1020098A04D /* BOINCGUIApp.cpp */,
 			);
 			name = mac;
 			sourceTree = SOURCE_ROOT;
@@ -2191,6 +2198,7 @@
 			buildPhases = (
 				DD89161D0F3B17E900DE5B1C /* Sources */,
 				DD89161F0F3B17E900DE5B1C /* Frameworks */,
+				DDC8FB2B1F6D398700BE55B8 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -2246,6 +2254,7 @@
 				DDB873EA0C850BC800E0DE1F /* Sources */,
 				DDB873F80C850BC800E0DE1F /* Frameworks */,
 				DD5E20A7140CE808000FADAA /* Run Script */,
+				DDC8FB2C1F6D39B800BE55B8 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -2681,6 +2690,32 @@
 			shellPath = /bin/sh;
 			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n\"${BUILT_PRODUCTS_DIR}/SetVersion\"\n";
 		};
+		DDC8FB2B1F6D398700BE55B8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" -nt \"${SRCROOT}/../api/MultiGPUMig.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" \"${SRCROOT}/../api/MultiGPUMig.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" \"${SRCROOT}/../api/MultiGPUMigServer.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" \"${SRCROOT}/../api/MultiGPUMigServer.c\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" -nt \"${SRCROOT}/../api/MultiGPUMigUser.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" \"${SRCROOT}/../api/MultiGPUMigUser.c\"\nfi\n";
+		};
+		DDC8FB2C1F6D39B800BE55B8 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" -nt \"${SRCROOT}/../api/MultiGPUMig.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" \"${SRCROOT}/../api/MultiGPUMig.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" \"${SRCROOT}/../api/MultiGPUMigServer.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" \"${SRCROOT}/../api/MultiGPUMigServer.c\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" -nt \"${SRCROOT}/../api/MultiGPUMigUser.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" \"${SRCROOT}/../api/MultiGPUMigUser.c\"\nfi\n";
+		};
 		DDD336F91062235D00867C7D /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2849,7 +2884,6 @@
 				DDD52DCE0C03CAE6009B5FC0 /* ViewWork.cpp in Sources */,
 				DDC3D55E0D507D1700BE6D23 /* BOINCClientManager.cpp in Sources */,
 				DDCF84080E1B7C0A005EDC45 /* DlgItemProperties.cpp in Sources */,
-				DDDEDF711F2F354C00614748 /* keyword.cpp in Sources */,
 				DDC132F30E2DAB1B0014D305 /* AsyncRPC.cpp in Sources */,
 				DDDE43B10EC04C1800083520 /* DlgExitMessage.cpp in Sources */,
 				DDC836E60EDEA5DB001C2EF9 /* TermsOfUsePage.cpp in Sources */,
@@ -2896,7 +2930,6 @@
 				DD52C81108B5D44D008D9AA4 /* gui_rpc_client.cpp in Sources */,
 				DD52C81208B5D44E008D9AA4 /* gui_rpc_client_ops.cpp in Sources */,
 				DD52C81308B5D44F008D9AA4 /* gui_rpc_client_print.cpp in Sources */,
-				DDA674861F1C70C800C95646 /* keyword.cpp in Sources */,
 				DD407A5807D2FB8D00163EF5 /* hostinfo.cpp in Sources */,
 				DD407A5B07D2FBA000163EF5 /* md5.cpp in Sources */,
 				DD407A5D07D2FBA300163EF5 /* md5_file.cpp in Sources */,
@@ -3030,6 +3063,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDC8FB2A1F6D393C00BE55B8 /* MultiGPUMig.defs in Sources */,
 				DD89163D0F3B182700DE5B1C /* ss_app.cpp in Sources */,
 				DD8916950F3B1BFF00DE5B1C /* mac_backtrace.cpp in Sources */,
 				DD8916960F3B1C0000DE5B1C /* QBacktrace.c in Sources */,
@@ -3043,7 +3077,6 @@
 				DD8917A30F3B207800DE5B1C /* diagnostics.cpp in Sources */,
 				DD8917A50F3B207E00DE5B1C /* filesys.cpp in Sources */,
 				DD8917A70F3B208500DE5B1C /* gui_rpc_client.cpp in Sources */,
-				DDDEDF701F2F354000614748 /* keyword.cpp in Sources */,
 				DD8917AB0F3B209500DE5B1C /* hostinfo.cpp in Sources */,
 				DD8917AE0F3B20B100DE5B1C /* md5.cpp in Sources */,
 				DD8917B00F3B20B500DE5B1C /* md5_file.cpp in Sources */,
@@ -3081,14 +3114,15 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDEEAA991F73D3D70051E8C5 /* MultiGPUMig.defs in Sources */,
 				DD9917271E69A8D100555337 /* mac_spawn.cpp in Sources */,
-				DDDEDF6F1F2F353B00614748 /* keyword.cpp in Sources */,
 				DDFD5F0F0818F2EE002B23D4 /* gui_rpc_client.cpp in Sources */,
 				DDE900261E643E39003728F2 /* mac_util.mm in Sources */,
 				DD73E3B608A07FC600656EB1 /* gui_rpc_client_ops.cpp in Sources */,
 				DDFD5F270818F329002B23D4 /* filesys.cpp in Sources */,
 				DD73E3A708A07CA600656EB1 /* hostinfo.cpp in Sources */,
 				DDFD5F280818F33C002B23D4 /* md5.cpp in Sources */,
+				DDA5ED9C1F7D0AAE002EADC8 /* app_ipc.cpp in Sources */,
 				DDFD5F290818F346002B23D4 /* md5_file.cpp in Sources */,
 				DDFD5F2A0818F34F002B23D4 /* mfile.cpp in Sources */,
 				DDFD5F2B0818F359002B23D4 /* miofile.cpp in Sources */,
@@ -3122,6 +3156,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD64D8011F6BE5BA00FEEAAA /* MultiGPUMig.defs in Sources */,
 				DDB874470C850D3000E0DE1F /* graphics2_unix.cpp in Sources */,
 				DDB874480C850D3000E0DE1F /* graphics2.cpp in Sources */,
 				DDB873F40C850BC800E0DE1F /* gutil_text.cpp in Sources */,
@@ -3256,7 +3291,6 @@
 				DD3157C316740D5300B6C909 /* gpu_intel.cpp in Sources */,
 				DD30CACF1C6B3C7F00AE1D14 /* project_init.cpp in Sources */,
 				DD76BF9517CB45D20075936D /* opencl_boinc.cpp in Sources */,
-				DDA674851F1C70C800C95646 /* keyword.cpp in Sources */,
 				DD6A829C181103990037172D /* thread.cpp in Sources */,
 				DDDC2055183B560B00CB5845 /* mac_address.cpp in Sources */,
 				DD55AF6D1916248200259439 /* coproc_sched.cpp in Sources */,
@@ -3686,6 +3720,7 @@
 		DD8916210F3B17E900DE5B1C /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				HEADER_SEARCH_PATHS = (
 					../api/,
 					../samples/jpeglib/,

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -277,6 +277,11 @@
 		DD81C820144D900B000BE61A /* rdrle.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7DE144D900B000BE61A /* rdrle.c */; };
 		DD81C821144D900B000BE61A /* rdswitch.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7DF144D900B000BE61A /* rdswitch.c */; };
 		DD81C822144D900B000BE61A /* rdtarga.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7E0144D900B000BE61A /* rdtarga.c */; };
+		DD82D83C1F831E0500EEC6AD /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD82D83A1F831E0500EEC6AD /* keyword.cpp */; };
+		DD82D83D1F831E0500EEC6AD /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD82D83A1F831E0500EEC6AD /* keyword.cpp */; };
+		DD82D83E1F831E0500EEC6AD /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD82D83A1F831E0500EEC6AD /* keyword.cpp */; };
+		DD82D83F1F831E0500EEC6AD /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD82D83A1F831E0500EEC6AD /* keyword.cpp */; };
+		DD82D8401F831E0500EEC6AD /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD82D83A1F831E0500EEC6AD /* keyword.cpp */; };
 		DD83028D1E07F87400B53CAC /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
 		DD85AE4B0F5D284D0031F7AC /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1929D80918A2F100C31BCF /* Security.framework */; };
 		DD867B7510DCE77700128AB4 /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
@@ -1041,6 +1046,8 @@
 		DD81C7DE144D900B000BE61A /* rdrle.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rdrle.c; path = ../samples/jpeglib/rdrle.c; sourceTree = "<group>"; };
 		DD81C7DF144D900B000BE61A /* rdswitch.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rdswitch.c; path = ../samples/jpeglib/rdswitch.c; sourceTree = "<group>"; };
 		DD81C7E0144D900B000BE61A /* rdtarga.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = rdtarga.c; path = ../samples/jpeglib/rdtarga.c; sourceTree = "<group>"; };
+		DD82D83A1F831E0500EEC6AD /* keyword.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = keyword.cpp; sourceTree = "<group>"; };
+		DD82D83B1F831E0500EEC6AD /* keyword.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = keyword.h; sourceTree = "<group>"; };
 		DD8916280F3B17E900DE5B1C /* boincscr */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = boincscr; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD89163B0F3B182700DE5B1C /* boinc_ss_opengl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = boinc_ss_opengl.h; path = ../clientscr/boinc_ss_opengl.h; sourceTree = SOURCE_ROOT; };
 		DD89163C0F3B182700DE5B1C /* ss_app.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ss_app.cpp; path = ../clientscr/ss_app.cpp; sourceTree = SOURCE_ROOT; };
@@ -1816,6 +1823,8 @@
 				DD81C60307C5D8630098A04D /* gui_rpc_client.h */,
 				DD344BB607C5AEEE0043025C /* hostinfo.cpp */,
 				DD344BB707C5AEEE0043025C /* hostinfo.h */,
+				DD82D83A1F831E0500EEC6AD /* keyword.cpp */,
+				DD82D83B1F831E0500EEC6AD /* keyword.h */,
 				DDA6BCED0BD4546D008F7921 /* mac */,
 				F5159562029EB02001F5651B /* md5.cpp */,
 				F5159563029EB02001F5651B /* md5.h */,
@@ -2884,6 +2893,7 @@
 				DDD52DCE0C03CAE6009B5FC0 /* ViewWork.cpp in Sources */,
 				DDC3D55E0D507D1700BE6D23 /* BOINCClientManager.cpp in Sources */,
 				DDCF84080E1B7C0A005EDC45 /* DlgItemProperties.cpp in Sources */,
+				DD82D83F1F831E0500EEC6AD /* keyword.cpp in Sources */,
 				DDC132F30E2DAB1B0014D305 /* AsyncRPC.cpp in Sources */,
 				DDDE43B10EC04C1800083520 /* DlgExitMessage.cpp in Sources */,
 				DDC836E60EDEA5DB001C2EF9 /* TermsOfUsePage.cpp in Sources */,
@@ -2930,6 +2940,7 @@
 				DD52C81108B5D44D008D9AA4 /* gui_rpc_client.cpp in Sources */,
 				DD52C81208B5D44E008D9AA4 /* gui_rpc_client_ops.cpp in Sources */,
 				DD52C81308B5D44F008D9AA4 /* gui_rpc_client_print.cpp in Sources */,
+				DD82D83D1F831E0500EEC6AD /* keyword.cpp in Sources */,
 				DD407A5807D2FB8D00163EF5 /* hostinfo.cpp in Sources */,
 				DD407A5B07D2FBA000163EF5 /* md5.cpp in Sources */,
 				DD407A5D07D2FBA300163EF5 /* md5_file.cpp in Sources */,
@@ -3107,6 +3118,7 @@
 				DDB4A9201411871200032E5D /* proc_control.cpp in Sources */,
 				DDE7A3B115C6739E002B3B96 /* ttfont.cpp in Sources */,
 				DD76BF9917CB46610075936D /* opencl_boinc.cpp in Sources */,
+				DD82D8401F831E0500EEC6AD /* keyword.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3115,6 +3127,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDEEAA991F73D3D70051E8C5 /* MultiGPUMig.defs in Sources */,
+				DD82D83E1F831E0500EEC6AD /* keyword.cpp in Sources */,
 				DD9917271E69A8D100555337 /* mac_spawn.cpp in Sources */,
 				DDFD5F0F0818F2EE002B23D4 /* gui_rpc_client.cpp in Sources */,
 				DDE900261E643E39003728F2 /* mac_util.mm in Sources */,
@@ -3291,6 +3304,7 @@
 				DD3157C316740D5300B6C909 /* gpu_intel.cpp in Sources */,
 				DD30CACF1C6B3C7F00AE1D14 /* project_init.cpp in Sources */,
 				DD76BF9517CB45D20075936D /* opencl_boinc.cpp in Sources */,
+				DD82D83C1F831E0500EEC6AD /* keyword.cpp in Sources */,
 				DD6A829C181103990037172D /* thread.cpp in Sources */,
 				DDDC2055183B560B00CB5845 /* mac_address.cpp in Sources */,
 				DD55AF6D1916248200259439 /* coproc_sched.cpp in Sources */,


### PR DESCRIPTION
BOINC screensavers have 2 parts. The BOINC "screensaver coordinator" is an actual "native" screensaver for MS Windows (boinc.scr) or Macintosh (BOINCSaver.saver). It communicates with the BOINC client via RPCs to determine which project applications (tasks) are currently running, and which of those have associated graphics executables. Depending on the user's screensaver preference settings, it cycles through the running tasks, launching one of the associated graphics executables at a time. The graphics executables usually communicate with their associated worker app to display information about the work being done by that task.

In addition to being run by the BOINC screensaver coordinator, users can run the graphics executables from the BOINC Manager via the "Show graphics" button when they select a graphics-capable running task.

When no active tasks with associated graphics are running, BOINC's screensaver coordinator launches BOINC's default graphics executable (boincscr). Depending on the user's screensaver preference settings, it may also intersperse displaying boincscr with project application graphics.

On MS Windows, and also on Macs prior to OS 10.13, the graphics executables display their windows over the screensaver coordinator's window, giving the appearance that they are part of the native screensaver. But Mac OS 10.13 has changes which prevent any application from covering the native screensaver's window.

I designed the changes in this PR with several main goals:

 * Minimize the effort required for projects to update their graphics executables.

 * Use the same logic and methodology as before for displaying updated graphics executables on MS Windows and on Macs running versions of OS X prior to OS 10.13 (backward compatibility.)

 * Use the same logic and methodology as before for displaying graphics executables via BOINC Manager's "Show graphics" button, whether or not the graphics executable has been updated, and on any version of OS X we currently support (OS 10.6 - OS 10.13) (backward compatibility).

 * On Mac OS 10.13, give the user an explanation of why graphics executables that have not yet been updated don't appear in the screensaver, and move on as quickly and efficiently as possible to ones that can be displayed.

The fix for this problem on OS 10.13 involves establishing communication between the screensaver coordinator and the graphics executable via Mach-O inter-process communication. It also takes advantage of a feature available in OS X called IOSurfaceBuffer. IOSurfaceBuffer allows OpenGL applications to share images with another process, while continuing to take advantage of the rendering acceleration provided by the GPU. We can use this approach because BOINC graphics executables built with the standard BOINC graphics libraries use OpenGL.

To update their graphics executables, projects simply need to follow these 3 steps:
[1] Rebuild the BOINC graphics library for the Mac (libboinc_graphics2.a) from the sources in this PR
[2] Relink the executable with the updated library
[3] Distribute the updated executable to BOINC clients

Here are a few more details about updating graphics executables:

The graphics library (libboinc_graphics2.a) is built as target gfx2libboinc in the Xcode project.

Do not be concerned if you see errors that any of these are missing, as they will be built by Xcode before they are needed: MultiGPUMig.h, MultiGPUMigServer.c, MultiGPUMigServer.h or MultiGPUMigUser.c.

It is easiest to build libboinc_graphics2.a using Xcode. The following commands in the Mac's Terminal app (/Applications/Utilities/Terminal) will build all the BOINC libraries:
  $ cd {path to boinc sources}/mac_build/
  $ source BuildMacBOINC.sh -lib
For more information and additional options, see section [6] of the file "mac_build/HowToBuildBOINC_XCode.rtf" from the GIT repository.

If you must build libboinc_graphics2.a using a make file, you must modify the make file to first compile api/MultiGPUMig.defs, which will create the files MultiGPUMig.h, MultiGPUMigServer.c, MultiGPUMigServer.h and MultiGPUMigUser.c. 

If you use Xcode to build your graphics app, you must add IOSurface.framework to the list of "External Frameworks and Libraries" in your project. If you build your graphics app using the command line (for example, with cc and ld), you must also add "-framework IOSurface" to your linker flags (LDFLAGS).
