### PR TITLE
Drupal: Allow users to ignore private messages.

### DIFF
--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.module
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.module
@@ -185,6 +185,39 @@ function boinccore_menu_alter(&$items) {
       'type' => MENU_CALLBACK,
     );
   }
+
+  // 'Remove' menu paths for ignore_user and privatemsg
+  // (pm_block_user) module which we have 'overridden' with
+  // boincwork's own functions.
+  if (module_exists('ignore_user')) {
+    $check = array(
+      'ignore_user/add',
+      'ignore_user/remove',
+    );
+    foreach ($check as $path) {
+      if (isset($items[$path])) {
+        $items[$path]['access callback'] = FALSE;
+      }
+    }
+
+    // Redirect user to privacy prefs page.
+    $path1 = 'ignore_user/list';
+    if (isset($items[$path1])) {
+      $items[$path1]['page callback'] = 'drupal_goto';
+      $items[$path1]['page arguments'] = array('account/prefs/privacy');
+    }
+  }
+
+  if (module_exists('pm_block_user')) {
+    $check = array(
+      'messages/block/%user',
+    );
+    foreach ($check as $path) {
+      if (isset($items[$path])) {
+        $items[$path]['access callback'] = FALSE;
+      }
+    }
+  }
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/boincteam/boincteam.module
+++ b/drupal/sites/default/boinc/modules/boincteam/boincteam.module
@@ -96,7 +96,7 @@ function boincteam_menu() {
     'type' => MENU_CALLBACK
   );
   $items['community/teams/%/user-name-autocomplete'] = array(
-    'page callback' => '_boincteam_user_name_autocomplete',
+    'page callback' => '_boincuser_user_name_autocomplete',
     'access callback' => 'boincteam_is_founder',
     'access arguments' => array(2),
     'type' => MENU_CALLBACK,

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
@@ -137,19 +137,3 @@ function _boincteam_userids($boincteamid, $boincid=TRUE) {
     return array_map('boincuser_lookup_uid', $ids);
   }
 }
-
-/**
- * Autocomplete function to search for username in boinc user
- * database.
- */
-function _boincteam_user_name_autocomplete($string) {
-  $matches = array();
-  db_set_active('boinc');
-  $result = db_query_range("SELECT id,name FROM {user} WHERE name LIKE '%s%'", $string, 0, 10);
-  db_set_active('default');
-  while ($user = db_fetch_object($result)) {
-    $matches[$user->name . '_' . $user->id] = $user->name . " (" . $user->id . ')';
-  }
-
-  drupal_json((object)$matches);
-}

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1499,7 +1499,6 @@ function boincuser_account_finish() {
     $modsentence = bts('Please note: user profiles are subject to moderation.', array(), NULL, 'boinc:account-finish');
   }
 
