### PR TITLE
Drupal: Rules updates

### DIFF
--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -201,6 +201,730 @@ function boinc_standard_node_info() {
 function boinc_standard_rules_defaults() {
   return array(
     'rules' => array(
+      'rules_forum_topic_is_edited_and_marked_sticky_by_moderator_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic is edited and marked sticky by moderator/admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+            '#weight' => 0,
+          ),
+          '1' => array(
+            '#weight' => 0,
+            '0' => array(
+              '#weight' => 0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0,
+            ),
+          ),
+          '3' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node content unchanged',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return $node->body == $node_unchanged->body;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+          '4' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node made sticky',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->sticky == 0 && $node->sticky == 1;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] marked sticky by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been marked sticky by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'action',
+            '#weight' => 0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_is_edited_and_marked_unsticky_by_moderator_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic is edited and marked unsticky by moderator/admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+            '#weight' => 0,
+          ),
+          '1' => array(
+            '#weight' => 0,
+            '0' => array(
+              '#weight' => 0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0,
+            ),
+          ),
+          '3' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node content unchanged',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return $node->body == $node_unchanged->body;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+          '4' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node made sticky',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->sticky == 1 && $node->sticky == 0;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] marked unsticky by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been marked unsticky by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'action',
+            '#weight' => 0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_is_edited_and_locked_by_moderator_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic is edited and locked by moderator/admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+            '#weight' => 0,
+          ),
+          '1' => array(
+            '#weight' => 0,
+            '0' => array(
+              '#weight' => 0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0,
+            ),
+          ),
+          '3' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node content unchanged',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return $node->body == $node_unchanged->body;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+          '4' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node locked',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->comment == 2 && $node->comment == 1;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] locked by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been locked by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'action',
+            '#weight' => 0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_is_edited_and_unlocked_by_moderator_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic is edited and unlocked by moderator/admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+            '#weight' => 0,
+          ),
+          '1' => array(
+            '#weight' => 0,
+            '0' => array(
+              '#weight' => 0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0,
+            ),
+          ),
+          '3' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node content unchanged',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return $node->body == $node_unchanged->body;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+          '4' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node unlocked',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->comment == 1 && $node->comment == 2;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] unlocked by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been unlocked by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'action',
+            '#weight' => 0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
       'rules_forum_topic_is_edited_and_hidden_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
