### PR TITLE
Drupal: Change library names

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1383,7 +1383,7 @@ function boincuser_home_page() {
  */
 function boincuser_create_account() {
   require_boinc('boinc_db');
-  require_boinc('user');
+  require_boinc('user_util');
   require_boinc('xml');
   $params = array(
     'email_addr' => isset($_GET['email_addr']) ? $_GET['email_addr'] : '',

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -106,7 +106,7 @@ function boincuser_register_validate($form_values) {
  */
 function boincuser_register_make_user($params) {    
   // Include BOINC user library
-  require_boinc('user');
+  require_boinc('user_util');
   // Create the BOINC user
   $boinc_user = make_user($params['email_addr'], $params['name'], $params['passwd_hash'], $params['country'], $params['postal_code']);
   return $boinc_user;


### PR DESCRIPTION
Changed `user` to `user_util` to match changes due to commit below.

This change is due to : https://github.com/BOINC/boinc/commit/e712c7af9ac5b4f9c16d691e656788a2112cefe3

Fixes: https://dev.gridrepublic.org/browse/DBOINCP-441