### PR TITLE
add remote submit from Condor parameter tuning capability

### DIFF
--- a/lib/remote_submit.cpp
+++ b/lib/remote_submit.cpp
@@ -36,6 +36,14 @@
 using std::vector;
 using std::string;
 
+#define DEFAULT_FPOPS_EST 3600e9
+#define DEFAULT_FPOPS_BOUND 86400e9
+#define DEFAULT_MEMORY_BOUND 5e8 
+#define DEFAULT_DISK_BOUND 1e9 
+#define DEFAULT_DELAY_BOUND 604800 
+#define DEFAULT_APP_VERSION_NUM 0 
+
+
 //#define SHOW_REQUEST
 //#define SHOW_REPLY
 
@@ -396,6 +404,11 @@ int submit_jobs(
     int batch_id,
     vector<JOB> jobs,
     string& error_msg,
+    char rsc_fpops_est [256],
+    char rsc_fpops_bound [256],
+    char rsc_memory_bound [256],
+    char rsc_disk_bound [256],
+    char delay_bound [256],
     int app_version_num
 ) {
     char buf[1024], url[1024];
@@ -412,11 +425,66 @@ int submit_jobs(
         app_version_num
     );
     string request = buf;
+
+
+    if (strcmp(rsc_fpops_est, "NULL") != 0) {
+        sprintf(buf, "  <rsc_fpops_est>%f</rsc_fpops_est>\n", atof(rsc_fpops_est));
+        request += buf;
+    }
+
+    if (strcmp(rsc_fpops_bound, "NULL") != 0) {
+        sprintf(buf, "  <rsc_fpops_bound>%f</rsc_fpops_bound>\n", atof(rsc_fpops_bound));
+        request += buf;
+    }
+
+    if (strcmp(rsc_memory_bound, "NULL") != 0) {
+        sprintf(buf, "  <rsc_memory_bound>%f</rsc_memory_bound>\n", atof(rsc_memory_bound));
+        request += buf;
+    }
+
+    if (strcmp(rsc_disk_bound, "NULL") != 0) {
+        sprintf(buf, "  <rsc_disk_bound>%f</rsc_disk_bound>\n", atof(rsc_disk_bound));
+        request += buf;
+    }
+
+    if (strcmp(delay_bound, "NULL") != 0) {
+        sprintf(buf, "  <delay_bound>%f</delay_bound>\n", atof(delay_bound));
+        request += buf;
+    }
+
     for (unsigned int i=0; i<jobs.size(); i++) {
         JOB job = jobs[i];
         request += "<job>\n";
         sprintf(buf, "  <name>%s</name>\n", job.job_name);
         request += buf;
+
+
+        if (strcmp(rsc_fpops_est, "NULL") != 0) {
+            sprintf(buf, "  <rsc_fpops_est>%f</rsc_fpops_est>\n", atof(rsc_fpops_est));
+            request += buf;
+        }
+
+        if (strcmp(rsc_fpops_bound, "NULL") != 0) {
+            sprintf(buf, "  <rsc_fpops_bound>%f</rsc_fpops_bound>\n", atof(rsc_fpops_bound));
+            request += buf;
+        }
+
+        if (strcmp(rsc_memory_bound, "NULL") != 0) {
+            sprintf(buf, "  <rsc_memory_bound>%f</rsc_memory_bound>\n", atof(rsc_memory_bound));
+            request += buf;
+        }
+
+        if (strcmp(rsc_disk_bound, "NULL") != 0) {
+            sprintf(buf, "  <rsc_disk_bound>%f</rsc_disk_bound>\n", atof(rsc_disk_bound));
+            request += buf;
+        }
+
+        if (strcmp(delay_bound, "NULL") != 0) {
+            sprintf(buf, "  <delay_bound>%f</delay_bound>\n", atof(delay_bound));
+            request += buf;
+        }
+
+
         if (!job.cmdline_args.empty()) {
             request += "<command_line>" + job.cmdline_args + "</command_line>\n";
         }

--- a/lib/remote_submit.h
+++ b/lib/remote_submit.h
@@ -148,6 +148,11 @@ extern int submit_jobs(
     int batch_id,
     std::vector<JOB> jobs,
     std::string& error_msg,
+    char rsc_fpops_est[256],
+    char rsc_fpops_bound[256],
+    char rsc_memory_bound[256],
+    char rsc_disk_bound[256],
+    char delay_bound[256],
     int app_version_num = 0
 );
 

--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -70,6 +70,12 @@ struct SUBMIT_REQ {
     char app_name[256];
     vector<JOB> jobs;
     int batch_id;
+    char rsc_fpops_est[256];
+    char rsc_fpops_bound[256];
+    char rsc_memory_bound[256];
+    char rsc_disk_bound[256];
+    char delay_bound[256];
+    char app_version_num[256];
 };
 
 struct LOCAL_FILE {
@@ -279,6 +285,26 @@ int COMMAND::parse_submit(char* p) {
         }
         submit_req.jobs.push_back(job);
     }
+
+    char *chr = NULL;
+    chr = strtok_r(NULL, " ", &p);
+    if (chr != NULL) {
+        strlcpy(submit_req.rsc_fpops_est, chr, sizeof(submit_req.rsc_fpops_est));
+        strlcpy(submit_req.rsc_fpops_bound, strtok_r(NULL, " ", &p), sizeof(submit_req.rsc_fpops_bound));
+        strlcpy(submit_req.rsc_memory_bound, strtok_r(NULL, " ", &p), sizeof(submit_req.rsc_memory_bound));
+        strlcpy(submit_req.rsc_disk_bound, strtok_r(NULL, " ", &p), sizeof(submit_req.rsc_disk_bound));
+        strlcpy(submit_req.delay_bound, strtok_r(NULL, " ", &p), sizeof(submit_req.delay_bound));
+        strlcpy(submit_req.app_version_num, strtok_r(NULL, " ", &p), sizeof(submit_req.app_version_num));
+
+    } else {
+        strlcpy(submit_req.rsc_fpops_est, "", sizeof(submit_req.rsc_fpops_est));
+        strlcpy(submit_req.rsc_fpops_bound, "", sizeof(submit_req.rsc_fpops_bound));
+        strlcpy(submit_req.rsc_memory_bound, "", sizeof(submit_req.rsc_memory_bound));
+        strlcpy(submit_req.rsc_disk_bound, "", sizeof(submit_req.rsc_disk_bound));
+        strlcpy(submit_req.delay_bound, "", sizeof(submit_req.delay_bound));
+        strlcpy(submit_req.app_version_num, "", sizeof(submit_req.app_version_num));
+    }
+
     return 0;
 }
 
@@ -324,7 +350,9 @@ void handle_submit(COMMAND& c) {
 
     retval = submit_jobs(
         project_url, authenticator,
-        req.app_name, req.batch_id, req.jobs, error_msg
+	req.app_name, req.batch_id, req.jobs, error_msg, req.rsc_fpops_est,
+                req.rsc_fpops_bound, req.rsc_memory_bound, 
+                req.rsc_disk_bound, req.delay_bound, atoi(req.app_version_num)
     );
     if (retval) {
         sprintf(buf, "error\\ submitting\\ jobs:\\ %d\\ ", retval);

--- a/sched/adjust_user_priority.cpp
+++ b/sched/adjust_user_priority.cpp
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
     int userid=0;
     char* app_name = NULL;
     double flop_count = 0;
+    int jobs = 0;
 
     for (int i=1; i<argc; i++) {
         if (!strcmp(argv[i], "--no_update")) {
@@ -54,6 +55,8 @@ int main(int argc, char** argv) {
             app_name = argv[++i];
         } else if (!strcmp(argv[i], "--flops")) {
             flop_count = atof(argv[++i]);
+        } else if (!strcmp(argv[i], "--jobs")) {
+            jobs = atoi(argv[++i]);
         } else {
             fprintf(stderr, "bad arg: %s\n", argv[i]);
             usage();
@@ -62,6 +65,15 @@ int main(int argc, char** argv) {
     if (!app_name) usage("missing --app\n");
     if (!userid) usage("missing --user\n");
     if (flop_count <= 0) usage("missing --flops\n");
+
+    //If no total flops are given from the submitter directly we can 
+    //infer it from the number of jobs times the DEFAULT_FPOPS_EST
+    //If no number of jobs is given either there is nothing we can do
+
+    if (flop_count <= 0) {
+       if (jobs <= 0) usage("missing --flops\n");
+       else flop_count = jobs * DEFAULT_FPOPS_EST;   
+    }
 
     int retval = config.parse_file();
     if (retval) {

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -278,7 +278,12 @@ int create_work2(
     SCHED_CONFIG& config_loc,
     const char* command_line,
     const char* additional_xml,
-    char* query_string
+    char* query_string,
+    double rsc_fpops_est,
+    double rsc_fpops_bound,
+    double rsc_memory_bound,
+    double rsc_disk_bound,
+    double delay_bound
 ) {
     int retval;
     char wu_template[BLOB_SIZE];
@@ -300,6 +305,15 @@ int create_work2(
         fprintf(stderr, "process_input_template(): %s\n", boincerror(retval));
         return retval;
     }
+
+    //If these values were changed by the submitter override the template ones
+    //which were parsed above
+
+    if (rsc_fpops_est != -1) wu.rsc_fpops_est = rsc_fpops_est;
+    if (rsc_fpops_bound != -1) wu.rsc_fpops_bound = rsc_fpops_bound;
+    if (rsc_memory_bound != -1) wu.rsc_memory_bound = rsc_memory_bound;
+    if (rsc_disk_bound != -1) wu.rsc_disk_bound = rsc_disk_bound;
+    if (delay_bound != -1) wu.delay_bound = delay_bound;
 
     // check for presence of result template.
     // we don't need to actually look at it.

--- a/tools/backend_lib.h
+++ b/tools/backend_lib.h
@@ -24,6 +24,12 @@
 #include "sched_config.h"
 #include "boinc_db.h"
 
+#define DEFAULT_FPOPS_EST 3600e9
+#define DEFAULT_FPOPS_BOUND 86400e9
+#define DEFAULT_MEMORY_BOUND 5e8 
+#define DEFAULT_DISK_BOUND 1e11
+#define DEFAULT_DELAY_BOUND 604800
+
 // describes an input file;
 // either an argument to create_work(),
 // or a <file_info> in input template
@@ -99,7 +105,12 @@ extern int create_work2(
     SCHED_CONFIG&,
     const char* command_line = NULL,
     const char* additional_xml = NULL,
-    char* query_string = 0
+    char* query_string = 0,
+    double rsc_fpops_est = -1,
+    double rsc_fpops_bound = -1,
+    double rsc_memory_bound = -1,
+    double rsc_disk_bound = -1,
+    double delay_bound = -1
 );
 
 extern int stage_file(const char*, bool);

--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -147,12 +147,12 @@ struct JOB_DESC {
         wu.max_error_results = 3;
         wu.max_total_results = 10;
         wu.max_success_results = 6;
-        wu.rsc_fpops_est = 3600e9;
-        wu.rsc_fpops_bound =  86400e9;
-        wu.rsc_memory_bound = 5e8;
-        wu.rsc_disk_bound = 1e9;
+	wu.rsc_fpops_est = DEFAULT_FPOPS_EST;
+	wu.rsc_fpops_bound = DEFAULT_FPOPS_BOUND;
+	wu.rsc_memory_bound = DEFAULT_MEMORY_BOUND;
+	wu.rsc_disk_bound = DEFAULT_DISK_BOUND;
         wu.rsc_bandwidth_bound = 0.0;
-        wu.delay_bound = 7*86400;
+        wu.delay_bound = DEFAULT_DELAY_BOUND;
 
     }
     void create();
@@ -237,6 +237,16 @@ int main(int argc, char** argv) {
     bool show_wu_name = true;
     bool use_stdin = false;
 
+    //If these values are passed in the command line
+    //store them here so we can later override 
+    //the ones potentially found in the input template.
+
+    double rsc_fpops_est = -1;
+    double rsc_fpops_bound = -1;
+    double rsc_memory_bound = -1;
+    double rsc_disk_bound = -1;
+    double delay_bound = -1;
+
     strcpy(app.name, "");
     strcpy(db_passwd, "");
     const char* config_dir = 0;
@@ -264,18 +274,28 @@ int main(int argc, char** argv) {
             jd.wu.priority = atoi(argv[++i]);
         } else if (arg(argv, i, "rsc_fpops_est")) {
             jd.wu.rsc_fpops_est = atof(argv[++i]);
+	    //Storing for later
+	    rsc_fpops_est = jd.wu.rsc_fpops_est; 
         } else if (arg(argv, i, "rsc_fpops_bound")) {
             jd.wu.rsc_fpops_bound = atof(argv[++i]);
+	    //Storing for later
+	    rsc_fpops_bound = jd.wu.rsc_fpops_bound; 
         } else if (arg(argv, i, "rsc_memory_bound")) {
             jd.wu.rsc_memory_bound = atof(argv[++i]);
+	    //Storing for later
+	    rsc_memory_bound = jd.wu.rsc_memory_bound; 
         } else if (arg(argv, i, "size_class")) {
             jd.wu.size_class = atoi(argv[++i]);
         } else if (arg(argv, i, "app_version_num")) {
             jd.wu.app_version_num = atoi(argv[++i]);
         } else if (arg(argv, i, "rsc_disk_bound")) {
             jd.wu.rsc_disk_bound = atof(argv[++i]);
+	    //Storing for later
+	    rsc_disk_bound = jd.wu.rsc_disk_bound; 
         } else if (arg(argv, i, "delay_bound")) {
             jd.wu.delay_bound = atoi(argv[++i]);
+	    //Storing for later
+	    delay_bound = jd.wu.delay_bound; 
         } else if (arg(argv, i, "hr_class")) {
             jd.wu.hr_class = atoi(argv[++i]);
         } else if (arg(argv, i, "min_quorum")) {
@@ -490,7 +510,12 @@ int main(int argc, char** argv) {
                     config,
                     jd2.command_line,
                     jd2.additional_xml,
-                    value_buf
+		    value_buf,
+		    rsc_fpops_est,
+		    rsc_fpops_bound,
+		    rsc_memory_bound,
+		    rsc_disk_bound,
+		    delay_bound
                 );
                 if (retval) {
                     fprintf(stderr, "create_work() failed: %d\n", retval);


### PR DESCRIPTION
This pull request is to make it possible to set the following parameters: 

`rsc_fpops_est, rsc_fpops_bound, rsc_memory_bound, rsc_disk_bound, delay_bound, app_version_num `

when submitting to BOINC through Condor.  

See: https://github.com/htcondor/htcondor/pull/19