### PR TITLE
Drupal: Unbanned users set role 'community member'.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
@@ -56,7 +56,7 @@ function boincuser_check_credit_requirements() {
   $community_role = array_search('community member', user_roles(true));
   $unrestricted_role = array_search('verified contributor', user_roles(true));
   
-  // Set user roles based on current penalty status and total credit
+  // Set user roles based on current penalty status...
   if ($account->boincuser_penalty_expiration > time()) {
     drupal_set_message(bts(
       'You are banned from community participation until @date',
@@ -72,25 +72,36 @@ function boincuser_check_credit_requirements() {
     }
     user_save($account, array('roles' => $account->roles));
   }
-  elseif ($account->boincuser_total_credit >= $min_credit_to_post) {
-    if (!isset($account->roles[$unrestricted_role])) {
-      // This user is now above the credit threshold and is allowed full
-      // privileges
-      $account->roles[$unrestricted_role] = 'verified contributor';
-      user_save($account, array('roles' => $account->roles));
-    }
-  }
   else {
-    drupal_set_message(bts(
-      'You must earn @count more credits to be able to post comments on this site.',
-      array('@count' => $min_credit_to_post - $account->boincuser_total_credit)
-    ), 'warning', FALSE);
-    if (isset($account->roles[$unrestricted_role])) {
-      // Either the threshold has been raised or credits have been revoked;
-      // this user no longer qualifies for full privileges
-      unset($account->roles[$unrestricted_role]);
+    if (!isset($account->roles[$community_role])) {
+      // The user should be a 'community member' role. If the user was
+      // previously banned, this will restore that role.
+      $account->roles[$community_role] = 'community member';
       user_save($account, array('roles' => $account->roles));
     }
+
+    // ... and total credit.
+    if ($account->boincuser_total_credit >= $min_credit_to_post) {
+      if (!isset($account->roles[$unrestricted_role])) {
+        // This user is now above the credit threshold and is allowed full
+        // privileges
+        $account->roles[$unrestricted_role] = 'verified contributor';
+        user_save($account, array('roles' => $account->roles));
+      }
+    }
+    else {
+      drupal_set_message(bts(
+        'You must earn @count more credits to be able to post comments on this site.',
+        array('@count' => $min_credit_to_post - $account->boincuser_total_credit)
+      ), 'warning', FALSE);
+      if (isset($account->roles[$unrestricted_role])) {
+        // Either the threshold has been raised or credits have been revoked;
+        // this user no longer qualifies for full privileges
+        unset($account->roles[$unrestricted_role]);
+        user_save($account, array('roles' => $account->roles));
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
Fixed bug returning a previously banned user to the role 'community member'.

https://dev.gridrepublic.org/browse/DBOINCP-416