### PR TITLE
Manager: update Xcode project and scripts for wxWidgets 3.1.0 because…

### DIFF
--- a/3rdParty/buildMacDependencies.sh
+++ b/3rdParty/buildMacDependencies.sh
@@ -116,6 +116,14 @@ download_and_build() {
             # already built but not for correct architectures so force rebuild
             doClean="-clean"
         fi
+    else
+        # tell subsequent scripts to build everything from scratch
+        doClean="-clean"
+        # delete any FILEFLAGS for other versions of this library built previously
+        BASENAME="${DIRNAME%-*}"
+        rm -f "${PREFIX}/${BASENAME}"*
+        # delete any previous build of this library (may be redundant with -clean)
+        rm -f "${PREFIX}/lib/${PRODUCTNAME}"
     fi
     if [ ! -d ${DIRNAME} ]; then
         if [ ! -e ${FILENAME} ]; then

--- a/3rdParty/buildMacDependencies.sh
+++ b/3rdParty/buildMacDependencies.sh
@@ -148,9 +148,6 @@ if [ "${doclean}" = "yes" ]; then
     mkdir -p "${PREFIX}"
 fi
 
-# TEMPORARY CODE TO REMOVE INCORRECT FLAGFILE FROM EARLIER BUGGY SCRIPT
-rm -f "${PREFIX}/wxWidgets-3.1.0_done"
-
 # this will pull in the variables used below
 source "${ROOTDIR}/mac_build/dependencyNames.sh"
 

--- a/3rdParty/buildMacDependencies.sh
+++ b/3rdParty/buildMacDependencies.sh
@@ -148,6 +148,9 @@ if [ "${doclean}" = "yes" ]; then
     mkdir -p "${PREFIX}"
 fi
 
+# TEMPORARY CODE TO REMOVE INCORRECT FLAGFILE FROM EARLIER BUGGY SCRIPT
+rm -f "${PREFIX}/wxWidgets-3.1.0_done"
+
 # this will pull in the variables used below
 source "${ROOTDIR}/mac_build/dependencyNames.sh"
 

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -2385,7 +2385,7 @@
 			attributes = {
 				LastUpgradeCheck = 0620;
 			};
-			buildConfigurationList = DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc" */;
+			buildConfigurationList = DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc_wx310" */;
 			compatibilityVersion = "Xcode 3.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
@@ -3547,13 +3547,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ../clientgui/mac/MacGUI.pch;
 				HEADER_SEARCH_PATHS = (
-					"../../wxWidgets-3.0.0/include",
-					"../../wxWidgets-3.0.0/build/osx/setup/cocoa/include",
+					"../../wxWidgets-3.1.0/include",
+					"../../wxWidgets-3.1.0/build/osx/setup/cocoa/include",
 					../clientgui,
 				);
 				INFOPLIST_FILE = Info.plist;
 				LIBRARY_SEARCH_PATHS = (
-					"../../wxWidgets-3.0.0/build/osx/build/Debug",
+					"../../wxWidgets-3.1.0/build/osx/build/Debug",
 					"../../sqlite-autoconf-3110000/.libs/",
 				);
 				OTHER_CFLAGS = (
@@ -3566,6 +3566,7 @@
 					"-D__WXMAC__",
 					"-D_DEBUG",
 					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1060",
+					"-DwxADJUST_MINSIZE=0",
 				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -3601,13 +3602,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ../clientgui/mac/MacGUI.pch;
 				HEADER_SEARCH_PATHS = (
-					"../../wxWidgets-3.0.0/include",
-					"../../wxWidgets-3.0.0/build/osx/setup/cocoa/include",
+					"../../wxWidgets-3.1.0/include",
+					"../../wxWidgets-3.1.0/build/osx/setup/cocoa/include",
 					../clientgui,
 				);
 				INFOPLIST_FILE = Info.plist;
 				LIBRARY_SEARCH_PATHS = (
-					"../../wxWidgets-3.0.0/build/osx/build/Release",
+					"../../wxWidgets-3.1.0/build/osx/build/Release",
 					"../../sqlite-autoconf-3110000/.libs/",
 				);
 				OTHER_CFLAGS = (
@@ -3622,6 +3623,7 @@
 					"-D_NDEBUG",
 					"-DBUILDING_MANAGER",
 					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1060",
+					"-DwxADJUST_MINSIZE=0",
 				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
 				OTHER_LDFLAGS = (
@@ -4405,7 +4407,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Development;
 		};
-		DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc" */ = {
+		DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc_wx310" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DD9E2382091CBDAE0048316E /* Development */,

--- a/mac_build/buildWxMac.sh
+++ b/mac_build/buildWxMac.sh
@@ -18,7 +18,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Script to build the wxMac-3.0.0 wxCocoa library for BOINC
+# Script to build the wxMac-3.1.0 wxCocoa library for BOINC
 #
 # by Charlie Fenton    7/21/06
 # Updated for wx-Mac 2.8.10 and Unicode 4/17/09
@@ -33,11 +33,12 @@
 # Fix wxListCtrl flicker when resizing columns in wxCocoa 3.0.0 6/13/14
 # Revise fix for wxListCtrl flicker to match the fix in wxWidgets trunk 6/19/14
 # Build 64-bit library (temporarily build both 32-bit and 64-bit libraries) 10/22/17
+# Update for wxCocoa 3.1.0 10/25/17
 #
 ## This script requires OS 10.6 or later
 ##
-## In Terminal, CD to the wxWidgets-3.0.0 directory.
-##    cd [path]/wxWidgets-3.0.0/
+## In Terminal, CD to the wxWidgets-3.1.0 directory.
+##    cd [path]/wxWidgets-3.1.0/
 ## then run this script:
 ##    source [ path_to_this_script ] [ -clean ] [ -nodebug ] [--prefix PATH]
 ##
@@ -63,12 +64,12 @@ fi
 
 echo ""
 
-# Patch wxWidgets-3.0.0/src/png/pngstruct.h
+# Patch wxWidgets-3.1.0/src/png/pngstruct.h
 if [ ! -f src/png/pngstruct.h.orig ]; then
     cat >> /tmp/pngstruct_h_diff << ENDOFFILE
 --- pngstruct.h	2013-11-11 05:10:39.000000000 -0800
 +++ pngstruct_patched.h	2014-02-18 01:31:53.000000000 -0800
-@@ -34,6 +34,13 @@
+@@ -33,6 +33,13 @@
  #  undef const
  #endif
 
@@ -100,9 +101,9 @@ if [ ! -f build/osx/setup/cocoa/include/wx/setup.h.orig ]; then
     cd ../.. || return 1
 
     cat >> /tmp/setup_h_diff << ENDOFFILE
---- setup.h	2014-02-18 05:17:45.000000000 -0800
-+++ setup_patched.h	2014-02-18 05:19:50.000000000 -0800
-@@ -339,7 +339,10 @@
+--- setup.h    2017-10-25 02:22:00.000000000 -0700
++++ setup_patched.h    2017-10-25 02:32:21.000000000 -0700
+@@ -343,7 +343,10 @@
  // Recommended setting: 1 if you use the standard streams anyhow and so
  //                      dependency on the standard streams library is not a
  //                      problem
@@ -114,33 +115,20 @@ if [ ! -f build/osx/setup/cocoa/include/wx/setup.h.orig ]; then
 
  // Enable minimal interoperability with the standard C++ string class if 1.
  // "Minimal" means that wxString can be constructed from std::string or
+@@ -668,7 +671,7 @@
+ // Default is 1.
+ //
+ // Recommended setting: 1
+-#define wxUSE_MEDIACTRL     1
++#define wxUSE_MEDIACTRL     0   // 1
+
+ // Use wxWidget's XRC XML-based resource system.  Recommended.
+ //
 ENDOFFILE
     patch -bfi /tmp/setup_h_diff build/osx/setup/cocoa/include/wx/setup.h
     rm -f /tmp/setup_h_diff
 else
     echo "build/osx/setup/cocoa/include/wx/setup.h already patched"
-fi
-
-echo ""
-
-# Patch wxWidgets-3.0.0/src/osx/carbon/dcclient.cpp to eliminate flicker when resizing columns
-if [ ! -f src/osx/carbon/dcclient.cpp.orig ]; then
-    cat >> /tmp/listctrl_cpp_diff << ENDOFFILE
---- src/osx/carbon/dcclient.cpp	2014-06-12 22:15:31.000000000 -0700
-+++ src/osx/carbon/dcclient-patched.cpp 2014-06-19 01:04:58.000000000 -0700
-@@ -174,7 +174,7 @@
-
- wxClientDCImpl::~wxClientDCImpl()
- {
--    if( GetGraphicsContext() && GetGraphicsContext()->GetNativeContext() )
-+if( GetGraphicsContext() && GetGraphicsContext()->GetNativeContext() && !m_release )
-         Flush();
- }
-ENDOFFILE
-    patch -bfi /tmp/listctrl_cpp_diff src/osx/carbon/dcclient.cpp
-    rm -f /tmp/listctrl_cpp_diff
-else
-    echo "src/osx/carbon/dcclient.cpp already patched"
 fi
 
 echo ""
@@ -201,7 +189,7 @@ else
     ## We must override some of the build settings in wxWindows.xcodeproj
     ## For wxWidgets 3.0.0 through 3.1.0 (at least) we must use legacy WebKit APIs
     ## for x86_64, so we must define WK_API_ENABLED=0
-    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Release $doclean build ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0" | $beautifier; retval=${PIPESTATUS[0]}
+    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Release $doclean build ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=${PIPESTATUS[0]}
     if [ ${retval} -ne 0 ]; then return 1; fi
     if [ "x${lprefix}" != "x" ]; then
         # copy library and headers to $lprefix
@@ -238,7 +226,7 @@ else
     ## We must override some of the build settings in wxWindows.xcodeproj
     ## For wxWidgets 3.0.0 through 3.1.0 (at least) we must use legacy WebKit APIs
     ## for x86_64, so we must define WK_API_ENABLED=0
-    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Debug $doclean build ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0" | $beautifier; retval=${PIPESTATUS[0]}
+    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Debug $doclean build ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=${PIPESTATUS[0]}
     if [ ${retval} -ne 0 ]; then return 1; fi
     if [ "x${lprefix}" != "x" ]; then
         # copy debug library to $PREFIX

--- a/mac_build/dependencyNames.sh
+++ b/mac_build/dependencyNames.sh
@@ -47,9 +47,9 @@ curlDirName="curl-7.50.2"
 curlFileName="curl-7.50.2.tar.gz"
 curlURL="http://curl.haxx.se/download/curl-7.50.2.tar.gz"
 
-wxWidgetsDirName="wxWidgets-3.0.0"
-wxWidgetsFileName="wxWidgets-3.0.0.tar.bz2"
-wxWidgetsURL="http://sourceforge.net/projects/wxwindows/files/3.0.0/wxWidgets-3.0.0.tar.bz2"
+wxWidgetsDirName="wxWidgets-3.1.0"
+wxWidgetsFileName="wxWidgets-3.1.0.tar.bz2"
+wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"
 
 sqliteDirName="sqlite-autoconf-3110000"
 sqliteFileName="sqlite-autoconf-3110000.tar.gz"

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -203,11 +203,11 @@ mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/sk
 # have permission to set owner to boinc_master.
 mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/projects/virtualbox
 
-##cp -fpR $BUILDPATH/WaitPermissions.app ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
+##cp -fpR "${BUILDPATH}/WaitPermissions.app" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
 
-cp -fpRL $BUILDPATH/switcher ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher/
-cp -fpRL $BUILDPATH/setprojectgrp ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher/
-## cp -fpRL $BUILDPATH/AppStats ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher/
+cp -fpRL "${BUILDPATH}/switcher" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher/
+cp -fpRL "${BUILDPATH}/setprojectgrp" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher/
+## cp -fpRL "${BUILDPATH}/AppStats" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher/
 
 cd "${BOINCPath}/clientgui/skins"
 cp -fpRL Default ../../../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/skins/
@@ -220,9 +220,9 @@ cp -fp win_build/installerv2/redist/all_projects_list.xml ../BOINC_Installer/Pkg
 cp -fp clientscr/res/boinc_logo_black.jpg ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
 cp -fp api/ttf/liberation-fonts-ttf-2.00.0/LiberationSans-Regular.ttf ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/LiberationSans-Regular.ttf
 cp -fp clientscr/ss_config.xml ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
-cp -fpRL $BUILDPATH/boincscr ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
+cp -fpRL "${BUILDPATH}/boincscr" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
 
-cp -fpRL $BUILDPATH/BOINCManager.app ../BOINC_Installer/Pkg_Root/Applications/
+cp -fpRL "${BUILDPATH}/BOINCManager.app" ../BOINC_Installer/Pkg_Root/Applications/
 
 ## OS 10.6 and OS10.7 require screensavers built with Garbage Collection, but Xcode 5.0.2
 ## was the last version of Xcode which supported building with Garbage Collection, so we
@@ -231,7 +231,7 @@ cp -fpRL $BUILDPATH/BOINCManager.app ../BOINC_Installer/Pkg_Root/Applications/
 ## correct binary for the version of OS X and delete the other one. This scripy assumes
 ## that $BUILDPATH/BOINCSaver.saver was built to use Automatic Reference Counting (ARC)
 ## and not built to use GC.
-cp -fpRL $BUILDPATH/BOINCSaver.saver ../BOINC_Installer/Pkg_Root/Library/Screen\ Savers/
+cp -fpRL "${BUILDPATH}/BOINCSaver.saver" ../BOINC_Installer/Pkg_Root/Library/Screen\ Savers/
 ditto -xk ./clientscr/BOINCSaver_MacOS10_6_7.zip ../BOINC_Installer/Pkg_Root/Library/Screen\ Savers/BOINCSaver.saver/Contents/MacOS
 
 ## Copy the localization files into the installer tree
@@ -304,7 +304,7 @@ cp -fp COPYRIGHT ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$
 sudo chown -R 501:admin ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/COPYRIGHT.txt
 sudo chmod -R 644 ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/COPYRIGHT.txt
 
-cp -fpRL $BUILDPATH/Uninstall\ BOINC.app ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras
+cp -fpRL "${BUILDPATH}/Uninstall BOINC.app" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras
 # Copy the localization files for the uninstaller into its bundle
 find locale -name 'BOINC-Setup.mo' | cut -d '/' -f 2 | awk '{print "\"../BOINC_Installer/locale/"$0"\""}' | xargs mkdir -p
 
@@ -316,9 +316,9 @@ sudo chown -R root:admin ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_
 sudo chmod -R u+r-w,g+r-w,o+r-w ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall\ BOINC.app
 
 # Copy the installer wrapper application "BOINC Installer.app"
-cp -fpRL $BUILDPATH/BOINC\ Installer.app ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/
+cp -fpRL "${BUILDPATH}/BOINC Installer.app" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/
 
-cp -fpR $BUILDPATH/PostInstall.app "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources"
+cp -fpR "${BUILDPATH}/PostInstall.app" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources"
 
 # Prepare to build the BOINC+VirtualBox installer if VirtualBox.pkg exists
 VirtualBoxPackageName="VirtualBox.pkg"
@@ -400,18 +400,18 @@ sudo chown -R 501:admin ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$
 sudo chmod -R 644 ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/*
 
 mkdir -p ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir
-cp -fpRL $BUILDPATH/boinc ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
-cp -fpRL $BUILDPATH/boinccmd ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
+cp -fpRL "${BUILDPATH}/boinc" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
+cp -fpRL "${BUILDPATH}/boinccmd" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 cp -fpRL curl/ca-bundle.crt ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 
 mkdir -p ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher
-cp -fpRL $BUILDPATH/switcher ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher/
-cp -fpRL $BUILDPATH/setprojectgrp ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher/
+cp -fpRL "${BUILDPATH}/switcher" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher/
+cp -fpRL "${BUILDPATH}/setprojectgrp" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher/
 
 sudo chown -R root:admin ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/*
 sudo chmod -R u+rw-s,g+r-ws,o+r-w ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/*
 
-cp -fpRL $BUILDPATH/SymbolTables/ ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_SymbolTables/
+cp -fpRL "${BUILDPATH}/SymbolTables/" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_SymbolTables/
 
 ## If you wish to code sign the installer and uninstaller, create a file 
 ## ~/BOINCCodeSignIdentities.txt whose first line is the code signing identity


### PR DESCRIPTION
… wxWidgets 3.0.0 can not be built using Xcode 9 due to APIs no longer supported by the header files in the OS 10.13 SDK