### PR TITLE
web: use "name@xxx.yyy" instead of "name@domain" to show form of emai…

### DIFF
--- a/html/inc/user_util.inc
+++ b/html/inc/user_util.inc
@@ -167,7 +167,7 @@ function validate_post_make_user() {
 
     $new_email_addr = strtolower(post_str("new_email_addr"));
     if (!is_valid_email_addr($new_email_addr)) {
-        show_error(tra("Invalid email address: you must enter a valid address of the form name@domain"));
+        show_error(tra("Invalid email address: please enter a valid address of the form name@xxx.yyy"));
     }
     $user = BoincUser::lookup_email_addr($new_email_addr);
     if ($user) {


### PR DESCRIPTION
…l addr.

Users may not know what "domain" means.
Also don't use "name@gmail.com"; they'll think they need a gmail addr.