### PR TITLE
mgr: fix eventlog colors

### DIFF
--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -248,13 +248,47 @@ bool CDlgEventLog::Create( wxWindow* parent, wxWindowID id, const wxString& capt
         wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW),
         wxNullFont
     );
+
 #if EVENT_LOG_STRIPES
+    m_pList->EnableAlternateRowColours();
+    wxColour stripe_color;
+
+#if wxCHECK_VERSION(3, 1, 0)
+    stripe_color = m_pList->GetAlternateRowColour();
+    if (!stripe_color.IsOk())
+#endif
+    {
+        // copied from wxListCtrlBase::EnableAlternateRowColours(bool)
+
+        // Determine the alternate rows colour automatically from the
+        // background colour.
+        const wxColour bgColour = m_pList->GetBackgroundColour();
+
+        // Depending on the background, alternate row color
+        // will be 3% more dark or 50% brighter.
+        int alpha = bgColour.GetRGB() > 0x808080 ? 97 : 150;
+        stripe_color = bgColour.ChangeLightness(alpha);
+    }
+
+#ifdef __WXMSW__
+    // work around a bug in wxWidgets 3.1 and earlier
+    // if row background color is wxSYS_COLOR_BTNFACE selected unfocused row is drawn with wrong colors
+    if (stripe_color == wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE)) {
+        // adjust the color just enough to make it different
+        stripe_color.SetRGB(stripe_color.GetRGB() + 1);
+    }
+#endif
+
     m_pMessageInfoGrayAttr = new wxListItemAttr(
         wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT),
-        wxColour(240, 240, 240),
+        stripe_color,
         wxNullFont
     );
-    m_pMessageErrorGrayAttr = new wxListItemAttr(*wxRED, wxColour(240, 240, 240), wxNullFont);
+    m_pMessageErrorGrayAttr = new wxListItemAttr(
+        *wxRED,
+        stripe_color,
+        wxNullFont
+    );
 #else
     m_pMessageInfoGrayAttr = new wxListItemAttr(*m_pMessageInfoAttr);
     m_pMessageErrorGrayAttr = new wxListItemAttr(*m_pMessageErrorAttr);

--- a/clientgui/DlgEventLogListCtrl.cpp
+++ b/clientgui/DlgEventLogListCtrl.cpp
@@ -137,11 +137,6 @@ wxListItemAttr* CDlgEventLogListCtrl::OnGetItemAttr(long item) const {
 }
 
 
-wxColour CDlgEventLogListCtrl::GetBackgroundColour() {
-    return *wxWHITE;
-}
-
-
 void CDlgEventLogListCtrl::OnMouseUp(wxMouseEvent& event) {
     m_pParentView->UpdateButtons();
     event.Skip();

--- a/clientgui/DlgEventLogListCtrl.h
+++ b/clientgui/DlgEventLogListCtrl.h
@@ -33,8 +33,6 @@ class CDlgEventLog;
 
 class CDlgEventLogListCtrl : public DLG_LISTCTRL_BASE
 {
-using DLG_LISTCTRL_BASE::GetBackgroundColour;
-
     DECLARE_DYNAMIC_CLASS(CDlgEventLogListCtrl)
     DECLARE_EVENT_TABLE()
 
@@ -54,7 +52,6 @@ private:
     virtual wxString        OnGetItemText(long item, long column) const;
     virtual int             OnGetItemImage(long item) const;
     virtual wxListItemAttr* OnGetItemAttr(long item) const;
-    virtual wxColour        GetBackgroundColour();
     void                    OnMouseUp(wxMouseEvent& event);
 
     void                    OnShow( wxShowEvent& event );


### PR DESCRIPTION
On Windows, `wxListCtrl` has a bug that makes it draw selected unfocused rows with colors used for selected focused rows when the row background color is `wxSYS_COLOUR_BTNFACE`.

With default color schemes, on Windows XP the list is drawn correctly, but on Windows 10 the `(240,240,240)` used in stripe color is coincidentally the same as `wxSYS_COLOUR_BTNFACE` and selected rows are drawn with wrong colors.

Fix this by using the same stripe color that wxWidgets would use by default and that is used in Projects, Tasks and Transfers lists. Future proof the code by including a workaround just in case Windows changes color scheme again. If such color scheme change occurs then the same workaround needs to be added to Projects, Tasks and Transfers lists.

Fixes #1083.

To support the above change remove `CDlgEventLogListCtrl::GetBackgroundColour()`. The method was private and not callable from CDlgEventLog and overriding the corresponding base class method wasn't useful in the first place.