### PR TITLE
Mac update dependencies

### DIFF
--- a/mac_build/HowToBuildBOINC_XCode.rtf
+++ b/mac_build/HowToBuildBOINC_XCode.rtf
@@ -1,30 +1,32 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1265\cocoasubrtf210
+{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf200
 \cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fmodern\fcharset0 Courier;\f2\fswiss\fcharset0 ArialMT;
 \f3\fnil\fcharset0 Menlo-Regular;\f4\fnil\fcharset0 LucidaGrande;}
 {\colortbl;\red255\green255\blue255;\red186\green0\blue0;\red14\green14\blue255;\red245\green245\blue245;
 \red246\green246\blue246;}
+{\*\expandedcolortbl;;\csgenericrgb\c72941\c0\c0;\csgenericrgb\c5490\c5490\c100000;\csgenericrgb\c96078\c96078\c96078;
+\csgenericrgb\c96471\c96471\c96471;}
 \margl1440\margr1440\vieww14780\viewh11840\viewkind0
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \f0\b\fs28 \cf0 Building BOINC Client and Manager on Macintosh OSX\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b0\fs24 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 \cf0 Written by Charlie Fenton\
-Last updated 6/8/17\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+Last updated 1/25/18\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
-This document applies to BOINC version 7.7.3 and later.  It has instructions for building the BOINC Client and Manager for Macintosh OSX.  Information for building science project applications to run under BOINC on Macintosh OSX can be found {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/BuildMacApp"}}{\fldrslt here}}.  \
+This document applies to BOINC version 7.9.0 and later.  It has instructions for building the BOINC Client and Manager for Macintosh OSX.  Information for building science project applications to run under BOINC on Macintosh OSX can be found {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/BuildMacApp"}}{\fldrslt here}}.  \
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b \cf0 Note:
 \b0  the information in this document changes from time to time for different versions of BOINC.  For any version of BOINC source files, the corresponding version of this document can be found in the source tree at:\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f1\fs26 \cf0                    boinc/mac_build/HowToBuildBOINC_XCode.rtf\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f0\fs24 \cf0 \
 Contents of this document:\
@@ -37,63 +39,63 @@ Contents of this document:\
 \'95 Debugging into wxWidgets.\
 \'95 Installing and setting up Xcode.\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \b\fs28 \cf0 Important requirements for building BOINC software for the Mac
 \b0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
-\pard\pardeftab720\sa260
-\cf0 As of version 6.13.0, BOINC does not support Macintosh PowerPC processors.Although BOINC supports 64-bit Intel project applications on Mac OS 10.6.0 and above, the only parts of the BOINC client package built as 64-bit executables are the screensaver coordinator and the BOINC client itself.  The BOINC libraries also include a 64-bit build so that they can be linked with 64-bit project applications.\
+\pard\pardeftab720\sa260\partightenfactor0
+\cf0 As of version 6.13.0, BOINC does not support Macintosh PowerPC processors. As of 7.9.0, BOINC is built entirely for 64-bit Intel.  The BOINC libraries also include a 32-bit build so that they can be linked with 32-bit project applications on systems that support 32-bit applications.\
 You need to take certain steps to ensure that you use only APIs that are available in all the OS versions BOINC supports for each architecture. The best way to accomplish this is to use a single development system running OS 10.8.x or later and cross-compile for the various platforms. The remainder of this document describes that process.\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 \cf0 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
 
 \b \cf0 The above requirements apply not only to BOINC itself, but also to the WxWidgets, c-ares, cURL, openSSL,  freetype, ftgl and SQLite3 libraries, as well as all project applications
 \b0 .  \
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 Be sure to follow the directions in this document to ensure that these requirements are met.\
 \
-\pard\pardeftab720\sa260
+\pard\pardeftab720\sa260\partightenfactor0
 \cf0 Starting with version 7.5.0, the BOINC screensaver supports only Mac OS 10.6.0 and later.\
-\pard\pardeftab720\sa260\qc
+\pard\pardeftab720\sa260\qc\partightenfactor0
 
 \b\fs28 \cf0 Cross-Platform Development
 \f2\fs32 \
-\pard\pardeftab720\sa260
+\pard\pardeftab720\sa260\partightenfactor0
 
 \f0\b0\fs24 \cf0 Apple provides the tools necessary to build BOINC on any Mac running OS 10.8.x or later.\
 You get these tools, including the GCC or Apple LLVM compiler and system library header files, by installing the Xcode Tools package. \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
 
-\b \cf0 Building BOINC now requires Xcode Tools version 4.6 or later. 
+\b \cf0 Building BOINC now requires Xcode Tools version 6.0 or later. 
 \b0  \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
