### PR TITLE
Revert "web: always use secure URL base if available."

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -123,7 +123,7 @@ function secure_url_base() {
 }
 
 function url_base() {
-    return secure_url_base();
+    return is_https()?secure_url_base():URL_BASE;
 }
 
 function send_cookie($name, $value, $permanent, $ops=false) {


### PR DESCRIPTION
This reverts commit 1140ec069daae827509ea17e07dfca5aa1b2dd1f.

I'm trying to get the following working: When accessing the site over http, I want to serve the stylesheet over http. When accessing over https, I want the sylesheet over https. 

With the above commit, that becomes impossible, since the sytlesheet is always served over https (and this breaks the site in cases where the https access is impossible). 

I'm wondering what was the rationale for the commit in the first place? If it was for kind of a blanket redirect, I think the correct method would really be https://wiki.apache.org/httpd/RedirectSSL. If that's the case, then I'd recommend we revert the commit (which can be done by accepting this PR). If it was for something else, then could you let me know for what and I can try to think of a solution that simultaneously allows my use-case? Thanks.