### PR TITLE
client: if using a dynamic AM and have idle resources, tell the AM

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -1087,6 +1087,10 @@ bool ACCT_MGR_INFO::poll() {
             if (gstate.now < starved_rpc_min_time) {
                 return false;
             }
+            msg_printf(NULL, MSG_INFO,
+                "Some devices idle - requesting new projects from %s",
+                gstate.acct_mgr_info.project_name
+            );
             gstate.acct_mgr_op.do_rpc(*this, false);
             starved_rpc_backoff *= 2;
             if (starved_rpc_backoff > 86400) {

--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -190,7 +190,7 @@ int ACCT_MGR_OP::do_rpc(ACCT_MGR_INFO& _ami, bool _via_gui) {
         //
         if (ami.dynamic) {
             fprintf(f,
-                "      <nrpc_failures>%d</nrpc_failures>"
+                "      <nrpc_failures>%d</nrpc_failures>\n"
                 "      <cpu_ec>%f</cpu_ec>\n"
                 "      <cpu_time>%f</cpu_time>\n"
                 "      <gpu_ec>%f</gpu_ec>\n"

--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -61,7 +61,7 @@ struct ACCT_MGR_INFO : PROJ_AM {
     bool no_project_notices;
         // if set, don't show notices from projects
 
-    // TODO: get rid of the following
+    // TODO: get rid of the following here and in the manager
     bool cookie_required;
         // use of cookies are required during initial signup
         // NOTE: This bool gets dropped after the client has
@@ -75,6 +75,16 @@ struct ACCT_MGR_INFO : PROJ_AM {
     bool send_rec;
         // send REC in AM RPCs
     USER_KEYWORDS user_keywords;
+        // user's yes/no keywords.
+        // These are conveyed to projects in scheduler requests
+
+    // vars related to starvation prevention,
+    // where we issue a "starved RPC" if a resource has been idle
+    // for more than 10 min
+
+    double first_starved;           // start of starvation interval
+    double starved_rpc_backoff;     // interval between starved RPCs
+    double starved_rpc_min_time;    // earliest time to do a starved RPC
 
     inline bool using_am() {
         if (!strlen(master_url)) return false;

--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -72,8 +72,10 @@ struct ACCT_MGR_INFO : PROJ_AM {
         // what login name and password they have been assigned
 
     bool password_error;
-    bool send_rec;
-        // send REC in AM RPCs
+    bool dynamic;
+        // This AM dynamically decides what projects to assign.
+        // - send EC in AM RPCs
+        // - send starvation info if idle resources
     USER_KEYWORDS user_keywords;
         // user's yes/no keywords.
         // These are conveyed to projects in scheduler requests

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -932,8 +932,10 @@ int CLIENT_STATE::handle_scheduler_reply(
         workunits.push_back(wup);
     }
     double est_rsc_runtime[MAX_RSC];
+    bool got_work_for_rsc[MAX_RSC];
     for (int j=0; j<coprocs.n_rsc; j++) {
         est_rsc_runtime[j] = 0;
+        got_work_for_rsc[j] = false;
     }
     for (i=0; i<sr.results.size(); i++) {
         RESULT* rp2 = lookup_result(project, sr.results[i].name);
@@ -981,9 +983,11 @@ int CLIENT_STATE::handle_scheduler_reply(
             rp->abort_inactive(EXIT_MISSING_COPROC);
         } else {
             rp->set_state(RESULT_NEW, "handle_scheduler_reply");
+            got_work_for_rsc[0] = true;
             int rt = rp->avp->gpu_usage.rsc_type;
             if (rt > 0) {
                 est_rsc_runtime[rt] += rp->estimated_runtime();
+                got_work_for_rsc[rt] = true;
                 gpus_usable = true;
                     // trigger a check of whether GPU is actually usable
             } else {
@@ -995,6 +999,20 @@ int CLIENT_STATE::handle_scheduler_reply(
         new_results.push_back(rp);
         results.push_back(rp);
     }
+
+    // find the resources for which we requested work and didn't get any
+    // This is currently used for AM starvation mechanism.
+    //
+    if (!sr.too_recent) {
+        for (int j=0; j<coprocs.n_rsc; j++) {
+            RSC_WORK_FETCH& rwf = rsc_work_fetch[j];
+            project->sched_req_no_work[j] =
+                (rwf.req_secs>0 || rwf.req_instances>0)
+                && !got_work_for_rsc[j]
+            ;
+        }
+    }
+
     sort_results();
 
     if (log_flags.sched_op_debug) {

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -1006,9 +1006,10 @@ int CLIENT_STATE::handle_scheduler_reply(
     if (!sr.too_recent) {
         for (int j=0; j<coprocs.n_rsc; j++) {
             RSC_WORK_FETCH& rwf = rsc_work_fetch[j];
-            project->sched_req_no_work[j] =
-                (rwf.req_secs>0 || rwf.req_instances>0)
-                && !got_work_for_rsc[j]
+            if (got_work_for_rsc[j]) {
+                project->sched_req_no_work[j] = false;
+            } else if (rwf.req_secs>0 || rwf.req_instances>0) {
+                project->sched_req_no_work[j] = true;
             ;
         }
     }

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -1010,7 +1010,7 @@ int CLIENT_STATE::handle_scheduler_reply(
                 project->sched_req_no_work[j] = false;
             } else if (rwf.req_secs>0 || rwf.req_instances>0) {
                 project->sched_req_no_work[j] = true;
-            ;
+            }
         }
     }
 

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -945,6 +945,7 @@ static void handle_acct_mgr_rpc(GUI_RPC_CONN& grc) {
     bool use_config_file = false;
     bool bad_arg = false;
     bool url_found=false, name_found=false, password_found = false;
+    ACCT_MGR_INFO ami;
 
     while (!grc.xp.get_tag()) {
         if (grc.xp.parse_string("url", url)) {
@@ -970,10 +971,7 @@ static void handle_acct_mgr_rpc(GUI_RPC_CONN& grc) {
                 "Not using account manager"
             );
         } else {
-            url = gstate.acct_mgr_info.master_url;
-            name = gstate.acct_mgr_info.login_name;
-            password_hash = gstate.acct_mgr_info.password_hash;
-            authenticator = gstate.acct_mgr_info.authenticator;
+            ami = gstate.acct_mgr_info;
         }
     } else {
         bad_arg = !url_found || !name_found || !password_found;
@@ -986,7 +984,11 @@ static void handle_acct_mgr_rpc(GUI_RPC_CONN& grc) {
                 // Remove 'hash:'
                 password_hash = password.substr(5);
             }
-        }
+            safe_strcpy(ami.master_url, url.c_str());
+            safe_strcpy(ami.login_name, name.c_str());
+            safe_strcpy(ami.password_hash, password_hash.c_str());
+            safe_strcpy(ami.authenticator, authenticator.c_str());
+       }
     }
 
     if (bad_arg) {
@@ -997,11 +999,6 @@ static void handle_acct_mgr_rpc(GUI_RPC_CONN& grc) {
     ){
         grc.mfout.printf("<error>attached to a different AM - detach first</error>\n");
     } else {
-        ACCT_MGR_INFO ami;
-        safe_strcpy(ami.master_url, url.c_str());
-        safe_strcpy(ami.login_name, name.c_str());
-        safe_strcpy(ami.password_hash, password_hash.c_str());
-        safe_strcpy(ami.authenticator, authenticator.c_str());
         gstate.acct_mgr_op.do_rpc(ami, true);
         grc.mfout.printf("<success/>\n");
     }

--- a/client/project.cpp
+++ b/client/project.cpp
@@ -53,6 +53,7 @@ void PROJECT::init() {
         no_rsc_config[i] = false;
         no_rsc_apps[i] = false;
         no_rsc_ams[i] = false;
+        sched_req_no_work[i] = false;
     }
     safe_strcpy(host_venue, "");
     using_venue_specific_prefs = false;

--- a/client/project.h
+++ b/client/project.h
@@ -176,6 +176,9 @@ struct PROJECT : PROJ_AM {
         // This provides only the illusion of security.
     bool use_symlinks;
     bool report_results_immediately;
+    bool sched_req_no_work[MAX_RSC];
+        // the last sched request asked for work for resource i
+        // and didn't get any
 
     // items sent in scheduler replies,
     // requesting that various things be sent subsequent requests

--- a/client/rr_sim.h
+++ b/client/rr_sim.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -18,8 +18,9 @@
 #ifndef BOINC_RR_SIM_H
 #define BOINC_RR_SIM_H
 
-
 extern void rr_simulation();
 extern void print_deadline_misses();
+extern void get_nidle();
+extern bool any_resource_idle();
 
 #endif

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -558,6 +558,7 @@ void SCHEDULER_REPLY::clear() {
     send_job_log = 0;
     scheduler_version = 0;
     got_rss_feeds = false;
+    too_recent = false;
 }
 
 SCHEDULER_REPLY::SCHEDULER_REPLY() {
@@ -834,6 +835,9 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
             file_deletes.push_back(delete_file_name);
         } else if (xp.parse_str("message", msg_buf, sizeof(msg_buf))) {
             parse_attr(attr_buf, "priority", pri_buf, sizeof(pri_buf));
+            if (strstr(msg_buf, "too recent")) {
+                too_recent = true;
+            }
             USER_MESSAGE um(msg_buf, pri_buf);
             messages.push_back(um);
             continue;

--- a/client/scheduler_op.h
+++ b/client/scheduler_op.h
@@ -134,6 +134,8 @@ struct SCHEDULER_REPLY {
     std::vector<std::string> trickle_up_urls;
     bool got_rss_feeds;
         // whether scheduler reply included <rss_feeds>
+    bool too_recent;
+        // whether reply included "too recent" message
 
     void clear();
     SCHEDULER_REPLY();


### PR DESCRIPTION
Currently, this affects only clients using Science United