### PR TITLE
[WIP] Mac GFX Library: fix bugs introduced in commit baac677 when rendering…

### DIFF
--- a/api/graphics2.cpp
+++ b/api/graphics2.cpp
@@ -88,12 +88,7 @@ bool throttled_app_render(int x, int y, double t) {
             boinc_calling_thread_cpu_time(t0);
         }
         
-#ifdef __APPLE__
-        if (UseSharedOffscreenBuffer()) {
-            MacPrepareOffscreenBuffer();
-        }
-#endif
-        app_graphics_render(x, y, t);
+       app_graphics_render(x, y, t);
 
 #ifdef __APPLE__
         if (UseSharedOffscreenBuffer()) {

--- a/api/graphics2_unix.cpp
+++ b/api/graphics2_unix.cpp
@@ -115,12 +115,12 @@ static void maybe_render() {
     new_ypos = glutGet(GLUT_WINDOW_Y);
     new_width = glutGet(GLUT_WINDOW_WIDTH);
     new_height = glutGet(GLUT_WINDOW_HEIGHT);
-    
-    
+
+
     if (throttled_app_render(new_width, new_height, dtime())) {
 #ifdef __APPLE__
         if (UseSharedOffscreenBuffer()) {
-            return; // Don't try to send garbage to screen
+            return; // Don't waste cycles drawing to hidden window on screen
         }
 #endif
         glutSwapBuffers();
@@ -179,7 +179,7 @@ static void make_window(const char* title) {
 #ifdef __APPLE__
     glutWMCloseFunc(boinc_close_window_and_quit_aux);   // Enable the window's close box
     BringAppToFront();
-    // Show window only after a successful call to throttled_app_render(); 
+    // Show window only after a successful call to throttled_app_render();
     // this avoids momentary display of old image when screensaver restarts 
     // which made image appear to "jump."
     need_show = true;

--- a/api/x_opengl.h
+++ b/api/x_opengl.h
@@ -26,7 +26,6 @@ extern int xwin_glut_is_initialized();
 
 #ifdef __APPLE__
 extern void MacGLUTFix(bool isScreenSaver);
-extern void MacPrepareOffscreenBuffer(void);
 extern void MacPassOffscreenBufferToScreenSaver(void);
 extern void BringAppToFront(void);
 extern void HideThisApp(void);


### PR DESCRIPTION
Mac GFX Library: fix bugs introduced in commit baac677 when rendering some graphics apps. Project graphics apps for Macintosh should be relinked with libboinc_graphics2.a built using these updated source files.

Note: This branch will merge into master. Since these changes affect only the libboinc_graphics2.a library and so affect only project graphics apps, I don't know if it is desirable to also merge this into the client_release/7/7.8 branch.