### PR TITLE
Server: add support for pre-assigned credit

### DIFF
--- a/sched/make_work.cpp
+++ b/sched/make_work.cpp
@@ -21,6 +21,7 @@
 //      [ --cushion n ]      // make work if fewer than N unsent results
 //      [ --max_wus n ]      // don't make work if more than N total WUs
 //      [ --one_pass ]       // quit after one pass
+//      [ --credit_from_wu ] // copy canonical_credit
 //
 // Create WU and result records as needed to maintain a pool of work
 // (for testing purposes).
@@ -59,6 +60,7 @@ using std::string;
 int max_wus = 0;
 int cushion = 300;
 bool one_pass = false;
+bool credit_from_wu = false;
 
 // edit a WU XML doc, replacing one filename by another
 // (should appear twice, within <file_info> and <file_ref>)
@@ -128,7 +130,7 @@ void make_new_wu(DB_WORKUNIT& original_wu, char* starting_xml, int start_time) {
     sprintf(wu.name, "wu_%d_%d", start_time, wu_seqno++);
     wu.need_validate = false;
     wu.canonical_resultid = 0;
-    wu.canonical_credit = 0;
+    wu.canonical_credit = credit_from_wu?original_wu.canonical_credit:0;
     wu.hr_class = 0;
     wu.transition_time = time(0);
     wu.error_mask = 0;
@@ -326,6 +328,8 @@ int main(int argc, char** argv) {
             max_wus = atoi(argv[i]);
         } else if (is_arg(argv[i], "one_pass")) {
             one_pass = true;
+        } else if (is_arg(argv[i], "credit_from_wu")) {
+            credit_from_wu = true;
         } else if (is_arg(argv[1], "h") || is_arg(argv[1], "help")) {
             usage(argv[0]);
             exit(0);

--- a/sched/validate_util.cpp
+++ b/sched/validate_util.cpp
@@ -211,20 +211,4 @@ int get_logical_name(RESULT& result, string& path, string& name) {
     return ERR_XML_PARSE;
 }
 
-int get_credit_from_wu(WORKUNIT& wu, vector<RESULT>&, double& credit) {
-    double x;
-    int retval;
-    DB_WORKUNIT dbwu;
-
-    dbwu.id = wu.id;
-    retval = dbwu.get_field_str("xml_doc", dbwu.xml_doc, sizeof(dbwu.xml_doc));
-    if (!retval) {
-        if (parse_double(dbwu.xml_doc, "<credit>", x)) {
-            credit = x;
-            return 0;
-        }
-    }
-    return ERR_XML_PARSE;
-}
-
 const char *BOINC_RCSID_07049e8a0e = "$Id$";

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -438,13 +438,12 @@ int handle_wu(
                 }
 
                 if (credit_from_wu) {
-                    retval = get_credit_from_wu(wu, viable_results, credit);
-                    if (retval) {
+                    credit = wu.canonical_credit;
+                    if (credit == 0) {
                         log_messages.printf(MSG_CRITICAL,
-                            "[WU#%lu %s] get_credit_from_wu(): credit not specified in WU\n",
+                            "[WU#%lu %s] credit not specified in WU\n",
                             wu.id, wu.name
                         );
-                        credit = 0;
                     }
                 } else if (credit_from_runtime) {
                     credit = 0;

--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -55,7 +55,6 @@ void usage() {
         "\n"
         "Options:\n"
         "   --appname name\n"
-        "   [ --additional_xml x ]\n"
         "   [ --app_version_num N ]\n"
         "   [ --batch n ]\n"
         "   [ --broadcast ]\n"
@@ -63,6 +62,7 @@ void usage() {
         "   [ --broadcast_team ID ]\n"
         "   [ --command_line \"X\" ]\n"
         "   [ --config_dir path ]\n"
+        "   [ --credit X ]\n"
         "   [ -d n ]\n"
         "   [ --delay_bound x ]\n"
         "   [ --hr_class n ]\n"
@@ -122,7 +122,6 @@ struct JOB_DESC {
     char result_template_path[MAXPATHLEN];
     vector <INFILE_DESC> infiles;
     char* command_line;
-    char additional_xml[256];
     bool assign_flag;
     bool assign_multi;
     int assign_id;
@@ -135,7 +134,6 @@ struct JOB_DESC {
         assign_multi = false;
         strcpy(wu_template_file, "");
         strcpy(result_template_file, "");
-        strcpy(additional_xml, "");
         assign_id = 0;
         assign_type = ASSIGN_NONE;
 
@@ -263,6 +261,8 @@ int main(int argc, char** argv) {
             jd.wu.batch = atoi(argv[++i]);
         } else if (arg(argv, i, "priority")) {
             jd.wu.priority = atoi(argv[++i]);
+        } else if (arg(argv, i, "credit")) {
+            jd.wu.canonical_credit = atof(argv[++i]);
         } else if (arg(argv, i, "rsc_fpops_est")) {
             jd.wu.rsc_fpops_est = atof(argv[++i]);
         } else if (arg(argv, i, "rsc_fpops_bound")) {
@@ -293,8 +293,6 @@ int main(int argc, char** argv) {
             jd.wu.opaque = atoi(argv[++i]);
         } else if (arg(argv, i, "command_line")) {
             jd.command_line= argv[++i];
-        } else if (arg(argv, i, "additional_xml")) {
-            safe_strcpy(jd.additional_xml, argv[++i]);
         } else if (arg(argv, i, "wu_id")) {
             jd.wu.id = atoi(argv[++i]);
         } else if (arg(argv, i, "broadcast")) {
@@ -490,7 +488,7 @@ int main(int argc, char** argv) {
                     jd2.infiles,
                     config,
                     jd2.command_line,
-                    jd2.additional_xml,
+                    NULL,
                     value_buf
                 );
                 if (retval) {
@@ -558,8 +556,7 @@ void JOB_DESC::create() {
         result_template_path,
         infiles,
         config,
-        command_line,
-        additional_xml
+        command_line
     );
     if (retval) {
         fprintf(stderr, "create_work: %s\n", boincerror(retval));

--- a/tools/stage_file
+++ b/tools/stage_file
@@ -47,8 +47,11 @@ if (!file_exists("html/inc/dir_hier.inc")
     error_exit("This script must be run in the project directory.\n");
 }
 
-require_once("html/inc/dir_hier.inc");
-require_once("html/inc/util_basic.inc");
+$dir = getcwd();
+chdir("html/inc");
+require_once("dir_hier.inc");
+require_once("util_basic.inc");
+chdir($dir);
 
 function usage() {
     error_exit("usage: stage_file [--gzip] [--copy] path


### PR DESCRIPTION
You can now pre-assign a job's credit, as described here:
https://boinc.berkeley.edu/trac/wiki/CreditOptions

Note: this feature was originally available via an
--additional_xml "<credit>xx</credit>" arg to create_work.
This is an ugly kludge; I removed it.
In fact, the --additional_xml arg should be removed at some point.

Also: change stage_file to it cd's to html/bin when including stuff;
this is needed since util_basic.inc now includes something else