### PR TITLE
Add a mechanism allowing project admins to "delete" a user

### DIFF
--- a/html/inc/friend.inc
+++ b/html/inc/friend.inc
@@ -115,4 +115,10 @@ function friend_accept_rss($notify, &$title, &$msg, &$url) {
     $url = secure_url_base().USER_HOME;
 }
 
+// delete friendship connections
+//
+function delete_friends($user) {
+    BoincFriend::delete_aux("user_src=$user->id or user_dest=$user->id");
+}
+
 ?>

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -24,6 +24,8 @@ require_once("../inc/friend.inc");
 require_once("../inc/forum_db.inc");
 require_once("../inc/notify.inc");
 require_once("../inc/ldap.inc");
+require_once("../inc/host.inc");
+require_once("../inc/friend.inc");
 
 if (!defined('REMOTE_PROJECTS_TTL')) {
     define('REMOTE_PROJECTS_TTL', 86400);
@@ -544,6 +546,29 @@ function show_account_private($user) {
             end_table();
         }
     );
+}
+
+// "delete" an account: leave user record (for DB consistency) but:
+//  - set email address and authenticator to "deleted_pid_time"
+//  - clear name, country, postal_code
+//  - remove from team
+//  - delete posts, subscriptions, and forum prefs
+//  - delete private messages (sent and received)
+//  - delete profile and associated image
+// for each host:
+//  - clear domain_name, last_ip_addr
+//
+function delete_account($user) {
+    $x = "deleted_".time()."_".random_string();
+    $retval = $user->update("email_addr='$x', authenticator='$x', name='deleted', country='', postal_code='', has_profile=0");
+    if (!$retval) return false;
+    user_quit_team($user);
+    forum_delete_user($user);
+    pm_delete_user($user);
+    anonymize_hosts($user);
+    delete_profile($user);
+    delete_friends($user);
+    return true;
 }
 
 $cvs_version_tracker[]="\$Id$";  //Generated automatically - do not edit

--- a/html/ops/delete_user.php
+++ b/html/ops/delete_user.php
@@ -1,0 +1,37 @@
+#!/usr/bin/env php
+<?php
+
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// usage: delete_user.php ID
+// effectively delete the user with given ID
+// USE THIS WITH EXTREME CAUTION.  CAN'T UNDO.
+
+require_once("../inc/user.inc");
+require_once("../inc/boinc_db.inc");
+
+die("Delete this line first\n");
+
+$id = (int) $argv[1];
+
+$user = BoincUser::lookup_id($id);
+if (!$user) die("no such user\n");
+
+delete_account($user);
+
+?>

--- a/html/user/delete_account.php
+++ b/html/user/delete_account.php
@@ -17,36 +17,15 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// "delete" an account:
-//  - set email address and authenticator to "deleted_pid_time"
-//  - clear name, country, postal_code
-//  - remove from team
-//  - delete posts, subscriptions, and forum prefs
-//  - delete private messages (sent and received)
-//  - delete profile and associated image
-// for each host:
-//  - clear domain_name, last_ip_addr
+// Disabled because of the possibility of misuse.
+// Admins can delete accounts with ops/delete_user.php
 
 require_once("../inc/util.inc");
-require_once("../inc/host.inc");
-require_once("../inc/profile.inc");
-require_once("../inc/pm.inc");
+require_once("../inc/user.inc");
 
 check_get_args(array("cmd"));
 
 die("This feature has been disabled.  Please contact project administators.");
-
-function delete_account($user) {
-    $x = "deleted_".time()."_".random_string();
-    $retval = $user->update("email_addr='$x', authenticator='$x', name='', country='', postal_code='', has_profile=0");
-    if (!$retval) return false;
-    user_quit_team($user);
-    forum_delete_user($user);
-    pm_delete_user($user);
-    anonymize_hosts($user);
-    delete_profile($user);
-    return true;
-}
 
 $user = get_logged_in_user();
 

--- a/html/user/show_user.php
+++ b/html/user/show_user.php
@@ -71,6 +71,9 @@ if ($format=="xml"){
         if (!$user) {
             error_page("No such user $id");
         }
+        if (strstr($user->authenticator, "deleted")) {
+            error_page("No such user");
+        }
         BoincForumPrefs::lookup($user);
         $user = @get_other_projects($user);
         $community_links =  get_community_links_object($user);


### PR DESCRIPTION
This leaves the user record and host records in the DB
to avoid dangling references from the result table.
It:
- changes the user name, email addr, and auth to "deleted_xxx"
- removes the user from team
- removes posts by the user
- removes PMs by the user
- removes friend connection
- removes profile
- "anonymizes" the hosts (erase IP addr and domain name)

Note 1: this is accessed by admins using a script in ops/;
It's not available to users.

Note 2: this may not satisfy the requirements of EU-GDPR
since it doesn't delete the user and host records.