### PR TITLE
Drupal: Harden email change procedure

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -200,6 +200,14 @@ function boincuser_menu() {
     'access callback' => TRUE,
     'type' => MENU_CALLBACK,
   );
+  $items['user/%user/recoveremail/%'] = array(
+    'title' => t('Revert email change'),
+    'description' => t('Form to revert email to previous address.'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('boincuser_revertemail', 3),
+    'access callback' => 'user_is_logged_in',
+    'type' => MENU_CALLBACK,
+  );
   return $items;
 }
 
@@ -297,7 +305,9 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
           expavg_time,
           cross_project_id,
           teamid,
-          venue
+          venue,
+          previous_email_addr,
+          email_addr_change_time
         FROM {user}
         WHERE id = %d",
         $account->boincuser_id
@@ -311,6 +321,8 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
       $account->boincuser_cpid = md5($boinc_user->cross_project_id . $account->mail);
       $account->boincuser_default_pref_set = $boinc_user->venue;
       $account->boincteam_id = $boinc_user->teamid;
+      $account->boincuser_previous_email_addr = $boinc_user->previous_email_addr;
+      $account->boincuser_email_addr_change_time = $boinc_user->email_addr_change_time;
       db_set_active('default');
       // Set Drupal team ID
       $account->team = NULL;
