### PR TITLE
Code changes needed to add the WCG brand for the mac applications

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1839,7 +1839,7 @@ void CAdvancedFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
                 fscanf(f, "BrandId=%ld\n", &iBrandID);
                 fclose(f);
             }
-            if ((iBrandID > 0) && (iBrandID < 4))
+            if ((iBrandID > 0) && (iBrandID < 5))
 #endif
             {
                 // If successful, hide the main window if we showed it

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -154,6 +154,12 @@ bool CBOINCGUIApp::OnInit() {
     SetAppName(wxT("BOINC Manager"));
     SetVendorName(wxT("Space Sciences Laboratory, U.C. Berkeley"));
 
+#ifdef __WXMAC__
+    char displayName[MAXPATHLEN];
+    getDisplayNameForThisApp(displayName, sizeof(displayName));
+    SetAppDisplayName(wxString(displayName)); // {ass the display name to wxWidgets
+#endif
+
 
     // Initialize the configuration storage module
     m_pConfig = new wxConfig(GetAppName());
@@ -272,7 +278,6 @@ bool CBOINCGUIApp::OnInit() {
     // Load desired manager skin
     m_pConfig->Read(wxT("Skin"), &strDesiredSkinName, m_pSkinManager->GetDefaultSkinName());
     m_pSkinManager->ReloadSkin(strDesiredSkinName);
-
 
 #ifdef SANDBOX
     // Make sure owners, groups and permissions are correct for the current setting of g_use_sandbox

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -223,7 +223,8 @@ public:
     //
     bool                WasFileModifiedBeforeSystemBoot(char * filePath);
     void                HideThisApp(void);
-
+    void                getDisplayNameForThisApp(char* pathBuf, size_t bufSize);
+    
 #if !wxCHECK_VERSION(3,0,1)
 // This should be fixed after wxCocoa 3.0.0:
 // http://trac.wxwidgets.org/ticket/16156

--- a/clientgui/mac/BOINCGUIApp.mm
+++ b/clientgui/mac/BOINCGUIApp.mm
@@ -137,6 +137,19 @@ void CBOINCGUIApp::ShowApplication(bool bShow) {
 }
 
 
+///
+/// Gets the display name for this app
+void CBOINCGUIApp::getDisplayNameForThisApp(char* pathBuf, size_t bufSize) {
+    // Get the app's main bundle
+    NSBundle *main = [NSBundle mainBundle];
+    NSString *thePath = main.localizedInfoDictionary[(NSString *)kCFBundleNameKey];
+    if (thePath == nil) {
+        thePath = [NSProcessInfo processInfo].processName;
+    }
+    strlcpy(pathBuf, [thePath UTF8String], bufSize);
+}
+
+
 // NSTitledWindowMask is deprecated in OS 10.12 and is replaced by
 // NSWindowStyleMaskTitled, which is not defined before OS 10.12
 #ifndef NSWindowStyleMaskTitled

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -126,13 +126,15 @@ int SetBOINCAppOwnersGroupsAndPermissions(char *path) {
     Boolean                 isDirectory;
     OSStatus                err = noErr;
     
-#define NUMBRANDS 3
+#define NUMBRANDS 5
 
 char *saverName[NUMBRANDS];
 
 saverName[0] = "BOINCSaver";
 saverName[1] = "GridRepublic";
 saverName[2] = "Progress Thru Processors";
+saverName[3] = "Charity Engine";
+saverName[4] = "World Community Grid";
 
     if (geteuid() != 0) {
         ShowSecurityError("SetBOINCAppOwnersGroupsAndPermissions must be called as root");

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -817,7 +817,7 @@ void CSimpleFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
                 fscanf(f, "BrandId=%ld\n", &iBrandID);
                 fclose(f);
             }
-            if ((iBrandID > 0) && (iBrandID < 4))
+            if ((iBrandID > 0) && (iBrandID < 5))
 #endif
             {
                 // If successful, hide the main window if we showed it

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -410,6 +410,9 @@ OSStatus CScreensaver::initBOINCApp() {
     case 3:
         m_BrandText = "Charity Engine Desktop";
          break;
+    case 4:
+        m_BrandText = "World Community Grid";
+         break;
     default:
         m_BrandText = "BOINC";
         break;

--- a/clientscr/ss_app.cpp
+++ b/clientscr/ss_app.cpp
@@ -83,6 +83,7 @@ CC_STATUS cc_status;
 #define GRIDREPUBLIC_BRAND_ID 1
 #define PROGRESSTHRUPROCESSORS_BRAND_ID 2
 #define CHARITYENGINE_BRAND_ID 3
+#define WORLDCOMMUNITYGRID_BRAND_ID 4
 
 char* brand_name = "BOINC";
 char* logo_file = "boinc_logo_black.jpg";
@@ -535,6 +536,9 @@ int main(int argc, char** argv) {
         } else if (brandId == CHARITYENGINE_BRAND_ID) {
             brand_name = "Charity Engine";
             logo_file = "CE_ss_logo.jpg";
+        } else if (brandId == WORLDCOMMUNITYGRID_BRAND_ID) {
+            brand_name = "World Community Grid";
+            logo_file = "wcg_ss_logo.jpg";
         }
     }
 #endif

--- a/mac_installer/AddRemoveUser.cpp
+++ b/mac_installer/AddRemoveUser.cpp
@@ -40,7 +40,7 @@ long GetBrandID(void);
 static int parse_posic_spawn_command_line(char* p, char** argv);
 int callPosixSpawn(const char *cmd);
 
-#define NUMBRANDS 4
+#define NUMBRANDS 5
 static char *appName[NUMBRANDS];
 static char *appPath[NUMBRANDS];
 static char *brandName[NUMBRANDS];
@@ -77,6 +77,9 @@ int main(int argc, char *argv[])
     appName[3] = "Charity Engine Desktop";
     appPath[3] = "/Applications/Charity Engine Desktop.app";
     brandName[3] = "Charity Engine";
+    appName[4] = "World Community Grid";
+    appPath[4] = "/Applications/World Community Grid.app";
+    brandName[4] = "World Community Grid";
 
     brandID = GetBrandID();
 

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -143,7 +143,7 @@ void notused() {
 }
 /* END TEMPORARY ITEMS TO ALLOW TRANSLATORS TO START WORK */
 
-#define NUMBRANDS 4
+#define NUMBRANDS 5
 #define MAX_LANGUAGES_TO_TRY 5
 
 static char * Catalog_Name = (char *)"BOINC-Setup";
@@ -221,6 +221,13 @@ int main(int argc, char *argv[])
     saverName[3] = "Charity Engine";
     receiptName[3] = "/Library/Receipts/Charity Engine Installer.pkg";
     skinName[3] = "Charity Engine";
+
+    appName[4] = "World Community Grid";
+    appPath[4] = "/Applications/World Community Grid.app";
+    brandName[4] = "World Community Grid";
+    saverName[4] = "World Community Grid";
+    receiptName[4] = "/Library/Receipts/World Community Grid Installer.pkg";
+    skinName[4] = "World Community Grid";
 
     printf("\nStarting PostInstall app %s\n\n", argv[1]);
     fflush(stdout);

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -390,6 +390,12 @@ static OSStatus DoUninstall(void) {
         kill(BOINCManagerPID, SIGTERM);
         sleep(2);
     }
+    
+    BOINCManagerPID = getPidIfRunning("edu.berkeley.boinc");
+    if (BOINCManagerPID) {
+        kill(BOINCManagerPID, SIGTERM);
+    }
+    sleep(2);
 
     // Core Client may still be running if it was started without Manager
     coreClientPID = FindProcessPID("boinc", 0);
@@ -478,17 +484,22 @@ static OSStatus DoUninstall(void) {
     callPosixSpawn ("rm -rf \"/Applications/Charity Engine Desktop.app\"");
     callPosixSpawn ("rm -rf \"/Library/Screen Savers/Charity Engine.saver\"");
     
+    callPosixSpawn ("rm -rf \"/Applications/World Community Grid.app\"");
+    callPosixSpawn ("rm -rf \"/Library/Screen Savers/World Community Grid.saver\"");
+
     // Delete any receipt from an older installer (which had 
     // a wrapper application around the installer package.)
     callPosixSpawn ("rm -rf /Library/Receipts/GridRepublic.pkg");
     callPosixSpawn ("rm -rf /Library/Receipts/Progress\\ Thru\\ Processors.pkg");
     callPosixSpawn ("rm -rf /Library/Receipts/Charity\\ Engine.pkg");
+    callPosixSpawn ("rm -rf /Library/Receipts/World\\ Community\\ Grid.pkg");
     callPosixSpawn ("rm -rf /Library/Receipts/BOINC.pkg");
 
     // Delete any receipt from a newer installer (a bare package.) 
     callPosixSpawn ("rm -rf /Library/Receipts/GridRepublic\\ Installer.pkg");
     callPosixSpawn ("rm -rf /Library/Receipts/Progress\\ Thru\\ Processors\\ Installer.pkg");
     callPosixSpawn ("rm -rf /Library/Receipts/Charity\\ Engine\\ Installer.pkg");
+    callPosixSpawn ("rm -rf /Library/Receipts/World\\ Community\\ Grid\\ Installer.pkg");
     callPosixSpawn ("rm -rf /Library/Receipts/BOINC\\ Installer.pkg");
 
     // Phase 5: Set BOINC Data owner and group to logged in user
@@ -805,6 +816,7 @@ static OSStatus CleanupAllVisibleUsers(void)
                     DeleteLoginItemOSAScript(pw->pw_name, "GridRepublic Desktop");
                     DeleteLoginItemOSAScript(pw->pw_name, "Progress Thru Processors Desktop");
                     DeleteLoginItemOSAScript(pw->pw_name, "Charity Engine Desktop");
+                    DeleteLoginItemOSAScript(pw->pw_name, "World Community Grid");
 
 #if TESTING
                 } else {
@@ -848,6 +860,11 @@ static OSStatus CleanupAllVisibleUsers(void)
                         changeSaver = true;
                         break;
                     }
+
+                    if (strstr(s, "World Community Grid")) {
+                        changeSaver = true;
+                        break;
+                    }
                 }
                 pclose(f);
             }
@@ -864,6 +881,9 @@ static OSStatus CleanupAllVisibleUsers(void)
                     changeSaver = true;
                 }
                 if (strstr(s, "Charity Engine")) {
+                    changeSaver = true;
+                }
+                if (strstr(s, "World Community Grid")) {
                     changeSaver = true;
                 }
             }
@@ -952,6 +972,8 @@ static void DeleteLoginItemFromPListFile(void)
         if (strstr(theName, "PROGRESS THRU PROCESSORS DESKTOP"))
             success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
         if (strstr(theName, "CHARITY ENGINE DESKTOP"))
+            success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
+        if (strstr(theName, "World Community Grid"))
             success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
     }
 }


### PR DESCRIPTION
The current code includes the knowledge of four brands for the Mac applications: BOINC, Grid Republic, Progress thru Processors, and Charity Engine. This pull request includes the changes needed to add a fifth brand for WCG. This will allow Mac installers built with these changes to overwrite the WCG branded manager and screen saver when they are developed in the future. The changes to allow for the building of a WCG branded installer will be included in a future pull request.