### PR TITLE
Obtain the rsc_fpops_est from the job_params

### DIFF
--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -426,6 +426,8 @@ function submit_batch($r) {
             $total_flops += $job->rsc_fpops_est;
         } else if ($job->input_template && $job->input_template->workunit->rsc_fpops_est) {
             $total_flops += (double) $job->input_template->workunit->rsc_fpops_est;
+        } else if ($r->batch->job_params->rsc_fpops_est) {
+            $total_flops += (double) $r->batch->job_params->rsc_fpops_est;
         } else {
             $x = (double) $template->workunit->rsc_fpops_est;
             if ($x) {


### PR DESCRIPTION
Obtain the rsc_fpops_est from the job_params when using remote submission to avoid  the _no rsc_fpops_est given_ error. 