### PR TITLE
Drupal: Trim strings in project-specific XML to help translators.

### DIFF
--- a/drupal/sites/default/boinc/modules/boinctranslate/includes/boinctranslate.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boinctranslate/includes/boinctranslate.helpers.inc
@@ -1391,3 +1391,17 @@ function _boinctranslate_filter_tips_long() {
 <p>The editor/admin may add as many of these tokens as you wish. You may add and remove them at your discretion. It is permitted for a page as no tokens, as the entire content will be a single chunk- such as for a shorter page.</p>
 ");
 }
+
+/*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
+ * Misc utility/helper functions
+ *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */
+
+/**
+ * Split a string by newline, and trim each line, implode back into a
+ * string. Used for cleaning whitespace title & description elements
+ * from project preferences XML upload before adding to translation
+ * database.
+ */
+function _boinctranslate_supertrim($instr) {
+  return implode("\n", array_map('trim', preg_split('/\r\n|\r|\n/', $instr) ) );
+}

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.helpers.inc
@@ -407,12 +407,12 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
       
       // Translate elements as appropriate
       if ($title) {
-        i18nstrings_update('project:prefs_xml', $title);
-        $title = i18nstrings('project:prefs_xml', $title);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($title));
+        $title = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($title));
       }
       if ($description) {
-        i18nstrings_update('project:prefs_xml', $description);
-        $description = i18nstrings('project:prefs_xml', $description);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($description));
+        $description = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($description));
       }
       
       $form[$name] = array(
@@ -455,12 +455,12 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
       
       // Translate elements as appropriate
       if ($title) {
-        i18nstrings_update('project:prefs_xml', $title);
-        $title = i18nstrings('project:prefs_xml', $title);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($title));
+        $title = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($title));
       }
       if ($description) {
-        i18nstrings_update('project:prefs_xml', $description);
-        $description = i18nstrings('project:prefs_xml', $description);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($description));
+        $description = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($description));
       }
       
       $form[$name] = array(
@@ -512,12 +512,12 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
       
       // Translate elements as appropriate
       if ($title) {
-        i18nstrings_update('project:prefs_xml', $title);
-        $title = i18nstrings('project:prefs_xml', $title);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($title));
+        $title = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($title));
       }
       if ($description) {
-        i18nstrings_update('project:prefs_xml', $description);
-        $description = i18nstrings('project:prefs_xml', $description);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($description));
+        $description = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($description));
       }
       
       $form[$name] = array(
@@ -536,8 +536,8 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
     
       // Translate elements as appropriate
       if ($title) {
-        i18nstrings_update('project:prefs_xml', $title);
-        $title = i18nstrings('project:prefs_xml', $title);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($title));
+        $title = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($title));
       }
     
     $form['applications'] = array(
@@ -596,8 +596,8 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
       
       // Translate elements as appropriate
       if ($title) {
-        i18nstrings_update('project:prefs_xml', $title);
-        $title = i18nstrings('project:prefs_xml', $title);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($title));
+        $title = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($title));
       }
       
       $form[$name] = array(
@@ -625,8 +625,8 @@ function boincwork_generate_prefs_element(&$form, $type, $elements, $user_prefs 
       
       // Translate elements as appropriate
       if ($title) {
-        i18nstrings_update('project:prefs_xml', $title);
-        $title = i18nstrings('project:prefs_xml', $title);
+        i18nstrings_update('project:prefs_xml', _boinctranslate_supertrim($title));
+        $title = i18nstrings('project:prefs_xml', _boinctranslate_supertrim($title));
       }
       
       $form[$name] = array(
@@ -1112,7 +1112,6 @@ function boincwork_format_stats($number, $max_digits = 4) {
   
   return $number;
 }
-
 
   //------------------------------------------------------------------------------------------------
   //  load_configuration(): Convert structured text/xml to array


### PR DESCRIPTION
Add custom trim function to code where the strings in the project-specific XML are aded to translation table(s).
Custom function removes whitespace from beginning and end of each line, separated by newline.

https://dev.gridrepublic.org/browse/DBOINCP-418