### PR TITLE
web: don't check for stop_web in page_head().

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -303,7 +303,6 @@ function page_head(
         break;
     }
     project_banner($title, $url_prefix, $is_main);
-    check_web_stopped();
 }
 }
 


### PR DESCRIPTION
Allow projects to show (non-DB) content even if stop_web is present
(e.g. description of the project on front page).
stop_web really means "the DB is offline".