### PR TITLE
Add server-side support for simplified register/download/attach

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -359,7 +359,8 @@ void DB_USER::db_print(char* buf){
         "seti_id=%d, seti_nresults=%d, seti_last_result_time=%d, "
         "seti_total_cpu=%.15e, signature='%s', has_profile=%d, "
         "cross_project_id='%s', passwd_hash='%s', "
-        "email_validated=%d, donated=%d",
+        "email_validated=%d, donated=%d, "
+        "login_token='%s', login_token_time=%f",
         create_time, email_addr, name,
         authenticator,
         country, postal_code,
@@ -370,7 +371,8 @@ void DB_USER::db_print(char* buf){
         seti_id, seti_nresults, seti_last_result_time,
         seti_total_cpu, signature, has_profile,
         cross_project_id, passwd_hash,
-        email_validated, donated
+        email_validated, donated,
+        login_token, login_token_time
     );
     UNESCAPE(email_addr);
     UNESCAPE(name);
@@ -413,6 +415,8 @@ void DB_USER::db_parse(MYSQL_ROW &r) {
     strcpy2(passwd_hash, r[i++]);
     email_validated = atoi(r[i++]);
     donated = atoi(r[i++]);
+    strcpy2(login_token, r[i++]);
+    login_token_time = atof(r[i++]);
 }
 
 void DB_TEAM::db_print(char* buf){

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -212,6 +212,8 @@ struct USER {
     char passwd_hash[256];
     bool email_validated;           // deprecated
     int donated;
+    char login_token[32];
+    double login_token_time;
     void clear();
 };
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -110,6 +110,8 @@ create table user (
     passwd_hash             varchar(254)    not null,
     email_validated         smallint        not null,
     donated                 smallint        not null,
+    login_token             char(32)        not null,
+    login_token_time        double          not null,
     primary key (id)
 ) engine=InnoDB;
 
@@ -759,11 +761,4 @@ create table credit_team (
     expavg_time             double          not null,
     credit_type             integer         not null,
     primary key (teamid, appid, credit_type)
-) engine=InnoDB;
-
-create table login_token (
-    userid                  integer         not null,
-    create_time             double          not null,
-    token                   char(32)        not null,
-    unique (token)
 ) engine=InnoDB;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -760,3 +760,10 @@ create table credit_team (
     credit_type             integer         not null,
     primary key (teamid, appid, credit_type)
 ) engine=InnoDB;
+
+create table login_token (
+    userid                  integer         not null,
+    create_time             double          not null,
+    token                   char(32)        not null,
+    unique (token)
+) engine=InnoDB;

--- a/html/inc/account.inc
+++ b/html/inc/account.inc
@@ -1,7 +1,7 @@
 <?php
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2015 University of California
+// Copyright (C) 2017 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -16,7 +16,21 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// forms for account creation and login
+// functions related to account creation and login:
+// - forms for create / login
+// - function to make login token
+
+// make login token record; return token
+//
+function make_login_token($user) {
+    $token = substr(random_string(), 0, 8);
+    $now = time();
+    $ret = BoincLoginToken::insert("(userid, token, create_time) values ($user->id, '$token', $now)");
+    if (!$ret) {
+        return null;
+    }
+    return $token;
+}
 
 function create_account_form($teamid, $next_url) {
     global $recaptcha_public_key;

--- a/html/inc/account.inc
+++ b/html/inc/account.inc
@@ -25,7 +25,7 @@
 function make_login_token($user) {
     $token = substr(random_string(), 0, 8);
     $now = time();
-    $user->update("login_token='$login_token', login_token_time=$now where id=$user->id");
+    $user->update("login_token='$token', login_token_time=$now");
     return $token;
 }
 

--- a/html/inc/account.inc
+++ b/html/inc/account.inc
@@ -20,15 +20,12 @@
 // - forms for create / login
 // - function to make login token
 
-// make login token record; return token
+// make login token, store in user record, return token
 //
 function make_login_token($user) {
     $token = substr(random_string(), 0, 8);
     $now = time();
-    $ret = BoincLoginToken::insert("(userid, token, create_time) values ($user->id, '$token', $now)");
-    if (!$ret) {
-        return null;
-    }
+    $user->update("login_token='$login_token', login_token_time=$now where id=$user->id");
     return $token;
 }
 

--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -784,19 +784,6 @@ class BoincCreditTeam {
     }
 }
 
-class BoincLoginToken {
-    static function lookup($clause) {
-        $db = BoincDb::get();
-        return $db->lookup('login_token', 'BoincLoginToken', $clause);
-    }
-    static function insert($clause) {
-        $db = BoincDb::get();
-        $ret = $db->insert('login_token', $clause);
-        if (!$ret) return false;
-        return true;
-    }
-}
-
 // DEPRECATED: use BoincDb::escape_string where possible
 // 
 // apply this to any user-supplied strings used in queries

--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -784,6 +784,19 @@ class BoincCreditTeam {
     }
 }
 
+class BoincLoginToken {
+    static function lookup($clause) {
+        $db = BoincDb::get();
+        return $db->lookup('login_token', 'BoincLoginToken', $clause);
+    }
+    static function insert($clause) {
+        $db = BoincDb::get();
+        $ret = $db->insert('login_token', $clause);
+        if (!$ret) return false;
+        return true;
+    }
+}
+
 // DEPRECATED: use BoincDb::escape_string where possible
 // 
 // apply this to any user-supplied strings used in queries

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -514,6 +514,8 @@ function row_heading($x, $class='bg-primary') {
     );
 }
 
