### PR TITLE
[AppVeyor] Skip commits that are not related to Windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,17 @@ branches:
 
 skip_tags: true
 
+skip_commits:
+  files:
+    - android/
+    - doc/
+    - drupal/
+    - html/
+    - locale/
+    - mac_build/
+    - mac_installer/
+    - py/
+
 configuration:
   - Debug
 #  - Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ skip_tags: true
 skip_commits:
   files:
     - android/
+    - db/
     - doc/
     - drupal/
     - html/
@@ -27,6 +28,9 @@ skip_commits:
     - mac_build/
     - mac_installer/
     - py/
+    - tools/
+    - vda/
+    - xcompile/
 
 configuration:
   - Debug


### PR DESCRIPTION
Add 'skip_commits' section to skip commits that are not related to Windows builds.
This PR contains changed to skip on;y most used folders and do not contain ones that are changed very rare.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>