### PR TITLE
Mac ram size hotfix

### DIFF
--- a/mac_installer/complist.plist
+++ b/mac_installer/complist.plist
@@ -16,7 +16,7 @@
 	</dict>
 	<dict>
 		<key>BundleIsVersionChecked</key>
-		<true/>
+		<false/>
 		<key>BundleOverwriteAction</key>
 		<string>upgrade</string>
 		<key>RootRelativeBundlePath</key>


### PR DESCRIPTION
Fixes a bug which caused BOINC client built with SDK OS 10.11 or later to fail to get correct system RAM size when running on older versions of OS X. This should also be cherry picked to master for BOINC version 7.9.

Also replicates commit 5296088 previously made in master into 7.8 branch: correctly replace screensaver when installing an older version of BOINC to replace a newer version.