### PR TITLE
client: fix bug in set_app_config GUI RPC

### DIFF
--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -596,10 +596,10 @@ int main(int argc, char** argv) {
         strcpy(a.name, "uppercase");
         a.max_concurrent = 2;
         ac.app_configs.push_back(a);
-        retval = rpc.set_app_config(argv[2], ac);
+        retval = rpc.set_app_config(next_arg(argc, argv, i), ac);
     } else if (!strcmp(cmd, "--get_app_config")) {
         APP_CONFIGS ac;
-        retval = rpc.get_app_config(argv[2], ac);
+        retval = rpc.get_app_config(next_arg(argc, argv, i), ac);
         if (!retval) {
             MIOFILE mf;
             mf.init_file(stdout);

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1113,7 +1113,9 @@ static void handle_get_app_config(GUI_RPC_CONN& grc) {
     sprintf(path, "%s/%s", p->project_dir(), APP_CONFIG_FILE_NAME);
     printf("path: %s\n", path);
     int retval = read_file_string(path, s);
-    if (!retval) {
+    if (retval) {
+        grc.mfout.printf("<error>app_config.xml not found</error>\n");
+    } else {
         strip_whitespace(s);
         grc.mfout.printf("%s\n", s.c_str());
     }
@@ -1171,7 +1173,7 @@ static void handle_set_app_config(GUI_RPC_CONN& grc) {
     }
     char path[MAXPATHLEN];
     sprintf(path, "%s/app_config.xml", p->project_dir());
-    FILE* f = fopen(path, "w");
+    FILE* f = boinc_fopen(path, "w");
     if (!f) {
         msg_printf(p, MSG_INTERNAL_ERROR,
             "Can't open app config file %s", path
@@ -1183,6 +1185,7 @@ static void handle_set_app_config(GUI_RPC_CONN& grc) {
     MIOFILE mf;
     mf.init_file(f);
     ac.write(mf);
+    fclose(f);
     grc.mfout.printf("<success/>\n");
 }
 


### PR DESCRIPTION
forgot to fclose().
Also have get_app_config() return error if no file.
Probably should do this for other get-file RPCs as well.