### PR TITLE
web: remove "forgot email?" link.  "Login with authenticator" no long…

### DIFF
--- a/html/inc/account.inc
+++ b/html/inc/account.inc
@@ -119,7 +119,6 @@ function login_form($next_url) {
     } else {
         $x = tra("Email address:");
     }
-    $x .= '<br><small><a href="get_passwd.php">'.tra("forgot email address?")."</a></small>";
     form_input_text($x, "email_addr");
     form_input_text(
         tra("Password:").'<br><small><a href="get_passwd.php">' . tra("forgot password?") . "</a></small>",

--- a/html/user/show_user.php
+++ b/html/user/show_user.php
@@ -89,13 +89,13 @@ if ($format=="xml"){
     page_head($user->name);
     start_table();
     echo "<tr><td valign=top>";
-    start_table();
+    start_table("table-striped");
     show_user_summary_public($user);
     end_table();
     project_user_summary($user);
     show_other_projects($user, false);
     echo "</td><td valign=top>";
-    start_table();
+    start_table("table-striped");
     show_badges_row(true, $user);
     if (!DISABLE_PROFILES) {
         show_profile_link($user);

--- a/html/user/view_profile.php
+++ b/html/user/view_profile.php
@@ -61,7 +61,7 @@ start_table();
 show_profile($user, $logged_in_user);
 end_table();
 echo "</td><td valign=\"top\">";
-start_table();
+start_table("table-striped");
 row2(tra("Account data"),
     "<a href=\"show_user.php?userid=".$userid."\">".tra("View")."</a>"
 );


### PR DESCRIPTION
…er exists.

Note: you can supply authenticator instead of password in regular login form.
Occasionally a project admin may need to do this to log in as another user.