### PR TITLE
Drupal: Changed permissions of privatemsg module to not allow …

### DIFF
--- a/drupal/sites/all/features/private_messages/private_messages.features.user_permission.inc
+++ b/drupal/sites/all/features/private_messages/private_messages.features.user_permission.inc
@@ -11,7 +11,6 @@ function private_messages_user_default_permissions() {
     'name' => 'administer privatemsg settings',
     'roles' => array(
       '0' => 'administrator',
-      '1' => 'authenticated user',
     ),
   );
 


### PR DESCRIPTION
'authenticated user' access to the settings of private messages.

Part of https://dev.gridrepublic.org/browse/DBOINCP-415