### PR TITLE
Add generated systemd unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ boinc_path_config.py
 pkginfo
 prototype
 client/scripts/boinc-client
+client/scripts/boinc-client.service
 config.h
 config.log
 config.status

--- a/client/scripts/Makefile.am
+++ b/client/scripts/Makefile.am
@@ -2,16 +2,28 @@
 
 install-exec-hook:
 	chmod +x boinc-client
-	$(INSTALL) -d $(DESTDIR)$(sysconfdir)/init.d
-	$(INSTALL) -b boinc-client $(DESTDIR)$(sysconfdir)/init.d/boinc-client
+	if [ -d /etc/init.d ] ; then \
+		$(INSTALL) -d $(DESTDIR)$(sysconfdir)/init.d ; \
+		$(INSTALL) -b boinc-client $(DESTDIR)$(sysconfdir)/init.d/boinc-client ; \
+	fi
+	if [ -d /usr/lib/systemd/system ] ; then \
+		$(INSTALL) -d $(DESTDIR)/usr/lib/systemd/system/ ; \
+		$(INSTALL_DATA) boinc-client.service $(DESTDIR)/usr/lib/systemd/system/boinc-client.service ; \
+	elif [ -d /lib/systemd/system ] ; then \
+		$(INSTALL) -d $(DESTDIR)/lib/systemd/system/ ; \
+		$(INSTALL_DATA) boinc-client.service $(DESTDIR)/lib/systemd/system/boinc-client.service ; \
+	fi
 	if [ -d /etc/sysconfig ] ; then \
 	  $(INSTALL) -d $(DESTDIR)$(sysconfdir)/sysconfig ; \
-	  $(INSTALL) $(srcdir)/boinc-client.conf $(DESTDIR)$(sysconfdir)/sysconfig/boinc-client ; \
+	  $(INSTALL_DATA) $(srcdir)/boinc-client.conf $(DESTDIR)$(sysconfdir)/sysconfig/boinc-client ; \
 	elif [ -d /etc/default ] ; then \
 	  $(INSTALL) -d $(DESTDIR)$(sysconfdir)/default ; \
-	  $(INSTALL) $(srcdir)/boinc-client.conf $(DESTDIR)$(sysconfdir)/default/boinc-client ; \
+	  $(INSTALL_DATA) $(srcdir)/boinc-client.conf $(DESTDIR)$(sysconfdir)/default/boinc-client ; \
 	else \
 	  $(INSTALL) -d $(DESTDIR)$(sysconfdir) ; \
-	  $(INSTALL) $(srcdir)/boinc-client.conf $(DESTDIR)$(sysconfdir)/boinc-client.conf ; \
+	  $(INSTALL_DATA) $(srcdir)/boinc-client.conf $(DESTDIR)$(sysconfdir)/boinc-client.conf ; \
 	fi
 
+clean:
+	rm boinc-client.service
+	rm boinc-client

--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -1,0 +1,19 @@
+[Unit]
+Description=Berkeley Open Infrastructure Network Computing Client
+Documentation=man:boinc(1)
+After=network-online.target
+
+[Service]
+ProtectHome=true
+Type=simple
+Nice=10
+User=boinc
+WorkingDirectory=~
+ExecStart=@exec_prefix@/bin/boinc
+ExecStop=@exec_prefix@/bin/boinccmd --quit
+ExecReload=@exec_prefix@/bin/boinccmd --read_cc_config
+ExecStopPost=/bin/rm -f lockfile
+IOSchedulingClass=idle
+
+[Install]
+WantedBy=multi-user.target

--- a/configure.ac
+++ b/configure.ac
@@ -1302,6 +1302,7 @@ AC_CONFIG_FILES([
                  client/win/boinc_path_config.py:py/boinc_path_config.py.in
                  client/scripts/Makefile
                  client/scripts/boinc-client
+                 client/scripts/boinc-client.service
                  db/Makefile
                  doc/Makefile
                  doc/manpages/Makefile


### PR DESCRIPTION
Both Fedora and Debian have their own systemd units for boinc;
this is based on elements of both so we stop duplicating effort.

Closes: #2255