### PR TITLE
Mac installer: correctly replace screensaver when installing an older…

### DIFF
--- a/mac_installer/complist.plist
+++ b/mac_installer/complist.plist
@@ -16,7 +16,7 @@
 	</dict>
 	<dict>
 		<key>BundleIsVersionChecked</key>
-		<true/>
+		<false/>
 		<key>BundleOverwriteAction</key>
 		<string>upgrade</string>
 		<key>RootRelativeBundlePath</key>


### PR DESCRIPTION
… version of BOINC to replace a newer version

The Mac installer was incorrectly deleting the screensaver when an older version was being installed over a newer version, due to an incorrect setting. This fixes the setting so that the same version of the screensaver is installed as the other components.