### PR TITLE
Add missing mac_spawn entries to lib/Makefile.am

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -92,6 +92,7 @@ if OS_DARWIN
 mac_sources = \
     procinfo_mac.cpp \
     mac/mac_backtrace.cpp \
+    mac/mac_spawn.cpp \
     mac/QBacktrace.c \
     mac/QCrashReport.c \
     mac/QMachOImage.c \
@@ -101,6 +102,7 @@ mac_sources = \
 mac_headers = \
     mac/dyld_gdb.h \
     mac/mac_backtrace.h \
+    mac/mac_spawn.h \
     mac/QBacktrace.h \
     mac/QCrashReport.h \
     mac/QMachOImage.h \


### PR DESCRIPTION
When building the core boinc library on OSX it seems it is missing some files.
The library builds ok, but when linking to an external program I get linker errors on spawn().

Adding these files to the Makefile.am makes the problem go away :)