### PR TITLE
web: add functions text_start() and text_end() to limit line length

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -1110,6 +1110,16 @@ function google_search_form($url) {
     ";
 }
 
+// use the following around text with long lines,
+// to limit the width and make it more readable.
+//
+function text_start($width=640) {
+    echo sprintf("<div style=\"max-width: %dpx;\">\n", $width);
+}
+function text_end() {
+    echo "</div>\n";
+}
+
 $cvs_version_tracker[]="\$Id$";  //Generated automatically - do not edit
 
 ?>


### PR DESCRIPTION
on pages with lots of text, to make it more readable.
Width is a parameter, default 640.