### PR TITLE
 remote job submission: fix create_batch XML after API change

### DIFF
--- a/lib/remote_submit.cpp
+++ b/lib/remote_submit.cpp
@@ -285,11 +285,9 @@ int create_batch(
     sprintf(request,
         "<create_batch>\n"
         "   <authenticator>%s</authenticator>\n"
-        "      <batch>\n"
-        "         <batch_name>%s</batch_name>\n"
-        "         <app_name>%s</app_name>\n"
-        "         <expire_time>%f</expire_time>\n"
-        "      </batch>\n"
+        "   <batch_name>%s</batch_name>\n"
+        "   <app_name>%s</app_name>\n"
+        "   <expire_time>%f</expire_time>\n"
         "</create_batch>\n",
         authenticator,
         batch_name,


### PR DESCRIPTION
Commit SHA:381e0caf1489b5d1190563e96ce95f64bc385265 changed the XML RPC for remote submission by removing the superfluous batch tag. This change aligns the remote submission library with the modified RPC.