### PR TITLE
[WIP] [Manager] Add HTML TOU support to Wizard

### DIFF
--- a/clientgui/TermsOfUsePage.cpp
+++ b/clientgui/TermsOfUsePage.cpp
@@ -54,6 +54,7 @@ BEGIN_EVENT_TABLE( CTermsOfUsePage, wxWizardPageEx )
     EVT_WIZARDEX_CANCEL( -1, CTermsOfUsePage::OnCancel )
     EVT_RADIOBUTTON( ID_TERMSOFUSEAGREECTRL, CTermsOfUsePage::OnTermsOfUseStatusChange )
     EVT_RADIOBUTTON( ID_TERMSOFUSEDISAGREECTRL, CTermsOfUsePage::OnTermsOfUseStatusChange )
+    EVT_HTML_LINK_CLICKED(ID_TERMSOFUSECTRL, CTermsOfUsePage::OnLinkClicked)
 ////@end CTermsOfUsePage event table entries
  
 END_EVENT_TABLE()
@@ -138,7 +139,19 @@ void CTermsOfUsePage::CreateControls()
 
 ////@end CTermsOfUsePage content construction
 }
-  
+
+
+void CTermsOfUsePage::OnLinkClicked( wxHtmlLinkEvent& event ) {
+    wxString url = event.GetLinkInfo().GetHref();
+    if (url.StartsWith(wxT("http://")) || url.StartsWith(wxT("https://"))) {
+        // wxHtmlLinkEvent doesn't have Veto(), but only loads the page if you
+          // call Skip().
+            wxLaunchDefaultBrowser(url);
+    } else {
+        event.Skip();
+    }
+ }
+
 /*!
  * Gets the previous page.
  */

--- a/clientgui/TermsOfUsePage.cpp
+++ b/clientgui/TermsOfUsePage.cpp
@@ -224,14 +224,10 @@ void CTermsOfUsePage::OnPageChanged( wxWizardExEvent& event ) {
         _("Please read the following terms of use:")
     );
 
