### PR TITLE
Fix missing user_id on download page

### DIFF
--- a/html/user/download.php
+++ b/html/user/download.php
@@ -117,6 +117,7 @@ function download_button_vbox($v, $project_id, $token, $user) {
         '<form action="https://boinc.berkeley.edu/concierge.php" method="post">
         <input type=hidden name=project_id value="%d">
         <input type=hidden name=token value="%s">
+        <input type=hidden name=user_id value="%d">
         <input type=hidden name=filename value="%s">
         <button class="btn btn-success">
         <font size=+1><u>Download BOINC + VirtualBox</u></font>

--- a/html/user/download.php
+++ b/html/user/download.php
@@ -113,6 +113,10 @@ function download_button($v, $project_id, $token, $user) {
 }
 
 function download_button_vbox($v, $project_id, $token, $user) {
+    // if no vbox version exists for platform, don't show vbox button
+    if(!$v->vbox_filename) {
+        return;
+    }
     return sprintf(
         '<form action="https://boinc.berkeley.edu/concierge.php" method="post">
         <input type=hidden name=project_id value="%d">


### PR DESCRIPTION
Fixes issue #2224 and fixes bug where the download page renders a broken vbox download button when a platform doesn't have a vbox version (the fix is to not render the button)