+// return hard-to-guess string of 32 random hex chars
+//
 function random_string() {
     return md5(uniqid(rand(), true));
 }

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1061,6 +1061,16 @@ function update_8_9_2017() {
     ");
 }
 
+function update_10_25_2017() {
+    do_query("create table login_token (
+        userid                  integer         not null,
+        create_time             double          not null,
+        token                   char(32)        not null,
+        unique (token)
+        ) engine=InnoDB;
+    ");
+}
+
 // Updates are done automatically if you use "upgrade".
 //
 // If you need to do updates manually,
@@ -1112,6 +1122,7 @@ $db_updates = array (
     array(27017, "update_6_13_2017"),
     array(27018, "update_7_21_2017"),
     array(27019, "update_8_9_2017"),
+    array(27020, "update_10_25_2017"),
 );
 
 ?>

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1062,12 +1062,9 @@ function update_8_9_2017() {
 }
 
 function update_10_25_2017() {
-    do_query("create table login_token (
-        userid                  integer         not null,
-        create_time             double          not null,
-        token                   char(32)        not null,
-        unique (token)
-        ) engine=InnoDB;
+    do_query("alter table user
+        add column login_token char(32) not null,
+        add column login_token_time double not null
     ");
 }
 

--- a/html/user/download.php
+++ b/html/user/download.php
@@ -16,49 +16,140 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// 2nd phase of the "join" process.
-// The user has created an account.
-// Now see if they need to download BOINC.
+// Show a page with download links and instructions.
+//
+// - get platform from user agent string
+// - find latest version for that platform (regular and vbox)
+// - Create a login token.
+// - Show download button(s)
+//   The download will be via concierge, using the login token.
+//
+// By default both regular and vbox buttons will be shown, if available.
+// You can suppress one or the other by setting
+// <disable_regular_download> or <disable_vbox_download>.
+//
+// Notes:
+// 1) You need to have the client versions file
+//    (https://boinc.berkeley.edu/download_all.php?xml=1)
+//    saved as "versions.xml" in your html/user dir
+// 2) Put your project ID in a constant PROJECT_ID
+//    (this all works only for listed projects)
 
 require_once("../inc/util.inc");
+require_once("../inc/account.inc");
 
-// return the URL of a script on the BOINC web site
-// that will send the needed cookies
-// and optionally download the appropriate installer,
+// take the client info string reported by web browser,
+// and return best guess for platform
 //
-function concierge_url($user, $download) {
-    global $master_url;
-    $project_name = parse_config(get_config(), "<long_name>");
-    $project_desc = parse_config(get_config(), "<project_desc>");
-    $project_inst = parse_config(get_config(), "<project_inst>");
-    $user = get_logged_in_user(false);
-    $x =  "http://boinc.berkeley.edu/concierge.php";
-    $x .= "?master_url=".urlencode($master_url);
-    $x .= "&project_name=".urlencode($project_name);
-    if ($project_desc) {
-        $x .= "&project_desc=".urlencode($project_desc);
-    }
-    if ($project_inst) {
-        $x .= "&project_inst=".urlencode($project_inst);
-    }
-    if ($user) {
-        $x .= "&auth=".urlencode($user->authenticator);
-        $x .= "&user_name=".urlencode($user->name);
-    }
-    if ($download) {
-        $x .= "&download=1";
-        if (parse_bool(get_config(), "need_vbox")) {
-            $x .= "&need_vbox=1";
+function client_info_to_platform($client_info) {
+    if (strstr($client_info, 'Windows')) {
+        if (strstr($client_info, 'Win64')||strstr($client_info, 'WOW64')) {
+            return 'windows_x86_64';
+        } else {
+            return 'windows_intelx86';
         }
+    } else if (strstr($client_info, 'Mac')) {
+        if (strstr($client_info, 'PPC Mac OS X')) {
+            return 'powerpc-apple-darwin';
+        } else {
+            return 'x86_64-apple-darwin';
+        }
+    } else if (strstr($client_info, 'Android')) {
+        // Check for Android before Linux,
+        // since Android contains the Linux kernel and the
+        // web browser user agent string lists Linux too.
+        //
+        return 'arm-android-linux-gnu';
+    } else if (strstr($client_info, 'Linux')) {
+        if (strstr($client_info, 'x86_64')) {
+            return 'x86_64-pc-linux-gnu';
+        } else {
+            return 'i686-pc-linux-gnu';
+        }
+    } else {
+        return null;
     }
-    return $x;
 }
 
-function show_download_page() {
-    page_head("Download required software");
+// find release version for user's platform
+//
+function get_version() {
+    $v = simplexml_load_file("versions.xml");
+    $client_info = $_SERVER['HTTP_USER_AGENT'];
+    $p = client_info_to_platform($client_info);
+    foreach ($v->version as $i=>$v) {
+        if ((string)$v->dbplatform != $p) {
+            continue;
+        }
+        if (!strstr((string)$v->description, "ecommended")) {
+            continue;
+        }
+        return $v;
+    }
+    return null;
+}
 
-    $config = get_config();
+function download_button($v, $project_id, $token) {
+    return sprintf(
+        '<form action="https://boinc.berkeley.edu/concierge.php" method="post">
+        <input type=hidden name=project_id value="%d">
+        <input type=hidden name=token value="%s">
+        <input type=hidden name=filename value="%s">
+        <button class="btn btn-info">
+        <font size=2><u>Download BOINC</u></font>
+        <br>for %s (%s MB)
+        <br><small>BOINC %s</small></button>
+        </form>
+        ',
+        $project_id,
+        $token,
+        (string)$v->filename,
+        (string)$v->platform,
+        (string)$v->size_mb,
+        (string)$v->version_num
+    );
+}
+
+function download_button_vbox($v, $project_id, $token) {
+    return sprintf(
+        '<form action="https://boinc.berkeley.edu/concierge.php" method="post">
+        <input type=hidden name=project_id value="%d">
+        <input type=hidden name=token value="%s">
+        <input type=hidden name=filename value="%s">
+        <button class="btn btn-success">
+        <font size=+1><u>Download BOINC + VirtualBox</u></font>
+        <br>for %s (%s MB)
+        <br><small>BOINC %s, VirtualBox %s</small></a>
+        </form>
+        ',
+        $project_id,
+        $token,
+        (string)$v->vbox_filename,
+        (string)$v->platform,
+        (string)$v->vbox_size_mb,
+        (string)$v->version_num,
+        (string)$v->vbox_version
+    );
+}
+
+function show_download_page($user) {
+    global $config;
     $need_vbox = parse_bool($config, "need_vbox");
+    $project_id = parse_config($config, "<project_id>");
+    if (!$project_id) {
+        error_page("must specify project ID in config.xml");
+    }
+    $v = get_version();
+
+    // if we can't figure out the user's platform,
+    // take them to the download_all page
+    //
+    if (!$v) {
+        Header("Location: https://boinc.berkeley.edu/download_all.php");
+        exit;
+    }
+
+    page_head("Download software");
     $mcv = parse_config($config, "<min_core_client_version>");
     $dlv = "BOINC";
     $dl = "BOINC";
@@ -66,60 +157,70 @@ function show_download_page() {
         $dlv .= " version " . version_string_maj_min_rel($mcv). " or later";
     }
 
-    $verb = "this is";
+    $phrase = "this is";
     if ($need_vbox) {
+        $mvv = parse_config($config, "<vbox_min_version>");
         $dl .= " and VirtualBox";
-        $dlv .= " and VirtualBox";
-        $verb = "these are";
+        $dlv .= " and VirtualBox ".version_string_maj_min_rel($mvv)." or later";
+        $phrase = "these are";
     }
-    echo "To participate in ".PROJECT.", $dlv must be installed.
+    echo "To participate in ".PROJECT.", $dlv must be installed on your computer.
         <p>
-        If $verb already installed, <a href=download.php?action=installed>click here</a>.  Otherwise
+        If $phrase already installed, <a href=download.php?action=installed>click here</a>.  Otherwise
         <p>
     ";
-    show_button("download.php?action=download", "Download $dl");
-
-    echo "<p>
+    $token = make_login_token($user);
+    echo "<center><table border=0 cellpadding=20>\n";
+    table_row(
+        "",
+        download_button_vbox($v, $project_id, $token),
+        "&nbsp;&nbsp;",
+        download_button($v, $project_id, $token),
+        ""
+    );
+    echo "</table></center>\n";
+    echo "<p><p>
         When the download is finished,
-        open the downloaded file to install BOINC.
+        open the downloaded file to install $dl.
     ";
-
     page_tail();
 }
 
-// User says needed software is installed.
-// Send cookies and tell user to run manager
+// if user already has BOINC installed, tell them how to attach
 //
-function show_installed_page($user) {
-    $url = concierge_url($user, false);
-    page_head("Add project");
-    echo "
-        <iframe width=0 height=0 frameborder=0 src=$url></iframe>
-        To start running ".PROJECT." on this computer:
+function installed() {
+    global $config;
+    $am = parse_bool($config, "account_manager");
+    if ($am) {
+        page_head("Use ".PROJECT);
+        echo "To add ".PROJECT." on this computer:
         <ul>
-        <li> Open the BOINC Manager.
-        <li> Select <b>Add Project</b>.
-        <li> You should see a welcome message; click OK.
+        <li> In the BOINC manager, go to the Tools menu
+        <li> Select Use Account Manager
+        <li> Select ".PROJECT." from the menu
+        <li> Enter your email address and ".PROJECT." password.
         </ul>
-    ";
+        ";
+    } else {
+        page_head("Add ".PROJECT);
+        echo "To add ".PROJECT." on this computer:
+        <ul>
+        <li> In the BOINC manager, go to the Tools menu
+        <li> Select Add Project
+        <li> Select ".PROJECT." from the menu
+        <li> Enter your email address and ".PROJECT." password.
+        </ul>
+        ";
+    }
     page_tail();
-}
-
-function download($user) {
-    $url = concierge_url($user, true);
-    Header("Location: $url");
 }
 
 $user = get_logged_in_user();
 $action = get_str("action", true);
 if ($action == "installed") {
-    show_installed_page($user);
-    exit;
+    installed();
+} else {
+    show_download_page($user);
 }
-if ($action == "download") {
-    download($user);
-}
-
-show_download_page();
 
 ?>

--- a/html/user/download.php
+++ b/html/user/download.php
@@ -89,11 +89,12 @@ function get_version() {
     return null;
 }
 
-function download_button($v, $project_id, $token) {
+function download_button($v, $project_id, $token, $user) {
     return sprintf(
         '<form action="https://boinc.berkeley.edu/concierge.php" method="post">
         <input type=hidden name=project_id value="%d">
         <input type=hidden name=token value="%s">
+        <input type=hidden name=user_id value="%d">
         <input type=hidden name=filename value="%s">
         <button class="btn btn-info">
         <font size=2><u>Download BOINC</u></font>
@@ -103,6 +104,7 @@ function download_button($v, $project_id, $token) {
         ',
         $project_id,
         $token,
+        $user->id,
         (string)$v->filename,
         (string)$v->platform,
         (string)$v->size_mb,
@@ -110,7 +112,7 @@ function download_button($v, $project_id, $token) {
     );
 }
 
-function download_button_vbox($v, $project_id, $token) {
+function download_button_vbox($v, $project_id, $token, $user) {
     return sprintf(
         '<form action="https://boinc.berkeley.edu/concierge.php" method="post">
         <input type=hidden name=project_id value="%d">
@@ -124,6 +126,7 @@ function download_button_vbox($v, $project_id, $token) {
         ',
         $project_id,
         $token,
+        $user->id,
         (string)$v->vbox_filename,
         (string)$v->platform,
         (string)$v->vbox_size_mb,
@@ -173,9 +176,9 @@ function show_download_page($user) {
     echo "<center><table border=0 cellpadding=20>\n";
     table_row(
         "",
-        download_button_vbox($v, $project_id, $token),
+        download_button_vbox($v, $project_id, $token, $user),
         "&nbsp;&nbsp;",
-        download_button($v, $project_id, $token),
+        download_button($v, $project_id, $token, $user),
         ""
     );
     echo "</table></center>\n";

--- a/html/user/login_token_lookup.php
+++ b/html/user/login_token_lookup.php
@@ -1,0 +1,45 @@
+<?php
+
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2017 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// RPC handler for looking up a login token
+
+require_once("../inc/boinc_db.inc");
+require_once("../inc/xml.inc");
+
+function main($token) {
+    $lt = BoincLoginToken::lookup("token='$token'");
+    if (!$ret) {
+        xml_error("token not found");
+    }
+    $user = BoincUser::lookup_id("$lt->userid");
+    if (!$user) {
+        xml_error("user not found");
+    }
+    $name = htmlentities($user->name);
+    $auth = weak_auth($user);
+    echo "<login_token_reply>
+    <weak_auth>$auth</weak_auth>
+    <user_name>$name</user_name>
+</login_token_reply>
+";
+}
+
+main(get_str("token"));
+
+?>

--- a/html/user/login_token_lookup.php
+++ b/html/user/login_token_lookup.php
@@ -23,13 +23,14 @@ require_once("../inc/boinc_db.inc");
 require_once("../inc/xml.inc");
 
 function main($token) {
-    $lt = BoincLoginToken::lookup("token='$token'");
-    if (!$ret) {
-        xml_error("token not found");
-    }
-    $user = BoincUser::lookup_id("$lt->userid");
+    $user_id = get_str("user_id");
+    $token = get_str("token");
+    $user = BoincUser::lookup_id($user_id);
     if (!$user) {
         xml_error("user not found");
+    }
+    if (time() - $user->login_token_time > 86400) {
+        xml_error("token timed out");
     }
     $name = htmlentities($user->name);
     $auth = weak_auth($user);
@@ -40,6 +41,6 @@ function main($token) {
 ";
 }
 
-main(get_str("token"));
+main();
 
 ?>

--- a/html/user/login_token_lookup.php
+++ b/html/user/login_token_lookup.php
@@ -22,7 +22,7 @@
 require_once("../inc/boinc_db.inc");
 require_once("../inc/xml.inc");
 
-function main($token) {
+function main() {
     $user_id = get_str("user_id");
     $token = get_str("token");
     $user = BoincUser::lookup_id($user_id);

--- a/html/user/register.php
+++ b/html/user/register.php
@@ -24,32 +24,28 @@
 
 require_once("../inc/util.inc");
 require_once("../inc/account.inc");
+require_once("../inc/recaptchalib.php");
 
 function reg_form() {
+    global $recaptcha_public_key;
+
     $config = get_config();
     $disable_acct = parse_bool($config, "disable_account_creation");
-    page_head("Register");
-    start_table();
-    echo "<tr><td>";
+    page_head("Register",  null, null, null, boinc_recaptcha_get_head_extra());
     echo "<h3>Create an account</h3>";
+    form_start("create_account_action.php", "post");
     create_account_form(0, "download.php");
-    echo "</td><td>";
+    if ($recaptcha_public_key) {
+        form_general("", boinc_recaptcha_get_html($recaptcha_public_key));
+    }
+    form_submit("Join");
+    form_end();
+
     echo "<h3>If you already have an account, log in</h3>";
     login_form("download.php");
     echo "</td></tr>";
-    end_table();
     page_tail();
 }
 
-// if user is logged in, go straight to download page
-//
-$user = get_logged_in_user(false);
-if ($user) {
-    header("Location: download.php");
-    exit;
-}
-
-// otherwise show registration form
-//
 reg_form();
 ?>

--- a/version.h
+++ b/version.h
@@ -46,3 +46,4 @@
 #endif /* #if (defined(_WIN32) || defined(__APPLE__)) */
 
 #endif /* #ifndef BOINC_VERSION_H */
+


### PR DESCRIPTION
Add the server parts of the scheme described here:
https://boinc.berkeley.edu/trac/wiki/SimpleAttach

This includes:
- add login_token table and function for creating login tokens
- add Web RPC login_token_lookup.php for mapping token to auth
- change concierge protocol to take project ID and login token
- update download.php so that it gets client version info
    from versions.xml (from BOINC web site)
    and displays buttons with OS name, versions and file sizes
    like on the BOINC download page
- make "register.php" work

I've tested this all the way through downloading the installer file
with the augmented name.
Changes to the installer and client are needed to complete the system.