### PR TITLE
web: add option for limiting # of links per post

### DIFF
--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -113,6 +113,17 @@ $special_user_bitfield[S_VOLUNTEER_TESTER] = tra("Volunteer tester");
 $special_user_bitfield[S_SCIENTIST] = tra("Project scientist");
 $special_user_bitfield[S_HELP_DESK_EXPERT] = tra("Help desk expert");
 
+function link_count($x) {
+    $n = 0;
+    while (1) {
+        $x = strstr($x, "[url");
+        if (!$x) break;
+        $n++;
+        $x = substr($x, 4);
+    }
+    return $n;
+}
+
 // show a banner with search form on left and PM info on right
 //
 function show_forum_header($user) {
@@ -865,6 +876,12 @@ function notify_subscribers($thread, $user) {
 // Don't do these things directly - use these functions
 //
 function create_post($content, $parent_id, $user, $forum, $thread, $signature) {
+    if (POST_MAX_LINKS
+        && link_count($content) > POST_MAX_LINKS
+        && !is_moderator($user, $forum)
+    ) {
+        return 0;
+    }
     $content = substr($content, 0, 64000);
     $content = BoincDb::escape_string($content);
     $now = time();
@@ -900,6 +917,12 @@ function update_forum_timestamp($forum) {
 }
 
 function create_thread($title, $content, $user, $forum, $signature, $export) {
+    if (POST_MAX_LINKS
+        && link_count($content) > POST_MAX_LINKS
+        && !is_moderator($user, $forum)
+    ) {
+        return 0;
+    }
     $title = trim($title);
     $title = sanitize_tags($title);
     $title = BoincDb::escape_string($title);

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -94,6 +94,9 @@ if (!defined('NO_GLOBAL_PREFS')) {
 if (!defined('USER_HOME')) {
     define('USER_HOME', 'home.php');
 }
+if (!defined('POST_MAX_LINKS')) {
+    define('POST_MAX_LINKS', 0);
+}
 
 // sleep this long on any login failure
 // (slow the rate of hacker attacks)

--- a/html/user/forum_edit.php
+++ b/html/user/forum_edit.php
@@ -60,6 +60,12 @@ $title = post_str("title", true);
 $preview = post_str("preview", true);
 
 if (post_str('submit',true) && (!$preview)) {
+    if (POST_MAX_LINKS
+        && link_count($content) > POST_MAX_LINKS
+        && !is_moderator($logged_in_user, $forum)
+    ) {
+        error_page("Can't update post");
+    }
     check_tokens($logged_in_user->authenticator);
     
     $add_signature = (post_str('add_signature', true) == "1")?1:0;

--- a/html/user/forum_post.php
+++ b/html/user/forum_post.php
@@ -67,7 +67,11 @@ if ($content && $title && (!$preview)){
         $thread = create_thread(
             $title, $content, $logged_in_user, $forum, $add_signature, $export
         );
-        header('Location: forum_thread.php?id=' . $thread->id);
+        if ($thread) {
+            header('Location: forum_thread.php?id=' . $thread->id);
+        } else {
+            error_page("Can't create thread");
+        }
     }
 }
 


### PR DESCRIPTION
One form of spam involves putting lots of links in a post.
This lets you limit it by setting POST_MAX_LINKS in project.inc.
Limit doesn't apply to moderators.