### PR TITLE
WIP: web: Fix bug creating token table with MySQL and MariaDB < 10.2

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -767,7 +767,7 @@ create table token (
     token                   varchar(255)    not null,
     userid                  integer         not null,
     type                    char            not null,
-    create_time             integer         not null default unix_timestamp(),
+    create_time             integer         not null,
     expire_time             integer,
     primary key (token),
     index token_userid (userid)

--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -783,10 +783,11 @@ class BoincToken {
         return $db->lookup('token', 'BoincToken', $clause);
     }
     
-    static function lookup_valid_token($userid, $token) {
+    static function lookup_valid_token($userid, $token, $type) {
         $db = BoincDb::get();
         $token = BoincDb::escape_string($token);
-        return self::lookup("userid=$userid and token='$token' and expire_time > unix_timestamp()");
+        $type = BoincDb::escape_string($type);
+        return self::lookup("userid=$userid and token='$token' and expire_time > unix_timestamp() and type = '$type'");
     }
     
     static function enum($where_clause) {

--- a/html/inc/token.inc
+++ b/html/inc/token.inc
@@ -1,0 +1,45 @@
+<?php
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <https://www.gnu.org/licenses/>.
+
+require_once("../inc/boinc_db.inc");
+require_once("../inc/util.inc");
+
+// Constants for valid token types
+define("TOKEN_TYPE_DELETE_ACCOUNT", "D");
+
+// Constants for token durations
+define("TOKEN_DURATION_ONE_DAY", "86400");
+
+function create_confirm_delete_account_token($user) {
+    $token = random_string();
+    $ret = BoincToken::insert("(token,userid,type,create_time,expire_time) values ('$token', $user->id, '".TOKEN_TYPE_DELETE_ACCOUNT."', unix_timestamp(), unix_timestamp()+".TOKEN_DURATION_ONE_DAY.")");
+    if ( !$ret ) {
+        return null;
+    }
+    return $token;
+}
+
+function is_valid_delete_account_token($userid, $token) {
+    $boincToken = BoincToken::lookup_valid_token($userid, $token, TOKEN_TYPE_DELETE_ACCOUNT);
+    if ( $boincToken == null ) {
+        return false;
+    }
+    return true;
+}
+
+?>

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1080,7 +1080,7 @@ function update_4_5_2018() {
         token                   varchar(255)    not null,
         userid                  integer         not null,
         type                    char            not null,
-        create_time             integer         not null default unix_timestamp(),
+        create_time             integer         not null,
         expire_time             integer,
         primary key (token),
         index token_userid (userid)
@@ -1093,6 +1093,12 @@ function update_4_6_2018() {
         modify column total_credit double not null default 0.0,
         modify column expavg_credit double not null default 0.0,
         modify column seti_id integer not null default 0
+    ");
+}
+
+function update_4_18_2018() {
+    do_query("alter table token
+        modify column create_time integer not null
     ");
 }
 
@@ -1151,6 +1157,7 @@ $db_updates = array (
     array(27021, "update_3_8_2018"),
     array(27022, "update_4_5_2018"),
     array(27023, "update_4_6_2018"),
+    array(27024, "update_4_18_2018")
 );
 
 ?>

--- a/html/ops/test_token.php
+++ b/html/ops/test_token.php
@@ -1,11 +1,12 @@
 #! /usr/bin/env php
 <?php
 require_once("../inc/util.inc");
+require_once("../inc/token.inc");
 require_once("../inc/db_ops.inc");
 
 $token = random_string();
 
-BoincToken::insert("(token,userid,type,expire_time) values ('$token', 0, 'T', unix_timestamp()+3600)");
+BoincToken::insert("(token,userid,type,create_time, expire_time) values ('$token', 0, 'T', unix_timestamp(), unix_timestamp()+3600)");
 
 $boincTokens = BoincToken::enum("userid=0");
 foreach($boincTokens as $boincToken) {
@@ -24,5 +25,25 @@ echo $boincToken->type . "\n";
 echo $boincToken->create_time . "\n";
 echo $boincToken->expire_time . "\n";
 
+echo "---------------\n";
+$boincToken = BoincToken::lookup_valid_token(0, $token, 'T');
+if ( $boincToken != null ) {
+   echo "Found valid token\n";
+}
+
+echo "---------------\n";
+$boincToken = BoincToken::lookup_valid_token(0, 'notrealtoken', 'T');
+if ( $boincToken == null ) {
+   echo "Successfully didn't find invalid token\n";
+}
+
+
+echo "---------------\n";
+$user = new BoincUser();
+$user->id=0;
+$token = create_confirm_delete_account_token($user);
+if ( is_valid_delete_account_token($user->id, $token) ) {
+    echo "Successfully created and validated delete account token";
+}
 
 ?>


### PR DESCRIPTION
This pull requests fixes a bug in creating the token table with MySQL and MariaDB earlier than version 10.2 that was introduced in pull request #2453 

It also includes code for how tokens will be used (for reference by @Uplinger and @drshawnkwang  who are already looking to use this code) from the work I'm doing in pull request #2472.