-    std::string tou = pc.terms_of_use;
-    xml_unescape(tou);
-    wxString terms_of_use(tou.c_str(), wxConvUTF8);
-    // HTML TOU can have no open/close html tags
-    // so I see no proper way to identify
-    // whether it is html or plain text
-    // and I have to use this dirty hack
-    if (pc.terms_of_use == tou) {
+    wxString terms_of_use(pc.terms_of_use.c_str(), wxConvUTF8);
+    // We need to replace all line endings in text TOU
+    // to make it looks properly in HTML Window
+    if (!pc.terms_of_use_is_html) {
         terms_of_use.Replace("\r\n", "<br>");
         terms_of_use.Replace("\r", "<br>");
         terms_of_use.Replace("\n", "<br>");

--- a/clientgui/TermsOfUsePage.cpp
+++ b/clientgui/TermsOfUsePage.cpp
@@ -103,6 +103,8 @@ bool CTermsOfUsePage::Create( CBOINCBaseWizard* parent )
  
 void CTermsOfUsePage::CreateControls()
 {    
+#define TERMSOFUSEWIDTH ADJUSTFORXDPI(580)
+#define TERMSOFUSEHEIGHT ADJUSTFORYDPI(250)
 ////@begin CTermsOfUsePage content construction
     CTermsOfUsePage* itemWizardPage96 = this;
 
@@ -120,8 +122,8 @@ void CTermsOfUsePage::CreateControls()
     m_pDirectionsStaticCtrl->Create( itemWizardPage96, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     itemBoxSizer97->Add(m_pDirectionsStaticCtrl, 0, wxALIGN_LEFT|wxALL, 5);
 
-    m_pTermsOfUseCtrl = new wxTextCtrl;
-    m_pTermsOfUseCtrl->Create( itemWizardPage96, ID_TERMSOFUSECTRL, wxEmptyString, wxDefaultPosition, wxSize(300, 125), wxTE_MULTILINE|wxTE_READONLY|wxTE_RICH );
+    m_pTermsOfUseCtrl = new wxHtmlWindow;
+    m_pTermsOfUseCtrl->Create( itemWizardPage96, ID_TERMSOFUSECTRL, wxDefaultPosition, wxSize(TERMSOFUSEWIDTH, TERMSOFUSEHEIGHT), wxHW_SCROLLBAR_AUTO, wxEmptyString);
     itemBoxSizer97->Add(m_pTermsOfUseCtrl, 0, wxGROW|wxALL, 5);
 
     m_pAgreeCtrl = new wxRadioButton;
@@ -222,10 +224,19 @@ void CTermsOfUsePage::OnPageChanged( wxWizardExEvent& event ) {
         _("Please read the following terms of use:")
     );
 
-    m_pTermsOfUseCtrl->SetValue(
-        wxString(pc.terms_of_use.c_str(), wxConvUTF8)
-    );
-    m_pTermsOfUseCtrl->SetSelection(0,0);
+    std::string tou = pc.terms_of_use;
+    xml_unescape(tou);
+    wxString terms_of_use(tou.c_str(), wxConvUTF8);
+    // HTML TOU can have no open/close html tags
+    // so I see no proper way to identify
+    // whether it is html or plain text
+    // and I have to use this dirty hack
+    if (pc.terms_of_use == tou) {
+        terms_of_use.Replace("\r\n", "<br>");
+        terms_of_use.Replace("\r", "<br>");
+        terms_of_use.Replace("\n", "<br>");
+    }
+    m_pTermsOfUseCtrl->SetPage(terms_of_use);
 
     m_pAgreeCtrl->SetLabel(
         _("I agree to the terms of use.")

--- a/clientgui/TermsOfUsePage.cpp
+++ b/clientgui/TermsOfUsePage.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/TermsOfUsePage.h
+++ b/clientgui/TermsOfUsePage.h
@@ -87,7 +87,7 @@ public:
 ////@begin CTermsOfUsePage member variables
     wxStaticText* m_pTitleStaticCtrl;
     wxStaticText* m_pDirectionsStaticCtrl;
-    wxTextCtrl* m_pTermsOfUseCtrl;
+    wxHtmlWindow* m_pTermsOfUseCtrl;
     wxRadioButton* m_pAgreeCtrl;
     wxRadioButton* m_pDisagreeCtrl;
 ////@end CTermsOfUsePage member variables

--- a/clientgui/TermsOfUsePage.h
+++ b/clientgui/TermsOfUsePage.h
@@ -42,6 +42,9 @@ public:
 
     /// Creates the controls and sizers
     void CreateControls();
+    
+    /// Handles clicks on links
+    void OnLinkClicked( wxHtmlLinkEvent & event );
 
 ////@begin CTermsOfUsePage event handler declarations
 

--- a/clientgui/TermsOfUsePage.h
+++ b/clientgui/TermsOfUsePage.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -554,6 +554,7 @@ struct PROJECT_CONFIG {
     bool web_stopped;           // DB-driven web functions disabled
     int min_client_version;
 	std::string error_msg;
+    bool terms_of_use_is_html;
     std::string terms_of_use;
         // if present, show this text in an "accept terms of use?" dialog
         // before allowing attachment to continue.

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -1323,7 +1323,14 @@ int PROJECT_CONFIG::parse(XML_PARSER& xp) {
         if (xp.match_tag("terms_of_use")) {
             char buf[65536];
             if (!xp.element_contents("</terms_of_use>", buf, sizeof(buf))) {
+                // HTML TOU can have no open/close html tags
+                // so I see no proper way to identify
+                // whether it is html or plain text
+                // and I have to use this dirty hack
+                const string tou = buf;
+                xml_unescape(buf);
                 terms_of_use = buf;
+                terms_of_use_is_html = terms_of_use != tou;
             }
             continue;
         }
@@ -1345,6 +1352,7 @@ void PROJECT_CONFIG::clear() {
     master_url.clear();
     web_rpc_url_base.clear();
     error_msg.clear();
+    terms_of_use_is_html = false;
     terms_of_use.clear();
     local_revision = 0;
     min_passwd_length = 6;

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -412,6 +412,12 @@ void xml_unescape(char* buf) {
         } else if (!strncmp(in, "&amp;", 5)) {
             *out++ = '&';
             in += 5;
+        } else if (!strncmp(in, "&#xD;", 5) || !strncmp(in, "&#xd;", 5)) {
+            *out++ = '\r';
+            in += 5;
+        } else if (!strncmp(in, "&#xA;", 5) || !strncmp(in, "&#xa;", 5)) {
+            *out++ = '\n';
+            in += 5;
         } else if (!strncmp(in, "&#", 2)) {
             in += 2;
             char c = atoi(in);

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License


### PR DESCRIPTION
Terms Of Use can be displayed now as HTML as well as plain text.
Fixed xml_unescape function to support escaped \r and \n tags.
Enlarged the size of Terms Of Use field to fill all wizard page.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>