### PR TITLE
Remove HOST_USAGE.max_ncpus.  It's not used anywhere.

### DIFF
--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -768,7 +768,6 @@ void APP_VERSION::init() {
     safe_strcpy(plan_class, "");
     safe_strcpy(api_version, "");
     avg_ncpus = 1;
-    max_ncpus = 1;
     gpu_usage.rsc_type = 0;
     gpu_usage.usage = 0;
     gpu_ram = 0;
@@ -855,7 +854,7 @@ int APP_VERSION::parse(XML_PARSER& xp) {
         if (xp.parse_str("platform", platform, sizeof(platform))) continue;
         if (xp.parse_str("plan_class", plan_class, sizeof(plan_class))) continue;
         if (xp.parse_double("avg_ncpus", avg_ncpus)) continue;
-        if (xp.parse_double("max_ncpus", max_ncpus)) continue;
+        if (xp.parse_double("max_ncpus", dtemp)) continue;
         if (xp.parse_double("flops", dtemp)) {
             if (dtemp <= 0) {
                 msg_printf(0, MSG_INTERNAL_ERROR,
@@ -914,13 +913,11 @@ int APP_VERSION::write(MIOFILE& out, bool write_file_info) {
         "    <version_num>%d</version_num>\n"
         "    <platform>%s</platform>\n"
         "    <avg_ncpus>%f</avg_ncpus>\n"
-        "    <max_ncpus>%f</max_ncpus>\n"
         "    <flops>%f</flops>\n",
         app_name,
         version_num,
         platform,
         avg_ncpus,
-        max_ncpus,
         flops
     );
     if (strlen(plan_class)) {

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -292,7 +292,6 @@ struct APP_VERSION {
     char plan_class[64];
     char api_version[16];
     double avg_ncpus;
-    double max_ncpus;
     GPU_USAGE gpu_usage;    // can only use 1 GPU type
     double gpu_ram;
     double flops;

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -893,7 +893,6 @@ int CLIENT_STATE::handle_scheduler_reply(
             // update app version attributes in case they changed on server
             //
             avp->avg_ncpus = avpp.avg_ncpus;
-            avp->max_ncpus = avpp.max_ncpus;
             avp->flops = avpp.flops;
             safe_strcpy(avp->cmdline, avpp.cmdline);
             avp->gpu_usage = avpp.gpu_usage;

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -866,7 +866,6 @@ bool PLAN_CLASS_SPEC::check(SCHEDULER_REQUEST& sreq, HOST_USAGE& hu) {
         hu.peak_flops = capped_host_fpops() * hu.avg_ncpus;
         hu.projected_flops = capped_host_fpops() * hu.avg_ncpus * projected_flops_scale;
     }
-    hu.max_ncpus = hu.avg_ncpus;
 
 #if 0
     if (config.debug_version_select) {

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -149,7 +149,6 @@ static inline bool app_plan_mt(SCHEDULER_REQUEST&, HOST_USAGE& hu) {
     int nthreads = (int)ncpus;
     if (nthreads > 64) nthreads = 64;
     hu.avg_ncpus = nthreads;
-    hu.max_ncpus = nthreads;
     sprintf(hu.cmdline, "--nthreads %d", nthreads);
     hu.projected_flops = capped_host_fpops()*hu.avg_ncpus*.99;
         // the .99 ensures that on uniprocessors a sequential app
@@ -270,7 +269,6 @@ static bool ati_check(COPROC_ATI& c, HOST_USAGE& hu,
         hu.avg_ncpus
     );
     hu.peak_flops = hu.gpu_usage*c.peak_flops + hu.avg_ncpus*capped_host_fpops();
-    hu.max_ncpus = hu.avg_ncpus;
     return true;
 }
 
@@ -487,7 +485,6 @@ static bool cuda_check(COPROC_NVIDIA& c, HOST_USAGE& hu,
         hu.avg_ncpus
     );
     hu.peak_flops = hu.gpu_usage*c.peak_flops + hu.avg_ncpus*capped_host_fpops();
-    hu.max_ncpus = hu.avg_ncpus;
     return true;
 }
 
@@ -606,7 +603,6 @@ static inline bool app_plan_nvidia(
 //
 static inline bool app_plan_nci(SCHEDULER_REQUEST&, HOST_USAGE& hu) {
     hu.avg_ncpus = .01;
-    hu.max_ncpus = .01;
     hu.projected_flops = capped_host_fpops()*1.01;
         // The *1.01 is needed to ensure that we'll send this app
         // version rather than a non-plan-class one
@@ -631,7 +627,6 @@ static inline bool app_plan_sse3(
         }
     }
     hu.avg_ncpus = 1;
-    hu.max_ncpus = 1;
     hu.projected_flops = 1.1*capped_host_fpops();
     hu.peak_flops = capped_host_fpops();
     return true;
@@ -694,7 +689,6 @@ static inline bool opencl_check(
         hu.avg_ncpus
     );
     hu.peak_flops = ndevs*cp.peak_flops + hu.avg_ncpus*capped_host_fpops();
-    hu.max_ncpus = hu.avg_ncpus;
     return true;
 }
 
@@ -888,13 +882,11 @@ static inline bool app_plan_vbox(
 
     double flops_scale = 1;
     hu.avg_ncpus = 1;
-    hu.max_ncpus = 1;
     if (strstr(plan_class, "mt")) {
         if (can_use_multicore) {
             // Use number of usable CPUs, taking user prefs into account
             double ncpus = g_wreq->effective_ncpus;
             hu.avg_ncpus = ncpus;
-            hu.max_ncpus = ncpus;
             sprintf(hu.cmdline, "--nthreads %f", ncpus);
         }
         // use the non-mt version rather than the mt version with 1 CPU
@@ -902,7 +894,7 @@ static inline bool app_plan_vbox(
         flops_scale = .99;
     }
     hu.projected_flops = flops_scale * capped_host_fpops()*hu.avg_ncpus;
-    hu.peak_flops = capped_host_fpops()*hu.max_ncpus;
+    hu.peak_flops = capped_host_fpops()*hu.avg_ncpus;
     if (config.debug_version_select) {
         log_messages.printf(MSG_NORMAL,
             "[version] %s app projected %.2fG\n",

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -1193,10 +1193,8 @@ int APP_VERSION::write(FILE* fout) {
     }
     fprintf(fout,
         "    <avg_ncpus>%f</avg_ncpus>\n"
-        "    <max_ncpus>%f</max_ncpus>\n"
         "    <flops>%f</flops>\n",
         bavp->host_usage.avg_ncpus,
-        bavp->host_usage.max_ncpus,
         bavp->host_usage.projected_flops
     );
     if (strlen(bavp->host_usage.cmdline)) {

--- a/sched/sched_types.h
+++ b/sched/sched_types.h
@@ -66,7 +66,6 @@ struct HOST_USAGE {
     double gpu_usage;
     double gpu_ram;
     double avg_ncpus;
-    double max_ncpus;
     double mem_usage;
         // mem usage if specified by the plan class
         // (overrides wu.rsc_memory_bound)
@@ -86,7 +85,6 @@ struct HOST_USAGE {
         gpu_usage = 0;
         gpu_ram = 0;
         avg_ncpus = 1;
-        max_ncpus = 1;
         mem_usage = 0;
         projected_flops = 0;
         peak_flops = 0;
@@ -98,7 +96,6 @@ struct HOST_USAGE {
         gpu_usage = 0;
         gpu_ram = 0;
         avg_ncpus = 1;
-        max_ncpus = 1;
         mem_usage = 0;
         if (flops <= 0) flops = 1e9;
         projected_flops = flops;


### PR DESCRIPTION
avg_ncpus is always used instead.

Note: there are two other things named "max_ncpus".
One is a computing prefs field (limit on # of CPUs to use).
The other, a field of SCHED_CONFIG,
is the max # of CPUs the scheduler will believe a client has
in deciding how many jobs to send it.