### PR TITLE
[Manager] Fix fields populating on 'Add Project' wizard on launch

### DIFF
--- a/clientgui/ProjectInfoPage.cpp
+++ b/clientgui/ProjectInfoPage.cpp
@@ -561,7 +561,7 @@ void CProjectInfoPage::OnProjectSelected( wxCommandEvent& WXUNUSED(event) ) {
         m_pProjectDetailsOrganizationCtrl->SetLabel(strOrganization);
         m_pProjectDetailsOrganizationCtrl->SetToolTip(pProjectInfo->m_strOrganization);
 
-    }
+     }
 
     wxLogTrace(wxT("Function Start/End"), wxT("CProjectInfoPage::OnProjectSelected - Function End"));
 }
@@ -794,7 +794,7 @@ void CProjectInfoPage::EllipseStringIfNeeded(wxString& s, wxWindow *win) {
     wxSize sz = win->GetParent()->GetSize();
     win->GetPosition(&x, &y);
     int maxWidth = sz.GetWidth() - x - 10;
-    
+
     win->GetTextExtent(s, &w, &h);
     
     // Adapted from ellipis code in wxRendererGeneric::DrawHeaderButtonContents()
@@ -813,4 +813,10 @@ void CProjectInfoPage::EllipseStringIfNeeded(wxString& s, wxWindow *win) {
             w += ellipsisWidth;
         }
     }
+}
+
+void CProjectInfoPage::RefreshPage() {
+    // Trigger initial event to populate the list control
+    wxCommandEvent evtEvent(wxEVT_COMMAND_COMBOBOX_SELECTED, ID_CATEGORIES);
+    ProcessEvent(evtEvent);
 }

--- a/clientgui/ProjectInfoPage.cpp
+++ b/clientgui/ProjectInfoPage.cpp
@@ -561,7 +561,7 @@ void CProjectInfoPage::OnProjectSelected( wxCommandEvent& WXUNUSED(event) ) {
         m_pProjectDetailsOrganizationCtrl->SetLabel(strOrganization);
         m_pProjectDetailsOrganizationCtrl->SetToolTip(pProjectInfo->m_strOrganization);
 
-     }
+    }
 
     wxLogTrace(wxT("Function Start/End"), wxT("CProjectInfoPage::OnProjectSelected - Function End"));
 }
@@ -794,7 +794,6 @@ void CProjectInfoPage::EllipseStringIfNeeded(wxString& s, wxWindow *win) {
     wxSize sz = win->GetParent()->GetSize();
     win->GetPosition(&x, &y);
     int maxWidth = sz.GetWidth() - x - 10;
-
     win->GetTextExtent(s, &w, &h);
     
     // Adapted from ellipis code in wxRendererGeneric::DrawHeaderButtonContents()

--- a/clientgui/ProjectInfoPage.h
+++ b/clientgui/ProjectInfoPage.h
@@ -89,6 +89,8 @@ public:
 
     void EllipseStringIfNeeded(wxString& s, wxWindow *win);
 
+    void RefreshPage();
+
 ////@begin CProjectInfoPage member variables
     wxStaticText* m_pTitleStaticCtrl;
     wxStaticText* m_pDescriptionStaticCtrl;

--- a/clientgui/wizardex.cpp
+++ b/clientgui/wizardex.cpp
@@ -120,7 +120,7 @@ wxSize wxWizardExSizer::GetMaxChildSize()
     }
 
 #ifdef __WXDEBUG__
-    if ( m_childSize.IsFullySpecified() && m_childSize != maxOfMin )
+    if ( !m_owner->m_pageRefreshed && m_childSize.IsFullySpecified() && m_childSize != maxOfMin )
     {
         wxFAIL_MSG( _T("Size changed in wxWizard::GetPageAreaSizer()")
                     _T("after RunWizard().\n")
@@ -135,6 +135,8 @@ wxSize wxWizardExSizer::GetMaxChildSize()
     {
         m_childSize = maxOfMin;
     }
+
+    m_owner->m_pageRefreshed = false;
 
     return maxOfMin;
 }
@@ -212,6 +214,10 @@ bool wxWizardPageEx::Create(
     return true;
 }
 
+void wxWizardPageEx::RefreshPage()
+{
+}
+
 // ----------------------------------------------------------------------------
 // event tables and such
 // ----------------------------------------------------------------------------
@@ -228,6 +234,8 @@ BEGIN_EVENT_TABLE(wxWizardEx, wxDialog)
     EVT_BUTTON(wxID_BACKWARD, wxWizardEx::OnBackOrNext)
     EVT_BUTTON(wxID_FORWARD, wxWizardEx::OnBackOrNext)
     EVT_BUTTON(wxID_HELP, wxWizardEx::OnHelp)
+
+    EVT_SHOW(wxWizardEx::OnShowEvent)
 
     EVT_WIZARDEX_PAGE_CHANGED(wxID_ANY, wxWizardEx::OnWizEvent)
     EVT_WIZARDEX_PAGE_CHANGING(wxID_ANY, wxWizardEx::OnWizEvent)
@@ -265,6 +273,7 @@ bool wxWizardEx::Create(wxWindow *parent,
     bool result = wxDialog::Create(parent,id,title,pos,wxDefaultSize,style);
 
     m_posWizard = pos;
+    m_pageRefreshed = false;
 
     DoCreateControls();
 
@@ -742,6 +751,14 @@ void wxWizardEx::OnWizEvent(wxWizardExEvent& event)
        )
     {
         Destroy();
+    }
+}
+
+void wxWizardEx::OnShowEvent(wxShowEvent& event)
+{
+    if (event.IsShown() && m_page != NULL) {
+        m_pageRefreshed = true;
+        m_page->RefreshPage();
     }
 }
 

--- a/clientgui/wizardex.h
+++ b/clientgui/wizardex.h
@@ -60,6 +60,8 @@ public:
     virtual wxWizardPageEx *GetPrev() const = 0;
     virtual wxWizardPageEx *GetNext() const = 0;
 
+    virtual void RefreshPage();
+
 #if wxUSE_VALIDATORS
     /// Override the base functions to allow a validator to be assigned to this page.
     bool TransferDataToWindow()
@@ -217,6 +219,8 @@ private:
 
     void OnWizEvent(wxWizardExEvent& event);
 
+    void OnShowEvent(wxShowEvent& event);
+
     void AddBitmapRow(wxBoxSizer *mainColumn);
     void AddStaticLine(wxBoxSizer *mainColumn);
     void AddBackNextPair(wxBoxSizer *buttonRow);
@@ -230,6 +234,8 @@ private:
 
     // wizard state
     wxWizardPageEx *m_page;       // the current page or NULL
+
+    bool m_pageRefreshed;
 
     // wizard controls
 protected:


### PR DESCRIPTION
When opening 'Add Project' wizard it shows next fields empty:
Research area, Organisation, and Web site.
This happens because of EllipseStringIfNeeded() function that truncates the string to 0 symbols because the wizard window was not constructed yet and has undefined size.

This fixes #2444.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>