### PR TITLE
Drupal: Set additional Views to use replica DB.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincteam/boincteam.module
+++ b/drupal/sites/default/boinc/modules/boincteam/boincteam.module
@@ -141,6 +141,26 @@ function boincteam_top_teams() {
   
 }
 
+/**
+* Implementation of hook_views_pre_execute().
+*/
+function boincteam_views_pre_execute(&$view) {
+  /* Specific boinc_teams sub-views use the boinc readonly replica
+   * DB. These sub-views defined below by their title. If additional
+   * sub-views need to be added, add their title to the list of cases
+   * below. If a sub-view needs to be reverted to use the master DB,
+   * then remove it from the list of cases.
+   */
+  if ($view->name == 'boinc_teams') {
+    switch ($view->display[$view->current_display]->display_title) {
+    case 'Top teams overview pane':
+    case 'Top teams pane':
+    case 'Page':
+      $view->base_database = 'boinc_ro';
+    }
+  }
+}
+
 
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
  * BOINC team functions

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.views.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.views.inc
@@ -23,7 +23,7 @@ function boincuser_views_data() {
       'field' => 'id',
       'title' => t('BOINC user'),
       'help' => t('BOINC account data for a user'),
-      'database' => 'boinc_rw'
+      'database' => 'boinc_ro'
   );
 
   // Describe each of the individual fields in this table to Views. For


### PR DESCRIPTION
View boinc_users to use boinc_ro replica DB. 
Some boinc_teams sub-views set to use replica DB as well, on a title-by-title basis.