### PR TITLE
Updated registration flow

### DIFF
--- a/html/project.sample/project.inc
+++ b/html/project.sample/project.inc
@@ -118,7 +118,7 @@ function make_php_mailer() {
 //
 function project_banner($title, $prefix, $is_main) {
     if ($is_main) {
-        echo '<img class="img-responsive" src="img/water.jpg">';
+        echo '<img class="img-responsive" style="width:100%" src="img/water.jpg">';
     }
     sample_navbar(secure_url_base(), get_logged_in_user(false), false);
     if ($title) {
@@ -130,9 +130,9 @@ function project_banner($title, $prefix, $is_main) {
 function project_footer($show_return, $show_date, $prefix) {
     // If you include any links, prepend URL with $prefix
     //
-    echo '<p></p>
-        <a class="brand boinc-logo" href="https://boinc.berkeley.edu/"><img align="middle" border="0" src="'.secure_url_base().'img/pb_boinc.gif" alt="Powered by BOINC"></a>
-        <br>
+    echo '<br>
+        <a class="brand boinc-logo" href="http://boinc.berkeley.edu/"><img class="img-responsive center-block" src="'.secure_url_base().'img/pb_boinc.gif" alt="Powered by BOINC"></a>
+        <div class="form-group"></div>
         <p class="text-center"> &copy;'.gmdate("Y ").COPYRIGHT_HOLDER.'</p>
     ';
     if ($show_date) {

--- a/html/user/download.php
+++ b/html/user/download.php
@@ -76,15 +76,18 @@ function get_version($dev) {
     $v = simplexml_load_file("versions.xml");
     $client_info = $_SERVER['HTTP_USER_AGENT'];
     $p = client_info_to_platform($client_info);
-    $string = $dev?"Development":"Recommended";
     foreach ($v->version as $i=>$v) {
         if ((string)$v->dbplatform != $p) {
             continue;
         }
-        if (!strstr((string)$v->description, $string)) {
-            continue;
+        if (strstr((string)$v->description, "Recommended")) {
+            return $v;
         }
-        return $v;
+        if ($dev) {
+            if (strstr((string)$v->description, "Development")) {
+                return $v;
+            }
+        }
     }
     return null;
 }

--- a/html/user/download.php
+++ b/html/user/download.php
@@ -17,6 +17,10 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // Show a page with download links and instructions.
+// There's a logged-in user.
+//
+// If no project ID, redirect to BOINC web site
+// otherwise...
 //
 // - get platform from user agent string
 // - find latest version for that platform (regular and vbox)
@@ -143,21 +147,50 @@ function download_button_vbox($v, $project_id, $token, $user) {
     );
 }
 
+// We can't use auto-attach; direct them to the BOINC download page
+//
+function direct_to_boinc() {
+    global $master_url;
+    page_head(tra("Download BOINC"));
+    text_start();
+    echo sprintf(
+        '<p>%s
+        <p><p>
+        %s
+        <p>
+        <a href=https://boinc.berkeley.edu/download.php>%s</a>
+        ',
+        tra("To download and install BOINC,
+            click on the link below and follow the instructions.
+        "),
+        tra("When BOINC first runs it will ask you to select a project.
+            Select %1 from the list,
+            or enter this project's URL: %2",
+            PROJECT,
+            $master_url
+        ),
+        tra("Go the BOINC download page.")
+    );
+    text_end();
+    page_tail();
+}
+
 function show_download_page($user, $dev) {
     global $config;
     $need_vbox = parse_bool($config, "need_vbox");
     $project_id = parse_config($config, "<project_id>");
     if (!$project_id) {
-        error_page("must specify project ID in config.xml");
+        direct_to_boinc();
+        return;
     }
     $v = get_version($dev);
 
     // if we can't figure out the user's platform,
-    // take them to the download_all page on the BOINC site
+    // take them to the download page on the BOINC site
     //
     if (!$v) {
-        Header("Location: https://boinc.berkeley.edu/download_all.php");
-        exit;
+        direct_to_boinc();
+        return;
     }
 
     page_head("Download software");
@@ -200,6 +233,8 @@ function show_download_page($user, $dev) {
     echo "</table></center>\n";
     echo "<p><p>";
     echo tra("When the download is finished, open the downloaded file to install %1.", $dl);
+    echo "<p><p>";
+    echo tra("All done? %1Click here to finish%2.", "<a href=welcome.php>", "</a>");
     page_tail();
 }
 
@@ -241,6 +276,11 @@ function installed() {
             tra("Enter your %1 email address and password.", PROJECT)
         );
     }
+    echo "<p><p>";
+    echo sprintf('<a href=home.php class="btn btn-success">%s</a>
+        ',
+        tra('Continue to your home page')
+    );
     page_tail();
 }
 

--- a/html/user/forum_forum.php
+++ b/html/user/forum_forum.php
@@ -138,14 +138,18 @@ function show_forum($forum, $start, $sort_style, $user) {
     );
     echo $page_nav;
     start_table('table-striped');
-    row_heading_array(array(
-        "",
-        tra("Threads"),
-        tra("Posts"),
-        tra("Author"),
-        tra("Views"),
-        "<nobr>".tra("Last post")."</nobr>"
-    ));
+    row_heading_array(
+        array(
+            "",
+            tra("Threads"),
+            tra("Posts"),
+            tra("Author"),
+            tra("Views"),
+            "<nobr>".tra("Last post")."</nobr>"
+        ),
+        array("", "width=35%", "", "", "", "")
+
+    );
 
     $sticky_first = !$user || !$user->prefs->ignore_sticky_posts;
 

--- a/html/user/forum_index.php
+++ b/html/user/forum_index.php
@@ -91,12 +91,15 @@ foreach ($categories as $category) {
         echo "<p>";
         show_mark_as_read_button($user);
         start_table('table-striped');
-        row_heading_array(array(
-            tra("Topic"),
-            tra("Threads"),
-            tra("Posts"),
-            tra("Last post")
-        ));
+        row_heading_array(
+            array(
+                tra("Topic"),
+                tra("Threads"),
+                tra("Posts"),
+                tra("Last post")
+            ),
+            array("width=30%", "", "", "")
+        );
     }
     if (strlen($category->name)) {
         echo '

--- a/html/user/join.php
+++ b/html/user/join.php
@@ -21,22 +21,33 @@
 // from the BOINC web site,
 // and creates an account using the Manager.
 //
-// signup.php is the newer version, with web signup and autoattach
+// Link to here (e.g. from front-page Join button
+// if you're not a vetted project.
+// If you are, link to signup.php instead
+//
+// This page routes people to the right place depending on whether
+// they already have BOINC installed on this device.
 
 require_once("../inc/util.inc");
+
+// "old" (misnomer) means BOINC is already installed on this device
 
 function show_choose($is_old) {
     panel(null,
         function() use($is_old) {
+            echo tra("Is BOINC installed on this device?");
+            $y = tra("Yes");
+            $n = tra("No");
             if ($is_old) {
-                echo ' <a href="join.php">'.tra('I\'m new').'</a> &nbsp; |&nbsp; '.tra('I\'m a BOINC user').'
-                ';
+                echo sprintf(
+                    ' <b>%s</b> &nbsp; |&nbsp; <a href="join.php">%s</a>',
+                    $y, $n
+                );
             } else {
-                echo tra('I\'m new')
-                    .' &nbsp; |&nbsp;  <a href="join.php?old=1">'
-                    .tra('I\'m a BOINC user')
-                    .'</a>
-                ';
+                echo sprintf(
+                    ' <a href="join.php?old=1">%s</a> &nbsp; |&nbsp; <b>%s</b>',
+                    $y, $n
+                );
             }
         }
     );
@@ -51,14 +62,14 @@ function show_new() {
                 <li> '
                 .tra('Read our %1 Rules and Policies %2.', '<a href="info.php">', '</a>')
                 .'<li> <p>'
-                .tra('Download the BOINC desktop software.')
+                .tra('Download and install BOINC.')
                     .'</p><p>
                     <a href="http://boinc.berkeley.edu/download.php" class="btn btn-success">'.tra('Download').'</a>
                     </p><p>'
                     .tra('For Android devices, download BOINC from the Google Play Store or Amazon App Store.')
                     .'</p>
                 <li> '
-                .tra('Run the installer.').'
+                .tra('Run BOINC.').'
                 <li> '.tra("Choose %1 from the list, or enter %2", "<strong>".PROJECT."</strong>", "<strong>$master_url</strong>").'
                 </ol>
             ';
@@ -73,20 +84,12 @@ function show_old() {
             echo '
                 <ul>
                 <li> '
-                .tra('Install BOINC on this device if not already present.')
-                .'<p>
-                <li> '
-                .tra('Select Tools / Add Project. Choose %1 from the list, or enter %2', "<strong>".PROJECT."</strong>", "<strong>$master_url</strong>")
-                .' <p>
-                <li> '
-                .tra('If you\'re running a command-line version of BOINC on this computer, %1 create an account %2, then use %3 boinccmd --project_attach %4 to add the project.',
-                    '<a href="create_account_form.php">',
-                    '</a>',
-                    '<strong><a href="http://boinc.berkeley.edu/wiki/Boinccmd_tool">',
-                    '</a></strong>'
-                )
-                .'
-                </ul>
+                .tra('Read our %1 Rules and Policies %2.', '<a href="info.php">', '</a>')
+                .'<p><li> '
+                .tra('In the BOINC Manager, select Tools / Add Project.')
+                .'<p><li> '
+                .tra('Choose %1 from the list, or enter %2', "<strong>".PROJECT."</strong>", "<strong>$master_url</strong>")
+                .'</ul>
             ';
         }
     );

--- a/html/user/prefs.php
+++ b/html/user/prefs.php
@@ -22,7 +22,10 @@ require_once("../inc/prefs_project.inc");
 
 $user = get_logged_in_user();
 
-$subset = get_str("subset");
+$subset = get_str("subset", true);
+if (!$subset) {
+    $subset = "global";
+}
 $columns = get_int("cols", true);
 $updated = get_int("updated", true);
 $defaults = get_int("defaults", true);

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -95,9 +95,13 @@ function left(){
                     <ul>
                     <li> %s
                     <li> %s
+                    <li> %s
                     </ul>
                     ',
                     tra("Want to help more?"),
+                    tra("If BOINC is not installed on this computer, %1download it%2.",
+                        "<a href=download.php>", "</a>"
+                    ),
                     tra("Install BOINC on your other computers, tablets, and phones."),
                     tra("Tell your friends about BOINC, and show them how to join %1.", PROJECT)
                 );
@@ -119,8 +123,7 @@ function left(){
                 } else {
                     // use auto-attach if possible
                     //
-                    $x = $project_id?"signup.php":"join.php";
-                    echo '<center><a href="'.$x.'" class="btn btn-success"><font size=+2>'.tra('Join %1', PROJECT).'</font></a></center>
+                    echo '<center><a href="signup.php" class="btn btn-success"><font size=+2>'.tra('Join %1', PROJECT).'</font></a></center>
                     ';
                     echo "<p><p>".tra("Already joined? %1Log in%2.",
                         "<a href=login_form.php>", "</a>"

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -36,7 +36,7 @@ require_once("../inc/bootstrap.inc");
 
 $config = get_config();
 $no_web_account_creation = parse_bool($config, "no_web_account_creation");
-$project_id = parse_config($config, "project_id");
+$project_id = parse_config($config, "<project_id>");
     
 $stopped = web_stopped();
 $user = get_logged_in_user(false);
@@ -63,7 +63,6 @@ function left(){
     panel(
         $user?tra("Welcome, %1", $user->name):tra("What is %1?", PROJECT),
         function() use($user) {
-            global $no_web_account_creation, $master_url;
             global $no_web_account_creation, $master_url, $project_id;
             if ($user) {
                 $dt = time() - $user->create_time;

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -75,8 +75,7 @@ function left(){
                     );
                 } else {
                     $x = format_credit($user->expavg_credit);
-                    $y = number_format($user->expavg_credit/200, 3);
-                    echo tra("You've contributed about %1 credits per day (%2 GFLOPS) to %3 recently.", $x, $y, PROJECT);
+                    echo tra("You've contributed about %1 credits per day to %2 recently.", $x, PROJECT);
                     if ($user->expavg_credit > 1) {
                         echo " ";
                         echo tra("Thanks!");

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -90,22 +90,28 @@ function left(){
                     ',
                     tra('Continue to your home page')
                 );
-            } else {
-                echo "
-                    <p>
-                    XXX is a research project, based at <a href=#>YYY</a>,
-                    that uses Internet-connected
-                    computers to do research in XXX.
-                    You can contribute to our research
-                    by running a free program on your computer.
-                    </p>
-                ";
-                echo "
+                echo "<p><p>";
+                echo sprintf('%s
                     <ul>
-                    <li> <a href=#>Our research</a>
-                    <li> <a href=#>Our team</a>
+                    <li> %s
+                    <li> %s
                     </ul>
-                ";
+                    ',
+                    tra("Want to help more?"),
+                    tra("Install BOINC on your other computers, tablets, and phones."),
+                    tra("Tell your friends about BOINC, and show them how to join %1.", PROJECT)
+                );
+            } else {
+                echo "<p>";
+                $pd = "../project/project_description.php";
+                if (file_exists($pd)) {
+                    include($pd);
+                } else {
+                    echo "No project description yet. Create a file html/project/project_description.php
+                        that prints a short description of your project.
+                    ";
+                }
+                echo "</p>\n";
                 if (NO_COMPUTING) {
                     echo "
                         <a href=\"create_account_form.php\">Create an account</a>
@@ -116,7 +122,9 @@ function left(){
                     $x = $project_id?"signup.php":"join.php";
                     echo '<center><a href="'.$x.'" class="btn btn-success"><font size=+2>'.tra('Join %1', PROJECT).'</font></a></center>
                     ';
-
+                    echo "<p><p>".tra("Already joined? %1Log in%2.",
+                        "<a href=login_form.php>", "</a>"
+                    );
                 }
             }
         }
@@ -125,7 +133,7 @@ function left(){
     if (!$stopped) {
         $profile = get_current_uotd();
         if ($profile) {
-            panel('User of the Day',
+            panel(tra('User of the Day'),
                 function() use ($profile) {
                     show_uotd($profile);
                 }

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -69,16 +69,20 @@ function left(){
                 if ($dt < 86400) {
                     echo tra("Thanks for joining %1", PROJECT);
                 } else if ($user->total_credit == 0) {
-                    echo "Your computer hasn't completed any tasks yet.  If you need help, <a href=https://boinc.berkeley.edu/help.php>go here</a>";
+                    echo tra("Your computer hasn't completed any tasks yet.  If you need help, %1go here%2.",
+                            "<a href=https://boinc.berkeley.edu/help.php>",
+                            "</a>"
+                    );
                 } else {
                     $x = format_credit($user->expavg_credit);
                     $y = number_format($user->expavg_credit/200, 3);
                     echo tra("You've contributed about %1 credits per day (%2 GFLOPS) to %3 recently.", $x, $y, PROJECT);
                     if ($user->expavg_credit > 1) {
-                        echo "Thanks!";
+                        echo " ";
+                        echo tra("Thanks!");
                     } else {
                         echo "<p><p>";
-                        echo "Please make sure BOINC is installed and enabled on your computer.";
+                        echo tra("Please make sure BOINC is installed and enabled on your computer.");
                     }
                 }
                 echo "<p><p>";

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -36,6 +36,7 @@ require_once("../inc/bootstrap.inc");
 
 $config = get_config();
 $no_web_account_creation = parse_bool($config, "no_web_account_creation");
+$project_id = parse_config($config, "project_id");
     
 $stopped = web_stopped();
 $user = get_logged_in_user(false);
@@ -58,11 +59,12 @@ function top() {
 }
 
 function left(){
-    global $user, $no_web_account_creation, $master_url;
+    global $user, $no_web_account_creation, $master_url, $project_id;
     panel(
         $user?tra("Welcome, %1", $user->name):tra("What is %1?", PROJECT),
         function() use($user) {
             global $no_web_account_creation, $master_url;
+            global $no_web_account_creation, $master_url, $project_id;
             if ($user) {
                 $dt = time() - $user->create_time;
                 if ($dt < 86400) {
@@ -79,8 +81,8 @@ function left(){
                         echo "<p><p>";
                         echo "Please make sure BOINC is installed and enabled on your computer.";
                     }
-                    echo "<p>";
                 }
+                echo "<p><p>";
                 echo sprintf('<center><a href=home.php class="btn btn-success">%s</a></center>
                     ',
                     tra('Continue to your home page')
@@ -106,7 +108,10 @@ function left(){
                         <a href=\"create_account_form.php\">Create an account</a>
                     ";
                 } else {
-                    echo '<center><a href="signup.php" class="btn btn-success"><font size=+2>'.tra('Join %1', PROJECT).'</font></a></center>
+                    // use auto-attach if possible
+                    //
+                    $x = $project_id?"signup.php":"join.php";
+                    echo '<center><a href="'.$x.'" class="btn btn-success"><font size=+2>'.tra('Join %1', PROJECT).'</font></a></center>
                     ';
 
                 }

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -95,7 +95,6 @@ function left(){
                     <li> %s
                     <li> %s
                     <li> %s
-                    </ul>
                     ',
                     tra("Want to help more?"),
                     tra("If BOINC is not installed on this computer, %1download it%2.",
@@ -104,6 +103,10 @@ function left(){
                     tra("Install BOINC on your other computers, tablets, and phones."),
                     tra("Tell your friends about BOINC, and show them how to join %1.", PROJECT)
                 );
+                if (function_exists('project_help_more')) {
+                    project_help_more();
+                }
+                echo "</ul>\n";
             } else {
                 echo "<p>";
                 $pd = "../project/project_description.php";

--- a/html/user/welcome.php
+++ b/html/user/welcome.php
@@ -1,0 +1,109 @@
+<?php
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+require_once("../inc/util.inc");
+page_head(tra("Welcome to %1", PROJECT));
+text_start();
+echo tra("
+    At this point BOINC should be installed and running on your computer;
+    the system tray should have an icon like this: %1
+    If not, %2get help here%3.
+    ",
+    "<img src=https://boinc.berkeley.edu/logo/boinc32.bmp>",
+    "<a href=https://boinc.berkeley.edu/wiki/BOINC_Help>",
+    "</a>"
+);
+
+echo sprintf('
+    <h3>%s</h3>
+    <p>
+    %s',
+    tra("What happens now?"),
+    tra("BOINC, running in the background, will download computing jobs,
+        process them, and upload the results.
+        This will happen automatically; you don't have to do anything.
+        This computation may cause your computer's fan to run,
+        and it may slightly increase your electric bill.
+    ")
+);
+
+echo sprintf('
+    <h3>%s</h3>
+    <p>
+    %s',
+    tra("How to monitor and control BOINC"),
+    tra("You can monitor what BOINC is doing, and control it, using the BOINC Manager.
+        Open this by double-clicking on the BOINC icon.
+        Details are %1here%2.",
+        "<a href=https://boinc.berkeley.edu/wiki/BOINC_Manager>",
+        "</a>"
+    )
+);
+
+echo sprintf('
+    <h3>%s</h3>
+    <p>
+    %s',
+    tra("Computing preferences"),
+    tra("BOINC is designed to not impact
+        the performance of your computer for normal use.
+        If it does, you can reduce this impact by,
+        for example, limiting the amount of memory BOINC uses.
+        You can control many settings.
+        Check this out %1here%2.",
+        "<a href=prefs.php>",
+        "</a>"
+    )
+);
+
+
+echo sprintf('
+    <h3>%s</h3>
+    <p>
+    %s',
+    tra("Community"),
+    tra("You can meet and communicate with other %1 participants
+        in a variety of ways - take a look under the Community
+        menu above.", PROJECT
+    )
+);
+
+echo sprintf('
+    <h3>%s</h3>
+    <p>
+    %s',
+    tra("Other projects"),
+    tra("%1 is one of many science projects using BOINC.
+        Your computer is now 'attached' to %1,
+        but you can attach it to other projects if you want.
+        It will process jobs for all attached projects.
+        %2Learn about how to do this%3.",
+        PROJECT,
+        "<a href=https://boinc.berkeley.edu/wiki/Choosing_and_joining_projects>",
+        "</a>"
+    )
+);
+
+echo "<p><p>";
+echo sprintf('<a href=home.php class="btn btn-success">%s</a>
+    ',
+    tra('Continue to your home page')
+);
+text_end();
+page_tail();
+?>


### PR DESCRIPTION
New and improved registration flow.

Account creation is now done by default on the web, not in the BOINC Manager.
We can add consent stuff here as needed.

For projects that are vetted, and that put their project ID in config.xml,
the autoattach feature now works.
This means that new users (downloading BOINC for the first time)
will be pre-attached to the project when BOINC first runs.
No need for a separate attach/login in the Manager.

I've deployed this on SETI@home; seems to work as intended.