### PR TITLE
MySQL doesn't allow integers to have default values of functions

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -767,8 +767,15 @@ create table token (
     token                   varchar(255)    not null,
     userid                  integer         not null,
     type                    char            not null,
-    create_time             integer         not null default unix_timestamp(),
+    create_time             integer         default null,
     expire_time             integer,
     primary key (token),
     index token_userid (userid)
 ) engine=InnoDB;
+
+create trigger trig_token_creation_timestamp_default before insert on token for each row
+begin
+    if (new.create_time is null) then
+        set new.create_time = unix_timestamp();
+    end if;
+end$$

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1087,14 +1087,6 @@ function update_4_5_2018() {
             index token_userid (userid)
         ) engine=InnoDB;
     ");
-    do_query("
-        create trigger trig_token_creation_timestamp_default before insert on token for each row
-        begin
-            if (new.create_time is null) then
-                set new.create_time = unix_timestamp();
-            end if;
-        end$$
-    ");
 }
 
 function update_4_6_2018() {
@@ -1102,6 +1094,21 @@ function update_4_6_2018() {
         modify column total_credit double not null default 0.0,
         modify column expavg_credit double not null default 0.0,
         modify column seti_id integer not null default 0
+    ");
+}
+
+function update_4_18_2018() {
+    do_query("
+        alter table token
+        modify create_time integer default null
+    ");
+    do_query("
+        create trigger trig_token_creation_timestamp_default before insert on token for each row
+        begin
+            if (new.create_time is null) then
+                set new.create_time = unix_timestamp();
+            end if;
+        end;
     ");
 }
 
@@ -1160,6 +1167,7 @@ $db_updates = array (
     array(27021, "update_3_8_2018"),
     array(27022, "update_4_5_2018"),
     array(27023, "update_4_6_2018"),
+    array(27024, "update_4_18_2018"),
 );
 
 ?>

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1076,15 +1076,24 @@ function update_3_8_2018() {
 }
 
 function update_4_5_2018() {
-    do_query("create table token (
-        token                   varchar(255)    not null,
-        userid                  integer         not null,
-        type                    char            not null,
-        create_time             integer         not null default unix_timestamp(),
-        expire_time             integer,
-        primary key (token),
-        index token_userid (userid)
-        ) engine=InnoDB
+    do_query("
+        create table token (
+            token                   varchar(255)    not null,
+            userid                  integer         not null,
+            type                    char            not null,
+            create_time             integer         default null,
+            expire_time             integer,
+            primary key (token),
+            index token_userid (userid)
+        ) engine=InnoDB;
+    ");
+    do_query("
+        create trigger trig_token_creation_timestamp_default before insert on token for each row
+        begin
+            if (new.create_time is null) then
+                set new.create_time = unix_timestamp();
+            end if;
+        end$$
     ");
 }
 


### PR DESCRIPTION
create_time is an integer with a default value of unix_timestamp(). MySQL doesn't allow for this, and throws syntax errors during the make_project phase. This update gives the same result in a MySQL friendly fashion.