### PR TITLE
Fix buffer size for call of function GetWindowText

### DIFF
--- a/clientsetup/win/CAShutdownBOINCManager.cpp
+++ b/clientsetup/win/CAShutdownBOINCManager.cpp
@@ -83,7 +83,7 @@ UINT CAShutdownBOINCManager::OnExecution()
         hWndBOINCManagerSystray = FindWindow( _T("wxTaskBarExWindowClass"), _T("BOINCManagerSystray") );
         if ( NULL != hWndBOINCManagerSystray )
         {
-            GetWindowText( hWndBOINCManagerSystray, szWindowTitle, (sizeof(szWindowTitle) * sizeof(TCHAR)));
+            GetWindowText( hWndBOINCManagerSystray, szWindowTitle, (sizeof(szWindowTitle) / sizeof(TCHAR)));
             LogProgress( szWindowTitle );
 
             lrReturnValue = SendMessage( hWndBOINCManagerSystray, WM_TASKBARSHUTDOWN, NULL, NULL );


### PR DESCRIPTION
Cppcheck found this issue: Multiplying sizeof() with sizeof() indicates a logic error.
GetWindowText expects the number of characters (3. argument) that fit into the buffer (2. argument).
So a division seems to be correct here instead of a multiplication.