### PR TITLE
appveyor.yml: remove 'build' section due to changes after Appveyor up…

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,4 @@ before_build:
 build_script:
   - devenv %solution_name% /Build "%configuration%|%platform%"
 
-build:
-  parallel: true
-  verbosity: minimal
-
 test: off


### PR DESCRIPTION
…date

Fix for #2178: AppVeyor worker image update has broken BOINC Windows build

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>