### PR TITLE
Manager: 'Add Project Wizard': Change label from 'Forgot your passwor…

### DIFF
--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -492,7 +492,7 @@ void CAccountInfoPage::OnPageChanged( wxWizardExEvent& /* event */ ) {
 
     if (!IS_ACCOUNTMANAGERWIZARD()) {
         m_pAccountForgotPasswordCtrl->SetLabel(
-            _("Forgot your password?")
+            _("Forgot your account info?")
         );
         m_pAccountForgotPasswordCtrl->SetURL(
             wxString(pWA->GetProjectURL() + _T("get_passwd.php"))


### PR DESCRIPTION
…d?' to 'Forgot your account info?'

This fixes #1049.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>