### PR TITLE
Mac: Automate updating cURL build script

### DIFF
--- a/mac_build/buildFTGL.sh
+++ b/mac_build/buildFTGL.sh
@@ -66,6 +66,9 @@ while [[ $# -gt 0 ]]; do
     shift # past argument or value
 done
 
+# needed for ftgl 2.1.3-rc5 to find our freetype 2.9 build not the system one
+export PKG_CONFIG_PATH=${libftpath}/lib/pkgconfig:${PKG_CONFIG_PATH}
+
 SRCDIR=$PWD
 
 if [ "${doclean}" != "yes" ]; then


### PR DESCRIPTION
Mac: Eliminate needing to update the script which build cURL for each new version of c-ares or OpenSSL; get the names of current c-ares and OpenSSL directories from dependencyNames.sh.

This will reduce the likelihood of errors caused by forgetting to manually update this script.