### PR TITLE
Fixed insert into host

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -524,7 +524,8 @@ void DB_HOST::db_print(char* buf){
         "host_cpid='%s', external_ip_addr='%s', max_results_day=%d, "
         "error_rate=%.15e, "
         "product_name='%s', "
-        "gpu_active_frac=%.15e ",
+        "gpu_active_frac=%.15e, "
+        "p_ngpus=%d, p_gpu_fpops=%.15e ",
         create_time, userid,
         rpc_seqno, rpc_time,
         total_credit, expavg_credit, expavg_time,
@@ -546,7 +547,8 @@ void DB_HOST::db_print(char* buf){
         host_cpid, external_ip_addr, _max_results_day,
         _error_rate,
         product_name,
-        gpu_active_frac
+        gpu_active_frac,
+        p_ngpus, p_gpu_fpops
     );
     UNESCAPE(domain_name);
     UNESCAPE(serialnum);


### PR DESCRIPTION
In 90f8a1d4b4280ead1d7046efdcaa28eb603ca763 the p_ngpus and p_gpu_fpops fields were added to the host table, and make fields updation, but not the insertion.
On one server I got an error: Database error: Field 'p_ngpus' doesn't have a default value.