@@ -447,7 +459,7 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
         switch ($edit['update_source']) {
         case 'user_account':
           // Ensure that BOINC data is altered
-          $boinc_user = BoincUser::lookup_id($account->boincuser_id);
+
           $changing_email = ($edit['mail'] AND $edit['mail'] != $boinc_user->email_addr) ? true : false;
           $changing_pass = ($edit['pass']) ? true : false;
           if ($changing_email OR $changing_pass) {
@@ -455,10 +467,25 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
             $passwd = ($edit['pass']) ? $edit['pass'] : $edit['current_pass'];
             $passwd_hash = password_hash( md5($passwd.$edit['mail']), PASSWORD_DEFAULT );
             $email_addr = $edit['mail'];
+
+            if ($changing_email) {
+              // locally store current email to set as previous email
+              $prev_email = $account->mail;
+              $mytime = (user_access('administer users')) ? $boinc_user->email_addr_change_time : time();
+              $querypart = "email_addr='{$email_addr}', passwd_hash='{$passwd_hash}', previous_email_addr = '{$prev_email}', email_addr_change_time = $mytime";
+            }
+            else {
+              $querypart = "email_addr='{$email_addr}', passwd_hash='{$passwd_hash}'";
+            }
+
             // Update user account information
-            $result = $boinc_user->update(
-                "email_addr='{$email_addr}', passwd_hash='{$passwd_hash}'"
-            );
+            $result = $boinc_user->update($querypart);
+
+            if ($changing_email) {
+              // reload account
+              $account = user_load($account->uid);
+              _boincuser_send_emailchange($account, $email_addr, $prev_email);
+            }
           }
           break;
         case 'user_profile':
@@ -621,6 +648,8 @@ function boincuser_views_api() {
 * Implementation of hook_form_alter()
 */
 function boincuser_form_alter(&$form, $form_state, $form_id) {
+  require_boinc('token');
+
   global $user;
   switch ($form_id) {
   case 'flag_confirm':
@@ -855,6 +884,9 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
     $account = user_load($form['#uid']);
     drupal_set_title($account->boincuser_name);
     
+    // Set special message if user has not agreed to TOU
+    }
+
     // A bit hackish... but don't require the user to enter his password if
     // coming from the password reset function
     $reset_pass = (strpos($_SERVER['HTTP_REFERER'], "/user/reset/{$form['#uid']}") === FALSE) ? 0 : 1;
@@ -869,6 +901,20 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
     $form['account']['name']['#description'] .= '<p>This is the drupal (internal) username. The title above shows the BOINC username, which is the display name used publically that the user can change in Community Preferences.';
     $form['account']['mail']['#size'] = 40;
     $form['account']['pass']['#size'] = 17;
+
+    // If email address was changed less than 7 days (7 * 86400 s)
+    // ago, it cannot be changed again.
+    $duration = TOKEN_DURATION_ONE_WEEK;
+    if (($account->boincuser_email_addr_change_time + $duration) > time()) {
+      $form['account']['mail']['#required'] = FALSE;
+      $form['account']['mailhelp'] = array(
+        '#value' => bts("You email address was changed within the past seven (7) days. Please look for an email to !prev_email if you need to revert this change. You may change your email address on !time.",
+          array(
+            '!prev_email' => $account->boincuser_previous_email_addr,
+            '!time' => date('F j, Y \a\t G:i T', $account->boincuser_email_addr_change_time + $duration),
+          ), NULL, 'boinc:account-credentials-change'),
+      );
+    }
 
     if (!$reset_pass AND ($user->uid == $account->uid OR !user_access('administer users'))) {
       // Add a password authenticator, required to change email or pw
@@ -949,6 +995,7 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
     );
     
     // Rearrange form elements
+    $form['account']['mailhelp']['#weight'] = 4;
     $form['account']['mail']['#weight'] = 5;
     $form['account']['pass']['#weight'] = 15;
     $form['account']['boincuser_id']['#weight'] = 45;
@@ -1555,6 +1602,7 @@ function boincuser_create_account() {
   }
   
   // Process input
+  // @todo - lookup_prev_email_addr - check for unique email
   $boinc_user = BoincUser::lookup_email_addr($params['email_addr']);
   if ($boinc_user) {
     // Return authenticator for existing users

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1621,7 +1621,13 @@ function boincuser_create_account() {
   }
   
   // Process input
-  // @todo - lookup_prev_email_addr - check for unique email
+  // Check this email against previous email addresses.
+  $tmpuser = BoincUser::lookup_pr3ev_email_addr($params['email_addr']);
+  if ($tmpuser) {
+    xml_error(-137);
+  }
+
+  // Check this email on current email addresses.
   $boinc_user = BoincUser::lookup_email_addr($params['email_addr']);
   if ($boinc_user) {
     // Return authenticator for existing users

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -260,6 +260,7 @@ function boincuser_init() {
           'privacy',
           'moderation',
           'account/info/edit',
+          'user/' . $user->uid . '/edit',
           'user/' . $user->uid . '/recoveremail/*',
         );
         if (module_exists('boincuser_delete')) {
@@ -531,6 +532,14 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
 function boincuser_user_login(&$edit, $account) {
   $existinguser_tou = variable_get('boinc_weboptions_existinguser_tou', FALSE);
   $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+
+  // Use the same code as boincuser_form_alter(), for case
+  // 'user_profile_form', if the refering page is the user password
+  // reset form, then do not check for terms of use.
+  $reset_pass = (strpos($_SERVER['HTTP_REFERER'], "/user/reset/{$form['#uid']}") === FALSE) ? 0 : 1;
+  if ($reset_pass) {
+    return;
+  }
 
   // Check if user has agreed to terms of use.
   if ( (!empty($termsofuse)) and ($account->uid) and 

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -201,7 +201,7 @@ function boincuser_menu() {
     'type' => MENU_CALLBACK,
   );
   $items['user/%user/recoveremail/%'] = array(
-    'title' => t('Revert email change'),
+    'title' => t('Recover previous email'),
     'description' => t('Form to revert email to previous address.'),
     'page callback' => 'drupal_get_form',
     'page arguments' => array('boincuser_revertemail', 3),
@@ -259,6 +259,8 @@ function boincuser_init() {
           'logout',
           'privacy',
           'moderation',
+          'account/info/edit',
+          'user/' . $user->uid . '/recoveremail/*',
         );
         if (module_exists('boincuser_delete')) {
           $paths_to_ignore[] = 'user/' . $user->uid . '/delete';
@@ -879,12 +881,21 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
     
   // User credentials form
   case 'user_profile_form':
-    
+
     // Use the displaly name as the title, not the username
     $account = user_load($form['#uid']);
     drupal_set_title($account->boincuser_name);
     
     // Set special message if user has not agreed to TOU
+    $existinguser_tou = variable_get('boinc_weboptions_existinguser_tou', FALSE);
+    $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
+    if ( (!boincuser_check_termsofuse($account)) and ($existinguser_tou) and (!empty($termsofuse)) ) {
+      drupal_set_message(
+        bts('INFO: You have not agreed to the terms of use for @project. You may use this form to change your email address and/or password. Please note: you may not delete your account within seven (7) days of changing your email address.',
+        array(
+          '@project' => variable_get('site_name','Drupal-BOINC'),
+        ), NULL, 'boinc:account-credentials-change')
+      );
     }
 
     // A bit hackish... but don't require the user to enter his password if
@@ -1034,6 +1045,7 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
         '#value' => 'user_account'
       )
     ));
+
     break;
     
   case 'profile_node_form':

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -536,7 +536,7 @@ function boincuser_user_login(&$edit, $account) {
   // Use the same code as boincuser_form_alter(), for case
   // 'user_profile_form', if the refering page is the user password
   // reset form, then do not check for terms of use.
-  $reset_pass = (strpos($_SERVER['HTTP_REFERER'], "/user/reset/{$form['#uid']}") === FALSE) ? 0 : 1;
+  $reset_pass = (strpos($_SERVER['HTTP_REFERER'], "/user/reset/$account->uid") === FALSE) ? 0 : 1;
   if ($reset_pass) {
     return;
   }
@@ -1631,7 +1631,7 @@ function boincuser_create_account() {
   
   // Process input
   // Check this email against previous email addresses.
-  $tmpuser = BoincUser::lookup_pr3ev_email_addr($params['email_addr']);
+  $tmpuser = BoincUser::lookup_prev_email_addr($params['email_addr']);
   if ($tmpuser) {
     xml_error(-137);
   }

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -886,16 +886,23 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
     $account = user_load($form['#uid']);
     drupal_set_title($account->boincuser_name);
     
+    // Message for admins
+    if (user_access('administer users')) {
+      drupal_set_message(
+        bts('WARNING: You are editing the information for user. Please note: you may change a user\'s password by itself. But to change the user\'s email address you must change both the email address and the password simultaneously.')
+      , 'warning');
+    }
+
     // Set special message if user has not agreed to TOU
     $existinguser_tou = variable_get('boinc_weboptions_existinguser_tou', FALSE);
     $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
-    if ( (!boincuser_check_termsofuse($account)) and ($existinguser_tou) and (!empty($termsofuse)) ) {
+    if ( (!boincuser_check_termsofuse($account)) and ($existinguser_tou) and (!empty($termsofuse)) and (!user_access('administer users')) ) {
       drupal_set_message(
         bts('INFO: You have not agreed to the terms of use for @project. You may use this form to change your email address and/or password. Please note: you may not delete your account within seven (7) days of changing your email address.',
         array(
           '@project' => variable_get('site_name','Drupal-BOINC'),
         ), NULL, 'boinc:account-credentials-change')
-      );
+      , 'info');
     }
 
     // A bit hackish... but don't require the user to enter his password if
@@ -916,7 +923,7 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
     // If email address was changed less than 7 days (7 * 86400 s)
     // ago, it cannot be changed again.
     $duration = TOKEN_DURATION_ONE_WEEK;
-    if (($account->boincuser_email_addr_change_time + $duration) > time()) {
+    if (($account->boincuser_email_addr_change_time + $duration) > time() and (!user_access('administer users'))) {
       $form['account']['mail']['#required'] = FALSE;
       $form['account']['mailhelp'] = array(
         '#value' => bts("You email address was changed within the past seven (7) days. Please look for an email to !prev_email if you need to revert this change. You may change your email address on !time.",

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser_delete/boincuser_delete.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser_delete/boincuser_delete.module
@@ -120,7 +120,7 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
             array(
               '!time' => date('F j, Y \a\t G:i T', $form['_account']['#value']->boincuser_email_addr_change_time + $duration),
             ), NULL, 'boinc:account-credentials-change')
-        );
+        , 'info');
         $disable_delete = TRUE;
       }
 
@@ -145,8 +145,6 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
         '#prefix' => "<div id='delete-instructions'>",
         '#suffix' => "</div>",
       );
-
-      // @todo - add markup section - if previous email address timestamp is < 7 days, then show message saying when account may be deleted. Also, remove the 'submit button' below.
 
       $form['main']['user_delete_action'] = array(
         '#type' => 'radios',

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser_delete/boincuser_delete.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser_delete/boincuser_delete.module
@@ -111,6 +111,7 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
       break;
     case 'user_confirm_delete':
 
+      $disable_delete = FALSE;
       // If email address was changed less than 7 days (7 * 86400 s)
       // ago, it cannot be changed again.
       $duration = TOKEN_DURATION_ONE_WEEK;

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser_delete/boincuser_delete.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser_delete/boincuser_delete.module
@@ -111,6 +111,19 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
       break;
     case 'user_confirm_delete':
 
+      // If email address was changed less than 7 days (7 * 86400 s)
+      // ago, it cannot be changed again.
+      $duration = TOKEN_DURATION_ONE_WEEK;
+      if (($form['_account']['#value']->boincuser_email_addr_change_time + $duration) > time()) {
+        drupal_set_message(
+          bts("INFO: Your email address was changed within the past seven (7) days. You may not delete your account until after !time.",
+            array(
+              '!time' => date('F j, Y \a\t G:i T', $form['_account']['#value']->boincuser_email_addr_change_time + $duration),
+            ), NULL, 'boinc:account-credentials-change')
+        );
+        $disable_delete = TRUE;
+      }
+
       $question = 'Are you sure you want to delete the account <em>' . htmlspecialchars($form['_account']['#value']->boincuser_name) . '</em>?';
       drupal_set_title($question);
 
@@ -123,8 +136,11 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
 
       $form['main']['help'] = array(
         '#value' => bts(
-          "<p><b>Instructions:</b> In order to delete your account, you must provide your password below. You will then be sent an email to the email address on record, with a one-time token that expires in 24-hours. Clicking on this link will bring you to a second form where you must enter your password again. After doing so your account will be deleted.</p>",
-          array(), NULL, 'boinc:delete-user-account'),
+          "<p><b>Instructions:</b> In order to delete your account, you must provide your password below. You will then be sent an email to the email address on record, with a one-time token that expires in 24-hours. Clicking on this link will bring you to a second form where you must enter your password again. After doing so your account will be deleted.</p>" .
+          "<p>If necessary, you may !link first before deleting your addcount. But you must wait <b>seven (7) days</b> after an email address change before you may delete your account.</p>",
+          array(
+            '!link' => l(bts('change your email address', array(), NULL, 'boinc:delete-user-account'), '/account/info/edit'),
+          ), NULL, 'boinc:delete-user-account'),
         '#weight' => 11,
         '#prefix' => "<div id='delete-instructions'>",
         '#suffix' => "</div>",
@@ -139,6 +155,9 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
         ),
         '#weight' => 21,
       );
+      if ($disable_delete) {
+        $form['main']['user_delete_action']['#disabled'] = TRUE;
+      }
 
       $form['separator_bottom'] = array(
         '#value' => '<div class="separator buttons"></div>',
@@ -146,15 +165,17 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
       );
 
       // Password field
-      $form['main']['current_pass'] = array(
-        '#type' => 'password',
-        '#title' => bts('Enter your password before clicking Submit', array(), NULL, 'boinc:delete-user-account'),
-        '#size' => 17,
-        '#attributes' => array(
-          'autocomplete' => 'off',
-        ),
-        '#weight' => 25,
-      );
+      if (!$disable_delete) {
+        $form['main']['current_pass'] = array(
+          '#type' => 'password',
+          '#title' => bts('Enter your password before clicking Submit', array(), NULL, 'boinc:delete-user-account'),
+          '#size' => 17,
+          '#attributes' => array(
+            'autocomplete' => 'off',
+          ),
+          '#weight' => 25,
+        );
+      }
 
       // Configure the action buttons
       $uid = $form['_account']['#value']->uid;
@@ -169,14 +190,19 @@ function boincuser_delete_form_alter(&$form, $form_state, $form_id) {
       $form['actions']['submit']['#prefix'] = '<li class="first tab">';
       $form['actions']['submit']['#suffix'] = '</li>';
       $form['actions']['submit']['#value'] = bts('Submit', array(), NULL, 'boinc:form-submit');
-      // @todo -  if previous email address timestamp is < 7 days, then disable the submuit button.
-      //$form['actions']['submit']['#disabled'] = TRUE;
       $form['actions']['submit']['#weight'] = 1002;
+      if ($disable_delete) {
+        $form['actions']['submit']['#disabled'] = TRUE;
+        $form['actions']['submit']['#value'] = '';
+      }
 
       $form['actions']['cancel']['#prefix'] = '<li class="tab">';
       $form['actions']['cancel']['#suffix'] = '</li>';
       $form['actions']['cancel']['#weight'] = 1003;
       $form['actions']['cancel']['#value'] = l(bts('Cancel', array(), NULL, 'boinc:form-cancel'), 'account/info/edit');
+      if ($disable_delete) {
+        $form['actions']['cancel']['#prefix'] = '<li class="first tab">';
+      }
 
       $form['actions']['form control tabs suffix'] = array(
         '#value' => '</ul>',

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -110,7 +110,16 @@ function boincuser_register_validate($form, &$form_state) {
     }
   }
 
-  // @todo - check previous email addresses first
+  $tmp_user = BoincUser::lookup_prev_email_addr($form_state['values']['mail']);
+  if ($tmp_user) {
+    // User already exists
+    form_set_error('mail', bts('An account already exists for @email. Contact the administrators for @project for additional help.',
+      array(
+        '@email' => $form_state['values']['mail'],
+        '@project' => variable_get('site_name', 'Drupal-BOINC'), NULL, 'boinc:add-new-user',
+      )
+    , NULL, 'boinc:register-new-user'));
+  }
 
   // Check for an existing BOINC user
   // This is somewhat redundent as Drupal will also check if the email
@@ -767,27 +776,31 @@ function boincuser_revertemail(&$form_state, $token) {
   global $user;
   $form = array();
 
+  // drupal JS for dynamic password validation
+  _user_password_dynamic_validation();
+
   // check BOINC user exists
   $account = user_load(array('uid' => $user->uid));
   $uid = $user->uid;
   $boincid = $account->boincuser_id;
   // check $token is valid
   if (!is_valid_token($boincid, $token, 'E')) {
-    drupal_set_message(bts('ERROR: You have supplied an incorrect (most likely expired) token. Please obtain a new token by !link your account be deleted.',
+    drupal_set_message(bts('ERROR: You have supplied an incorrect (most likely expired) token. Please obtain a new token by !link your email address.',
     array(
-      '!link' => l(bts('re-requesting', array(), NULL, 'boinc:delete-user-account'), "/user/${uid}/delete"),
+      '!link' => l(bts('changing', array(), NULL, 'boinc:revert-email-change'), "/account/info/edit"),
     ),
-    NULL, 'boinc:delete-user-account'), 'error');
+    NULL, 'boinc:revert-email-change'), 'error');
     drupal_goto();
   }
 
-  // Attach account to this form.
+  // Attach account and token to this form.
   $form['_account'] = array('#type' => 'value', '#value' => $account);
+  $form['_token'] = array('#type' => 'value', '#value' => $token);
 
   // Instructions
   $form['main']['instructions1'] = array(
     '#value' => '<p>'.
-    bts('In order to change your email back to the previous address (!prev_email), you must also change your password.',
+    bts('In order to change your email back to your previous email address, <strong>!prev_email</strong>, you must also change your password.',
       array(
         '!prev_email' => $account->boincuser_previous_email_addr,
       ),
@@ -795,21 +808,76 @@ function boincuser_revertemail(&$form_state, $token) {
     '</p>',
   );
 
-  // @todo - add two password fields and submit/cancel buttons.
+  $form['main']['pass'] = array(
+    '#type' => 'password_confirm',
+    '#description' => 'Enter a new password in both fields',
+    '#size' => 17,
+  );
+
+  // Wrap action buttons for styling consistency
+  $form['buttons']['form control tabs prefix'] = array(
+      '#value' => '<ul class="form-control tab-list">',
+      '#weight' => 1001,
+  );
+  $form['buttons']['submit']['#type'] = 'submit';
+  $form['buttons']['submit']['#prefix'] = '<li class="first tab">';
+  $form['buttons']['submit']['#value'] = bts('Submit', array(), NULL, 'boinc:form-submit');
+  $form['buttons']['submit']['#suffix'] = '</li>';
+  $form['buttons']['submit']['#weight'] = 1002;
+  $form['buttons']['cancel'] = array(
+      '#value' => '<li class="tab">' . l(bts('Cancel', array(), NULL, 'boinc:form-cancel'), 'user/info/edit') . '</li>',
+      '#weight' => 1005,
+  );
+  $form['buttons']['form control tabs suffix'] = array(
+      '#value' => '</ul>',
+      '#weight' => 1010,
+  );
+
+  return $form;
 }
 
 /**
  * Validation handler for revertemail form
  */
 function boincuser_revertemail_validate($form, &$form_state) {
-  // @todo - add validation.
-  // Check email for account collision using BoincUser::lookup_email_addr( previous_email ).
+  // Load account and boincuser
+  $account = $form_state['values']['_account'];
+  $boinc_user = BoincUser::lookup_id($account->uid);
+
+  if (BoincUser::lookup_email_addr($boinc_user->previous_email_addr)) {
+    form_set_error('mail', bts('An account already exists for @email. Please contact admins for @project. Previous email address cannot be used because another account is using it as their email address.',
+      array(
+        '@email' => $boinc_user->previous_email_addr,
+        '@project' => variable_get('site_name', 'Drupal-BOINC'),
+      ),
+    NULL, 'boinc:add-new-user'));
+  }
+
 }
 
 /**
  * Submit handler for revertemail form
  */
 function boincuser_revertemail_submit($form, &$form_state) {
-  // @todo - add submit
-  // Save previous email and new password in database: BOINC and drupal (email only).
+  require_boinc('password_compat/password');
+
+  // Load account and boincuser
+  $account = $form_state['values']['_account'];
+  $boinc_user = BoincUser::lookup_id_nocache($account->boincuser_id);
+
+  $pem = $boinc_user->previous_email_addr;
+
+  // Set new password based on previous email address and entered
+  // password.
+  $new_passwd_hash = password_hash( md5($form_state['values']['pass'].$pem), PASSWORD_DEFAULT);
+
+  $boinc_user->update("email_addr='${pem}', previous_email_addr='', email_addr_change_time=0, passwd_hash='${new_passwd_hash}'");
+
+  // Set email in drupal database to previous email
+  user_save($account, array('mail' => $pem));
+
+  // delete the token
+  $result = delete_token($account->boincuser_id, $form_state['values']['_token'], 'E');
+
+  drupal_goto('account');
 }

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -110,6 +110,8 @@ function boincuser_register_validate($form, &$form_state) {
     }
   }
 
+  // @todo - check previous email addresses first
+
   // Check for an existing BOINC user
   // This is somewhat redundent as Drupal will also check if the email
   // is a duplicate. However, in the case where there is no Drupal
@@ -374,9 +376,25 @@ function boincuser_account_validate($edit, $account) {
   $changing_pass = ($edit['pass']) ? true : false;
   if ($changing_email) {
     // E-mail address is set to change; check for an existing BOINC user
-    $boinc_user_already_exists = BoincUser::lookup_email_addr($edit['mail']);
+    // Check previous email addresses as well, this user's current
+    // email cannot be the same as another user's previous email
+    // address.
+    $boinc_user_already_exists = ( BoincUser::lookup_email_addr($edit['mail']) || BoincUser::lookup_prev_email_addr($edit['mail']) );
     if ($boinc_user_already_exists) {
       form_set_error('mail', bts('A BOINC account already exists for @email.', array('@email' => $edit['mail']), NULL, 'boinc:add-new-user'));
+    }
+
+    // Check email has not been changed in last X days (default X=7).
+    $duration = 86400 * 7;
+    if ( (($boinc_user->email_addr_change_time + $duration) > time()) and (!(user_access('administer users'))) ) {
+      form_set_error('email_addr_change_time',
+        bts('Your email address was changed within the past seven (7) days. You must wait until !futuredate to change your email again. If you need to reverse this change, please look for an email sent to !prev_email_addr.',
+        array(
+          '!futuredate' => date('F j, Y \a\t H:i T', $boinc_user->email_addr_change_time + $duration),
+          '!prev_email_addr' => $boinc_user->previous_email_addr,
+        ),
+        NULL, 'boinc:account-credentials-change')
+      );
     }
   }
 
@@ -396,6 +414,7 @@ function boincuser_account_validate($edit, $account) {
       elseif ( (!password_verify($given_hash, $boinc_user->passwd_hash)) and ($given_hash != $boinc_user->passwd_hash) ) {
         form_set_error('current_pass', bts('Password entered is not valid. Please verify that it is correct.', array(), NULL, 'boinc:account-credentials-change'));
       }
+
     }
   }
 
@@ -701,10 +720,12 @@ function boincuser_termsofuse_form() {
   $form['form control tabs'] = array(
     '#value' => '<li class="tab">' . l(bts('NO - LOGOUT', array(), NULL, 'boinc:form-cancel'), '/logout') . '</li>',
   );
-  $deletelink = '/user/' . $user->uid . '/delete';
-  $form['deleteaccount'] = array(
-    '#value' => '<li class="tab">' . l(bts('NO - DELETE ACCOUNT', array(), NULL, 'boinc:form-delete-user'), $deletelink) . '</li>',
-  );
+  if (module_exists('boincuser_delete')) {
+    $deletelink = '/user/' . $user->uid . '/delete';
+    $form['deleteaccount'] = array(
+      '#value' => '<li class="tab">' . l(bts('NO - DELETE ACCOUNT', array(), NULL, 'boinc:form-delete-user'), $deletelink) . '</li>',
+    );
+  }
 
   // Set form redirect
   $form['#redirect'] = $_REQUEST['destination'];
@@ -732,4 +753,63 @@ function boincuser_termsofuse_form_submit($form, &$form_state) {
   if ($_SESSION['messages']['warning']) {
     unset($_SESSION['messages']['warning']);
   }
+}
+
+/**
+ * Revert email to previous email address. The user must supply a
+ * token given via e-mail. The token is active for 7 days, and is
+ * removed after used.
+ */
+function boincuser_revertemail(&$form_state, $token) {
+  require_boinc('token');
+  require_boinc('util');
+
+  global $user;
+  $form = array();
+
+  // check BOINC user exists
+  $account = user_load(array('uid' => $user->uid));
+  $uid = $user->uid;
+  $boincid = $account->boincuser_id;
+  // check $token is valid
+  if (!is_valid_token($boincid, $token, 'E')) {
+    drupal_set_message(bts('ERROR: You have supplied an incorrect (most likely expired) token. Please obtain a new token by !link your account be deleted.',
+    array(
+      '!link' => l(bts('re-requesting', array(), NULL, 'boinc:delete-user-account'), "/user/${uid}/delete"),
+    ),
+    NULL, 'boinc:delete-user-account'), 'error');
+    drupal_goto();
+  }
+
+  // Attach account to this form.
+  $form['_account'] = array('#type' => 'value', '#value' => $account);
+
+  // Instructions
+  $form['main']['instructions1'] = array(
+    '#value' => '<p>'.
+    bts('In order to change your email back to the previous address (!prev_email), you must also change your password.',
+      array(
+        '!prev_email' => $account->boincuser_previous_email_addr,
+      ),
+      NULL, 'boinc:revert-email-change').
+    '</p>',
+  );
+
+  // @todo - add two password fields and submit/cancel buttons.
+}
+
+/**
+ * Validation handler for revertemail form
+ */
+function boincuser_revertemail_validate($form, &$form_state) {
+  // @todo - add validation.
+  // Check email for account collision using BoincUser::lookup_email_addr( previous_email ).
+}
+
+/**
+ * Submit handler for revertemail form
+ */
+function boincuser_revertemail_submit($form, &$form_state) {
+  // @todo - add submit
+  // Save previous email and new password in database: BOINC and drupal (email only).
 }

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
@@ -198,6 +198,81 @@ function boincuser_select_user_of_the_day() {
   return $uotd;
 }
 
+
+/**
+ * Send the user an email about his/her email change.
+ *
+ * An email is sent to the user's previous email address informing
+ * them of the email change, and providing a way to revert the
+ * change. An email is also sent to the new (current) address,
+ * informing the user of the change.
+ *
+ * The user is given a secure URL with which to revert the
+ * change. Because the email address is not yet changed by Drupal when
+ * this function is called, it may be called with optional parameters
+ * new and prev email.
+ */
+function _boincuser_send_emailchange($account, $new_email=NULL, $prev_email=NULL) {
+  require_boinc('token');
+  module_load_include('inc', 'rules', 'modules/system.rules');
+
+  global $base_url;
+  $site_name = variable_get('site_name', 'Drupal-BOINC');
+
+  if (is_null($new_email)) {
+    $new_email = $account->mail;
+  }
+  if (is_null($prev_email)) {
+    $prev_email = $account->boincuser_previous_email_addr;
+  }
+
+  // @todo - set constant in drupal, or use BOINC contsants
+  $duration = TOKEN_DURATION_ONE_WEEK;
+  $changedate = date('F j, Y \a\t G:i T', $account->boincuser_email_addr_change_time);
+  $newdate = date('F j, Y \a\t G:i T', $account->boincuser_email_addr_change_time + $duration);
+
+  $token = create_token($account->boincuser_id, TOKEN_TYPE_CHANGE_EMAIL, $duration);
+
+  // Send email #1 to current address
+  $mysubject = "Notification of email change at {$site_name}";
+  $mymessage = ''
+      . "{$account->boincuser_name},\n"
+      . "\n"
+      . "Your email address was changed from {$prev_email} to {$new_email} "
+      . "on {$changedate}. You will not be able to change your email address "
+      . "until {$newdate}. If you need to reverse this change, please look for "
+      . "an email send to the email address: {$prev_email}.\n"
+      . "\n"
+      . "Thanks, \n"
+      . "{$site_name} support team\n";
+
+  $settings = array(
+    'from' => '',
+    'to' => $new_email,
+    'subject' => $mysubject,
+    'message' => $mymessage,
+  );
+  rules_action_mail_to_user($account, $settings);
+
+  // Send email #2 to previous address.
+  $mymessage = ''
+      . "Your email address has been changed. If you did not intend to take this action, then please click this link to reverse this change, or copy-and-paste the link into your browser location bar. You will need to change your password as well.\n"
+      . "\n"
+      . "{$base_url}/user/{$account->uid}/recoveremail/{$token}\n"
+      . "\n"
+      . "Thanks, \n"
+      . "{$site_name} support team\n";
+
+  $settings = array(
+    'from' => '',
+    'to' => $prev_email,
+    'subject' => $mysubject,
+    'message' => $mymessage,
+  );
+
+  rules_action_mail($settings);
+}
+
 /**
  * Determine the first unique name from a given base. Also cleans the
  * username so that it will be valid for drupal. And truncates user
@@ -290,7 +365,6 @@ function _boincuser_ignore_paths($path, $paths_to_ignore) {
   }
   return FALSE;
 }
-
 
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
  * General BOINC functions


### PR DESCRIPTION
This code change will make the Drupal web code match the upstream Web code (PR #2500) for user's email address change. The workflow is described in the [boinc wiki](https://boinc.berkeley.edu/trac/wiki/EmailChangeNotification).

https://dev.gridrepublic.org/browse/DBOINCP-436