-  // @todo - add bts() function calls
   $username = $user->boincuser_name;
   $site_name = variable_get('site_name', 'Drupal-BOINC');
   $output = "<p>" . bts('Thank you @user_name for joining @site_name. Your account has been created. Your BOINC client should start working on assigned tasks soon, without any additional action or configuration. Please visit the links below for more information and additional options. (Links will open in a new window.)',

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -187,6 +187,11 @@ function boincuser_menu() {
     'access callback' => TRUE,
     'type' => MENU_CALLBACK,
   );
+  $items['boincuser/autocomplete'] = array(
+    'page callback' => '_boincuser_user_name_autocomplete',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
   return $items;
 }
 

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
@@ -424,3 +424,20 @@ function boincuser_views_friends_block_header($context = null) {
   return '<h2 class="pane-title">' . bts('Friends (@count)', 
     array('@count' => $friend_count)) . '</h2>';
 }
+
+/**
+ * Autocomplete function to search for username in boinc user
+ * database.
+ */
+function _boincuser_user_name_autocomplete($string) {
+  $matches = array();
+  // @todo - use boinc_rw if/when read-only PR is merged
+  db_set_active('boinc');
+  $result = db_query_range("SELECT id,name FROM {user} WHERE name LIKE '%s%'", $string, 0, 10);
+  db_set_active('default');
+  while ($user = db_fetch_object($result)) {
+      $matches[$user->name . '_' . $user->id] = htmlentities($user->name) . " (" . $user->id . ')';
+  }
+
+  drupal_json((object)$matches);
+}

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -59,6 +59,23 @@ function boincwork_menu() {
     'type' => MENU_LOCAL_TASK,
     'weight' => 15
   );
+  // @todo - check ignore_user module installed
+  $items['account/prefs/privacy/ignore_user/add'] = array(
+    'title' => 'Add from ignore list',
+    'description' => 'Add user that you with to ignore to your ignore list.',
+    'page callback' => 'boincwork_ignore_user_add_user',
+    'access callback' => 'user_access',
+    'access arguments' => array('ignore user'),
+    'type' => MENU_CALLBACK,
+  );
+  $items['account/prefs/privacy/ignore_user/remove'] = array(
+    'title' => 'Remove from ignore list',
+    'description' => 'Remove user from your ignore list.',
+    'page callback' => 'boincwork_ignore_user_remove_user',
+    'access callback' => 'user_access',
+    'access arguments' => array('ignore user'),
+    'type' => MENU_CALLBACK,
+  );
   $items['account/certs'] = array(
     'title' =>'Account certificate',
     'page callback' => 'boincwork_certificates',

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -191,6 +191,17 @@ function boincwork_menu() {
 }
 
 /**
+ * Implementation of hook_theme().
+ */
+function boincwork_theme() {
+  return array(
+    'boincwork_privacyprefs_form' => array(
+      'arguments' => array('form'),
+    ),
+  );
+}
+
+/**
 * Implementation of hook_views_api().
 */
 function boincwork_views_api() {

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -257,6 +257,31 @@ function boincwork_locale_refresh() {
 }
 
 
+/**
+ * Implementation of hook_privatemsg_message_view_alter
+ */
+
+function boincwork_privatemsg_message_view_alter(&$vars) {
+  global $user;
+
+  $author = $vars['message']['author'];
+  if (!isset($vars['message']['thread_id'])) {
+    // No thread id, this is probably only a preview
+    return;
+  }
+  $thread_id = $vars['message']['thread_id'];
+
+  // @todo - add/replace with bts()
+  if ($user->uid != $author->uid) {
+    if ($vars['message']['is_blocked']) {
+      $vars['message_actions']['unignore_user'] = array('title' => t('Stop Ignoring User'), 'href' => 'account/prefs/privacy/ignore_user/remove/'. $author->uid, 'query' => 'destination=messages/view/' . $thread_id);
+    }
+    else {
+      $vars['message_actions']['ignore_user'] = array('title' => t('Ignore User'), 'href' => 'account/prefs/privacy/ignore_user/add/'. $author->uid, 'query' => 'destination=messages/view/' . $thread_id);
+    }
+  }
+}
+
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
  * Page callbacks from hook_menu()
  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -59,23 +59,24 @@ function boincwork_menu() {
     'type' => MENU_LOCAL_TASK,
     'weight' => 15
   );
-  // @todo - check ignore_user module installed
-  $items['account/prefs/privacy/ignore_user/add'] = array(
-    'title' => 'Add from ignore list',
-    'description' => 'Add user that you with to ignore to your ignore list.',
-    'page callback' => 'boincwork_ignore_user_add_user',
-    'access callback' => 'user_access',
-    'access arguments' => array('ignore user'),
-    'type' => MENU_CALLBACK,
-  );
-  $items['account/prefs/privacy/ignore_user/remove'] = array(
-    'title' => 'Remove from ignore list',
-    'description' => 'Remove user from your ignore list.',
-    'page callback' => 'boincwork_ignore_user_remove_user',
-    'access callback' => 'user_access',
-    'access arguments' => array('ignore user'),
-    'type' => MENU_CALLBACK,
-  );
+  if (module_exists('ignore_user')) {
+    $items['account/prefs/privacy/ignore_user/add'] = array(
+      'title' => 'Add from ignore list',
+      'description' => 'Add user that you with to ignore to your ignore list.',
+      'page callback' => 'boincwork_ignore_user_add_user',
+      'access callback' => 'user_access',
+      'access arguments' => array('ignore user'),
+      'type' => MENU_CALLBACK,
+    );
+    $items['account/prefs/privacy/ignore_user/remove'] = array(
+      'title' => 'Remove from ignore list',
+      'description' => 'Remove user from your ignore list.',
+      'page callback' => 'boincwork_ignore_user_remove_user',
+      'access callback' => 'user_access',
+      'access arguments' => array('ignore user'),
+      'type' => MENU_CALLBACK,
+    );
+  }// endif module_exists
   $items['account/certs'] = array(
     'title' =>'Account certificate',
     'page callback' => 'boincwork_certificates',
@@ -271,13 +272,20 @@ function boincwork_privatemsg_message_view_alter(&$vars) {
   }
   $thread_id = $vars['message']['thread_id'];
 
-  // @todo - add/replace with bts()
   if ($user->uid != $author->uid) {
     if ($vars['message']['is_blocked']) {
-      $vars['message_actions']['unignore_user'] = array('title' => t('Stop Ignoring User'), 'href' => 'account/prefs/privacy/ignore_user/remove/'. $author->uid, 'query' => 'destination=messages/view/' . $thread_id);
+      $vars['message_actions']['unignore_user'] = array(
+        'title' => bts('Stop Ignoring User', array(), NULL, 'boinc:ignore-user-remove'),
+        'href' => 'account/prefs/privacy/ignore_user/remove/'. $author->uid,
+        'query' => 'destination=messages/view/' . $thread_id,
+      );
     }
     else {
-      $vars['message_actions']['ignore_user'] = array('title' => t('Ignore User'), 'href' => 'account/prefs/privacy/ignore_user/add/'. $author->uid, 'query' => 'destination=messages/view/' . $thread_id);
+      $vars['message_actions']['ignore_user'] = array(
+        'title' => bts('Ignore User', array(), NULL, 'boinc:ignore-user-add'),
+        'href' => 'account/prefs/privacy/ignore_user/add/'. $author->uid,
+        'query' => 'destination=messages/view/' . $thread_id,
+      );
     }
   }
 }

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1726,58 +1726,57 @@ function boincwork_privacyprefs_form(&$form_state) {
   );
 
   // Ignore and block users
-  // @todo - check if ignore_user module/privatemsg module installed.
-  // @todo - add bts(), replace t() with bts()
-  $form['ignoreheader'] = array(
-    '#title' => bts('Ignore Users', array(), NULL, 'boinc:account-preferences-privacy'),
-    '#type' => 'fieldset',
-    '#description' => bts('You may ignore users in the forums and block users from sending you private messages.', array(), NULL, 'boinc:ignore-user-help'),
-    '#collapsible' => TRUE,
-    '#collapsed' => FALSE
-  );
-  
-  // Table for ignored users
-  $form['ignoreblock']['current_list'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Current users on your Ignore List'),
-  );
-  $form['ignoreblock']['current_list']['ignored_users'] = array(
-    '#type' => 'markup',
-    '#value' => '',
-  );
-
-  $ignored_users = _ignore_user_ignored_users();
-  foreach ($ignored_users as $ignored_user) {
-    $form['ignoreblock']['username'][$ignored_user['iuid']] = array(
-      '#value' => $ignored_user['username'],
+  if (module_exists('ignore_user')) {
+    $form['ignoreheader'] = array(
+      '#title' => bts('Ignore Users', array(), NULL, 'boinc:account-preferences-privacy'),
+      '#type' => 'fieldset',
+      '#description' => bts('<p>You may ignore users in the forums and block users from sending you private messages.<p>', array(), NULL, 'boinc:ignore-user-help'),
+      '#collapsible' => TRUE,
+      '#collapsed' => FALSE
     );
-    $form['ignoreblock']['delete'][$ignored_user['iuid']] = array(
-      '#value' => l(t('delete'), 'account/prefs/privacy/ignore_user/remove/'. $ignored_user['iuid'], array()),
+
+    // Table for ignored users
+    $form['ignoreheader']['ignoreblock'] = array(
+      '#type' => 'fieldset',
+      '#title' => bts('Current users on your Ignore List', array(), NULL, 'boinc:ignore-user-list'),
     );
-  }
-  $form['ignoreblock']['pager'] = array('#value' => theme('pager', NULL, 10, 0));
 
-  // Sub-form to add user to ignore list
-  // @todo - add/replace t() with bts()
-  $form['add_ignore_user'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Add user to Ignore List'),
-  );
+    $ignored_users = _ignore_user_ignored_users();
+    foreach ($ignored_users as $ignored_user) {
+      $form['ignoreheader']['ignoreblock']['username'][$ignored_user['iuid']] = array(
+        '#value' => $ignored_user['username'],
+      );
+      $form['ignoreheader']['ignoreblock']['delete'][$ignored_user['iuid']] = array(
+        '#value' => l(
+          bts('delete', array(), NULL, 'boinc:ignore-user-delete-button'),
+          'account/prefs/privacy/ignore_user/remove/'. $ignored_user['iuid'],
+          array()
+        ),
+      );
+    }
+    $form['ignoreheader']['ignoreblock']['pager'] = array('#value' => theme('pager', NULL, 10, 0));
 
-  $form['add_ignore_user']['username'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Username'),
-    '#description' => t('To lookup a username start typing in the search box. A list of usernames will appear as you type. The number appearing in the suffix is the BOINC id. You can find a user\'s BOINC id on their user profile page.'),
-    '#weight' => -10,
-    '#size' => 50,
-    '#autocomplete_path' => 'boincuser/autocomplete',
-  );
+    // Sub-form to add user to ignore list
+    $form['ignoreheader']['add_ignore_user'] = array(
+      '#type' => 'fieldset',
+      '#title' => bts('Add user to Ignore List', array(), NULL, 'boinc:ignore-user-add'),
+    );
 
-  $form['add_ignore_user']['submit'] = array(
-    '#type' => 'submit',
-    '#value' => t('Ignore user'),
-    '#submit' => array('_boincwork_ignore_list_form_submit'),
-  );
+    $form['ignoreheader']['add_ignore_user']['username'] = array(
+      '#type' => 'textfield',
+      '#title' => bts('Username', array(), NULL, 'boinc:ignore-user-searchbox'),
+      '#description' => bts('To lookup a username start typing in the search box. A list of usernames will appear as you type. The number appearing in the suffix is the BOINC id. You can find a user\'s BOINC id on their user profile page.', array(), NULL, 'boinc:ignore-user-searchbox-help'),
+      '#weight' => -10,
+      '#size' => 50,
+      '#autocomplete_path' => 'boincuser/autocomplete',
+    );
+
+    $form['ignoreheader']['add_ignore_user']['submit'] = array(
+      '#type' => 'submit',
+      '#value' => bts('Ignore user', array(), NULL, 'boinc:ignore-user-add'),
+      '#submit' => array('_boincwork_ignore_list_form_submit'),
+    );
+  }// endif module_exists
 
   $form['prefs']['separator_bottom'] = array(
     '#value' => '<div class="separator buttons"></div>'
@@ -1810,26 +1809,33 @@ function boincwork_privacyprefs_form(&$form_state) {
  */
 function theme_boincwork_privacyprefs_form($form) {
 
-  // @todo - add/replace t() with bts()
   $output = '';
   $output .= drupal_render($form['privacy']);
-  $output .= drupal_render($form['ignoreheader']);
+  //$output .= drupal_render($form['ignoreheader']);
 
-  $header = array(t('Username'), t('Operations'));
+  $header = array(
+    bts('Username', array(), NULL, 'boinc:ignore-user-list'),
+    bts('Operations', array(), NULL, 'boinc:ignore-user-list')
+  );
 
-  if (isset($form['ignoreblock']['username']) && is_array($form['ignoreblock']['username'])) {
-    foreach (element_children($form['ignoreblock']['username']) as $key) {
+  if (isset($form['ignoreheader']['ignoreblock']['username']) && is_array($form['ignoreheader']['ignoreblock']['username'])) {
+    foreach (element_children($form['ignoreheader']['ignoreblock']['username']) as $key) {
       $row = array();
-      $row[] = drupal_render($form['ignoreblock']['username'][$key]);
-      $row[] = drupal_render($form['ignoreblock']['delete'][$key]);
+      $row[] = drupal_render($form['ignoreheader']['ignoreblock']['username'][$key]);
+      $row[] = drupal_render($form['ignoreheader']['ignoreblock']['delete'][$key]);
       $rows[] = $row;
     }
   }
   else {
-    $rows[] = array(array('data' => t('You have not added any users to your Ignore List'), 'colspan' => '2'));
+    $rows[] = array(
+      array(
+        'data' => bts('You have not added any users to your Ignore List.', array(), NULL, 'boinc:ignore-user-list'),
+        'colspan' => '2',
+      )
+    );
   }
 
-  $form['ignoreblock']['current_list']['ignored_users']['#value'] = theme('table', $header, $rows);
+  $form['ignoreheader']['ignoreblock']['current_list']['ignored_users']['#value'] = theme('table', $header, $rows);
   $output .= drupal_render($form['ignoreblock']['current_list']);
 
   if ($form['pager']['#value']) {
@@ -1881,7 +1887,6 @@ function boincwork_privacyprefs_form_submit($form, &$form_state) {
  * ignore list.
  */
 function _boincwork_ignore_list_form_submit($form, $form_state) {
-  //@todo - add/replace bts()
   boincwork_ignore_user_add_user_username($form_state['values']['username']);
   drupal_set_message(
     bts('@username has been added to your ignore list. See your !privacy_preferences for more details.',

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1724,7 +1724,59 @@ function boincwork_privacyprefs_form(&$form_state) {
     '#attributes' => array('class' => 'fancy'),
     '#default_value' => $default['privacy']['show_hosts']
   );
+
+  // Ignore and block users
+  // @todo - add bts(), replace t() with bts()
+  $form['ignoreheader'] = array(
+    '#title' => bts('Ignore Users', array(), NULL, 'boinc:account-preferences-privacy'),
+    '#type' => 'fieldset',
+    '#description' => 'Here you can ignore users in the forums and block users from sending you private messages',
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE
+  );
   
+  // Table for ignored users
+  $form['ignoreblock']['current_list'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Current users on your Ignore List'),
+  );
+  $form['ignoreblock']['current_list']['ignored_users'] = array(
+    '#type' => 'markup',
+    '#value' => '',
+  );
+
+  $ignored_users = _ignore_user_ignored_users();
+  foreach ($ignored_users as $ignored_user) {
+    $form['ignoreblock']['username'][$ignored_user['iuid']] = array(
+      '#value' => $ignored_user['username'],
+    );
+    $form['ignoreblock']['delete'][$ignored_user['iuid']] = array(
+      '#value' => l(t('delete'), 'ignore_user/remove/'. $ignored_user['iuid'], array()),
+    );
+  }
+  $form['ignoreblock']['pager'] = array('#value' => theme('pager', NULL, 10, 0));
+
+  // Sub-form to add user to ignore list
+  // @todo - add/replace t() with bts()
+  $form['add_ignore_user'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Add user to Ignore List'),
+  );
+
+  $form['add_ignore_user']['username'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Username'),
+    '#description' => t('To lookup a username start typing in the search box. A list of usernames will appear as you type. The number appearing in the suffix is the BOINC id. You can find a user\'s BOINC id on their user profile page.'),
+    '#weight' => -10,
+    '#size' => 50,
+    '#autocomplete_path' => 'boincuser/autocomplete',
+  );
+
+  $form['add_ignore_user']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Ignore user'),
+  );
+
   $form['prefs']['separator_bottom'] = array(
     '#value' => '<div class="separator buttons"></div>'
   );
@@ -1747,6 +1799,42 @@ function boincwork_privacyprefs_form(&$form_state) {
   );
   
   return $form;
+}
+
+/**
+ * Theme the form where user's can manage their ignore list
+ */
+function theme_boincwork_privacyprefs_form($form) {
+
+  // @todo - add/replace t() with bts()
+  $output = '';
+  $output .= drupal_render($form['privacy']);
+  $output .= drupal_render($form['ignoreheader']);
+
+  $header = array(t('Username'), t('Operations'));
+
+  if (isset($form['ignoreblock']['username']) && is_array($form['ignoreblock']['username'])) {
+    foreach (element_children($form['ignoreblock']['username']) as $key) {
+      $row = array();
+      $row[] = drupal_render($form['ignoreblock']['username'][$key]);
+      $row[] = drupal_render($form['ignoreblock']['delete'][$key]);
+      $rows[] = $row;
+    }
+  }
+  else {
+    $rows[] = array(array('data' => t('You have not added any users to your Ignore List'), 'colspan' => '2'));
+  }
+
+  $form['ignoreblock']['current_list']['ignored_users']['#value'] = theme('table', $header, $rows);
+  $output .= drupal_render($form['ignoreblock']['current_list']);
+
+  if ($form['pager']['#value']) {
+    $output .= drupal_render($form['pager']);
+  }
+
+  $output .= drupal_render($form);
+
+  return $output;
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1726,6 +1726,7 @@ function boincwork_privacyprefs_form(&$form_state) {
   );
 
   // Ignore and block users
+  // @todo - check if ignore_user module/privatemsg module installed.
   // @todo - add bts(), replace t() with bts()
   $form['ignoreheader'] = array(
     '#title' => bts('Ignore Users', array(), NULL, 'boinc:account-preferences-privacy'),
@@ -1751,7 +1752,7 @@ function boincwork_privacyprefs_form(&$form_state) {
       '#value' => $ignored_user['username'],
     );
     $form['ignoreblock']['delete'][$ignored_user['iuid']] = array(
-      '#value' => l(t('delete'), 'ignore_user/remove/'. $ignored_user['iuid'], array()),
+      '#value' => l(t('delete'), 'account/prefs/privacy/ignore_user/remove/'. $ignored_user['iuid'], array()),
     );
   }
   $form['ignoreblock']['pager'] = array('#value' => theme('pager', NULL, 10, 0));
@@ -1775,6 +1776,7 @@ function boincwork_privacyprefs_form(&$form_state) {
   $form['add_ignore_user']['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Ignore user'),
+    '#submit' => array('_boincwork_ignore_list_form_submit'),
   );
 
   $form['prefs']['separator_bottom'] = array(
@@ -1789,6 +1791,8 @@ function boincwork_privacyprefs_form(&$form_state) {
     '#prefix' => '<li class="first tab">',
     '#type' => 'submit',
     '#value' => bts('Save changes', array(), NULL, 'boinc:form-save'),
+    '#validate' => array('boincwork_privacyprefs_form_validate'),
+    '#submit' => array('boincwork_privacyprefs_form_submit'),
     '#suffix' => '</li>'
   );
   $form['prefs']['form control tabs'] = array(
@@ -1870,6 +1874,16 @@ function boincwork_privacyprefs_form_submit($form, &$form_state) {
   db_set_active('default');
   
   drupal_set_message(t('Your privacy preferences have been updated.'));
+}
+
+/**
+ * Additional submit handler for privacy form, button to add user to
+ * ignore list.
+ */
+function _boincwork_ignore_list_form_submit($form, $form_state) {
+  //@todo - add/replace bts()
+  boincwork_ignore_user_add_user_username($form_state['values']['username']);
+  drupal_set_message(t('%username has been added to your ignore list', array('%username' => $form_state['values']['username'])));
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1727,7 +1727,7 @@ function boincwork_privacyprefs_form(&$form_state) {
 
   // Ignore and block users
   if (module_exists('ignore_user')) {
-    $form['ignoreheader'] = array(
+    $form['ignoreblock'] = array(
       '#title' => bts('Ignore Users', array(), NULL, 'boinc:account-preferences-privacy'),
       '#type' => 'fieldset',
       '#description' => bts('<p>You may ignore users in the forums and block users from sending you private messages.<p>', array(), NULL, 'boinc:ignore-user-help'),
@@ -1736,17 +1736,20 @@ function boincwork_privacyprefs_form(&$form_state) {
     );
 
     // Table for ignored users
-    $form['ignoreheader']['ignoreblock'] = array(
-      '#type' => 'fieldset',
-      '#title' => bts('Current users on your Ignore List', array(), NULL, 'boinc:ignore-user-list'),
+    $form['ignoreblock']['current_ignore_section'] = array(
+      '#type' => 'item',
+      '#value' => bts('Current users on your Ignore List', array(), NULL, 'boinc:ignore-user-list'),
+      '#prefix' => '<h4>',
+      '#suffix' => '</h4>',
+      '#weight' => -20,
     );
 
     $ignored_users = _ignore_user_ignored_users();
     foreach ($ignored_users as $ignored_user) {
-      $form['ignoreheader']['ignoreblock']['username'][$ignored_user['iuid']] = array(
+      $form['ignoreblock']['username'][$ignored_user['iuid']] = array(
         '#value' => $ignored_user['username'],
       );
-      $form['ignoreheader']['ignoreblock']['delete'][$ignored_user['iuid']] = array(
+      $form['ignoreblock']['delete'][$ignored_user['iuid']] = array(
         '#value' => l(
           bts('delete', array(), NULL, 'boinc:ignore-user-delete-button'),
           'account/prefs/privacy/ignore_user/remove/'. $ignored_user['iuid'],
@@ -1754,27 +1757,32 @@ function boincwork_privacyprefs_form(&$form_state) {
         ),
       );
     }
-    $form['ignoreheader']['ignoreblock']['pager'] = array('#value' => theme('pager', NULL, 10, 0));
+    $form['ignoreblock']['pager'] = array('#value' => theme('pager', NULL, 10, 0));
 
     // Sub-form to add user to ignore list
-    $form['ignoreheader']['add_ignore_user'] = array(
-      '#type' => 'fieldset',
-      '#title' => bts('Add user to Ignore List', array(), NULL, 'boinc:ignore-user-add'),
+    $form['ignoreblock']['add_ignore_user_section'] = array(
+      '#type' => 'item',
+      '#value' => bts('Add user to Ignore List', array(), NULL, 'boinc:ignore-user-add'),
+      '#prefix' => '<h4>',
+      '#suffix' => '</h4>',
+      '#weight' => 10,
     );
 
-    $form['ignoreheader']['add_ignore_user']['username'] = array(
+    $form['ignoreblock']['addusername_toignorelist'] = array(
       '#type' => 'textfield',
       '#title' => bts('Username', array(), NULL, 'boinc:ignore-user-searchbox'),
       '#description' => bts('To lookup a username start typing in the search box. A list of usernames will appear as you type. The number appearing in the suffix is the BOINC id. You can find a user\'s BOINC id on their user profile page.', array(), NULL, 'boinc:ignore-user-searchbox-help'),
-      '#weight' => -10,
+      '#weight' => 11,
       '#size' => 50,
       '#autocomplete_path' => 'boincuser/autocomplete',
     );
 
-    $form['ignoreheader']['add_ignore_user']['submit'] = array(
+    $form['ignoreblock']['addusername_submit'] = array(
       '#type' => 'submit',
       '#value' => bts('Ignore user', array(), NULL, 'boinc:ignore-user-add'),
       '#submit' => array('_boincwork_ignore_list_form_submit'),
+      '#weight' => 12,
+      '#attributes' => array('class' => 'add_ignore_user'),
     );
   }// endif module_exists
 
@@ -1811,18 +1819,17 @@ function theme_boincwork_privacyprefs_form($form) {
 
   $output = '';
   $output .= drupal_render($form['privacy']);
-  //$output .= drupal_render($form['ignoreheader']);
 
   $header = array(
     bts('Username', array(), NULL, 'boinc:ignore-user-list'),
     bts('Operations', array(), NULL, 'boinc:ignore-user-list')
   );
 
-  if (isset($form['ignoreheader']['ignoreblock']['username']) && is_array($form['ignoreheader']['ignoreblock']['username'])) {
-    foreach (element_children($form['ignoreheader']['ignoreblock']['username']) as $key) {
+  if (isset($form['ignoreblock']['username']) && is_array($form['ignoreblock']['username'])) {
+    foreach (element_children($form['ignoreblock']['username']) as $key) {
       $row = array();
-      $row[] = drupal_render($form['ignoreheader']['ignoreblock']['username'][$key]);
-      $row[] = drupal_render($form['ignoreheader']['ignoreblock']['delete'][$key]);
+      $row[] = drupal_render($form['ignoreblock']['username'][$key]);
+      $row[] = drupal_render($form['ignoreblock']['delete'][$key]);
       $rows[] = $row;
     }
   }
@@ -1835,8 +1842,9 @@ function theme_boincwork_privacyprefs_form($form) {
     );
   }
 
-  $form['ignoreheader']['ignoreblock']['current_list']['ignored_users']['#value'] = theme('table', $header, $rows);
-  $output .= drupal_render($form['ignoreblock']['current_list']);
+  $attr = array('class' => 'ignore_user');
+  $form['ignoreblock']['current_list']['ignored_users']['#value'] = theme('table', $header, $rows, $attr);
+  $output .= drupal_render($form['current_list']);
 
   if ($form['pager']['#value']) {
     $output .= drupal_render($form['pager']);
@@ -1887,11 +1895,11 @@ function boincwork_privacyprefs_form_submit($form, &$form_state) {
  * ignore list.
  */
 function _boincwork_ignore_list_form_submit($form, $form_state) {
-  boincwork_ignore_user_add_user_username($form_state['values']['username']);
+  boincwork_ignore_user_add_user_username($form_state['values']['addusername_toignorelist']);
   drupal_set_message(
     bts('@username has been added to your ignore list. See your !privacy_preferences for more details.',
       array(
-        '@username' => $form_state['values']['username'],
+        '@username' => $form_state['values']['addusername_toignorelist'],
         '!privacy_preferences' => l(bts('privacy preferences', array(), NULL, 'boinc:ignore-user-add'), 'account/prefs/privacy'),
       ),
       NULL, 'boinc:ignore-user-add'),

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1825,6 +1825,7 @@ function theme_boincwork_privacyprefs_form($form) {
     bts('Operations', array(), NULL, 'boinc:ignore-user-list')
   );
 
+  $rows = array();
   if (isset($form['ignoreblock']['username']) && is_array($form['ignoreblock']['username'])) {
     foreach (element_children($form['ignoreblock']['username']) as $key) {
       $row = array();

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1584,25 +1584,6 @@ function communityprefs_form(&$form_state) {
     );
   }
 
-  //Ignored users list
-  if (module_exists('ignore_user')) {
-    $form['forums']['ignored_users'] = array(
-      '#value' => '<div class="form-item">'
-        . '<label>'
-	. bts('Ignore Users in forums:', array(), NULL, 'boinc:account-preferences-community')
-	. '</label>'
-        . bts('<a href="@ignore-user-list">View/Edit</a> your ignored users list.',
-	    array(
-	      '@ignore-user-list' => url('ignore_user/list'),
-	      array(
-            'attributes' => array('class' => 'form-link')
-          )
-	    ),
-        NULL, 'boinc:account-preferences-community')
-	. '</div>',
-    );
-  }//endif module_exists('ignore_user')
-
   //Bottom separator
   $form['separator_bottom'] = array(
     '#value' => '<div class="separator buttons"></div>',

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1731,7 +1731,7 @@ function boincwork_privacyprefs_form(&$form_state) {
   $form['ignoreheader'] = array(
     '#title' => bts('Ignore Users', array(), NULL, 'boinc:account-preferences-privacy'),
     '#type' => 'fieldset',
-    '#description' => 'Here you can ignore users in the forums and block users from sending you private messages',
+    '#description' => bts('You may ignore users in the forums and block users from sending you private messages.', array(), NULL, 'boinc:ignore-user-help'),
     '#collapsible' => TRUE,
     '#collapsed' => FALSE
   );
@@ -1883,7 +1883,14 @@ function boincwork_privacyprefs_form_submit($form, &$form_state) {
 function _boincwork_ignore_list_form_submit($form, $form_state) {
   //@todo - add/replace bts()
   boincwork_ignore_user_add_user_username($form_state['values']['username']);
-  drupal_set_message(t('%username has been added to your ignore list', array('%username' => $form_state['values']['username'])));
+  drupal_set_message(
+    bts('@username has been added to your ignore list. See your !privacy_preferences for more details.',
+      array(
+        '@username' => $form_state['values']['username'],
+        '!privacy_preferences' => l(bts('privacy preferences', array(), NULL, 'boinc:ignore-user-add'), 'account/prefs/privacy'),
+      ),
+      NULL, 'boinc:ignore-user-add'),
+    'status');
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -902,7 +902,6 @@ function boincwork_save_prefs($prefs, $type = 'general', $venue = null, $account
 function boincwork_ignore_user_add_user_username($name = NULL) {
   global $user;
 
-  // @todo - add/replace bts()
   if (isset($name)) {
     // Get the BOINC ID from the name string, and lookup the
     // corresponding drupal user.
@@ -912,7 +911,7 @@ function boincwork_ignore_user_add_user_username($name = NULL) {
     $iuid = get_drupal_id($boincid);
 
     if ($user->uid == $iuid) {
-      drupal_set_message(t("You can't add yourself to your own ignore list"));
+      drupal_set_message(bts('You can\'t add yourself to your own ignore list.', array(), NULL, 'boinc:ignore-user-error-message'), 'error');
       drupal_goto('account/prefs/privacy');
     }
 
@@ -935,11 +934,10 @@ function boincwork_ignore_user_add_user_username($name = NULL) {
  * Add another user's UID to the current user's ignore list.
  */
 function boincwork_ignore_user_add_user($iuid = NULL) {
-  // @todo - add/replace bts()
   global $user;
 
   if ($user->uid == $iuid) {
-    drupal_set_message(t("You can't add yourself to your own ignore list"));
+    drupal_set_message(bts('You can\'t add yourself to your own ignore list.', array(), NULL, 'boinc:ignore-user-error-message'), 'error');
     drupal_goto();
   }
 

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -887,6 +887,78 @@ function boincwork_save_prefs($prefs, $type = 'general', $venue = null, $account
 }
 
 
+/*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
+ * Ignore user functions
+ *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */
+
+// These functions are boinc-ppecific "replacements" for the
+// ignore_user module's add and remove user functions.
+
+
+/**
+ *Add another user to the current user's ignore list using a BOINC
+ *username. Called from privacy preference form.
+ */
+function boincwork_ignore_user_add_user_username($name = NULL) {
+  global $user;
+
+  // @todo - add/replace bts()
+  if (isset($name)) {
+    // Get the BOINC ID from the name string, and lookup the
+    // corresponding drupal user.
+    $boincname = substr($name, 0, strrpos($name, '_'));
+    $boincid = substr($name, strrpos($name, '_') + 1);
+    // drupalid is the uid to be ignored.
+    $drupalid = get_drupal_id($boincid);
+
+    if ($user->uid == $drupalid) {
+      drupal_set_message(t("You can't add yourself to your own ignore list"));
+      drupal_goto('account/prefs/privacy');
+    }
+
+    if (!empty($drupalid)) {
+      db_query('DELETE FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $drupalid);
+      db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $drupalid);
+      // @todo - if privatemsg module installed, add uid to table pm_block_user to block PMs. 
+    }
+  }
+}
+
+/**
+ * Add another user's UID to the current user's ignore list.
+ */
+function boincwork_ignore_user_add_user($iuid = NULL) {
+  // @todo - add/replace bts()
+  global $user;
+
+  if ($user->uid == $iuid) {
+    drupal_set_message(t("You can't add yourself to your own ignore list"));
+    drupal_goto();
+    //drupal_goto('account');
+  }
+
+  if (is_numeric($iuid) && $iuid > 0) {
+    db_query('DELETE FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $iuid);
+    db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $iuid);
+
+    // @todo - if privatemsg module installed, add uid to table pm_block_user to block PMs. 
+    drupal_goto();
+  }
+  else {
+    drupal_not_found();
+  }
+}
+
+/**
+ * Remove user from user's ignore list.
+ */
+function boincwork_ignore_user_remove_user($iuid = NULL) {
+  global $user;
+
+  db_query('DELETE FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $iuid);
+  // @todo - if privatemsg module installed, remove PM blocked user from table pm_block_user.
+  drupal_goto('account/prefs/privacy');
+}
 
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
  * Utility functions

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -908,7 +908,7 @@ function boincwork_ignore_user_add_user_username($name = NULL) {
     // corresponding drupal user.
     $boincname = substr($name, 0, strrpos($name, '_'));
     $boincid = substr($name, strrpos($name, '_') + 1);
-    // iuid is the drupal uid to be ignored.
+    // iuid is the drupal uid to be ignored and author to be blocked.
     $iuid = get_drupal_id($boincid);
 
     if ($user->uid == $iuid) {
@@ -917,15 +917,16 @@ function boincwork_ignore_user_add_user_username($name = NULL) {
     }
 
     if (is_numeric($iuid) && $iuid > 0) {
-      if (!db_result(db_query('SELECT COUNT(iuid) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $iuid, $user->uid))) {
+      if (!db_result(db_query('SELECT COUNT(iuid) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $iuid))) {
         db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $iuid);
       }// endif db_result
 
       if (module_exists('pm_block_user')) {
-        if (!db_result(db_query('SELECT COUNT(recipient) FROM {pm_block_user} WHERE author = %d AND recipient = %d', $drupaluid, $user->uid))) {
+        if (!db_result(db_query('SELECT COUNT(recipient) FROM {pm_block_user} WHERE author = %d AND recipient = %d', $iuid, $user->uid))) {
           db_query('INSERT INTO {pm_block_user} (author, recipient) VALUES (%d, %d)', $iuid, $user->uid);
         }// endif db_result
       }// endif module_exists('pm_block_user')
+
     }// endif $iuid
   }
 }
@@ -940,20 +941,25 @@ function boincwork_ignore_user_add_user($iuid = NULL) {
   if ($user->uid == $iuid) {
     drupal_set_message(t("You can't add yourself to your own ignore list"));
     drupal_goto();
-    //drupal_goto('account');
   }
 
+  $otheraccount = user_load($iuid);
+
   if (is_numeric($iuid) && $iuid > 0) {
-    if (!db_result(db_query('SELECT COUNT(iuid) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $iuid, $user->uid))) {
+    if (!db_result(db_query('SELECT COUNT(iuid) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $iuid))) {
       db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $iuid);
     }// endif db_result
 
     if (module_exists('pm_block_user')) {
-      if (!db_result(db_query('SELECT COUNT(recipient) FROM {pm_block_user} WHERE author = %d AND recipient = %d', $drupaluid, $user->uid))) {
+      if (!db_result(db_query('SELECT COUNT(recipient) FROM {pm_block_user} WHERE author = %d AND recipient = %d', $iuid, $user->uid))) {
         db_query('INSERT INTO {pm_block_user} (author, recipient) VALUES (%d, %d)', $iuid, $user->uid);
       }// endif db_result
     }// endif module_exists('pm_block_user')
 
+    drupal_set_message(
+      bts('@username has been added to your ignore list',
+        array('@username' => $otheraccount->boincuser_name), NULL, 'boinc:ignore-user-added'),
+      'status');
     drupal_goto();
   }
   else {

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -908,19 +908,25 @@ function boincwork_ignore_user_add_user_username($name = NULL) {
     // corresponding drupal user.
     $boincname = substr($name, 0, strrpos($name, '_'));
     $boincid = substr($name, strrpos($name, '_') + 1);
-    // drupalid is the uid to be ignored.
-    $drupalid = get_drupal_id($boincid);
+    // iuid is the drupal uid to be ignored.
+    $iuid = get_drupal_id($boincid);
 
-    if ($user->uid == $drupalid) {
+    if ($user->uid == $iuid) {
       drupal_set_message(t("You can't add yourself to your own ignore list"));
       drupal_goto('account/prefs/privacy');
     }
 
-    if (!empty($drupalid)) {
-      db_query('DELETE FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $drupalid);
-      db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $drupalid);
-      // @todo - if privatemsg module installed, add uid to table pm_block_user to block PMs. 
-    }
+    if (is_numeric($iuid) && $iuid > 0) {
+      if (!db_result(db_query('SELECT COUNT(iuid) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $iuid, $user->uid))) {
+        db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $iuid);
+      }// endif db_result
+
+      if (module_exists('pm_block_user')) {
+        if (!db_result(db_query('SELECT COUNT(recipient) FROM {pm_block_user} WHERE author = %d AND recipient = %d', $drupaluid, $user->uid))) {
+          db_query('INSERT INTO {pm_block_user} (author, recipient) VALUES (%d, %d)', $iuid, $user->uid);
+        }// endif db_result
+      }// endif module_exists('pm_block_user')
+    }// endif $iuid
   }
 }
 
@@ -938,15 +944,21 @@ function boincwork_ignore_user_add_user($iuid = NULL) {
   }
 
   if (is_numeric($iuid) && $iuid > 0) {
-    db_query('DELETE FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $iuid);
-    db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $iuid);
+    if (!db_result(db_query('SELECT COUNT(iuid) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $iuid, $user->uid))) {
+      db_query('INSERT INTO {ignore_user} (uid, iuid) VALUES (%d, %d)', $user->uid, $iuid);
+    }// endif db_result
 
-    // @todo - if privatemsg module installed, add uid to table pm_block_user to block PMs. 
+    if (module_exists('pm_block_user')) {
+      if (!db_result(db_query('SELECT COUNT(recipient) FROM {pm_block_user} WHERE author = %d AND recipient = %d', $drupaluid, $user->uid))) {
+        db_query('INSERT INTO {pm_block_user} (author, recipient) VALUES (%d, %d)', $iuid, $user->uid);
+      }// endif db_result
+    }// endif module_exists('pm_block_user')
+
     drupal_goto();
   }
   else {
     drupal_not_found();
-  }
+  }// endif iuid
 }
 
 /**
@@ -956,7 +968,9 @@ function boincwork_ignore_user_remove_user($iuid = NULL) {
   global $user;
 
   db_query('DELETE FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $iuid);
-  // @todo - if privatemsg module installed, remove PM blocked user from table pm_block_user.
+  if (module_exists('pm_block_user')) {
+    db_query('DELETE FROM {pm_block_user} WHERE author = %d AND recipient = %d', $iuid, $user->uid);
+  }// endif module_exists
   drupal_goto('account/prefs/privacy');
 }
 

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -957,8 +957,12 @@ function boincwork_ignore_user_add_user($iuid = NULL) {
     }// endif module_exists('pm_block_user')
 
     drupal_set_message(
-      bts('@username has been added to your ignore list',
-        array('@username' => $otheraccount->boincuser_name), NULL, 'boinc:ignore-user-added'),
+      bts('@username has been added to your ignore list. See your !privacy_preferences for more details.',
+        array(
+          '@username' => $otheraccount->boincuser_name,
+          '!privacy_preferences' => l(bts('privacy preferences', array(), NULL, 'boinc:ignore-user-add'), 'account/prefs/privacy'),
+        ),
+        NULL, 'boinc:ignore-user-add'),
       'status');
     drupal_goto();
   }
@@ -972,11 +976,20 @@ function boincwork_ignore_user_add_user($iuid = NULL) {
  */
 function boincwork_ignore_user_remove_user($iuid = NULL) {
   global $user;
+  $otheraccount = user_load($iuid);
 
   db_query('DELETE FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $iuid);
   if (module_exists('pm_block_user')) {
     db_query('DELETE FROM {pm_block_user} WHERE author = %d AND recipient = %d', $iuid, $user->uid);
   }// endif module_exists
+  drupal_set_message(
+    bts('@username has been removed from your ignore list. See your !privacy_preferences for more details.',
+      array(
+        '@username' => $otheraccount->boincuser_name,
+        '!privacy_preferences' => l(bts('privacy preferences', array(), NULL, 'boinc:ignore-user-add'), 'account/prefs/privacy'),
+      ),
+      NULL, 'boinc:ignore-user-add'),
+    'status');
   drupal_goto('account/prefs/privacy');
 }
 

--- a/drupal/sites/default/boinc/modules/contrib/privatemsg/pm_block_user/pm_block_user.module
+++ b/drupal/sites/default/boinc/modules/contrib/privatemsg/pm_block_user/pm_block_user.module
@@ -548,28 +548,11 @@ function pm_block_user_privatemsg_sql_load_alter(&$fragments, $pmid, $uid) {
 /**
  * Implements hook_privatemsg_message_view_alter().
  */
-function pm_block_user_privatemsg_message_view_alter(&$vars) {
-  global $user;
-
-  $author = $vars['message']['author'];
-  if (_pm_block_user_rule_exists($author, $user, PM_BLOCK_USER_DISALLOW_BLOCKING)) {
-    return;
-  }
-  if (!isset($vars['message']['thread_id'])) {
-    // No thread id, this is probably only a preview
-    return;
-  }
-  $thread_id = $vars['message']['thread_id'];
-
-  if ($user->uid <> $author->uid) {
-    if ($vars['message']['is_blocked']) {
-      $vars['message_actions']['unblock_author'] = array('title' => t('Unblock author'), 'href' => 'messages/block/'. $author->uid, 'query' => 'destination=messages/view/' . $thread_id);
-    }
-    else {
-      $vars['message_actions']['block_author'] = array('title' => t('Block author'), 'href' => 'messages/block/'. $author->uid, 'query' => 'destination=messages/view/' . $thread_id);
-    }
-  }
-}
+// This function was removed as part of a feature improvement. It's
+// functionality has been copied to
+// boincwork_privatemsg_message_view_alter(), but since the two would
+// conflict if both were present in the codebase, this function has
+// been removed.
 
 /**
  * Implement hook_user().

--- a/drupal/sites/default/boinc/themes/boinc/boinc.info
+++ b/drupal/sites/default/boinc/themes/boinc/boinc.info
@@ -41,6 +41,7 @@ stylesheets[all][]   = css/nodes.css
 stylesheets[all][]   = css/comments.css
 stylesheets[all][]   = css/forms.css
 stylesheets[all][]   = css/fields.css
+stylesheets[all][]   = css/privatemsg-view.css
 stylesheets[all][]   = css/font-awesome.css
 stylesheets[all][]   = css/responsive-media.css
 stylesheets[all][]   = css/responsive-jswidth.css

--- a/drupal/sites/default/boinc/themes/boinc/css/forms.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/forms.css
@@ -117,6 +117,11 @@ table.preferences.combined .tab {
   min-height: 16px;
 }
 
+table.ignore_user {
+  width: 66%;
+  margin-bottom: 2em;
+}
+
 .form-checkboxes .form-item,
 .form-radios .form-item /* Pack groups of checkboxes and radio buttons closer together */ {
   margin: 0;
@@ -195,6 +200,9 @@ form ul.tab-list {
 }
 .form-submit:hover {
   text-decoration: underline;
+}
+.form-submit.add_ignore_user {
+  margin-top: 1em;
 }
 
 .container-inline div,

--- a/drupal/sites/default/boinc/themes/boinc/css/privatemsg-view.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/privatemsg-view.css
@@ -1,12 +1,6 @@
 .privatemsg-box-fb {
   text-align  : left;
 }
-
-.left-column {
-  float       : left;
-  width       : 100px;
-}
-
 .privatemsg-box-fb .avatar-fb {
   margin      : 5px;
   text-align  : center;
@@ -15,52 +9,42 @@
  float    : none;
  padding  : 0 0 0 0;
 }
-.middle-column {
-  float       : left;
-  width       : 150px;
-  text-align  : right;
-}
-.name {
-  margin      : 5px 15px 0px 0px;
-  font-size   : 11px;
-  font-weight : bold;
-}
-.date {
-  color         : #777777;
-  font-size     : 9px;
-  margin-right  : 0.3em;
-  display       : inline;
-}
-.right-column {
-  margin:0 0 0 250px;
-}
-.clear-both {
-  clear       : both;
-}
-.bottom-border {
-  border-bottom: 1px solid #C5C5C5;
-  margin       : 0 0 10px 250px;
-}
+
 .message-body {
   padding     : 0px;
   margin      : 0 0 0 5px;
   overflow    : auto;
 }
-
-.standard-links {
-  display: inline;
+.message-name {
+  margin      : 5px 15px 0px 0px;
+  font-size   : 11px;
+  font-weight : bold;
+  letter-spacing: 1px;
+  margin: 0;
+  padding: 0;
+  text-transform : uppercase;
+}
+.message-date {
+  color         : #777777;
+  font-size     : 9px;
+  margin-right  : 0.3em;
+  display       : inline;
+}
+.clear-both {
+  clear       : both;
 }
 
+.message-links {
+  display: inline;
+}
 ul.message-actions {
   margin-top: 0.2em;
   margin-bottom: 0.2em;
   padding: 0px;
   display: inline;
 }
-
 .message-actions li {
   list-style-type:none;
-  /*float:left;*/
   background-image:none;
   display: inline;
   border-left: 1px solid #808080;
@@ -68,13 +52,11 @@ ul.message-actions {
   margin-right: 0.3em;
   padding: 0 0 0 0.6em;
 }
-
 .message-actions li.first {
   border-width: 0;
   margin-left: 0;
   padding-left: 0;
 }
-
 .message-actions li a {
   color: #aaa;
   font-weight: bold;

--- a/drupal/sites/default/boinc/themes/boinc/css/privatemsg-view.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/privatemsg-view.css
@@ -1,0 +1,88 @@
+.privatemsg-box-fb {
+  text-align  : left;
+}
+
+.left-column {
+  float       : left;
+  width       : 100px;
+}
+
+.privatemsg-box-fb .avatar-fb {
+  margin      : 5px;
+  text-align  : center;
+}
+.privatemsg-box-fb .picture {
+ float    : none;
+ padding  : 0 0 0 0;
+}
+.middle-column {
+  float       : left;
+  width       : 150px;
+  text-align  : right;
+}
+.name {
+  margin      : 5px 15px 0px 0px;
+  font-size   : 11px;
+  font-weight : bold;
+}
+.date {
+  color         : #777777;
+  font-size     : 9px;
+  margin-right  : 0.3em;
+  display       : inline;
+}
+.right-column {
+  margin:0 0 0 250px;
+}
+.clear-both {
+  clear       : both;
+}
+.bottom-border {
+  border-bottom: 1px solid #C5C5C5;
+  margin       : 0 0 10px 250px;
+}
+.message-body {
+  padding     : 0px;
+  margin      : 0 0 0 5px;
+  overflow    : auto;
+}
+
+.standard-links {
+  display: inline;
+}
+
+ul.message-actions {
+  margin-top: 0.2em;
+  margin-bottom: 0.2em;
+  padding: 0px;
+  display: inline;
+}
+
+.message-actions li {
+  list-style-type:none;
+  /*float:left;*/
+  background-image:none;
+  display: inline;
+  border-left: 1px solid #808080;
+  margin-left: 0.3em;
+  margin-right: 0.3em;
+  padding: 0 0 0 0.6em;
+}
+
+.message-actions li.first {
+  border-width: 0;
+  margin-left: 0;
+  padding-left: 0;
+}
+
+.message-actions li a {
+  color: #aaa;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.privatemsg-view-pager {
+  margin: 20px 0 20px 200px;
+  padding-left: 10px;
+  width: 300px;
+}

--- a/drupal/sites/default/boinc/themes/boinc/template.php
+++ b/drupal/sites/default/boinc/themes/boinc/template.php
@@ -893,19 +893,18 @@ function _boinc_ignore_user_link($type, $object = NULL, $teaser = FALSE) {
   static $ignored;
   $links = array();
 
-  // @todo - add/replace bts()
   if ($type == 'node' && $user->uid != $object->uid && $object->uid != 0 && user_access('ignore user')) {
     if (!isset($ignored[$object->uid])) {
       $ignored[$object->uid] = db_result(db_query('SELECT COUNT(*) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $object->uid));
     }
     if ($ignored[$object->uid] == 0) {
       $links['ignore_user'] = array(
-        'title' => t('Ignore user'),
+        'title' => bts('Ignore user', array(), NULL, 'boinc:ignore-user-add'),
         'href' => 'account/prefs/privacy/ignore_user/add/'. $object->uid,
         'query' => 'destination='. $_GET['q'],
         'attributes' => array(
           'class' => 'ignore-user',
-          'title' => t('Add user to your ignore list'),
+          'title' => bts('Add user to your ignore list', array(), NULL, 'boinc:ignore-user-add'),
         ),
       );
     }
@@ -916,12 +915,12 @@ function _boinc_ignore_user_link($type, $object = NULL, $teaser = FALSE) {
     }
     if ($ignored[$object->uid] == 0) {
       $links['ignore_user'] = array(
-        'title' => t('Ignore user'),
+        'title' => bts('Ignore user', array(), NULL, 'boinc:ignore-user-add'),
         'href' => 'account/prefs/privacy/ignore_user/add/'. $object->uid,
         'query' => 'destination='. $_GET['q'],
         'attributes' => array(
           'class' => 'ignore-user',
-          'title' => t('Add user to your ignore list'),
+          'title' => bts('Add user to your ignore list', array(), NULL, 'boinc:ignore-user-add'),
         ),
       );
     }

--- a/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/comment.tpl.php
@@ -97,8 +97,7 @@
         }
         print '</div>';
       }
-      // Generate ignore user link
-      $ignore_link = ignore_user_link('comment', $comment);
+      // ignore user link is now generated in preprocess functions.
       //echo '<pre>' . print_r($links, TRUE) . '</pre>';
     ?>
     <div class="name"><?php print $author; ?></div>

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-forum.tpl.php
@@ -152,8 +152,7 @@
           }
           print '</div>';
         }
-        // Generate ignore user link
-        $ignore_link = ignore_user_link('node', $node);
+        // ignore user link is now generated in preprocess functions.
         //echo '<pre>' . print_r($node->links, TRUE) . '</pre>';
       ?>
       <div class="name"><?php print $name; ?></div>

--- a/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/node-team_forum.tpl.php
@@ -168,8 +168,7 @@
           }
           print '</div>';
         }
-        // Generate ignore user link
-        $ignore_link = ignore_user_link('node', $node);
+        // ignore user link is now generated in preprocess functions.
         //echo '<pre>' . print_r($node->links, TRUE) . '</pre>';
       ?>
       <div class="name"><?php print $name; ?></div>

--- a/drupal/sites/default/boinc/themes/boinc/templates/privatemsg-view.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/privatemsg-view.tpl.php
@@ -1,8 +1,3 @@
-<?php
-// Each file loads it's own styles because we cant predict which file will be
-// loaded.
-drupal_add_css(drupal_get_path('module', 'privatemsg') . '/styles/privatemsg-view.css');
-?>
 <?php print $anchors; ?>
 
 <div id="privatemsg-mid-<?php print $mid; ?>" class="privatemsg-box-fb <?php print $zebra; ?> clearfix">
@@ -11,12 +6,12 @@ drupal_add_css(drupal_get_path('module', 'privatemsg') . '/styles/privatemsg-vie
     <?php print $author_picture; ?>
   </div>
   <div class="message-body">
-    <div class="foobar">
-      <div class="name"><?php print $author_name_link; ?></div>
-      <div class="date">
+    <div class="headerinfo">
+      <div class="message-name"><?php print $author_name_link; ?></div>
+      <div class="message-date">
         <?php print $message_timestamp; ?>
       </div>
-      <div class="standard-links">
+      <div class="message-links">
         <?php if ( isset($message_actions)) : ?>
           <?php print $message_actions ?>
         <?php endif ?>

--- a/drupal/sites/default/boinc/themes/boinc/templates/privatemsg-view.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/privatemsg-view.tpl.php
@@ -11,16 +11,22 @@ drupal_add_css(drupal_get_path('module', 'privatemsg') . '/styles/privatemsg-vie
     <?php print $author_picture; ?>
   </div>
   <div class="message-body">
-    <div class="submitted">
+    <div class="foobar">
       <div class="name"><?php print $author_name_link; ?></div>
-      <?php print $message_timestamp; ?>
+      <div class="date">
+        <?php print $message_timestamp; ?>
+      </div>
+      <div class="standard-links">
+        <?php if ( isset($message_actions)) : ?>
+          <?php print $message_actions ?>
+        <?php endif ?>
+       </div>
     </div>
-    <?php if (isset($new)) : ?>
-      <span class="new"><?php print $new ?></span>
-    <?php endif ?>
-    <?php print $message_body; ?>
-    <?php if (isset($message_actions)) : ?>
-       <?php //print $message_actions ?>
-    <?php endif ?>
+    <div class="clear-both">
+      <?php if (isset($new)) : ?>
+        <span class="new"><?php print $new ?></span>
+      <?php endif ?>
+      <?php print $message_body; ?>
+    </div>
   </div> <!-- /.message-body -->
 </div>

--- a/drupal/sites/default/boinc/themes/boinc/templates/user-profile.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/user-profile.tpl.php
@@ -54,6 +54,7 @@ $website = check_plain($content_profile->field_url[0]['value']);
 $background = check_markup($content_profile->field_background[0]['value'], $content_profile->format, FALSE);
 $opinions = check_markup($content_profile->field_opinions[0]['value'], $content_profile->format, FALSE);
 $user_links = array();
+$user_links2l = array();
 $profile_is_approved = ($content_profile->status AND !$content_profile->moderate);
 $user_is_moderator = user_access('edit any profile content');
 $is_own_profile = ($user->uid == $account->uid);
@@ -98,17 +99,49 @@ if ($user->uid AND ($user->uid != $account->uid)) {
       );
     }
   }
+
+  if (module_exists('ignore_user')) {
+    static $ignored;
+    if ($user->uid != $account->uid && $account->uid != 0 && user_access('ignore user')) {
+      if (!isset($ignored[$account->uid])) {
+        $ignored[$account->uid] = db_result(db_query('SELECT COUNT(*) FROM {ignore_user} WHERE uid = %d AND iuid = %d', $user->uid, $account->uid));
+      }
+      if ($ignored[$account->uid] == 0) {
+        $ignore_link = array(
+          'title' => bts('Ignore user', array(), NULL, 'boinc:ignore-user-add'),
+          'href' => 'account/prefs/privacy/ignore_user/add/'. $account->uid,
+          'query' => 'destination='. $_GET['q'],
+          'attributes' => array(
+            'class' => 'ignore-user',
+            'title' => bts('Add user to your ignore list', array(), NULL, 'boinc:ignore-user-add'),
+          ),
+        );
+      }
+      else {
+        $ignore_link = array(
+          'title' => bts('Stop Ignoring user', array(), NULL, 'boinc:ignore-user-add'),
+          'href' => 'account/prefs/privacy/ignore_user/remove/'. $account->uid,
+          'query' => 'destination='. $_GET['q'],
+          'attributes' => array(
+            'class' => 'ignore-user',
+            'title' => bts('Remove user from your ignore list', array(), NULL, 'boinc:ignore-user-add'),
+          ),
+        );
+      }
+    $user_links2l[] = $ignore_link;
+    }
+  }
   
   if (user_access('assign community member role')
       OR user_access('assign all roles')) {
     if (array_search('community member', $account->roles)) {
-      $user_links[] = array(
+      $user_links2l[] = array(
         'title' => bts('Ban user', array(), NULL, 'boinc:moderate-ban-user'),
         'href' => "moderate/user/{$account->uid}/ban"
       );
     }
     else {
-      $user_links[] = array(
+      $user_links2l[] = array(
         'title' => bts('Lift user ban', array(), NULL, 'boinc:moderate-unban-user'),
         'href' => "user_control/{$account->uid}/lift-ban"
       );
@@ -154,12 +187,13 @@ if ($user->uid AND ($user->uid != $account->uid)) {
           <li class="primary <?php print ($key == 0) ? 'first ' : ''; ?>tab<?php print ($key == count($user_links)-1) ? ' last' : ''; ?>">
             <?php print l($link['title'], $link['href'], array('query' => drupal_get_destination())); ?>
           </li>
-          <!--
-          <?php if (module_exists('private_messages')): ?>
-            <li class="first tab"><?php print l(bts('Send message', array(), NULL, 'boinc:private-message'), privatemsg_get_link(array($account)), array('query' => drupal_get_destination())); ?></li>
-          <?php endif; ?>
-          <li class="last tab"><?php print l(bts('Add as friend', array(), NULL, 'boinc:friend-add'), "flag/confirm/flag/friend/{$account->uid}", array('query' => drupal_get_destination())); ?></li>
-          -->
+        <?php endforeach; ?>
+      </ul>
+      <ul class="tab-list">
+        <?php foreach ($user_links2l as $key => $link): ?>
+          <li class="primary <?php print ($key == 0) ? 'first ' : ''; ?>tab<?php print ($key == count($user_links2l)-1) ? ' last' : ''; ?>">
+            <?php print l($link['title'], $link['href'], array('query' => drupal_get_destination())); ?>
+          </li>
         <?php endforeach; ?>
       </ul>
     <?php endif; ?>


### PR DESCRIPTION
Privacy form now contains feature to ignore users, both in the forums and for private messages. There is a current list of ignore users and user may add more to the table. When another user ignored, they are also automatically added to the table which prevents them from sending a PM to the user who ignored them.

In addition, an ignore user button has been added to the user profile page, and to the private message view page, so that users may more easily ignore another.

https://dev.gridrepublic.org/browse/DBOINCP-338