### PR TITLE
make webview support optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ script:
 - if [[ "${BOINC_TYPE}" == "client" ]]; then ( ./configure --disable-server --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "apps" ]]; then ( ./configure --enable-apps --disable-server --disable-client --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( ./3rdParty/buildLinuxDependencies.sh && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux && make ) fi
+- if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( ./3rdParty/buildLinuxDependencies.sh --disable-webview --cache_dir ${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "osx" ]]; then ( ./3rdParty/buildMacDependencies.sh -q && ./mac_build/buildMacBOINC-CI.sh --no_shared_headers ) fi
 - if [[ "${BOINC_TYPE}" == "libs-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw ) fi
 - if [[ "${BOINC_TYPE}" == "apps-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw wrapper ) fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
 - if [[ "${BOINC_TYPE}" == "client" ]]; then ( ./configure --disable-server --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "apps" ]]; then ( ./configure --enable-apps --disable-server --disable-client --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( ./3rdParty/buildLinuxDependencies.sh && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux && make ) fi
-- if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( ./3rdParty/buildLinuxDependencies.sh --disable-webview --cache_dir ${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && make ) fi
+- if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( make distclean || ./3rdParty/buildLinuxDependencies.sh --disable-webview --cache_dir ${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "osx" ]]; then ( ./3rdParty/buildMacDependencies.sh -q && ./mac_build/buildMacBOINC-CI.sh --no_shared_headers ) fi
 - if [[ "${BOINC_TYPE}" == "libs-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw ) fi
 - if [[ "${BOINC_TYPE}" == "apps-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw wrapper ) fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
 - if [[ "${BOINC_TYPE}" == "client" ]]; then ( ./configure --disable-server --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "apps" ]]; then ( ./configure --enable-apps --disable-server --disable-client --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( ./3rdParty/buildLinuxDependencies.sh && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux && make ) fi
-- if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( make distclean || ./3rdParty/buildLinuxDependencies.sh --disable-webview --cache_dir ${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && make ) fi
+- if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( make distclean && ./3rdParty/buildLinuxDependencies.sh --disable-webview --cache_dir ${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "osx" ]]; then ( ./3rdParty/buildMacDependencies.sh -q && ./mac_build/buildMacBOINC-CI.sh --no_shared_headers ) fi
 - if [[ "${BOINC_TYPE}" == "libs-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw ) fi
 - if [[ "${BOINC_TYPE}" == "apps-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw wrapper ) fi

--- a/3rdParty/buildLinuxDependencies.sh
+++ b/3rdParty/buildLinuxDependencies.sh
@@ -63,8 +63,11 @@ while [[ $# -gt 0 ]]; do
         doclean="yes"
         ;;
         --debug)
-        wxoption="--debug"
+        wxoption="--debug ${wxoption}"
         build_config="Debug"
+        ;;
+        --disable-webview)
+        wxoption="--disable-webview ${wxoption} "
         ;;
         *)
         echo "unrecognized option $key"

--- a/3rdParty/buildWxLinux.sh
+++ b/3rdParty/buildWxLinux.sh
@@ -62,6 +62,7 @@ fi
 
 doclean=""
 debug_flag="--disable-debug_flag"
+webview_flag="--enable-webview"
 lprefix=""
 cmdline_prefix=""
 while [[ $# -gt 0 ]]; do
@@ -78,6 +79,9 @@ while [[ $# -gt 0 ]]; do
         cmdline_prefix="--prefix=${lprefix}"
         shift
         ;;
+        --disable-webview)
+        webview_flag="--disable-webview"
+        ;;
     esac
     shift # past argument or value
 done
@@ -88,7 +92,7 @@ fi
 mkdir -p buildgtk
 cd buildgtk || return 1
 
-../configure "${cmdline_prefix}" --with-gtk --disable-shared --enable-webview --disable-gtktest --disable-sdltest ${debug_flag}
+../configure "${cmdline_prefix}" --with-gtk --disable-shared ${webview_flag} --disable-gtktest --disable-sdltest ${debug_flag}
 if [ $? -ne 0 ]; then cd ..; return 1; fi
 make 1>/dev/null # the wxWidgets build is very noisy so tune it down to warnings and errors only
 if [ $? -ne 0 ]; then cd ..; return 1; fi

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -1073,6 +1073,9 @@ bool CDlgEventLog::OpenClipboard( wxInt32 size ) {
         m_strClipboardData = wxEmptyString;
         m_strClipboardData.Alloc( size );
 
+#if defined(__WXGTK__) || defined(__WXQT__)
+        wxTheClipboard->UsePrimarySelection(false);
+#endif
         wxTheClipboard->Clear();
     }
 

--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -62,9 +62,10 @@ CDlgItemProperties::CDlgItemProperties(wxWindow* parent) :
     m_bSizer1 = new wxBoxSizer( wxVERTICAL );
     
     const long style = wxBORDER_NONE;
-    m_txtInformation = wxWebView::New( this, wxID_ANY, wxWebViewDefaultURLStr, wxDefaultPosition, wxDefaultSize, wxWebViewBackendDefault, style );
-    m_txtInformation->EnableContextMenu( false );
-
+    m_txtInformation = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, wxEmptyString );
+    m_txtInformation->Bind(wxEVT_LEFT_DOWN, &CDlgItemProperties::OnMouseButtonEvent, this);
+    m_txtInformation->Bind(wxEVT_LEFT_UP, &CDlgItemProperties::OnMouseButtonEvent, this);
+    
     m_bSizer1->Add( m_txtInformation, 1, wxEXPAND | wxALL, 5 );
     
     wxBoxSizer *bSizer2 = new wxBoxSizer(wxHORIZONTAL);
@@ -75,6 +76,7 @@ CDlgItemProperties::CDlgItemProperties(wxWindow* parent) :
 
     m_pCopySelectedButton = new wxButton(this, ID_COPYSELECTED, _("Copy &Selected"), wxDefaultPosition, wxDefaultSize);
     bSizer2->Add(m_pCopySelectedButton, 0, wxALIGN_BOTTOM | wxALIGN_CENTER_HORIZONTAL | wxALL, 5);
+    m_pCopySelectedButton->Enable(false);
 
     m_btnClose = new wxButton( this, wxID_OK, _("&Close"), wxDefaultPosition, wxDefaultSize, 0 );
     m_btnClose->SetDefault(); 
@@ -522,53 +524,27 @@ wxString CDlgItemProperties::FormatApplicationName(RESULT* result ) {
 void CDlgItemProperties::renderInfos() {
     wxString str_bg;
     str_bg.Printf(wxT("#%x"), this->GetBackgroundColour().GetRGB());
-    wxFont font = this->GetFont();
-    wxString font_name = font.GetFaceName();
-    wxString font_size;
-    font_size.Printf(wxT("%d"), font.GetPointSize());
 
     std::string content;
     content += "<html>";
-    content += "<head>";
-    content += "<style>";
-    content += " body { ";
-    content += " background-color: " + str_bg + "; ";
-    content += " overflow : auto; ";
-    content += " } ";
-    content += " table { ";
-    content += " width: 100%; ";
-    content += " } ";
-    content += " span { ";
-    content += " white-space: nowrap; ";
-    content += " font-family: '" + font_name + "'; ";
-    content += " font-size: " + font_size + "pt; ";
-    content += " } ";
-    content += "</style>";
-    content += "</head>";
-    content += "<body>";
-    content += "<table>";
+    content += "<body bgcolor='" + str_bg + "'>";
+    content += "<table width='100%'>";
     for (size_t i = 0; i < m_items.size(); ++i) {
         if (m_items[i].item_type == ItemTypeSection) {
             content += "<tr>";
-            content += "<td colspan='2'>";
-            content += "<span>";
+            content += "<td colspan='2' nowrap>";
             content += "<b>";
             content += m_items[i].name;
             content += "</b>";
-            content += "</span>";
             content += "</td>";
             content += "</tr>";
         } else if (m_items[i].item_type == ItemTypeProperty) {
             content += "<tr>";
-            content += "<td>";
-            content += "<span>";
+            content += "<td nowrap>";
             content += m_items[i].name;
-            content += "</span>";
             content += "</td>";
-            content += "<td>";
-            content += "<span>";
+            content += "<td nowrap>";
             content += m_items[i].value;
-            content += "</span>";
             content += "</td>";
             content += "</tr>";
         }        
@@ -576,7 +552,7 @@ void CDlgItemProperties::renderInfos() {
     content += "</table>";
     content += "</body>";
     content += "</html>";
-    m_txtInformation->SetPage(wxString(content), "");
+    m_txtInformation->SetPage(content);
 }
 
 
@@ -590,20 +566,23 @@ void CDlgItemProperties::addProperty(const wxString& name, const wxString& value
     m_items.push_back(ITEM(ItemTypeProperty, name, value));
 }
 
-void CDlgItemProperties::OnCopySelected( wxCommandEvent& ) {
-    if (m_txtInformation->HasSelection()) {
-        m_txtInformation->Copy();
-    } else {
-        if (wxTheClipboard->Open()) {
-            wxTheClipboard->Clear();
-            wxTheClipboard->SetData(new wxTextDataObject(wxEmptyString));
-            wxTheClipboard->Close();
-        }
+void CDlgItemProperties::copyTextToClipboard(const wxString& text) {
+    if (wxTheClipboard->Open()) {
+        wxTheClipboard->Clear();
+        wxTheClipboard->SetData(new wxTextDataObject(text));
+        wxTheClipboard->Close();
     }
 }
 
+void CDlgItemProperties::OnMouseButtonEvent(wxMouseEvent& event) {
+    m_pCopySelectedButton->Enable(m_txtInformation->SelectionToText() != wxEmptyString);
+    event.Skip();
+}
+
+void CDlgItemProperties::OnCopySelected( wxCommandEvent& ) {
+    copyTextToClipboard(m_txtInformation->SelectionToText());
+}
+
 void CDlgItemProperties::OnCopyAll( wxCommandEvent& ) {
-    m_txtInformation->SelectAll();
-    m_txtInformation->Copy();
-    m_txtInformation->ClearSelection();
+    copyTextToClipboard(m_txtInformation->ToText());
 }

--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -524,10 +524,16 @@ wxString CDlgItemProperties::FormatApplicationName(RESULT* result ) {
 void CDlgItemProperties::renderInfos() {
     wxString str_bg;
     str_bg.Printf(wxT("#%x"), this->GetBackgroundColour().GetRGB());
+    wxString str_fg;
+    str_fg.Printf(wxT("#%x"), this->GetForegroundColour().GetRGB());
 
     std::string content;
     content += "<html>";
     content += "<body bgcolor='" + str_bg + "'>";
+    content += "<font";
+    content += " color='" + str_fg + "' ";
+    content += " face='" + this->GetFont().GetFaceName() + "' ";
+    content += ">";
     content += "<table width='100%'>";
     for (size_t i = 0; i < m_items.size(); ++i) {
         if (m_items[i].item_type == ItemTypeSection) {
@@ -550,6 +556,7 @@ void CDlgItemProperties::renderInfos() {
         }        
     }
     content += "</table>";
+    content += "</font>";
     content += "</body>";
     content += "</html>";
     m_txtInformation->SetPage(content);

--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -575,6 +575,9 @@ void CDlgItemProperties::addProperty(const wxString& name, const wxString& value
 
 void CDlgItemProperties::copyTextToClipboard(const wxString& text) {
     if (wxTheClipboard->Open()) {
+#if defined(__WXGTK__) || defined(__WXQT__)
+        wxTheClipboard->UsePrimarySelection(false);
+#endif
         wxTheClipboard->Clear();
         wxTheClipboard->SetData(new wxTextDataObject(text));
         wxTheClipboard->Close();

--- a/clientgui/DlgItemProperties.h
+++ b/clientgui/DlgItemProperties.h
@@ -23,19 +23,11 @@
 #pragma interface "DlgItemProperties.cpp"
 #endif
 
-#include <wx/intl.h>
-
-#include <wx/gdicmn.h>
-#include <wx/gbsizer.h>
 #include <wx/sizer.h>
-#include <wx/scrolwin.h>
-#include <wx/font.h>
-#include <wx/colour.h>
-#include <wx/settings.h>
 #include <wx/string.h>
 #include <wx/button.h>
 #include <wx/dialog.h>
-#include <wx/wxhtml.h>
+#include <wx/html/htmlwin.h>
 
 #include "MainDocument.h"
 
@@ -68,13 +60,15 @@ private:
        void renderInfos();
 	void addSection(const wxString& title);
 	void addProperty(const wxString& name, const wxString& value);
+    void copyTextToClipboard(const wxString& text);
+    void OnMouseButtonEvent(wxMouseEvent& event);
 protected:
         wxBoxSizer* m_bSizer1;
         wxButton* m_btnClose;
         wxButton* m_pCopySelectedButton;
         wxButton* m_pCopyAllButton;
         wxString m_strBaseConfigLocation;
-        wxWebView* m_txtInformation;
+        wxHtmlWindow* m_txtInformation;
 };
 
 #endif

--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -46,7 +46,7 @@ IMPLEMENT_DYNAMIC_CLASS( CNoticeListCtrl, wxWindow )
 /*!
  * CNoticeListCtrl event table definition
  */
- 
+
 BEGIN_EVENT_TABLE( CNoticeListCtrl, wxWindow )
 
 ////@begin CNoticeListCtrl event table entries
@@ -57,21 +57,21 @@ BEGIN_EVENT_TABLE( CNoticeListCtrl, wxWindow )
     EVT_HTML_LINK_CLICKED(ID_LIST_NOTIFICATIONSVIEW, CNoticeListCtrl::OnLinkClicked)
 #endif
 ////@end CNoticeListCtrl event table entries
- 
+
 END_EVENT_TABLE()
- 
+
 /*!
  * CNoticeListCtrl constructors
  */
- 
+
 CNoticeListCtrl::CNoticeListCtrl( ) {
 }
- 
+
 CNoticeListCtrl::CNoticeListCtrl( wxWindow* parent ) {
     Create( parent );
 }
- 
- 
+
+
 CNoticeListCtrl::~CNoticeListCtrl( ) {
 }
 
@@ -79,7 +79,7 @@ CNoticeListCtrl::~CNoticeListCtrl( ) {
 /*!
  * CNoticeListCtrl creator
  */
- 
+
 bool CNoticeListCtrl::Create( wxWindow* parent ) {
 ////@begin CNoticeListCtrl member initialisation
 ////@end CNoticeListCtrl member initialisation
@@ -96,14 +96,14 @@ bool CNoticeListCtrl::Create( wxWindow* parent ) {
 
     wxBoxSizer *topsizer;
     topsizer = new wxBoxSizer(wxVERTICAL);
-    
+
     topsizer->Add(m_browser, 1, wxEXPAND);
     SetAutoLayout(true);
     SetSizer(topsizer);
-    
+
     m_itemCount = 0;
     m_noticesBody = wxT("<html><head></head><body></body></html>");
-    
+
     // Display the fetching notices message until we have notices
     // to display or have determined that there are no notices.
     m_bDisplayFetchingNotices = false;
@@ -183,15 +183,15 @@ void CNoticeListCtrl::SetItemCount(int newCount) {
             eol_to_br(strDescription);
             localize(strDescription);
 
-            // RSS feeds and web pages may use protocol-relative (scheme-relative) 
+            // RSS feeds and web pages may use protocol-relative (scheme-relative)
             // URLs, such as <img src="//sample.com/test.jpg"/>
             // Since the html comes from a web server via http, the scheme is
-            // assumed to also be http.  But we have cached the html in a local 
+            // assumed to also be http.  But we have cached the html in a local
             // file, so it is no longer associated with the http protocol / scheme.
             // Therefore all our URLs must explicity specify the http protocol.
             //
-            // The second argument to wxWebView::SetPage is supposed to take care 
-            // of this automatically, but fails to do so under Windows, so we do 
+            // The second argument to wxWebView::SetPage is supposed to take care
+            // of this automatically, but fails to do so under Windows, so we do
             // it here explicitly.
             strDescription.Replace(wxT("\"//"), wxT("\"http://"));
 			strDescription.Replace(wxT("</a>"), wxT("</a> "));
@@ -199,7 +199,7 @@ void CNoticeListCtrl::SetItemCount(int newCount) {
             // Apparently attempting to follow links with other targets specified
             // fails to fire our event handler.  For now we will just strip out
             // the special _blank/_new target which is supposed to open a new
-            // browser window anyways.  
+            // browser window anyways.
             strDescription.Replace(wxT("target=\"_blank\""), wxT(""));
             strDescription.Replace(wxT("target=\"_new\""), wxT(""));
 
@@ -270,7 +270,7 @@ void CNoticeListCtrl::OnLinkClicked( wxWebViewEvent& event ) {
 
 
 void CNoticeListCtrl::OnWebViewError( wxWebViewEvent& event ) {
-   fprintf(stderr, "wxWebView error: target=%s, URL=%s\n", 
+   fprintf(stderr, "wxWebView error: target=%s, URL=%s\n",
             (event.GetTarget().ToStdString()).c_str(), (event.GetURL().ToStdString()).c_str());
 
     event.Skip();
@@ -298,7 +298,7 @@ bool CNoticeListCtrl::UpdateUI() {
     wxASSERT(pDoc);
     wxASSERT(wxDynamicCast(pDoc, CMainDocument));
 
-    // Call Freeze() / Thaw() only when actually needed; 
+    // Call Freeze() / Thaw() only when actually needed;
     // otherwise it causes unnecessary redraws
     int noticeCount = pDoc->GetNoticeCount();
     if ((noticeCount < 0) || (!pDoc->IsConnected()) || m_bNeedsReloading) {
@@ -312,7 +312,7 @@ bool CNoticeListCtrl::UpdateUI() {
         m_bNeedsReloading = false;
         return true;
     }
-    
+
     if (noticeCount == 0) {
         if (GetItemCount()) {
             SetItemCount(0);
@@ -323,7 +323,7 @@ bool CNoticeListCtrl::UpdateUI() {
         m_bNeedsReloading = false;
         return true;
     }
-    
+
     if (!bAlreadyRunning) {
         bAlreadyRunning = true;
         if (
@@ -341,6 +341,6 @@ bool CNoticeListCtrl::UpdateUI() {
 
         bAlreadyRunning = false;
     }
-        
+
     return true;
 }

--- a/clientgui/NoticeListCtrl.h
+++ b/clientgui/NoticeListCtrl.h
@@ -42,11 +42,14 @@ public:
 
     int     GetItemCount();
     void    SetItemCount(int newCount);
-    
-////@begin CNoticeListCtrl event handler declarations
 
+////@begin CNoticeListCtrl event handler declarations
+#if wxUSE_WEBVIEW
     void OnLinkClicked( wxWebViewEvent& event );
     void OnWebViewError( wxWebViewEvent& event );
+#else
+    void OnLinkClicked( wxHtmlLinkEvent & event );
+#endif
 
 ////@end CNoticeListCtrl event handler declarations
 
@@ -56,7 +59,11 @@ public:
     bool        m_bDisplayFetchingNotices;
     bool        m_bDisplayEmptyNotice;
 private:
+#if wxUSE_WEBVIEW
     wxWebView*  m_browser;
+#else
+    wxHtmlWindow* m_browser;
+#endif
     bool        m_bNeedsReloading;
     int         m_itemCount;
     wxString    m_noticesBody;

--- a/clientgui/stdwx.h
+++ b/clientgui/stdwx.h
@@ -117,8 +117,10 @@
 #include <wx/mstream.h>
 #include <wx/hash.h>
 #include <wx/selstore.h>
+#if wxUSE_WEBVIEW
 #include <wx/webview.h>
 #include <wx/webviewfshandler.h>
+#endif
 #include <wx/snglinst.h>
 #include <wx/bmpcbox.h>
 #include <wx/evtloop.h>


### PR DESCRIPTION
Some Linux distributions are dropping webkitgtk support which is needed for wxWebView to work. This will build a second wxWidgets cache that has no webview support in order to test new code.

This should in the end combine #2093, #2104 and the [Debian patch](https://bugs.debian.org/cgi-bin/bugreport.cgi?att=1;bug=876940;filename=boinc-no-webview.patch;msg=5) and build two managers. One with webview support and one without.