### PR TITLE
[Manager] Fix 'Next' button on previous pages after failed login

### DIFF
--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -292,6 +292,7 @@ void CAccountInfoPage::OnPageChanged( wxWizardExEvent& /* event */ ) {
     wxASSERT(wxDynamicCast(pSkinAdvanced, CSkinAdvanced));
     wxASSERT(wxDynamicCast(pSkinWizardATAM, CSkinWizardATAM));
 
+    pWA->EnableNextButton();
 
     // We are entering this page, so reterieve the previously used email
     // address and/or username.


### PR DESCRIPTION
If while using Wizard try to login to the project with wrong credentials
'Next' button is disabled forever.
This is fixed by enabling 'Next' button on AccountInfoPage by default.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>