@@ -654,7 +1378,7 @@ function boinc_standard_rules_defaults() {
           '2' => array(
             '#weight' => 0,
             '#info' => array(
-              'label' => 'PHP code: node status unchanged',
+              'label' => 'PHP code: node status, sticky, lock unchanged',
               'label callback' => FALSE,
               'module' => 'PHP',
               'eval input' => array(
@@ -663,7 +1387,7 @@ function boinc_standard_rules_defaults() {
             ),
             '#name' => 'rules_condition_custom_php',
             '#settings' => array(
-              'code' => 'return $node->status == $node_unchanged->status;',
+              'code' => 'return ($node->status == $node_unchanged->status && $node->sticky == $node_unchanged->sticky && $node->comment == $node_unchanged->comment);',
               'vars' => array(
                 '0' => 'node',
                 '1' => 'node_unchanged',

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -201,10 +201,10 @@ function boinc_standard_node_info() {
 function boinc_standard_rules_defaults() {
   return array(
     'rules' => array(
-      'rules_forum_topic_is_edited_and_marked_sticky_by_moderator_admin' => array(
+      'rules_forum_topic_marked_sticky_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is edited and marked sticky by moderator/admin',
+        '#label' => 'Forum topic marked sticky by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -382,10 +382,10 @@ function boinc_standard_rules_defaults() {
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_is_edited_and_marked_unsticky_by_moderator_admin' => array(
+      'rules_forum_topic_marked_unsticky_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is edited and marked unsticky by moderator/admin',
+        '#label' => 'Forum topic marked unsticky by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -563,10 +563,10 @@ function boinc_standard_rules_defaults() {
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_is_edited_and_locked_by_moderator_admin' => array(
+      'rules_forum_topic_locked_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is edited and locked by moderator/admin',
+        '#label' => 'Forum topic locked by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -744,10 +744,10 @@ function boinc_standard_rules_defaults() {
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_is_edited_and_unlocked_by_moderator_admin' => array(
+      'rules_forum_topic_unlocked_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is edited and unlocked by moderator/admin',
+        '#label' => 'Forum topic unlocked by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -925,10 +925,10 @@ function boinc_standard_rules_defaults() {
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_is_edited_and_hidden_by_moderator_admin' => array(
+      'rules_forum_topic_is_hidden_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is edited and hidden by moderator/admin',
+        '#label' => 'Forum topic is hidden by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -1106,10 +1106,10 @@ function boinc_standard_rules_defaults() {
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_is_edited_and_unhidden_by_moderator_admin' => array(
+      'rules_forum_topic_is_unhidden_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is edited and unhidden by moderator/admin',
+        '#label' => 'Forum topic is unhidden by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -1378,7 +1378,7 @@ function boinc_standard_rules_defaults() {
           '2' => array(
             '#weight' => 0,
             '#info' => array(
-              'label' => 'PHP code: node status, sticky, lock unchanged',
+              'label' => 'PHP code: content changed',
               'label callback' => FALSE,
               'module' => 'PHP',
               'eval input' => array(
@@ -1387,7 +1387,7 @@ function boinc_standard_rules_defaults() {
             ),
             '#name' => 'rules_condition_custom_php',
             '#settings' => array(
-              'code' => 'return ($node->status == $node_unchanged->status && $node->sticky == $node_unchanged->sticky && $node->comment == $node_unchanged->comment);',
+              'code' => 'return ($node->body != $node_unchanged->body);',
               'vars' => array(
                 '0' => 'node',
                 '1' => 'node_unchanged',
@@ -1411,6 +1411,160 @@ function boinc_standard_rules_defaults() {
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] edited by moderator/admin',
               'message' => "[node:type] '[node:title]' has been edited by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_is_moved_to_a_different_forum_by_moderator_or_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic is moved to a different forum by moderator or admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#weight' => 0,
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+          ),
+          '1' => array(
+            '#weight' => 0,
+            '0' => array(
+              '#weight' => 0,
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#type' => 'condition',
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0,
+            ),
+          ),
+          '2' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: node moved to new forum parent',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return ($node->forum_tid != $node_unchanged->forum_tid);',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#weight' => 0,
+            '#type' => 'action',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] moved by moderator/admin',
+              'message' => "[node:type] '[node:title]' has been moved by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]\r\n\r\nNew Parent: [node:menu-link-parent-path]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -1541,7 +1541,7 @@ function boinc_standard_rules_defaults() {
             ),
             '#name' => 'rules_condition_custom_php',
             '#settings' => array(
-              'code' => 'return ($node->forum_tid != $node_unchanged->forum_tid);',
+              'code' => 'return ($node->tid != $node_unchanged->tid);',
               'vars' => array(
                 '0' => 'node',
                 '1' => 'node_unchanged',

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -359,8 +359,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] hidden by moderator/admin',
-              'message' => '[node:type] \'[node:title]\' has been hidden by moderator/admin [user:display-name]. Link:
-[node:node-url]',
+              'message' => "[node:type] '[node:title]' has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -542,8 +541,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] unhidden by moderator/admin',
-              'message' => '[node:type] \'[node:title]\' has been unhidden by moderator/admin [user:display-name]. Link:
-[node:node-url]',
+              'message' => "[node:type] '[node:title]' has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -688,8 +686,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] edited by moderator/admin',
-              'message' => '[node:type] \'[node:title]\' has been edited by moderator/admin [user:display-name]. Link: 
-[node:node-url]',
+              'message' => "[node:type] '[node:title]' has been edited by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -817,8 +814,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Comment edited at [:global:site-name] by moderator or admin',
-              'message' => 'Comment has been edited by moderator/admin [user:display-name]. Link:
-[:global:site-url]/goto/comment/[comment:comment-cid]',
+              'message' => "Comment has been edited by moderator/admin [user:display-name].\r\n\r\nLink: [:global:site-url]/goto/comment/[comment:comment-cid]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -896,8 +892,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Comment at [:global:site-name] hidden by moderator or admin',
-              'message' => 'Comment has been hidden by moderator/admin [user:display-name]. Link:
-[:global:site-url]/goto/comment/[comment:comment-cid]',
+              'message' => "Comment has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: [:global:site-url]/goto/comment/[comment:comment-cid]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -984,9 +979,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Comment at [:global:site-name] unhidden by moderator or admin',
-              'message' => 'Comment has been unhidden by moderator/admin [user:display-name]. Link:
-[:global:site-url]/goto/comment/[comment:comment-cid]
-',
+              'message' => "Comment has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: [:global:site-url]/goto/comment/[comment:comment-cid]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1027,8 +1020,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Comment deleted at [:global:site-name] by admin',
-              'message' => 'Comment to [node:type] \'[node:title]\' deleted by admin [user:display-name]. Link:
-[node:node-url]',
+              'message' => "Comment to [node:type] '[node:title]' deleted by admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -1083,7 +1083,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] hidden by moderator/admin',
-              'message' => "[node:type] '[node:title]' has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1265,7 +1265,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] unhidden by moderator/admin',
-              'message' => "[node:type] '[node:title]' has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1410,7 +1410,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] edited by moderator/admin',
-              'message' => "[node:type] '[node:title]' has been edited by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has been edited by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1564,7 +1564,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] moved by moderator/admin',
-              'message' => "[node:type] '[node:title]' has been moved by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has been moved by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1718,7 +1718,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] renamed by moderator/admin',
-              'message' => "[node:type] '[node:title]' has its title renamed by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has its title renamed by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -2052,7 +2052,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Comment deleted at [:global:site-name] by admin',
-              'message' => "Comment to [node:type] '[node:title]' deleted by admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "Comment to [node:type] topic '[node:title]' deleted by admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(

--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -1564,7 +1564,161 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] moved by moderator/admin',
-              'message' => "[node:type] '[node:title]' has been moved by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]\r\n\r\nNew Parent: [node:menu-link-parent-path]",
+              'message' => "[node:type] '[node:title]' has been moved by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_nenamed_title_by_moderator_or_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic renamed title by moderator or admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#weight' => 0,
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+          ),
+          '1' => array(
+            '#weight' => 0,
+            '0' => array(
+              '#weight' => 0,
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#type' => 'condition',
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0,
+            ),
+          ),
+          '2' => array(
+            '#weight' => 0,
+            '#info' => array(
+              'label' => 'PHP code: title changed',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return ($node->title != $node_unchanged->title);',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#weight' => 0,
+            '#type' => 'action',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] renamed by moderator/admin',
+              'message' => "[node:type] '[node:title]' has its title renamed by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(


### PR DESCRIPTION
Update rules to include different rules for when a forum topic is moved, renamed, edited, marked (un)sticky, or (un)locked.

https://dev.gridrepublic.org/browse/DBOINCP-298