### PR TITLE
Drupal: User Opt-in consent and Web registration

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
@@ -319,6 +319,8 @@ function boincuser_admin_weboptions(&$form_state) {
 
   //form defaults
   $default = array(
+    'boinc_weboptions_enableaccountcreateRPC' => variable_get('boinc_weboptions_enableaccountcreateRPC', FALSE),
+    'boinc_weboptions_registrationmessage' => variable_get('boinc_weboptions_registrationmessage', 'Ipsum Lorem'),
     'boinc_weboptions_accountfinish' => variable_get('boinc_weboptions_accountfinish', ''),
     'boinc_weboptions_moderationpage' => variable_get('boinc_weboptions_moderationpage', ''),
     'boinc_weboptions_rulespolicies' => variable_get('boinc_weboptions_rulespolicies', ''),
@@ -326,6 +328,29 @@ function boincuser_admin_weboptions(&$form_state) {
   );
   
   // Define the form
+  $form['registrationtitle'] = array(
+    '#value' => '<h3>BOINC Registration</h3>',
+  );
+
+  $form['boinc_weboptions_enableaccountcreateRPC'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable create_account.php RPC'),
+    '#default_value' => $default['boinc_weboptions_enableaccountcreateRPC'],
+    '#description' => t('If checked, users will be able to create an account remotely using the create_account.php RPC. This option is independent of the user regsitration option found in ') . l(t('User management -> User settings'), '/admin/user/settings') . '. If enabled, user <b>may not be able to opt-in</b> to your site\'s privacy and data retention policies!',
+  );
+  $form['boinc_weboptions_registrationmessage'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Message for User Registration Page'),
+    '#default_value' => $default['boinc_weboptions_registrationmessage'],
+    '#cols' => 60,
+    '#rows' => 8,
+    '#description' => t('Text to be displayed on site\'s user registration page. Privacy policy and other data retention information goes here.'),
+  );
+
+  $form['pathtitle'] = array(
+    '#value' => '<h3>Path Options</h3>',
+  );
+
   $form['boinc_weboptions_accountfinish'] = array (
     '#type' => 'textfield',
     '#title' => t('Path to a custom account_finish.php page, should be a path to a node'),

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
@@ -44,6 +44,7 @@ function boincuser_admin_environment(&$form_state) {
     'boinc_server_status_url' => variable_get('boinc_server_status_url', ''),
     'boinc_app_list_url' => variable_get('boinc_app_list_url', ''),
     'boinc_debug_mode' => variable_get('boinc_debug_mode', 0),
+    'boinc_project_config_keywords' => variable_get('boinc_project_config_keywords', ''),
   );
   //drupal_set_message(print_r($default, true));
   //drupal_set_message(print_r($form_state, true));
@@ -145,6 +146,15 @@ function boincuser_admin_environment(&$form_state) {
     '#type' => 'checkbox',
     '#title' => t('Show debug messages in system log'),
     '#default_value' => $default['boinc_debug_mode']
+  );
+  $form['boinc_project_config_keywords'] = array(
+    '#type' => 'textarea',
+    '#title' => t('Project/Job Keywords for get_project_config RPC'),
+    '#default_value' => $default['boinc_project_config_keywords'],
+    '#description' => t('XML from this text box will be appended to the XML output from the get_project_config RPC. There is no check for XML validity! See !link for more details. It is okay to leave this blank.',
+    array(
+      '!link' => l('BOINC wiki page', 'https://boinc.berkeley.edu/trac/wiki/JobKeywords')
+    )),
   );
   return system_settings_form($form);
 }

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.admin.inc
@@ -319,8 +319,11 @@ function boincuser_admin_weboptions(&$form_state) {
 
   //form defaults
   $default = array(
-    'boinc_weboptions_enableaccountcreateRPC' => variable_get('boinc_weboptions_enableaccountcreateRPC', FALSE),
-    'boinc_weboptions_registrationmessage' => variable_get('boinc_weboptions_registrationmessage', 'Ipsum Lorem'),
+    'boinc_weboptions_enableaccountcreateRPC' => variable_get('boinc_weboptions_enableaccountcreateRPC', TRUE),
+    'boinc_weboptions_registrationtitle' => variable_get('boinc_weboptions_registrationtitle', 'Please read and acknowledge our terms of use'),
+    'boinc_weboptions_termsofuse' => variable_get('boinc_weboptions_termsofuse', ''),
+    'boinc_weboptions_agreequestion' => variable_get('boinc_weboptions_agreequestion', 'Do you agree with the above terms of use?'),
+    'boinc_weboptions_registrationtitle2' => variable_get('boinc_weboptions_registrationtitle2', 'Fill in your name, email, and choose a secure passphrase.'),
     'boinc_weboptions_accountfinish' => variable_get('boinc_weboptions_accountfinish', ''),
     'boinc_weboptions_moderationpage' => variable_get('boinc_weboptions_moderationpage', ''),
     'boinc_weboptions_rulespolicies' => variable_get('boinc_weboptions_rulespolicies', ''),
@@ -338,13 +341,35 @@ function boincuser_admin_weboptions(&$form_state) {
     '#default_value' => $default['boinc_weboptions_enableaccountcreateRPC'],
     '#description' => t('If checked, users will be able to create an account remotely using the create_account.php RPC. This option is independent of the user regsitration option found in ') . l(t('User management -> User settings'), '/admin/user/settings') . '. If enabled, user <b>may not be able to opt-in</b> to your site\'s privacy and data retention policies!',
   );
-  $form['boinc_weboptions_registrationmessage'] = array(
+
+  $form['boinc_weboptions_registrationtitle'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Title of regsistration page'),
+    '#description' => t('Title text presented above the terms of use text.'),
+    '#default_value' => $default['boinc_weboptions_registrationtitle'],
+  );
+
+  $form['boinc_weboptions_termsofuse'] = array(
     '#type' => 'textarea',
-    '#title' => t('Message for User Registration Page'),
-    '#default_value' => $default['boinc_weboptions_registrationmessage'],
+    '#title' => t('Terms of Use Message for User Registration Page'),
+    '#default_value' => $default['boinc_weboptions_termsofuse'],
     '#cols' => 60,
     '#rows' => 8,
-    '#description' => t('Text to be displayed on site\'s user registration page. Privacy policy and other data retention information goes here.'),
+    '#description' => t('Text to be displayed on site\'s user registration page. Privacy policy and other data retention information goes here. If empty, there will be no terms of use message, and the title above and checkbox below will not be shown.'),
+  );
+
+  $form['boinc_weboptions_agreequestion'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Terms of use opt-in question'),
+    '#description' => t('This text is presented to the user as the question next to the \'I agree\' checkbox.'),
+    '#default_value' => $default['boinc_weboptions_agreequestion'],
+  );
+
+  $form['boinc_weboptions_registrationtitle2'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Instructions for username/email/password questions'),
+    '#description' => t('Title text presented below terms of use and above username/email/password textfields.'),
+    '#default_value' => $default['boinc_weboptions_registrationtitle2'],
   );
 
   $form['pathtitle'] = array(

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.install
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.install
@@ -152,3 +152,23 @@ function boincuser_update_6200() {
 
   return $result;
 }
+
+/**
+ * Add privacy_consent_dt field to boincuser table. Used to record
+ * when user consented to site's terms-of-use.
+ *
+ */
+function boincuser_update_6300() {
+  $result = array();
+
+  $spec = array(
+    'description' => 'A timestamp which records when a user has consented to the site\'s terms of use.',
+    'type'     => 'int',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'default'  => 0,
+  );
+  db_add_field($result, 'boincuser', 'privacy_consent_dt', $spec);
+
+  return $result;
+}

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -130,6 +130,14 @@ function boincuser_menu() {
     'access arguments' => array('access content'),
     'type' => MENU_CALLBACK,
   );
+  $items['user/optin'] = array(
+    'title' => bts('Opt In to Terms of Use', array(), NULL, 'boinc:opt-in-form'),
+    'description' => 'Opt-in to site\'s term of use.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('boincuser_optinform'),
+    'access callback' => 'user_is_logged_in',
+    'type' => MENU_CALLBACK,
+  );
   $items['user_control'] = array(
     'page callback' => 'boincuser_control',
     'access arguments' => array('access user profiles'),
@@ -199,6 +207,7 @@ function boincuser_menu() {
  *
  */
 function boincuser_init() {
+  global $user;
   // Skip this check for charts, which are loaded separately
   // (may get duplicate or unexpected messages otherwise)
   if (substr($_GET['q'], 0, 7) == 'charts/') {
@@ -218,6 +227,36 @@ function boincuser_init() {
   if (module_exists('boincteam')) {
     // Display any persistent team messages
     boincteam_show_messages();
+  }
+
+  // Check if user has opt-in to the terms of use. If not, send the
+  // user to the terms-of-use form. This is only makes sense if the
+  // termsofuse is enabled, by having text in the termsofuse variable.
+  $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+  if ( (!empty($termsofuse)) and ($user->uid) ) {
+    if (!boincuser_check_termsofuse($user)) {
+
+      // Admins are exempt, otherwise the admin may not be able to
+      // access the site!
+      $administrator_role = array_search('administrator', user_roles(true));
+      if (!isset($user->roles[$administrator_role])) {
+        $path = drupal_get_path_alias($_GET['q']);
+
+        // Any paths that should NOT be redirected go here.
+        $paths_to_ignore = array(
+          'user/optin',
+          'logout',
+        );
+        if (module_exists('boincuser_delete')) {
+          $paths_to_ignore[] = 'user/' . $user->uid . '/delete';
+          // @todo - once the following path has been defined: add to this array
+          //$paths_to_ignore[] = 'user/' . $user->uid . '/deleteconfirm',
+        }
+        if (!in_array($path, $paths_to_ignore)) {
+          drupal_goto('user/optin');
+        }
+      }
+    }
   }
 }
 
@@ -430,6 +469,11 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
       }
       break;
 
+    case 'login':
+      // Function is forward compatible to Drupal 7
+      boincuser_user_login($edit, $account);
+      break;
+
     case 'delete':
       // Function is forward compatible to Drupal 7
       boincuser_user_delete($account);
@@ -437,6 +481,34 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
 
     default:
       
+    }
+  }
+}
+
+/**
+ * Implementation of hook_user_login(); When user-logins, checks if
+ * they have opt-in to the terms of use.
+ *(forward compatible to Drupal 7).
+ */
+function boincuser_user_login(&$edit, $account) {
+  $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+  if ( (!empty($termsofuse)) and ($account->uid) ) {
+
+    $administrator_role = array_search('administrator', user_roles(true));
+    if (!isset($account->roles[$administrator_role])) {
+
+      // Find and save the current destination and use as an parameter
+      // to send the user back to here he/she came from.
+      $np = ltrim('user/optin', '/');
+      $path_for_destination = rawurlencode($np);
+
+      $query_for_destination = '';
+      $prevdest = $_REQUEST['destination'];
+      if ($prevdest) {
+        $query_for_destination = '?destination=' . $prevdest;
+      }
+      $_REQUEST['destination'] = $path_for_destination . $query_for_destination;
+
     }
   }
 }

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1360,6 +1360,8 @@ function boincuser_home_page() {
  * Create a new user account based on supplied parameters.
  */
 function boincuser_create_account() {
+  global $base_url;
+
   require_boinc('boinc_db');
   require_boinc('user_util');
   require_boinc('xml');
@@ -1373,7 +1375,14 @@ function boincuser_create_account() {
   xml_header();
   
   // Account creation disabled
-  
+  $enablethisRPC = variable_get('boinc_weboptions_enableaccountcreateRPC', TRUE);
+  if (!$enablethisRPC) {
+    $mess = bts('Account creation is done through our Web site. Please register at @url', array(
+      '@url' => $base_url . '/user/registration',
+    ),
+    NULL, 'boinc:create_account');
+    xml_error(-208, $mess);
+  }
   // Invalid invite code
   
   // Validate input

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -310,26 +310,6 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
     case 'validate':
       if (isset($edit['validation_source'])) {
         switch ($edit['validation_source']) {
-        case 'user_register':
-          // Information being checked before adding a user
-          if (!boincuser_register_validate($edit)) {
-            // BOINC user validation failed for registration; set an error accordingly
-            form_set_error('mail', bts('An account already exists for @email. Log in or request password assistance to access your @project account.', array('@email' => $edit['mail'], '@project' => PROJECT), NULL, 'boinc:add-new-user'));
-          }
-          else {
-            // Save profile information for use during Insert
-            $_SESSION['profileInfo'] = array(
-              'country' => $edit['field_country'][0]['value'],
-              'zip' => $edit['field_zip'][0]['value'],                  
-              'url' => $edit['field_url'][0]['value'],
-              'background' => $edit['field_background'][0]['value'],
-              'opinions' => $edit['field_opinions'][0]['value']
-            );
-            // With BOINC validation passed, make sure name is unique
-            $edit['name'] = create_proper_drupalname($edit['boincuser_name']);
-          }
-          break;
-          
         case 'user_account':
           // Validate data before updating user account info
           boincuser_account_validate($edit, $account);
@@ -998,10 +978,6 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
         '#description' => bts('Spaces are allowed; punctuation is not allowed except for periods, hyphens, and underscores.', array(), NULL, 'boinc:user-register'), 
         '#required' => TRUE
       ),
-      'validation_source' => array(
-        '#type' => 'hidden',
-        '#value' => 'user_register'
-      )
     ));
     // Set name temporarily to dummy value to beat validation
     $form['name'] = array(

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1546,9 +1546,18 @@ function boincuser_create_account() {
       if ($boinc_user) {
         // Cross reference Drupal account with BOINC.
         $reference = db_query("INSERT INTO {boincuser} SET uid=%d, boinc_id=%d", $user->uid, $boinc_user->id);
+
         if (!$reference) {
           xml_error(-1, 'error connecting BOINC account to Drupal');
         }
+
+        // if terms of use exist, the user must have opted-in.
+        // @todo - test this block of code!
+        $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+        if (!empty($termsofuse)) {
+          boincuser_consentto_termsofuse($user);
+        }
+
         // Disable show_hosts flag, set to TRUE by default
         db_set_active('boinc_rw');
         db_query("UPDATE {user} SET show_hosts=0 WHERE id='%d'", $boinc_user->id);
@@ -1562,7 +1571,7 @@ function boincuser_create_account() {
       }// if boinc user created.
     }
     else {
-      watchdog('boincuser', 'create_accout: Failed to create Drupal user account for @email', array('@email' => $params['email_addr']), WATCHDOG_WARNING);
+      watchdog('boincuser', 'create_account: Failed to create Drupal user account for @email', array('@email' => $params['email_addr']), WATCHDOG_WARNING);
       xml_error(-1, 'error creating Drupal user account');
     }// if drupal user created.
   }// if existing user found.

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -993,6 +993,8 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
       );
     }
     
+    $form['#validate'][] = 'boincuser_register_validate';
+
     $form['submit']['#weight'] = 1001;
     break;
     

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -226,6 +226,9 @@ function boincuser_init() {
  * Drupal user operations
  */
 function boincuser_user($op, &$edit, &$account, $category = NULL) {
+  require_boinc('boinc_db');
+  require_boinc('user');
+  require_boinc('xml');
   // Handle BOINC integration for users with UID > 1 (skip anonymous and admin)
   if ($account->uid > 1) {
     switch($op) {
@@ -357,6 +360,7 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
           form_set_error('email', bts('Error creating BOINC account.', array(), NULL, 'boinc:add-new-user'));
           return;
         }
+
         // Add user to community role by default (not banned)
         $unrestricted_role = array_search('community member', user_roles(true)); 
         $edit['roles'] = array(
@@ -373,6 +377,9 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
         if (!$reference) {
           drupal_set_message(t('Error updating BOINC account.'), 'error');
         }
+        // Disable show_hosts flag, set to TRUE by default
+        db_query("UPDATE {user} SET show_hosts=0 WHERE id='%d'", $boinc_user->id);
+
         db_set_active('default');
         // Cross reference Drupal account with BOINC
         $reference = db_query("INSERT INTO {boincuser} SET uid='%d', boinc_id='%d'", $account->uid, $boinc_user->id);
@@ -985,6 +992,39 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
       '#value' => rand() . '.' . time()
     );
     
+    // Terms of use section
+    $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+    if (!empty($termsofuse)) {
+      $form['title1'] = array(
+        '#weight' => -12,
+        '#value' => '<h2>' . variable_get('boinc_weboptions_registrationtitle', 'Please read and acknowledge our terms of use'). '</h2>',
+        '#prefix' => '<div id="register-title1">',
+        '#suffix' => '</div>',
+      );
+
+      $form['termsofuse'] = array(
+        '#weight' => -10,
+        '#value' => $termsofuse,
+        '#prefix' => '<div id="register-termsofuse">',
+        '#suffix' => '</div>',
+      );
+
+      $form['optin'] = array(
+        '#type' => 'checkbox',
+        '#title' => variable_get('boinc_weboptions_agreequestion', 'Do you agree with the above terms of use?'),
+        '#weight' => -8,
+        '#prefix' => '<div id="register-checkbox">',
+        '#suffix' => '</div>',
+      );
+    }
+
+    $form['title2'] = array(
+      '#weight' => -6,
+      '#value' => '<h2>' . variable_get('boinc_weboptions_registrationtitle2', 'Fill in your name, email, and choose a secure passphrase.') . '</h2>',
+      '#prefix' => '<div id="register-title2">',
+      '#suffix' => '</div>',
+    );
+
     if (module_exists('captcha')) {
       // Add an optional captcha
       $form['register_captcha'] = array(

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1552,7 +1552,6 @@ function boincuser_create_account() {
         }
 
         // if terms of use exist, the user must have opted-in.
-        // @todo - test this block of code!
         $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
         if (!empty($termsofuse)) {
           boincuser_consentto_termsofuse($user);

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -97,8 +97,8 @@ function boincuser_register_validate($form, &$form_state) {
   require_boinc('boinc_db');
 
   // Check opt-in
-  if (!$form_state['values']['legaloptin']) {
-    form_set_error('legaloptin', bts('ERROR: You must acknowledge our terms of use by clicking the checkbox before registering for an account.', NULL, 'boinc:register-new-user'));
+  if (!$form_state['values']['optin']) {
+    form_set_error('optin', bts('ERROR: You must acknowledge our terms of use by clicking the checkbox before registering for an account.', NULL, 'boinc:register-new-user'));
   }
 
   // Check for an existing BOINC user
@@ -634,5 +634,92 @@ function boincuser_fix_unfriend_form_submit($form, &$form_state) {
   // Leaving action as "unfriend" causes problems
   if ($form_state['values']['action'] == 'unfriend') {
     $form_state['values']['action'] = 'unflag';
+  }
+}
+
+/*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
+ * Opt-in to terms of use form
+ *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */
+
+function boincuser_optinform() {
+  global $user;
+
+  // If user has already signed terms of use, and got to this form in error, send them to site home.
+  if (boincuser_check_termsofuse($user)) {
+    drupal_goto();
+  }
+
+  drupal_set_message( bts('WARNING: You have not opted-in to our terms of use. Please opt-in to the terms of use before continuing.', array(), NULL, 'boinc:opt-in-form'), 'warning' );
+
+  // Terms of use section
+  $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+  $form['title1'] = array(
+    '#weight' => -12,
+    '#value' => '<h2>' . variable_get('boinc_weboptions_registrationtitle', 'Please read and acknowledge our terms of use'). '</h2>',
+    '#prefix' => '<div id="register-title1">',
+    '#suffix' => '</div>',
+  );
+
+  $form['termsofuse'] = array(
+    '#weight' => -10,
+    '#value' => $termsofuse,
+    '#prefix' => '<div id="register-termsofuse">',
+    '#suffix' => '</div>',
+  );
+
+  $form['optin'] = array(
+    '#type' => 'checkbox',
+    '#title' => variable_get('boinc_weboptions_agreequestion', 'Do you agree with the above terms of use?'),
+    '#weight' => -8,
+    '#prefix' => '<div id="register-checkbox">',
+    '#suffix' => '</div>',
+  );
+
+  $form['spacer'] = array(
+    '#prefix' => '<div id="register-title2">',
+    '#value'  => '&nbsp;',
+    '#suffix' => '</div>',
+  );
+
+  // Form Control
+  $form['submit'] = array(
+    '#prefix' => '<p><p><p><li class="first tab">',
+    '#type' => 'submit',
+    '#value' => bts('Yes', array(), NULL, 'boinc:opt-in-form'),
+    '#suffix' => '</li>',
+  );
+  $form['form control tabs'] = array(
+    '#value' => '<li class="tab">' . l(bts('NO - LOGOUT', array(), NULL, 'boinc:form-cancel'), '/logout') . '</li>',
+  );
+  $deletelink = '/user/' . $user->uid . '/delete';
+  $form['deleteaccount'] = array(
+    '#value' => '<li class="tab">' . l(bts('NO - DELETE ACCOUNT', array(), NULL, 'boinc:delete'), $deletelink) . '</li>',
+  );
+
+  // Set form redirect
+  $form['#redirect'] = $_REQUEST['destination'];
+
+  // Add the current user's data into the form
+  $form['#account'] = $user;
+
+  return $form;
+}
+
+function boincuser_optinform_validate($form, &$form_state) {
+  // Check opt-in
+  if (!$form_state['values']['optin']) {
+    form_set_error('legaloptin', bts('ERROR: You must acknowledge our terms of use by clicking the checkbox before registering for an account.', array(), NULL, 'boinc:opt-in-form'));
+  }
+}
+
+function boincuser_optinform_submit($form, &$form_state) {
+  $user = $form['#account'];
+  if (!boincuser_consentto_termsofuse($user)) {
+    form_set_error('legaloptin', bts('There was an error in the opt-in process. Please contact the site administrators.', array(), NULL, 'boinc:opt-in-form'));
+  }
+
+  // Delete session messages
+  if ($_SESSION['messages']['warning']) {
+    unset($_SESSION['messages']['warning']);
   }
 }

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -92,13 +92,29 @@ function boincuser_login_register($boinc_user) {
 /**
  * New user registration validation handler.
  */
-function boincuser_register_validate($form_values) {            
+function boincuser_register_validate($form, &$form_state) {
+  //dd(get_defined_vars(), 'validate: all vars');
   // Include BOINC database objects library
   require_boinc('boinc_db');
+
   // Check for an existing BOINC user
-  $boinc_user = BoincUser::lookup_email_addr($form_values['mail']);
-  if ($boinc_user) return false;
-  return true;
+  $boinc_user = BoincUser::lookup_email_addr($form_state['values']['mail']);
+  if ($boinc_user) {
+    // User already exists
+    form_set_error('mail', bts('An account already exists for @email. Log in or request password assistance to access your @project account.', array('@email' => $edit['mail'], '@project' => PROJECT), NULL, 'boinc:add-new-user'));
+  }
+  else {
+    // Save profile information for use during Insert
+    $_SESSION['profileInfo'] = array(
+      'country' => $edit['field_country'][0]['value'],
+      'zip' => $edit['field_zip'][0]['value'],
+      'url' => $edit['field_url'][0]['value'],
+      'background' => $edit['field_background'][0]['value'],
+      'opinions' => $edit['field_opinions'][0]['value']
+    );
+    // With BOINC validation passed, make sure name is unique
+    $form_state['values']['name'] = create_proper_drupalname($form_state['values']['boincuser_name']);
+  }//endif $boinc_user
 }
 
 /**

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -93,15 +93,19 @@ function boincuser_login_register($boinc_user) {
  * New user registration validation handler.
  */
 function boincuser_register_validate($form, &$form_state) {
-  //dd(get_defined_vars(), 'validate: all vars');
   // Include BOINC database objects library
   require_boinc('boinc_db');
+
+  // Check opt-in
+  if (!$form_state['values']['legaloptin']) {
+    form_set_error('legaloptin', bts('ERROR: You must acknowledge our terms of use by clicking the checkbox before registering for an account.', NULL, 'boinc:register-new-user'));
+  }
 
   // Check for an existing BOINC user
   $boinc_user = BoincUser::lookup_email_addr($form_state['values']['mail']);
   if ($boinc_user) {
     // User already exists
-    form_set_error('mail', bts('An account already exists for @email. Log in or request password assistance to access your @project account.', array('@email' => $edit['mail'], '@project' => PROJECT), NULL, 'boinc:add-new-user'));
+    form_set_error('mail', bts('ERROR: An account already exists for @email. Log in or request password assistance to access your @project account.', array('@email' => $edit['mail'], '@project' => PROJECT), NULL, 'boinc:register-new-user'));
   }
   else {
     // Save profile information for use during Insert

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -97,8 +97,11 @@ function boincuser_register_validate($form, &$form_state) {
   require_boinc('boinc_db');
 
   // Check opt-in
-  if (!$form_state['values']['optin']) {
-    form_set_error('optin', bts('ERROR: You must acknowledge our terms of use by clicking the checkbox before registering for an account.', NULL, 'boinc:register-new-user'));
+  $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+  if (!empty($termsofuse)) {
+    if (!$form_state['values']['optin']) {
+      form_set_error('optin', bts('ERROR: You must acknowledge our terms of use by clicking the checkbox before registering for an account.', NULL, 'boinc:register-new-user'));
+    }
   }
 
   // Check for an existing BOINC user

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
@@ -234,6 +234,39 @@ function create_proper_drupalname($requested_name) {
 }
 
 
+/**
+ * Determine if user has opted-in to the terms of user. If not, the
+ * user must opt-in first. Returns TRUE/FALSE depending on database
+ * record.
+ *
+ */
+function boincuser_check_termsofuse($user) {
+  // @todo - the condition for the terms of use needs to be saved in the
+  // project's user table, which does not exist, but may be added
+  // upstream. If/when that occurs, check it here.
+  $qres = db_query('SELECT bu.privacy_consent_dt FROM {boincuser} AS bu WHERE uid=%d', $user->uid);
+  $optin_dt = db_result($qres);
+  // If datetime the user opted-in is larger than the current
+  // unixtime, then the check passes.
+  if ($optin_dt > 1 ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Use has consented to the tersm of use
+ */
+function boincuser_consentto_termsofuse($user) {
+  $uid = $user->uid;
+
+  // @todo - Modify BOINC project database user table to record opt-in datetime.
+  $sql = 'UPDATE {boincuser} set privacy_consent_dt = %d WHERE uid=%d';
+  $qrc = db_query($sql, time(), $uid);
+  return $qrc;
+}
+
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
  * General BOINC functions
  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */

--- a/drupal/sites/default/boinc/modules/boincwork/boincwork.module
+++ b/drupal/sites/default/boinc/modules/boincwork/boincwork.module
@@ -1041,7 +1041,133 @@ function boincwork_get_output() {
  * Get the project configuration XML; used by client software
  */
 function boincwork_get_project_config() {
-  include_boinc('user/get_project_config.php');
+  require_boinc( array('boinc_db', 'util', 'xml') );
+
+  // Begin Output
+  xml_header();
+
+  // get BOINC project config
+  $config = get_config();
+  $long_name = parse_config($config, "<long_name>");
+
+  $min_passwd_length = parse_config($config, "<min_passwd_length>");
+  if (!$min_passwd_length) {
+    $min_passwd_length = 6;
+  }
+  $disable_account_creation = parse_bool($config, "disable_account_creation");
+
+  // Main project config section
+  echo "<project_config>
+    <name>$long_name</name>
+    <master_url>$master_url</master_url>
+    <web_rpc_url_base>".secure_url_base()."</web_rpc_url_base>
+  ";
+
+  if (parse_config($config, "<account_manager>")) {
+    echo "    <account_manager/>\n";
+  }
+  $local_revision = @trim(file_get_contents("../../local.revision"));
+  if ($local_revision) {
+    echo "<local_revision>$local_revision</local_revision>\n";
+  }
+
+  if (web_stopped()) {
+    echo "
+        <error_num>-183</error_num>
+        <web_stopped>1</web_stopped>
+    ";
+  }
+  else {
+    echo "    <web_stopped>0</web_stopped>\n";
+  }
+
+  if ($disable_account_creation || defined('INVITE_CODES')) {
+    echo "    <account_creation_disabled/>\n";
+  }
+
+  if (defined('INVITE_CODES')) {
+    echo "    <invite_code_required/>\n";
+  }
+
+  echo "    <min_passwd_length>$min_passwd_length</min_passwd_length>\n";
+
+  if (sched_stopped()) {
+    echo "    <sched_stopped>1</sched_stopped>\n";
+  }
+  else {
+    echo "    <sched_stopped>0</sched_stopped>\n";
+  }
+
+  $min_core_client_version = parse_config($config, "<min_core_client_version>");
+  if ($min_core_client_version) {
+    echo "<min_client_version>$min_core_client_version</min_client_version>\n";
+  }
+
+  // Display platforms
+  boincwork_show_platforms();
+
+  // Terms of use (from Drupal)
+  $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+  if (!empty($termsofuse)) {
+    echo "    <terms_of_use>\n" . trim($termsofuse) . "\n</terms_of_use>\n";
+  }
+
+  // LDAP option
+  if (LDAP_HOST) {
+    echo "<ldap_auth/>\n";
+  }
+
+  // Additional XML keywords
+  $projectkeywords = variable_get('boinc_project_config_keywords', '');
+  if (!empty($projectkeywords)) {
+    echo $projectkeywords;
+  }
+  echo "</project_config>";
+}
+
+/**
+ * Helper function to generate XML for platforms for
+ * get_project_config.php. This all needs to work even when DB is
+ * down.  So cache list of platforms in a file, and update it every
+ * hour if possible.
+ */
+function boincwork_show_platforms() {
+  $xmlFragment = unserialize(get_cached_data(3600, "project_config_platform_xml"));
+  if ($xmlFragment==false){
+    $platforms = BoincDB::get()->enum_fields("platform, DBNAME.app_version, DBNAME.app", "BoincPlatform", "platform.name, platform.user_friendly_name, plan_class", "app_version.platformid = platform.id and app_version.appid = app.id and app_version.deprecated=0 and app.deprecated=0 group by platform.name, plan_class", "");
+
+    db_set_active("boinc_rw");
+    $psql = "SELECT p.name,"
+        ."p.user_friendly_name,"
+        ."av.plan_class "
+        ."FROM platform AS p "
+        ."INNER JOIN app_version AS av "
+        ."ON p.id=av.platformid "
+        ."INNER JOIN app "
+        ."ON av.appid=app.id "
+        ."WHERE av.deprecated=0 "
+        ."AND app.deprecated=0 "
+        ."GROUP BY p.name, av.plan_class";
+    $db_result = db_query($psql);
+    db_set_active("default");
+
+    if ($db_result) {
+      $xmlFragment = "    <platforms>";
+      while ($platform = db_fetch_object($db_result)) {
+        $xmlFragment .= "
+            <platform>
+                <platform_name>$platform->name</platform_name>
+                <user_friendly_name>$platform->user_friendly_name</user_friendly_name>";
+                if ($platform->plan_class) $xmlFragment .= "
+                <plan_class>$platform->plan_class</plan_class>\n";
+            $xmlFragment .= "
+            </platform>";
+      } // $platform
+      $xmlFragment .= "\n    </platforms>\n";
+    } // endif db_result
+    set_cached_data(3600, serialize($xmlFragment), "project_config_platform_xml");
+  }
+  echo $xmlFragment;
 }
 
 /**

--- a/drupal/sites/default/boinc/themes/boinc/css/pages.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/pages.css
@@ -1000,3 +1000,16 @@ table.user-projects {
 .panel-secondary #search-form #edit-keys {
   width: 100%;
 }
+
+
+/* User registration */
+#register-termsofuse {
+  white-space: pre-line;
+  overflow: auto;
+  width: 80%;
+  max-height: 300px;
+}
+
+#register-title2 {
+  clear: both;
+}


### PR DESCRIPTION
Two major changes:

1. Opt-in consent - use must opt-in to a terms of use when creating a new account.
  * Additionally, existing users may continue to use the site after logging in, unless they too consent to the terms of use.
  * The following may be disabled by simply removing the terms-of-use: if the variable is empty there is no consent.
  * For now, we use the `drupal` database, `boincuser` table to record the initial consent. This will hopefully move to a BOINC upstream database table in the near future.
2. Web registration - admin has the ability to enable/disable creating new accounts using the create_account RPC and the Web registration form. These may be independently toggled.


https://dev.gridrepublic.org/browse/DBOINCP-428