### PR TITLE
increased size of opencl_device_version[] from 64 to 128

### DIFF
--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -66,7 +66,7 @@ struct OPENCL_DEVICE_PROP {
 
     char opencl_platform_version[64];   // Version of OpenCL supported
                                         // the device's platform
-    char opencl_device_version[64];     // OpenCL version supported by device;
+    char opencl_device_version[128];     // OpenCL version supported by device;
                                         // example: "OpenCL 1.1 beta"
     int opencl_device_version_int;      // same, encoded as e.g. 101
     int get_device_version_int();       // call this to encode


### PR DESCRIPTION
Hello,

I have locally crafted OpenCL support for a BOINC project running on my ARM machine's MALI GPU. This gives quite some bang for few bucks with minuscule power consumption and as such be of importance for BOINC at large.

For it all to work smoothly, I unexpectedly also had to patch the BOINC client - the char[64] vector storing the OpenCL version is too short for the version string produced by the Firefly, i.e. "OpenCL 1.2 v1.r13p0-00rel0-git(a4271c9).31ba04af2d3c01618138bef3aed66c2c" which admittedly is somewhat awkward with 72+1 characters. I hope that you decide to support the emerging diversity of new OpenCL platforms and accept patches for their support.

This patch trivially extends the length of the static array, which is all I needed to get started and does not interfere with the remainder of the code base. Alternatively I would be happy to contribute also a dynamic implementation. Please kindly direct me.