-\pard\pardeftab720\sa260
-\cf0 You can download Xcode 4.6 or later from Apple's App Store (it is large: about 4 GB).  If you are a member of Apple's Mac Developer Program, you can also download it from Apple's web site: {\field{\*\fldinst{HYPERLINK "http://developer.apple.com"}}{\fldrslt 
+\pard\pardeftab720\sa260\partightenfactor0
+\cf0 You can download Xcode from Apple's App Store (it is large: over 4 GB).  If you are a member of Apple's Mac Developer Program, you can also download it from Apple's web site: {\field{\*\fldinst{HYPERLINK "http://developer.apple.com"}}{\fldrslt 
 \f1\fs26 http://developer.apple.com}}\cf2 .\cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 Source files are now archived using git.  For details, see:\
 	{\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/SourceCodeGit"}}{\fldrslt 
 \f1\fs26 http://boinc.berkeley.edu/trac/wiki/SourceCodeGit}}\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \b\fs28 \cf0 Building BOINC Manager with embedded Core Client\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b0\fs24 \cf0 \
 Note: building BOINC Manager 7.3.0 and later requires the OS 10.8 SDK or later.\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
-\cf0 BOINC depends on seven third-party libraries: wxWidgets-3.0.0, c-ares-1.11.0, curl-7.50.2, openssl-1.1.0, freetype-2.6.2, ftgl-2.1.3~rc5 and sqlite-3.11.0.  You can obtain the source files from the following URLs.  Clicking on the first URL of each pair will download the tar file.  The second URL will open the third party\'92s home web page.  On Mac OS X the tar file will usually be downloaded into the Downloads folder.  You will need to expand the tar files by double-clicking on them, which will create a folder and place the appropriate files into that folder. You will need to move these folders later.\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0 BOINC depends on seven third-party libraries: wxWidgets-3.1.0, c-ares-1.13.0, curl-7.58.0, openssl-1.1.0g, freetype-2.9, ftgl-2.1.3~rc5 and sqlite-3.22.0.  You can obtain the source files from the following URLs.  Clicking on the first URL of each pair will download the tar file.  The second URL will open the third party\'92s home web page.  On Mac OS X the tar file will usually be downloaded into the Downloads folder.  You will need to expand the tar files by double-clicking on them, which will create a folder and place the appropriate files into that folder. You will need to move these folders later.\
 \
-wxWidgets-3.0.0 (needed  only if you are building the BOINC Manager):\
-	{\field{\*\fldinst{HYPERLINK "http://sourceforge.net/projects/wxwindows/files/3.0.0/wxWidgets-3.0.0.tar.bz2/"}}{\fldrslt 
-\f1\fs26 http://sourceforge.net/projects/wxwindows/files/3.0.0/wxWidgets-3.0.0.tar.bz2/}}
+wxWidgets-3.1.0 (needed  only if you are building the BOINC Manager):\
+	{\field{\*\fldinst{HYPERLINK "https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"}}{\fldrslt 
+\f1\fs26 https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2}}
 \f1\fs26 \
 
 \f0\fs24 	{\field{\*\fldinst{HYPERLINK "http://www.wxwidgets.org"}}{\fldrslt 
@@ -101,95 +103,95 @@ wxWidgets-3.0.0 (needed  only if you are building the BOINC Manager):\
 \f1\fs26 \
 
 \f0\fs24 \
-sqlite-3.11.0 (needed  only if you are building the BOINC Manager):\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+sqlite-3.22.0 (needed  only if you are building the BOINC Manager):\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f1 \cf0 	{\field{\*\fldinst{HYPERLINK "http://www.sqlite.org/2016/sqlite-autoconf-3110000.tar.gz"}}{\fldrslt 
-\fs26 http://www.sqlite.org/2016/sqlite-autoconf-3110000.tar.gz}}
+\f1 \cf0 	{\field{\*\fldinst{HYPERLINK "https://www.sqlite.org/2018/sqlite-autoconf-3220000.tar.gz"}}{\fldrslt 
+\fs26 https://www.sqlite.org/2018/sqlite-autoconf-3220000.tar.gz}}
 \f0 \
 
 \f1 	{\field{\*\fldinst{HYPERLINK "http://www.sqlite.org/"}}{\fldrslt 
 \fs26 http://www.sqlite.org/}}
 \fs26 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \f0\fs24 \cf0 \
-curl-7.50.2:\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+curl-7.58.2:\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f1\fs26 \cf0 	{\field{\*\fldinst{HYPERLINK "http://curl.haxx.se/download/curl-7.50.2.tar.gz"}}{\fldrslt http://curl.haxx.se/download/curl-7.50.2.tar.gz}}\
+\f1\fs26 \cf0 	{\field{\*\fldinst{HYPERLINK "https://curl.haxx.se/download/curl-7.58.0.tar.gz"}}{\fldrslt https://curl.haxx.se/download/curl-7.58.0.tar.gz}}\
 	{\field{\*\fldinst{HYPERLINK "http://curl.haxx.se"}}{\fldrslt http://curl.haxx.se}}\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f0\fs24 \cf0 c-ares-1.11.0 (used by curl):\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\f0\fs24 \cf0 c-ares-1.13.0 (used by curl):\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f1\fs26 \cf0 	{\field{\*\fldinst{HYPERLINK "http://c-ares.haxx.se/download/c-ares-1.11.0.tar.gz"}}{\fldrslt http://c-ares.haxx.se/download/c-ares-1.11.0.tar.gz}}\
+\f1\fs26 \cf0 	{\field{\*\fldinst{HYPERLINK "https://c-ares.haxx.se/download/c-ares-1.13.0.tar.gz"}}{\fldrslt https://c-ares.haxx.se/download/c-ares-1.13.0.tar.gz}}\
 	{\field{\*\fldinst{HYPERLINK "http://daniel.haxx.se/projects/c-ares/"}}{\fldrslt http://daniel.haxx.se/projects/c-ares/}}\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f0\fs24 \cf0 openssl-1.1.0\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\f0\fs24 \cf0 openssl-1.1.0g\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f1\fs26 \cf0 	{\field{\*\fldinst{HYPERLINK "http://www.openssl.org/source/openssl-1.1.0.tar.gz"}}{\fldrslt http://www.openssl.org/source/openssl-1.1.0.tar.gz}}\
+\f1\fs26 \cf0 	{\field{\*\fldinst{HYPERLINK "https://www.openssl.org/source/openssl-1.1.0g.tar.gz"}}{\fldrslt https://www.openssl.org/source/openssl-1.1.0g.tar.gz}}\
 	{\field{\*\fldinst{HYPERLINK "http://www.openssl.org/"}}{\fldrslt http://www.openssl.org/}}\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f0\fs24 \cf0 freetype-2.6.2 (needed  only if you are building the BOINC default screensaver or a project screensaver):\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\f0\fs24 \cf0 freetype-2.9 (needed  only if you are building the BOINC default screensaver or a project screensaver):\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
-\f3\fs22 \cf3 \CocoaLigature0 	{\field{\*\fldinst{HYPERLINK "http://sourceforge.net/projects/freetype/files/freetype2/2.6.2/freetype-2.6.2.tar.bz2"}}{\fldrslt http://sourceforge.net/projects/freetype/files/freetype2/2.6.2/freetype-2.6.2.tar.bz2}}\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\f3\fs22 \cf3 \CocoaLigature0 	{\field{\*\fldinst{HYPERLINK "https://sourceforge.net/projects/freetype/files/freetype2/2.9/freetype-2.9.tar.bz2"}}{\fldrslt https://sourceforge.net/projects/freetype/files/freetype2/2.9/freetype-2.9.tar.bz2}}\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \f1\fs26 \cf0 \CocoaLigature1 	{\field{\*\fldinst{HYPERLINK "http://www.freetype.org/"}}{\fldrslt 
 \f3\fs22 \cf3 \CocoaLigature0 http://www.freetype.org/}}
 \f3\fs22 \cf3 \CocoaLigature0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \f0\fs24 \cf0 \CocoaLigature1 \
 ftgl-2.1.3~rc5 (needed  only if you are building the BOINC default screensaver or a project screensaver):\
 	{\field{\*\fldinst{HYPERLINK "http://sourceforge.net/projects/ftgl/files/FTGL%20Source/2.1.3~rc5/ftgl-2.1.3-rc5.tar.gz"}}{\fldrslt http://sourceforge.net/projects/ftgl/files/FTGL%20Source/2.1.3%7Erc5/ftgl-2.1.3-rc5.tar.gz}}\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \f1\fs26 \cf0 	{\field{\*\fldinst{HYPERLINK "http://sourceforge.net/projects/ftgl"}}{\fldrslt 
 \f3\fs22 \cf3 \CocoaLigature0 http://sourceforge.net/projects/ftgl}}\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \f0\fs24 \cf0 \
-\pard\pardeftab720\sa260
+\pard\pardeftab720\sa260\partightenfactor0
 \cf0 XCode will automatically check compatibility back to OS 10.6 if the following are defined during compilation:\
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \f1\fs26 \cf0 MAC_OS_X_VERSION_MAX_ALLOWED=1060\
 MAC_OS_X_VERSION_MIN_REQUIRED=1060\
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \f0\fs24 \cf0 \
-\pard\pardeftab720\sa260
-\cf0 These are not done automatically by either the Xcode projects which come with wxWidgets-3.0.0, nor  the AutoMake scripts supplied with wxWidgets-3.0.0, c-ares-1.11.0, curl-7.50.2, openssl-1.1.0, freetype-2.6.2, ftgl-2.1.3~rc5 and sqlite-3.11.0.  So be sure to use our special scripts to build these packages.\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\pardeftab720\sa260\partightenfactor0
+\cf0 These are not done automatically by either the Xcode projects which come with wxWidgets-3.1.0, nor  the AutoMake scripts supplied with wxWidgets-3.1.0, c-ares-1.13.0, curl-7.58.0, openssl-1.1.0g, freetype-2.9, ftgl-2.1.3~rc5 and sqlite-3.22.0.  So be sure to use our special scripts to build these packages.\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 [1] Make sure you are logged into the Mac using an account with administrator privileges.  Create a parent directory within which to work.  In this description; we will call it BOINC_dev, but you can name it anything you wish.\
 \
 [2] Move the following 7 directories from the Downloads folder into the BOINC_dev folder (omit any you don't need):\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f1\fs26 \cf0     c-ares-
-\fs24 1.11.0
+\fs24 1.13.0
 \fs26 \
-    curl-7.50.2\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
-\cf0     openssl-1.1.0\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
-\cf0     wxWidgets-3.0.0\
-    freetype-2.6.2\
+    curl-7.58.0\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+\cf0     openssl-1.1.0g\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
+\cf0     wxWidgets-3.1.0\
+    freetype-2.9\
     ftgl-2.1.3~rc5\
     
-\fs24 sqlite-3.11.0
+\fs24 sqlite-3.22.0
 \fs26 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f0\fs24 \cf0 \
 Important: do not change the names of any of these 7 directories.  Remember that the names are case sensitive.\
@@ -202,36 +204,36 @@ Important: do not change the names of any of these 7 directories.  Remember that
 \f1\fs26 git
 \f0\fs24  command):\
 \
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \f1\fs26 \cf0 cd \{path\}/BOINC_dev/\
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 \cf0 \cb4 git clone \cb1 https://github.com/BOINC/boinc.git \cb4 boinc
 \f0\fs24 \cb1 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
 (You may change the name of the 
 \f1\fs26 boinc
 \f0\fs24  directory to anything you wish.)  \
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 The command above retrieves the source code from the HEAD / MASTER (TRUNK) or development branch of the git repository.  For more information on getting the BOINC source code, see:\
 	{\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/SourceCodeGit"}}{\fldrslt 
 \f1\fs26 http://boinc.berkeley.edu/trac/wiki/SourceCodeGit}}\
 \
 [5] Run the script to build the c-ares, curl, openssl, wxWidgets, freetype, ftgl and sqlite3 libraries as follows:\
 \
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \f1\fs26 \cf0 cd \{path\}/BOINC_dev/boinc/mac_build/\
 source setupForBoinc.sh -clean
 \f0\fs24 \
 \
 If you don't wish to force a full rebuild of everything, omit the -clean argument.\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b \cf0 Note 1:
 \b0  Be sure to run the script using the 
@@ -241,13 +243,13 @@ If you don't wish to force a full rebuild of everything, omit the -clean argumen
 \f0\fs24  command to run them.\
 
 \b Note 2:
-\b0  This script tries to build all seven third-party libraries: wxWidgets-3.0.0, c-ares-1.11.0, curl-7.50.2, openssl-1.1.0,  freetype-2.6.2, ftgl-2.1.3~rc5 and sqlite-3.11.0.  When the script finishes, it will display a warning about any libraries it was unable to build (for example, if you have not downloaded them.)  To make it easier to find the error messages, clear the Terminal display and run the script again without 
+\b0  This script tries to build all seven third-party libraries: wxWidgets-3.1.0, c-ares-1.13.0, curl-7.58.0, openssl-1.1.0g,  freetype-2.9, ftgl-2.1.3~rc5 and sqlite-3.22.0.  When the script finishes, it will display a warning about any libraries it was unable to build (for example, if you have not downloaded them.)  To make it easier to find the error messages, clear the Terminal display and run the script again without 
 \f1 -clean
 \f0 .\
 
 \b Note 3: 
 \b0 The \{path\} must not contain any space characters.\
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \b \cf0 Hint: 
 \b0 You don't need to type the path to a file or folder into Terminal; just drag the file or folder icon from a Finder window onto the Terminal window.\
@@ -256,11 +258,11 @@ If you don't wish to force a full rebuild of everything, omit the -clean argumen
 \b0  To be compatible with OS 10.6 and OS 10.7, the screensaver must be built with Garbage Collection (GC) supported (and without Automatic Reference Counting) , but Xcode versions later than 5.0.2 do not allow building with GC. To allow building with newer versions of Xcode while keeping backward compatibility to OS 10.6, the GIT repository includes the screensaver executable built with GC, while the Xcode project builds the screensaver with ARC (for newer versions of OS X.) The 
 \f1\fs26 release_boinc.sh
 \f0\fs24  script (described later in this document) adds both the GC and ARC builds of the screensaver to the installer; the installer code selects the correct screensaver for the target version of OS X at install time.\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
 [6] Build BOINC as follows:\
 \
-\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural
+\pard\tx560\tx1120\tx1680\tx2240\tx2800\tx3360\tx3920\tx4480\tx5040\tx5600\tx6160\tx6720\pardirnatural\partightenfactor0
 \cf0 BOINC itself is built  using the 
 \b boinc.xcodeproj 
 \b0 file.  You can either build directly in Xcode
@@ -269,15 +271,15 @@ If you don't wish to force a full rebuild of everything, omit the -clean argumen
 \b BuildMacBOINC.sh
 \b0  script:\
 \
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \f1\fs26 \cf0 cd \{path\}/BOINC_dev/boinc/mac_build/\
 source BuildMacBOINC.sh
 \f0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
 The complete syntax for this script is\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f1\fs26 \cf0 source BuildMacBOINC.sh [-dev] [-noclean] [-all] [-lib] [-client] [-libc] [-c++11] [-help]
 \f0\fs24 \
@@ -303,7 +305,7 @@ The options for BuildMacBOINC.sh are:\
 \
  Both -lib and -client may be specified to build eight targets (no BOINC Manager or screensaver.)\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b \cf0 Note 1:
 \b0  
@@ -318,9 +320,9 @@ The options for BuildMacBOINC.sh are:\
 \
 
 \b Note 2: 
-\b0 To perform a release build under Xcode 4.6 when not using the 
+\b0 To perform a release build under Xcode 6 or later when not using the 
 \f1 BuildMacBOINC.sh
-\f0  script, select "Build for archiving" or "Build for Profiling" from Xcode's Product menu.  Under Xcode 5.0 or later, select "Build for Profiling."  To save disk space, do 
+\f0  script, select "Build for Profiling" from Xcode's Product menu.  To save disk space, do 
 \b not
 \b0  select "Archive."\
 \
@@ -350,16 +352,16 @@ The options for BuildMacBOINC.sh are:\
 \f1\fs26 DEVELOPER_DIR
 \f0\fs24  environment variable using the 
 \f1\fs26 env
-\f0\fs24  command.  For example, if you have installed Xcode 5.0.2 in the Applications directory and renamed 
+\f0\fs24  command.  For example, if you have installed Xcode 6.2 in the Applications directory and renamed 
 \f1\fs26 Xcode.app
 \f0\fs24  to 
-\f1\fs26 Xcode_5_0_2.app
+\f1\fs26 Xcode_6_2.app
 \f0\fs24 , you can invoke the script with:\
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
-\f1\fs26 \cf0 env DEVELOPER_DIR=/Applications/Xcode_5_0_2.app/Contents/Developer sh BuildMacBOINC.sh
+\f1\fs26 \cf0 env DEVELOPER_DIR=/Applications/Xcode_6_2.app/Contents/Developer sh BuildMacBOINC.sh
 \f0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
 The BOINC Xcode project has built-in scripts which create a text file with the path to the built products at either 
 \f1\fs26 BOINC_dev/boinc/mac_build/Build_Deployment_Dir
@@ -369,51 +371,51 @@ The BOINC Xcode project has built-in scripts which create a text file with the p
 \f1\fs26 release_boinc.sh
 \f0\fs24  script, but you can also use them to access the built products directly as follows; open the file with TextEdit and copy the path, then enter command-shift-G in the Finder and paste the path into the Finder's  dialog.\
 \
-The standard release of BOINC version 7.4.42 and later builds only for Macintosh computers with Intel processors.  Most of the executables are built only for the i386 architecture, except the BOINC client which is built only for the x86_64 architecture.  The BOINC libraries and the screensaver are built as universal binaries containing builds for two architectures: i386 and x86_64.\
+The standard release of BOINC version 7.9.0 and later builds only for Macintosh computers with 64-bit Intel processors.  The executables are built only for the x86_64 architecture.  The BOINC libraries are built as universal binaries containing builds for two architectures: i386 and x86_64.\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \b\fs28 \cf0 Building BOINC Manager Installer
 \b0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
 In order to execute BOINC Manager, you must install it using BOINC Manager Installer. Otherwise, you will encounter an error prompting for proper installation.\
 \
 To build the Installer for the BOINC Manager, you must be logged in as an administrator.  If you are building BOINC version number x.y.z, type the following in Terminal, then enter your administrator password when prompted by the script:\
 \
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \f1\fs26 \cf0 cd \{path\}/BOINC_dev/boinc/\
 source \{path\}/BOINC_dev/boinc/mac_installer/release_boinc.sh x y z\
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 
 \f0\fs24 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
-\cf0 Substitute the 3 parts of the BOINC version number for x y and z in the above.  For example, to build the installer for BOINC version 7.5.0, the command would be\
-\pard\pardeftab720
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
+\cf0 Substitute the 3 parts of the BOINC version number for x y and z in the above.  For example, to build the installer for BOINC version 7.9.0, the command would be\
+\pard\pardeftab720\partightenfactor0
 
-\f1\fs26 \cf0 source \{path\}/BOINC_dev/boinc/mac_installer/release_boinc.sh 7 5 0\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\f1\fs26 \cf0 source \{path\}/BOINC_dev/boinc/mac_installer/release_boinc.sh 7 9 0\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
-\f0\fs24 \cf0 This will create a directory "BOINC_Installer/New_Release_7_5_0" in the BOINC_dev directory, and the installer will be located in '
-\f1\fs26 \{path\}/BOINC_dev/BOINC_Installer/New_Release_7_5_0/boinc_7.5.0_macOSX_x86_64
+\f0\fs24 \cf0 This will create a directory "BOINC_Installer/New_Release_7_9_0" in the BOINC_dev directory, and the installer will be located in '
+\f1\fs26 \{path\}/BOINC_dev/BOINC_Installer/New_Release_7_9_0/boinc_7.9.0_macOSX_x86_64
 \f0\fs24 '.\
 \
 The installer script uses the deployment (release) build of BOINC; it won't work with a development (debug) build.\
 You can find the current version number in the file 
 \f1\fs26 \{path\}/BOINC_dev/boinc/version.h
 \fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f4 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \f0\b\fs28 \cf0 Code Signing the BOINC Manager Installer and Uninstaller
 \b0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f4 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \f0 \cf0 Mac OS 10.8 introduces a security feature called Gatekeeper, whose default settings won't allow a user to run applications or installers downloaded from the Internet unless they are signed by a registered Apple Developer.  The 
 \f1\fs26 release_boinc.sh
@@ -431,41 +433,41 @@ Developer ID Application: John Smith\
 \f0\fs24  file, then the script will not sign the installer or uninstaller.  Code signing is not necessary if you won't be transferring the built software over the Internet.   For more information on code signing identities see the documentation for the {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/codesign.1.html"}}{\fldrslt 
 \f1\fs26 codesign}} utility and Apple's {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/library/mac/documentation/Security/Conceptual/CodeSigningGuide/"}}{\fldrslt Code Signing Guide}}.  \
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \b\fs28 \cf0 Debugging and BOINC security
 \b0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 \cf0 Version 5.5.4 of BOINC Manager for the Macintosh introduced new, stricter security measures.  For details, please see the file 
 \f1\fs26 BOINC_dev/boinc/mac_installer/Readme.rtf
 \f0\fs24  and {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/sandbox.php"}}{\fldrslt http://boinc.berkeley.edu/sandbox.php}} and {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/SandboxUser"}}{\fldrslt 
 \f1 http://boinc.berkeley.edu/trac/wiki/SandboxUser}}\
 \
-\pard\tx960\tx1920\tx2880\tx3840\tx4800\tx5760\tx6720\tx7680\tx8640\tx9600\tx10560\tx11520\tx12480\tx13440\tx14400\tx15360\tx16320\tx17280\tx18240\tx19200\tx20160\tx21120\tx22080\tx23040\tx24000\tx24960\tx25920\tx26880\tx27840\tx28800\tx29760\tx30720\tx31680\tx32640\tx33600\tx34560\tx35520\tx36480\tx37440\tx38400\tx39360\tx40320\tx41280\tx42240\tx43200\tx44160\tx45120\tx46080\tx47040\tx48000\tx48960\tx49920\tx50880\tx51840\tx52800\tx53760\tx54720\tx55680\tx56640\tx57600\tx58560\tx59520\tx60480\tx61440\tx62400\tx63360\tx64320\tx65280\tx66240\tx67200\tx68160\tx69120\tx70080\tx71040\tx72000\tx72960\tx73920\tx74880\tx75840\tx76800\tx77760\tx78720\tx79680\tx80640\tx81600\tx82560\tx83520\tx84480\tx85440\tx86400\tx87360\tx88320\tx89280\tx90240\tx91200\tx92160\tx93120\tx94080\tx95040\tx96000\pardirnatural
-\cf0 \CocoaLigature0 The GDB debugger can't attach to applications which are running as a different user or group so it ignores the S_ISUID and S_ISGID permission bits when launching an application.  To work around this, the BOINC 
+\pard\tx960\tx1920\tx2880\tx3840\tx4800\tx5760\tx6720\tx7680\tx8640\tx9600\tx10560\tx11520\tx12480\tx13440\tx14400\tx15360\tx16320\tx17280\tx18240\tx19200\tx20160\tx21120\tx22080\tx23040\tx24000\tx24960\tx25920\tx26880\tx27840\tx28800\tx29760\tx30720\tx31680\tx32640\tx33600\tx34560\tx35520\tx36480\tx37440\tx38400\tx39360\tx40320\tx41280\tx42240\tx43200\tx44160\tx45120\tx46080\tx47040\tx48000\tx48960\tx49920\tx50880\tx51840\tx52800\tx53760\tx54720\tx55680\tx56640\tx57600\tx58560\tx59520\tx60480\tx61440\tx62400\tx63360\tx64320\tx65280\tx66240\tx67200\tx68160\tx69120\tx70080\tx71040\tx72000\tx72960\tx73920\tx74880\tx75840\tx76800\tx77760\tx78720\tx79680\tx80640\tx81600\tx82560\tx83520\tx84480\tx85440\tx86400\tx87360\tx88320\tx89280\tx90240\tx91200\tx92160\tx93120\tx94080\tx95040\tx96000\pardirnatural\partightenfactor0
+\cf0 \CocoaLigature0 The LLDB debugger can't attach to applications which are running as a different user or group so it ignores the S_ISUID and S_ISGID permission bits when launching an application.  To work around this, the BOINC 
 \i \CocoaLigature1 Development
-\i0 \CocoaLigature0  build does not use the special boinc_master or boinc_project users or groups, and so can be run under the debugger from Xcode.  This also streamlines the development cycle by avoiding the need to run the installer for every change.  (To generate the development build under Xcode 4.6, choose "Build" from the product menu, or enter command-B on the keyboard.)\
+\i0 \CocoaLigature0  build does not use the special boinc_master or boinc_project users or groups, and so can be run under the debugger from Xcode.  This also streamlines the development cycle by avoiding the need to run the installer for every change.  (To generate the development build under Xcode, choose "Build" from the product menu, or enter command-B on the keyboard.)\
 \
-To restore the standard ownerships and permissions, run the installer.\
+To restore the standard ownerships and permissions, run the installer or run the {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/mac_build/Mac_SA_Secure.sh"}}{\fldrslt Mac_SA_Secure.sh}} shell script in Terminal (the comments in this script have instructions for running it.)\
 \
-\pard\pardeftab720\sa260
+\pard\pardeftab720\sa260\partightenfactor0
 \cf0 \cb5 \CocoaLigature1 For information on interpreting crash dumps and backtraces, see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/MacBacktrace"}}{\fldrslt \cf2 Mac Backtrace}}.\cb1 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \b\fs28 \cf0 Debugging into wxWidgets
 \b0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
-\pard\tx960\tx1920\tx2880\tx3840\tx4800\tx5760\tx6720\tx7680\tx8640\tx9600\tx10560\tx11520\tx12480\tx13440\tx14400\tx15360\tx16320\tx17280\tx18240\tx19200\tx20160\tx21120\tx22080\tx23040\tx24000\tx24960\tx25920\tx26880\tx27840\tx28800\tx29760\tx30720\tx31680\tx32640\tx33600\tx34560\tx35520\tx36480\tx37440\tx38400\tx39360\tx40320\tx41280\tx42240\tx43200\tx44160\tx45120\tx46080\tx47040\tx48000\tx48960\tx49920\tx50880\tx51840\tx52800\tx53760\tx54720\tx55680\tx56640\tx57600\tx58560\tx59520\tx60480\tx61440\tx62400\tx63360\tx64320\tx65280\tx66240\tx67200\tx68160\tx69120\tx70080\tx71040\tx72000\tx72960\tx73920\tx74880\tx75840\tx76800\tx77760\tx78720\tx79680\tx80640\tx81600\tx82560\tx83520\tx84480\tx85440\tx86400\tx87360\tx88320\tx89280\tx90240\tx91200\tx92160\tx93120\tx94080\tx95040\tx96000\pardirnatural
+\pard\tx960\tx1920\tx2880\tx3840\tx4800\tx5760\tx6720\tx7680\tx8640\tx9600\tx10560\tx11520\tx12480\tx13440\tx14400\tx15360\tx16320\tx17280\tx18240\tx19200\tx20160\tx21120\tx22080\tx23040\tx24000\tx24960\tx25920\tx26880\tx27840\tx28800\tx29760\tx30720\tx31680\tx32640\tx33600\tx34560\tx35520\tx36480\tx37440\tx38400\tx39360\tx40320\tx41280\tx42240\tx43200\tx44160\tx45120\tx46080\tx47040\tx48000\tx48960\tx49920\tx50880\tx51840\tx52800\tx53760\tx54720\tx55680\tx56640\tx57600\tx58560\tx59520\tx60480\tx61440\tx62400\tx63360\tx64320\tx65280\tx66240\tx67200\tx68160\tx69120\tx70080\tx71040\tx72000\tx72960\tx73920\tx74880\tx75840\tx76800\tx77760\tx78720\tx79680\tx80640\tx81600\tx82560\tx83520\tx84480\tx85440\tx86400\tx87360\tx88320\tx89280\tx90240\tx91200\tx92160\tx93120\tx94080\tx95040\tx96000\pardirnatural\partightenfactor0
 \cf0 \CocoaLigature0 The BOINC Xcode project links the BOINC Manager with the non-debugging (Deployment) build of wxWidgets for the Deployment build configuration of the Manager, and with the debugging (Development) build of wxWidgets for the Development build configuration of the Manager.  You should use the Development build of the Manager and wxWidgets for debugging; this allows you to step into internal wxWidgets code. With the Development build, you can even put breakpoints in wxWidgets; this is most easily done after stepping into a function in wxWidgets source file containing the code where you wish to put the breakpoint.\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \b\fs28 \cf0 \CocoaLigature1 Installing and setting up Xcode
 \b0\fs24 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
 If Xcode is obtained from the Apple Store then it will be installed automatically into the Applications folder.  Double-click on the installed Xcode icon to run Xcode.  Xcode will display a dialog allowing you to finish the installation; you must do this before running BOINC's build scripts.  (Some versions of Xcode may not display this dialog until you open a file with Xcode.)\
 }

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -2390,7 +2390,7 @@
 			attributes = {
 				LastUpgradeCheck = 0620;
 			};
-			buildConfigurationList = DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc_wx310" */;
+			buildConfigurationList = DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc" */;
 			compatibilityVersion = "Xcode 3.0";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
@@ -3560,7 +3560,7 @@
 				INFOPLIST_FILE = Info.plist;
 				LIBRARY_SEARCH_PATHS = (
 					"../../wxWidgets-3.1.0/build/osx/build/Debug",
-					"../../sqlite-autoconf-3110000/.libs/",
+					"../../sqlite-autoconf-3220000/.libs/",
 				);
 				OTHER_CFLAGS = (
 					"-DHAVE_CONFIG_H",
@@ -3615,7 +3615,7 @@
 				INFOPLIST_FILE = Info.plist;
 				LIBRARY_SEARCH_PATHS = (
 					"../../wxWidgets-3.1.0/build/osx/build/Release",
-					"../../sqlite-autoconf-3110000/.libs/",
+					"../../sqlite-autoconf-3220000/.libs/",
 				);
 				OTHER_CFLAGS = (
 					"-DHAVE_CONFIG_H",
@@ -3739,13 +3739,13 @@
 				HEADER_SEARCH_PATHS = (
 					../api/,
 					../samples/jpeglib/,
-					"../../freetype-2.6.2/include",
+					"../../freetype-2.9/include",
 					"../../ftgl-2.1.3~rc5/src",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"${BUILT_PRODUCTS_DIR}/",
-					"../../freetype-2.6.2/objs/.libs",
+					"../../freetype-2.9/objs/.libs",
 					"../../ftgl-2.1.3~rc5/src/.libs",
 				);
 				OTHER_LDFLAGS = (
@@ -3766,13 +3766,13 @@
 				HEADER_SEARCH_PATHS = (
 					../api/,
 					../samples/jpeglib/,
-					"../../freetype-2.6.2/include",
+					"../../freetype-2.9/include",
 					"../../ftgl-2.1.3~rc5/src",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"${BUILT_PRODUCTS_DIR}/",
-					"../../freetype-2.6.2/objs/.libs",
+					"../../freetype-2.9/objs/.libs",
 					"../../ftgl-2.1.3~rc5/src/.libs",
 				);
 				OTHER_LDFLAGS = (
@@ -3875,14 +3875,14 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				HEADER_SEARCH_PATHS = (
-					"../../curl-7.50.2/include",
-					"../../openssl-1.1.0/include",
+					"../../curl-7.58.0/include",
+					"../../openssl-1.1.0g/include",
 				);
 				INFOPLIST_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = (
-					"../../curl-7.50.2/lib/.libs",
-					"../../c-ares-1.11.0/.libs",
-					"../../openssl-1.1.0/",
+					"../../curl-7.58.0/lib/.libs",
+					"../../c-ares-1.13.0/.libs",
+					"../../openssl-1.1.0g/",
 				);
 				"OTHER_CFLAGS[arch=x86_64]" = (
 					"-D_THREAD_SAFE",
@@ -3902,7 +3902,7 @@
 				);
 				PRODUCT_NAME = boinc;
 				STRIP_INSTALLED_PRODUCT = NO;
-				USER_HEADER_SEARCH_PATHS = "../../curl-7.50.2/include ../../openssl-1.1.0/include";
+				USER_HEADER_SEARCH_PATHS = "../../curl-7.58.0/include ../../openssl-1.1.0g/include";
 			};
 			name = Deployment;
 		};
@@ -4043,14 +4043,14 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEPLOYMENT_POSTPROCESSING = YES;
 				HEADER_SEARCH_PATHS = (
-					"../../curl-7.50.2/include",
-					"../../openssl-1.1.0/include",
+					"../../curl-7.58.0/include",
+					"../../openssl-1.1.0g/include",
 				);
 				INFOPLIST_PREPROCESSOR_DEFINITIONS = "";
 				LIBRARY_SEARCH_PATHS = (
-					"../../curl-7.50.2/lib/.libs",
-					"../../c-ares-1.11.0/.libs",
-					"../../openssl-1.1.0/",
+					"../../curl-7.58.0/lib/.libs",
+					"../../c-ares-1.13.0/.libs",
+					"../../openssl-1.1.0g/",
 				);
 				OTHER_CFLAGS = (
 					"-D_THREAD_SAFE",
@@ -4069,7 +4069,7 @@
 				);
 				PRODUCT_NAME = boinc;
 				STRIP_INSTALLED_PRODUCT = NO;
-				USER_HEADER_SEARCH_PATHS = "../../curl-7.50.2/include ../../openssl-1.1.0/include";
+				USER_HEADER_SEARCH_PATHS = "../../curl-7.58.0/include ../../openssl-1.1.0g/include";
 			};
 			name = Development;
 		};
@@ -4413,7 +4413,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Development;
 		};
-		DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc_wx310" */ = {
+		DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DD9E2382091CBDAE0048316E /* Development */,

--- a/mac_build/buildWxMac.sh
+++ b/mac_build/buildWxMac.sh
@@ -34,6 +34,7 @@
 # Revise fix for wxListCtrl flicker to match the fix in wxWidgets trunk 6/19/14
 # Build 64-bit library (temporarily build both 32-bit and 64-bit libraries) 10/22/17
 # Update for wxCocoa 3.1.0 10/25/17
+# Build only 64-bit library 1/25/18
 #
 ## This script requires OS 10.6 or later
 ##
@@ -171,11 +172,17 @@ retval=0
 alreadyBuilt=0
 
 if [ "${doclean}" != "clean" ] && [ -f "${libPathRel}/libwx_osx_cocoa_static.a" ]; then
-    lipo "${libPathRel}/libwx_osx_cocoa_static.a" -verify_arch i386 x86_64
+    lipo "${libPathRel}/libwx_osx_cocoa_static.a" -verify_arch x86_64
     if [ $? -eq 0 ]; then
         alreadyBuilt=1
+        lipo "${libPathRel}/libwx_osx_cocoa_static.a" -verify_arch i386
+        if [ $? -ne 0 ]; then
+            # already built for both 32 and 64 bit, rebuild for only 64 bit
+            alreadyBuilt=0
+            doclean="clean"
+        fi
     else
-        # already built but not for correct architectures
+        # already built but not for correct architecture
         doclean="clean"
     fi
 fi
@@ -189,7 +196,7 @@ else
     ## We must override some of the build settings in wxWindows.xcodeproj
     ## For wxWidgets 3.0.0 through 3.1.0 (at least) we must use legacy WebKit APIs
     ## for x86_64, so we must define WK_API_ENABLED=0
-    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Release $doclean build ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=${PIPESTATUS[0]}
+    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Release $doclean build ARCHS="x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=${PIPESTATUS[0]}
     if [ ${retval} -ne 0 ]; then return 1; fi
     if [ "x${lprefix}" != "x" ]; then
         # copy library and headers to $lprefix
@@ -208,9 +215,15 @@ fi
 
 alreadyBuilt=0
 if [ "${doclean}" != "clean" ] && [ -f "${libPathDbg}/libwx_osx_cocoa_static.a" ]; then
-    lipo "${libPathDbg}/libwx_osx_cocoa_static.a" -verify_arch i386 x86_64
+    lipo "${libPathDbg}/libwx_osx_cocoa_static.a" -verify_arch x86_64
     if [ $? -eq 0 ]; then
         alreadyBuilt=1
+        lipo "${libPathDbg}/libwx_osx_cocoa_static.a" -verify_arch i386
+        if [ $? -ne 0 ]; then
+            # already built for both 32 and 64 bit, rebuild for only 64 bit
+            alreadyBuilt=0
+            doclean="clean"
+        fi
     else
         # already built but not for correct architectures
         doclean="clean"
@@ -226,7 +239,7 @@ else
     ## We must override some of the build settings in wxWindows.xcodeproj
     ## For wxWidgets 3.0.0 through 3.1.0 (at least) we must use legacy WebKit APIs
     ## for x86_64, so we must define WK_API_ENABLED=0
-    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Debug $doclean build ARCHS="i386 x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=${PIPESTATUS[0]}
+    xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Debug $doclean build ARCHS="x86_64" ONLY_ACTIVE_ARCH=="NO" OTHER_CFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -fno-strict-aliasing -fno-common -DWK_API_ENABLED=0 -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=${PIPESTATUS[0]}
     if [ ${retval} -ne 0 ]; then return 1; fi
     if [ "x${lprefix}" != "x" ]; then
         # copy debug library to $PREFIX

--- a/mac_build/buildc-ares.sh
+++ b/mac_build/buildc-ares.sh
@@ -18,7 +18,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Script to build Macintosh 64-bit Intel library of c-ares-1.11.0 for
+# Script to build Macintosh 64-bit Intel library of c-ares for
 # use in building BOINC.
 #
 # by Charlie Fenton 7/21/06
@@ -28,6 +28,7 @@
 # Updated 2/11/14 for c-ares 1.10.0
 # Updated 9/2/14 for bulding c-ares as 64-bit binary
 # Updated 9/10/16 for bulding c-ares 1.11.0
+# Updated 1/25/18 for bulding c-ares 1.13.0 (updated comemnts only)
 #
 ## This script requires OS 10.6 or later
 #
@@ -35,8 +36,9 @@
 ## and clicked the Install button on the dialog which appears to
 ## complete the Xcode installation before running this script.
 #
-## In Terminal, CD to the c-ares-1.11.0 directory.
-##     cd [path]/c-ares-1.11.0/
+## Where x.xx.x is the c-ares version number:
+## In Terminal, CD to the c-ares-x.xx.x directory.
+##     cd [path]/c-ares-x.xx.x/
 ## then run this script:
 ##     source [path]/buildc-ares.sh [ -clean ] [--prefix PATH]
 ##

--- a/mac_build/buildcurl.sh
+++ b/mac_build/buildcurl.sh
@@ -18,7 +18,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Script to build Macintosh 32-bit Intel library of curl-7.50.2 for
+# Script to build Macintosh 64-bit Intel library of curl for
 # use in building BOINC.
 #
 # by Charlie Fenton 7/21/06
@@ -32,6 +32,7 @@
 # Updated 3/2/16 for curl 7.47.1 with c-ares 1.10.0
 # Updated 9/10/16 for curl 7.50.2 with c-ares 1.11.0
 # Updated 3/14/17 to patch curlrules.h to fix BOINC Manager compile error
+# Updated 1/25/18 for curl 7.58.0 with c-ares 1.13.0 & openssl 1.1.0g, don't patch currules.h
 #
 ## This script requires OS 10.6 or later
 #
@@ -39,8 +40,9 @@
 ## and clicked the Install button on the dialog which appears to
 ## complete the Xcode installation before running this script.
 #
-## In Terminal, CD to the curl-7.50.2 directory.
-##     cd [path]/curl-7.50.2/
+## Where x.xx.x is the curl version number:
+## In Terminal, CD to the curl-x.xx.x directory.
+##     cd [path]/curl-x.xx.x/
 ## then run this script:
 ##     source [path]/buildcurl.sh [ -clean ] [--prefix PATH]
 ##
@@ -50,36 +52,6 @@
 ##
 
 CURL_DIR=`pwd`
-
-# Patch curl-7.50.2/include/curl/curlrules.h so it doesn't
-# cause our 32-bit build of BOINC Manager to fail.
-if [ ! -f include/curl/curlrules.h.orig ]; then
-    cat >> /tmp/curlrules_h_diff << ENDOFFILE
---- /Volumes/Cheer/BOINC_GIT/curl-7.50.2/include/curl/curlrules_orig.h	2016-08-08 05:03:14.000000000 -0700
-+++ /Volumes/Cheer/BOINC_GIT/curl-7.50.2/include/curl/curlrules.h	2017-03-13 17:17:43.000000000 -0700
-@@ -74,6 +74,7 @@
- /*
-  * Verify that some macros are actually defined.
-  */
-+#if 0
-
- #ifndef CURL_SIZEOF_LONG
- #  error "CURL_SIZEOF_LONG definition is missing!"
-@@ -182,6 +183,8 @@
-   __curl_rule_05__
-     [CurlchkszGE(curl_socklen_t, int)];
-
-+#endif
-+
- /* ================================================================ */
- /*          EXTERNALLY AND INTERNALLY VISIBLE DEFINITIONS           */
- /* ================================================================ */
-ENDOFFILE
-    patch -bfi /tmp/curlrules_h_diff include/curl/curlrules.h
-    rm -f /tmp/curlrules_h_diff
-else
-    echo "include/curl/curlrules.h already patched"
-fi
 
 doclean=""
 lprefix=""
@@ -167,19 +139,19 @@ if [ "x${lprefix}" != "x" ]; then
     PKG_CONFIG_PATH="${lprefix}/lib/pkgconfig" ./configure --prefix=${lprefix} --enable-ares --enable-shared=NO --host=x86_64
     if [ $? -ne 0 ]; then return 1; fi
 else
-    # curl configure and make expect a path to _installed_ c-ares-1.11.0
+    # curl configure and make expect a path to _installed_ c-ares-1.13.0
     # so we temporarily installed c-ares at a path that does not contain spaces.
     # buildc-ares.sh installed c-ares to /tmp/installed-c-ares
     # and configured c-ares with prefix=/tmp/installed-c-ares
     if [ ! -f "${libcares}/libcares.a" ]; then
-        cd ../c-ares-1.11.0 || return 1
+        cd ../c-ares-1.13.0 || return 1
         make install
         cd "${CURL_DIR}" || return 1
     fi
 
-    export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64 -L${CURL_DIR}/../openssl-1.1.0 "
-    export CPPFLAGS="-isysroot ${SDKPATH} -arch x86_64 -I${CURL_DIR}/../openssl-1.1.0/include"
-    export CFLAGS="-isysroot ${SDKPATH} -arch x86_64 -I${CURL_DIR}/../openssl-1.1.0/include"
+    export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64 -L${CURL_DIR}/../openssl-1.1.0g "
+    export CPPFLAGS="-isysroot ${SDKPATH} -arch x86_64 -I${CURL_DIR}/../openssl-1.1.0g/include"
+    export CFLAGS="-isysroot ${SDKPATH} -arch x86_64 -I${CURL_DIR}/../openssl-1.1.0g/include"
     ./configure --enable-shared=NO --enable-ares="${libcares}" --host=x86_64
     if [ $? -ne 0 ]; then return 1; fi
     echo ""

--- a/mac_build/buildfreetype.sh
+++ b/mac_build/buildfreetype.sh
@@ -19,14 +19,17 @@
 #
 #
 # Script to build Macintosh Universal Intel library (i386 and x86_64)
-# of FreeType-2.6.2 for use in building BOINC graphics.
+# of FreeType for use in building BOINC graphics.
 # The resulting library is at:
-#   [path]/freetype-2.6.2/objs/.libs/libfreetype.a
+#   [path]/freetype-x.x.x/objs/.libs/libfreetype.a
+# where x.x.x is the freetype version number
+
 #
 # by Charlie Fenton 7/27/12
 # Updated 2/7/14 for OS 10.9
 # Updated 4/8/15 to check for spaces in path
 # Updated 1/5/16 for FreeType-2.6.2
+# Updated 1/25/18 for any version of FreeType (changed only comments)
 #
 ## This script requires OS 10.6 or later
 #
@@ -34,8 +37,9 @@
 ## and clicked the Install button on the dialog which appears to
 ## complete the Xcode installation before running this script.
 #
-## In Terminal, CD to the freetype-2.6.2 directory.
-##     cd [path]/freetype-2.6.2/
+## Where x.x.x is the freetype version number:
+## In Terminal, CD to the freetype-x.x.x directory.
+##     cd [path]/freetype-x.x.x/
 ## then run this script:
 ##     source [path]/buildfreetype.sh [ -clean ] [--prefix PATH]
 ##

--- a/mac_build/buildopenssl.sh
+++ b/mac_build/buildopenssl.sh
@@ -18,7 +18,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Script to build Macintosh 32-bit Intel openssl-1.1.0 libraries
+# Script to build Macintosh 64-bit Intel openssl libraries
 # libcrypto.a and libssl.a for use in building BOINC.
 #
 # by Charlie Fenton 6/25/12
@@ -32,6 +32,7 @@
 # Updated 12/11/15 for openssl-1.0.2e
 # Updated 3/2/16 for openssl-1.0.2g
 # Updated 9/10/16 for openssl-1.1.0
+# Updated 1/25/18 for bulding openssl 1.1.0g (updated comemnts only)
 #
 ## This script requires OS 10.6 or later
 #
@@ -39,8 +40,9 @@
 ## and clicked the Install button on the dialog which appears to
 ## complete the Xcode installation before running this script.
 #
-## In Terminal, CD to the openssl-1.1.0 directory.
-##     cd [path]/openssl-1.1.0/
+## Where x.xx.xy is the openssl version number:
+## In Terminal, CD to the openssl-x.xx.xy directory.
+##     cd [path]/openssl-x.xx.xy/
 ## then run this script:
 ##     source [path]/buildopenssl.sh [ -clean ] [--prefix PATH]
 ##

--- a/mac_build/buildsqlite3.sh
+++ b/mac_build/buildsqlite3.sh
@@ -18,7 +18,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Script to build Macintosh 32-bit Intel library of sqlite 3.11.0 for
+# Script to build Macintosh 64-bit Intel library of sqlite 3 for
 # use in building BOINC Manager.
 #
 # by Charlie Fenton 12/11/12
@@ -26,6 +26,7 @@
 # Updated 1/5/16 for sqlite 3.9.2
 # Updated 3/2/16 for sqlite 3.11.0
 # Updated 10/22/17 to build 64-bit library (temporarily build both 32-bit and 64-bit libraries)
+# Updated 1/25/18 to build only 64-bit library
 #
 ## This script requires OS 10.6 or later
 #
@@ -33,8 +34,9 @@
 ## and clicked the Install button on the dialog which appears to
 ## complete the Xcode installation before running this script.
 #
-## In Terminal, CD to the sqlite-autoconf-3110000 directory.
-##     cd [path]/sqlite-autoconf-3110000/
+## Where xxxxxxx is the version string in the directory name:
+## In Terminal, CD to the sqlite-autoconf-xxxxxxx directory.
+##     cd [path]/sqlite-autoconf-xxxxxxx/
 ## then run this script:
 ##     source [path]/buildsqlite3.sh [ -clean ] [--prefix PATH]
 ##
@@ -67,7 +69,7 @@ done
 
 if [ "${doclean}" != "yes" ]; then
     if [ -f "${libPath}/libsqlite3.a" ]; then
-        lipo "${libPath}/libsqlite3.a" -verify_arch i386 x86_64
+        lipo "${libPath}/libsqlite3.a" -verify_arch x86_64
         if [ $? -eq 0 ]; then
             cwd=$(pwd)
             dirname=${cwd##*/}
@@ -118,31 +120,6 @@ if [ -d "${libPath}" ]; then
     rm -f "${libPath}/libsqlite3.a"
 fi
 
-export PATH=/usr/local/bin:$PATH
-export CC="${GCCPATH}";export CXX="${GPPPATH}"
-export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,i386"
-export CPPFLAGS="-Os -isysroot ${SDKPATH} -arch i386 -DMAC_OS_X_VERSION_MAX_ALLOWED=1060 -DMAC_OS_X_VERSION_MIN_REQUIRED=1060"
-export CFLAGS="-Os -isysroot ${SDKPATH} -arch i386 -DMAC_OS_X_VERSION_MAX_ALLOWED=1060 -DMAC_OS_X_VERSION_MIN_REQUIRED=1060"
-export SDKROOT="${SDKPATH}"
-export MACOSX_DEPLOYMENT_TARGET=10.6
-
-if [ "x${lprefix}" != "x" ]; then
-    ./configure --prefix=${lprefix} --enable-shared=NO --host=i386
-    if [ $? -ne 0 ]; then return 1; fi
-else
-    ./configure --enable-shared=NO --host=i386
-    if [ $? -ne 0 ]; then return 1; fi
-fi
-
-if [ "${doclean}" = "yes" ]; then
-    make clean
-fi
-
-make 1>$stdout_target
-if [ $? -ne 0 ]; then return 1; fi
-
-mv .libs/libsqlite3.a  ./libsqlite3_1386.a
-
 # Build for x86_64 architecture
 make clean 1>$stdout_target
 
@@ -162,17 +139,8 @@ else
     if [ $? -ne 0 ]; then return 1; fi
 fi
 
-
 make 1>$stdout_target
 if [ $? -ne 0 ]; then return 1; fi
-
-mv .libs/libsqlite3.a  ./libsqlite3_x86_64.a
-# combine i386 and x86_64 libraries
-lipo -create ./libsqlite3_1386.a ./libsqlite3_x86_64.a -output .libs/libsqlite3.a
-if [ $? -ne 0 ]; then return 1; fi
-
-rm -f ./libsqlite3_1386.a
-rm -f ./libsqlite3_x86_64.a
 
 if [ "x${lprefix}" != "x" ]; then
     make install 1>$stdout_target

--- a/mac_build/dependencyNames.sh
+++ b/mac_build/dependencyNames.sh
@@ -35,32 +35,32 @@
 ## build settings.
 ##
 
-opensslDirName="openssl-1.1.0"
-opensslFileName="openssl-1.1.0.tar.gz"
-opensslURL="https://www.openssl.org/source/openssl-1.1.0.tar.gz"
+opensslDirName="openssl-1.1.0g"
+opensslFileName="openssl-1.1.0g.tar.gz"
+opensslURL="https://www.openssl.org/source/openssl-1.1.0g.tar.gz"
 
-caresDirName="c-ares-1.11.0"
-caresFileName="c-ares-1.11.0.tar.gz"
-caresURL="http://c-ares.haxx.se/download/c-ares-1.11.0.tar.gz"
+caresDirName="c-ares-1.13.0"
+caresFileName="c-ares-1.13.0.tar.gz"
+caresURL="https://c-ares.haxx.se/download/c-ares-1.13.0.tar.gz"
 
-curlDirName="curl-7.50.2"
-curlFileName="curl-7.50.2.tar.gz"
-curlURL="http://curl.haxx.se/download/curl-7.50.2.tar.gz"
+curlDirName="curl-7.58.0"
+curlFileName="curl-7.58.0.tar.gz"
+curlURL="https://curl.haxx.se/download/curl-7.58.0.tar.gz"
 
 wxWidgetsDirName="wxWidgets-3.1.0"
 wxWidgetsFileName="wxWidgets-3.1.0.tar.bz2"
 wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.0/wxWidgets-3.1.0.tar.bz2"
 
-sqliteDirName="sqlite-autoconf-3110000"
-sqliteFileName="sqlite-autoconf-3110000.tar.gz"
-sqliteURL="http://www.sqlite.org/2016/sqlite-autoconf-3110000.tar.gz"
+sqliteDirName="sqlite-autoconf-3220000"
+sqliteFileName="sqlite-autoconf-3220000.tar.gz"
+sqliteURL="https://www.sqlite.org/2018/sqlite-autoconf-3220000.tar.gz"
 
-freetypeDirName="freetype-2.6.2"
-freetypeFileName="freetype-2.6.2.tar.bz2"
-freetypeURL="http://sourceforge.net/projects/freetype/files/freetype2/2.6.2/freetype-2.6.2.tar.bz2"
+freetypeDirName="freetype-2.9"
+freetypeFileName="freetype-2.9.tar.bz2"
+freetypeURL="https://sourceforge.net/projects/freetype/files/freetype2/2.9/freetype-2.9.tar.bz2"
 
 ftglDirName="ftgl-2.1.3~rc5"
 ftglFileName="ftgl-2.1.3-rc5.tar.gz"
-ftglURL="http://sourceforge.net/projects/ftgl/files/FTGL%20Source/2.1.3%7Erc5/ftgl-2.1.3-rc5.tar.gz"
+ftglURL="https://sourceforge.net/projects/ftgl/files/FTGL%20Source/2.1.3%7Erc5/ftgl-2.1.3-rc5.tar.gz"
 
 return 0


### PR DESCRIPTION
In preparation for building and testing BOINC 7.9.0 for the Mac, update the following third party dependencies:
SQlite 3.11.0 -> SQlite 3.22.0
cURL 7.50.2 -> cURL 7.58.0
c-ares 1.11.0 -> c-ares 1.13.0
OpenSSL 1.1.0 -> OpenSSL 1.1.0g
FreeType 2.6.2 -> FreeType 2.9
I have previously updated wxWidgets 3.0.0 -> wxWidgets 3.1.0

Also:
* Build only 64-bit libraries for wxWidgets and SQLite, instead of 32-bit / 64-bit "universal" libraries. This will reduce the time to build them and reduce the storage requirements for Travis CI.
* Eliminate patching curlrules.h which was needed to build 32-bit BOINC Manager.