### PR TITLE
Drupal: Delete expired tokens in the token table.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1290,6 +1290,12 @@ function boincuser_cron() {
   if ($num_deleted>0) {
     watchdog('boincuser', "Deleted ${num_deleted} users from user_deleted table", WATCHDOG_NOTICE);
   }
+
+  // Delete expired tokens from token table
+  $tokens_deleted = BoincToken::delete_expired();
+  if ($tokens_deleted>0) {
+    watchdog('boincuser', "Deleted ${tokens_deleted} tokens from token table", WATCHDOG_NOTICE);
+  }
 }
 
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *


### PR DESCRIPTION
Part of https://dev.gridrepublic.org/browse/DBOINCP-429