### PR TITLE
client: remove /dev/input/ based idle detection

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1707,65 +1707,6 @@ inline bool all_tty_idle(time_t t) {
     return true;
 }
 
-static const struct dir_input_dev {
-    const char *dir;
-    const char *dev;
-} input_patterns[] = {
-#ifdef unix
-    { "/dev/input","event" },
-    { "/dev/input","mouse" },
-    { "/dev/input/mice","" },
-#endif
-    // add other ifdefs here as necessary.
-    { NULL, NULL },
-};
-
-vector<string> get_input_list() {
-    // Create a list of all terminal devices on the system.
-    char devname[1024];
-    char fullname[1024];
-    int done,i=0;
-    vector<string> input_list;
-
-    do {
-        DIRREF dev=dir_open(input_patterns[i].dir);
-        if (dev) {
-            do {
-                // get next file
-                done=dir_scan(devname,dev,1024);
-                // does it match our tty pattern? If so, add it to the tty list.
-                if (!done && (strstr(devname,input_patterns[i].dev) == devname)) {
-                    // don't add anything starting with .
-                    if (devname[0] != '.') {
-                        sprintf(fullname,"%s/%s",input_patterns[i].dir,devname);
-                        input_list.push_back(fullname);
-                    }
-                }
-            } while (!done);
-            dir_close(dev);
-        }
-        i++;
-    } while (input_patterns[i].dir != NULL);
-    return input_list;
-}
-
-inline bool all_input_idle(time_t t) {
-    static vector<string> input_list;
-    struct stat sbuf;
-    unsigned int i;
-
-    if (input_list.size()==0) input_list=get_input_list();
-    for (i=0; i<input_list.size(); i++) {
-        // ignore errors
-        if (!stat(input_list[i].c_str(), &sbuf)) {
-            // printf("input: %s %d %d\n",input_list[i].c_str(),sbuf.st_atime,t);
-            if (sbuf.st_atime >= t) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
 #ifdef __APPLE__
 
 // We can't link the client with the AppKit framework because the client
@@ -2202,15 +2143,6 @@ bool HOST_INFO::users_idle(bool check_all_logins, double idle_time_to_run) {
     }
 #endif // HAVE_XSS
 
-    // Lets at least check the dev entries which should be correct for
-    // USB keyboards and mice.  If the linux kernel doc is correct it should
-    // also work for bluetooth input devices as well.
-    //
-    // See: https://www.kernel.org/doc/Documentation/input/input.txt
-    //
-    if (!all_input_idle(idle_time)) {
-        return false;
-    }
 #else
     // We should find out which of the following are actually relevant
     // on which systems (if any)


### PR DESCRIPTION
The code tries to open /dev/input/mice as if it was a directory. If
there are no input devices, like in a headless machine, the code
repeatedly tries to make a list of input devices. On Debian, these bugs,
together with Debian's patches to BOINC, result in useless error
messages in client's log.

On SELinux systems, services can access device nodes in /dev/input/ only
if given that right in SELinux configuration. On some Fedora versions
BOINC client doesn't have that right and the code results in numerous
SELinux warnings. These warnings in turn result in high CPU usage when
the system analyzes the warnings.

Furthermore, the code doesn't work at all. The code expects that input
drivers update timestamps on device nodes when the drivers receive input
from devices. The input drivers however have no such code. Checking
driver commit logs suggest that if such code ever existed it was so long
time ago that we don't need to care about it and testing distros of
various ages confirms that.

Since the code doesn't and can't work solve the problems on Debian and
Fedora by just removing the code altogether. The code was only used on
Linux and /dev/input/ seems to be Linux only thing anyway.

Note that the client has similar code for checking terminal devices.
Contrary to the input device code that code does work correctly. This is
because programs running on a terminal have their inputs and outputs
connected to the terminal device node. Input to or output from a program
results in a read from or write to device node and terminal drivers do
have code that updates timestamps on reads and writes.

Closes #2335.
See #1187.