### PR TITLE
Mac screensaver: under OS 10.13+ if the BOINC screensaver cannot disp…

### DIFF
--- a/clientscr/Mac_Saver_ModuleView.h
+++ b/clientscr/Mac_Saver_ModuleView.h
@@ -42,6 +42,8 @@
 - (IBAction)closeSheetSave:(id) sender;
 - (IBAction)closeSheetCancel:(id) sender;
 
+- (bool) setUpToUseCGWindowList;
+
 @end
 
 @interface SharedGraphicsController : NSObject <NSMachPortDelegate>

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -850,6 +850,9 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
                 graphics_app_result_ptr = NULL;
                 m_bDefault_gfx_running = false;
                 m_bScience_gfx_running = false;
+#ifdef __APPLE__
+                launchedGfxApp("", 0, -1);
+#endif
                 continue;
             }
         }


### PR DESCRIPTION
…lay a graphics app with hardware acceleration using the IOSurface APIs because the app has not been linked with the current graphics libraries, then display it using the much slower CGWindowListCreateImage API.