### PR TITLE
Manager: Change back 'Forgot your account info?' to 'Forgot your pass…

### DIFF
--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -492,7 +492,7 @@ void CAccountInfoPage::OnPageChanged( wxWizardExEvent& /* event */ ) {
 
     if (!IS_ACCOUNTMANAGERWIZARD()) {
         m_pAccountForgotPasswordCtrl->SetLabel(
-            _("Forgot your account info?")
+            _("Forgot your password?")
         );
         m_pAccountForgotPasswordCtrl->SetURL(
             wxString(pWA->GetProjectURL() + _T("get_passwd.php"))


### PR DESCRIPTION
…word?'

This reverts #2197 pull request after the discussion on #1049.
Fixes #1049.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>