### PR TITLE
web: improve - but not fix - password visibility checkbox

### DIFF
--- a/html/inc/account.inc
+++ b/html/inc/account.inc
@@ -35,15 +35,16 @@ function passwd_visible_checkbox($name) {
     return sprintf('
 <script>
 function toggle_passwd() {
+    var c = document.getElementById("passwd_visible");
     var x = document.getElementById("%s");
-    if (x.type === "password") {
+    if (c.checked) {
         x.type = "text";
     } else {
         x.type = "password";
     }
 }
 </script>
-<input type="checkbox" onclick="toggle_passwd()"><small> Show password</small>
+<input type="checkbox" id="passwd_visible" onclick="toggle_passwd()"><small> Show password</small>
         ', $name
     );
 }


### PR DESCRIPTION
When you check the box it turns the input field type from "password" to "text".
If you navigate to another (say by clicking Submit)
and then return via the back button,
the checkbox is still checked but the input field type is back to "password"!
Further clicks toggle the type, so it's always wrong from that point.

I changed it so that clicking the checkbox sets the type
to the appropriate value rather than toggling it.
The type is still wrong after "back",
but it's right after further checkbox clicks.

Note: the example on w3schools.com
https://www.w3schools.com/howto/howto_js_toggle_password.asp
has the same bug.