### PR TITLE
[WIP] Handle missing gfx file

### DIFF
--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -896,10 +896,17 @@ void CViewWork::UpdateSelection() {
 
         // Disable Show Graphics button if the selected task can't display graphics
         //
-        if (!strlen(result->web_graphics_url) && !strlen(result->graphics_exec_path)) {
-            enableShowGraphics = false;
+        if (!strlen(result->web_graphics_url)) {
+            if(!strlen(result->graphics_exec_path)) {
+                enableShowGraphics = false;
+            } else {
+                if (!boinc_file_exists(result->graphics_exec_path)) {
+                    // graphics executable is missing (does not exist)
+                    enableShowGraphics = false;
+                }
+            }
         }
-
+        
         if (result->suspended_via_gui ||
             result->project_suspended_via_gui || 
             (result->scheduler_state != CPU_SCHED_SCHEDULED)

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -100,6 +100,17 @@ int CScreensaver::count_active_graphic_apps(RESULTS& res, RESULT* exclude) {
 
         if (!strlen(res.results[i]->graphics_exec_path)) continue;
         if (is_same_task(res.results[i], exclude)) continue;
+        if (!boinc_file_exists(res.results[i]->graphics_exec_path)) {
+            // Remove it from the vector if graphics executable is missing (does not exist)
+            BOINCTRACE(
+                _T("count_active_graphic_apps -- removing missing GFX app name = '%s', path = '%s'\n"),
+                res.results[i]->name, res.results[i]->graphics_exec_path
+            );
+            RESULT *rp = res.results[i];
+            res.results.erase(res.results.begin()+i);
+            delete rp;
+            continue;
+        }
 #ifdef __APPLE__
         // Remove it from the vector if incompatible with current version of OS X
         if (isIncompatible(res.results[i]->graphics_exec_path)) {


### PR DESCRIPTION
The BOINC Manager and Screensaver Coordinator do not correctly handle the rare case when there is a project graphics executable associated with a worker executable but the is graphics executable is missing from the project directory. 

If a task with this situation is selected in the Tasks tab of the Manager, the "Show graphics" button is enabled, but pressing it does nothing.

If a task with this situation is running, the Screensaver Coordinator tries to run it, but quickly determines that it is not running and then goes on to the next task with associated graphics. But if all running tasks are associated with the missing graphics executable, then it will continuously cycle through them, constantly displaying "BOINC screensaver loading" on MS Windows or "Starting screensaver graphics.\nPlease wait ..." on Macintosh.

The changes in this PR test that the graphics executable file actually exists. If not, the Manager does not enable the "Show graphics" button, and the Screensaver Coordinator does not include  it in its list of graphics executables that can be run.