### PR TITLE
[WIP] Updated early stage of websocket proxy development 

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -93,7 +93,7 @@ boinc_client_SOURCES = \
 boinc_client_DEPENDENCIES = $(LIBBOINC)
 boinc_client_CPPFLAGS = $(AM_CPPFLAGS)
 boinc_client_CXXFLAGS = $(AM_CXXFLAGS) $(SSL_CXXFLAGS)
-boinc_client_LDFLAGS = $(AM_LDFLAGS) $(SSL_LDFLAGS) -L$(top_srcdir)/lib
+boinc_client_LDFLAGS = $(AM_LDFLAGS) $(SSL_LDFLAGS) -L$(top_srcdir)/lib -l:libuWS.so
 if OS_WIN32
 boinc_client_CXXFLAGS += -I$(top_srcdir)/coprocs/NVIDIA/include
 boinc_client_SOURCES += hostinfo_win.cpp \


### PR DESCRIPTION
(Update of #2246)

This is a first approach and attempt at creating a proxy to allow the BOINC client to understand commands issued via websockets. The proxy should run within the same executable so that the whole procedure is transparent to the volunteers. As it stands now this is a prototype and should not be expected to function in any meaningful way. For that reason this pull request is not expected or intended to be merged. It is rather a way to start a conversation around the issue and to get more eyes on such an important piece of the potential future BOINC client.

This is a small test page: https://lhcathomedev.cern.ch/lhcathome-dev/websock_test.html that will return the version of a running client that implements these changes. The communication is done solely through websockets.

Since Firefox expects Secure Websockets (because the javascript is served from an https server) in this stage you will have to create your own certificate and key with (run from client directory):
`openssl req -new -newkey rsa:2048 -days 365 -nodes -x509 -keyout server.key -out server.pem`
and then add it by visiting https://localhost:3000 and following the prompts (add exception).

Prior to implementing changes this library has to be downloaded and installed: 
https://github.com/uNetworking/uWebSockets

Note: This is only tested on Linux (Debian and CentOS) and should not work on Windows or macOs