### PR TITLE
client: show build not OS platform in messages

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -438,7 +438,7 @@ int CLIENT_STATE::init() {
         core_client_version.major,
         core_client_version.minor,
         core_client_version.release,
-        get_primary_platform(),
+        HOSTTYPE,
 #ifdef _DEBUG
         " (DEBUG)"
 #else

--- a/client/cs_cmdline.cpp
+++ b/client/cs_cmdline.cpp
@@ -248,13 +248,7 @@ void CLIENT_STATE::parse_cmdline(int argc, char** argv) {
             if (i == argc-1) show_options = true;
             else safe_strcpy(update_prefs_url, argv[++i]);
         } else if (ARG(version)) {
-#ifdef __APPLE__
-            CLIENT_STATE cs;
-            cs.detect_platforms();
-            printf(BOINC_VERSION_STRING " %s\n", cs.get_primary_platform());
-#else
             printf(BOINC_VERSION_STRING " " HOSTTYPE "\n");
-#endif
             exit(0);
 #ifdef __APPLE__
         // workaround for bug in XCode 4.2: accept but ignore 

--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -73,7 +73,7 @@ static void get_user_agent_string() {
     if (g_user_agent_string[0]) return;
     snprintf(g_user_agent_string, sizeof(g_user_agent_string),
         "BOINC client (%s %d.%d.%d)",
-        gstate.get_primary_platform(),
+        HOSTTYPE,
         BOINC_MAJOR_VERSION, BOINC_MINOR_VERSION, BOINC_RELEASE
     );
     if (strlen(gstate.client_brand)) {

--- a/clientgui/mac/config.h
+++ b/clientgui/mac/config.h
@@ -337,8 +337,9 @@
 /* #undef HAVE__PROC_SELF_STAT */
 
 /* Host for this compilation */
-/* "i686-apple-darwin", "x86_64-apple-darwin" or "powerpc-apple-darwin" determined at run time */
-#define HOSTTYPE ""
+#ifdef __x86_64__
+#define HOSTTYPE "x86_64-apple-darwin"
+#endif
 
 /* "Define to 1 if largefile support causes missing symbols in C++" */
 /* #undef LARGEFILE_BREAKS_CXX */


### PR DESCRIPTION
The client shows what kind of operating system it has detected in startup log message and elsewhere. This is confusing and not helping in troubleshooting when people expect these messages to describe the client itself.

Change the messages to use client's build platform instead.

Startup log message, output of --version and user agent string should be safe to change without breaking anything. The client still uses OS platform in various places but changing these would break stuff:

- Scheduler request XML. Scheduler expects scheduler_request.platform_name to be OS primary platform.
- client_state.xml. Client writes OS primary platform and alt platforms separately to client_state.xml. The client reads primary platform only to see if it has changed. The client doesn't read alt platforms but some other program might and depends on the platforms being as they are now. Not changing this means the client won't be able to detect when its own platform has changed. OS platform changes are still detected.
- get_state GUI RPC. The client writes primary platform to client_state.platform_name and all platforms, including primary, to client_state.platform. BOINC Manager only reads client_state.platform. As such, client_state.platform_name could be changed to client's build platform but some 3rd party manager might depend on it being OS primary platform.
- time_stats_log. The client writes platform info there. Unclear who uses that information.

Closes #2386.