### PR TITLE
[Client] [WSL] Extend detection.

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -98,6 +98,7 @@ boinc_client_LDFLAGS = $(AM_LDFLAGS) $(SSL_LDFLAGS) -L$(top_srcdir)/lib
 if OS_WIN32
 boinc_client_CXXFLAGS += -I$(top_srcdir)/coprocs/NVIDIA/include
 boinc_client_SOURCES += hostinfo_win.cpp \
+	hostinfo_wsl.cpp \
 	sysmon_win.cpp \
 	win/boinc_cli.rc \
 	win/res/boinc.ico

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -253,10 +253,20 @@ void CLIENT_STATE::show_host_info() {
     );
 
 #ifdef _WIN64
-    if (host_info.os_wsl_enabled) {
-        msg_printf(NULL, MSG_INFO,
-            "WSL detected: %s: %s", host_info.os_wsl_name, host_info.os_wsl_version
-        );
+    if (host_info.wsl_available) {
+        msg_printf(NULL, MSG_INFO, "WSL detected:");
+        for (size_t i = 0; i < host_info.wsls.wsls.size(); ++i) {
+            const WSL& wsl = host_info.wsls.wsls[i];
+            if (wsl.is_default) {
+                msg_printf(NULL, MSG_INFO,
+                    "   [%s] (default): %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
+                );
+            } else {
+                msg_printf(NULL, MSG_INFO,
+                    "   [%s]: %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
+                );
+            }
+        }
     } else {
         msg_printf(NULL, MSG_INFO, "No WSL found.");
     }

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -317,9 +317,21 @@ int get_memory_info(double& bytes, double& swap) {
 
 typedef BOOL (WINAPI *PGPI)(DWORD, DWORD, DWORD, DWORD, PDWORD);
 
+BOOL get_OSVERSIONINFO(OSVERSIONINFOEX& osvi) {
+    ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
+    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+    // Try calling GetVersionEx using the OSVERSIONINFOEX structure.
+    // If that fails, try using the OSVERSIONINFO structure.
+    BOOL bOsVersionInfoEx = GetVersionEx((OSVERSIONINFO*)&osvi);
+    if (!bOsVersionInfoEx) {
+        osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
+        bOsVersionInfoEx = GetVersionEx((OSVERSIONINFO*)&osvi);
+    }
+    return bOsVersionInfoEx;
+}
+
 int get_os_information(
-    char* os_name, const int os_name_size, char* os_version, const int os_version_size,
-    bool& os_wsl_enabled, char* os_wsl_name, const int os_wsl_name_size, char* os_wsl_version, const int os_wsl_version_size
+    char* os_name, const int os_name_size, char* os_version, const int os_version_size
 ) {
     // This code snip-it was copied straight out of the MSDN Platform SDK
     //   Getting the System Version example and modified to dump the output
@@ -330,29 +342,18 @@ int get_os_information(
     OSVERSIONINFOEX osvi;
     SYSTEM_INFO si;
     PGPI pGPI;
-    BOOL bOsVersionInfoEx;
     DWORD dwType = 0;
 
     ZeroMemory(szVersion, sizeof(szVersion));
     ZeroMemory(szSKU, sizeof(szSKU));
     ZeroMemory(szServicePack, sizeof(szServicePack));
     ZeroMemory(&si, sizeof(SYSTEM_INFO));
-    ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
-    osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 
 
     // GetProductInfo is a Vista+ API
     pGPI = (PGPI) GetProcAddress(GetModuleHandle(_T("kernel32.dll")), "GetProductInfo");
 
-
-    // Try calling GetVersionEx using the OSVERSIONINFOEX structure.
-    // If that fails, try using the OSVERSIONINFO structure.
-    bOsVersionInfoEx = GetVersionEx ((OSVERSIONINFO*)&osvi);
-    if(!bOsVersionInfoEx) {
-        osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-        GetVersionEx ((OSVERSIONINFO*)&osvi);
-    }
-
+    BOOL bOsVersionInfoEx = get_OSVERSIONINFO(osvi);
 
     GetNativeSystemInfo(&si);
 
@@ -943,12 +944,6 @@ int get_os_information(
 
     snprintf( os_version, os_version_size, "%s%s%s", szSKU, szServicePack, szVersion );
 
-#ifdef _WIN64
-    if (osvi.dwMajorVersion >= 10) {
-        return get_wsl_information(os_wsl_enabled, os_wsl_name, os_wsl_name_size, os_wsl_version, os_wsl_version_size);
-    }
-#endif
-
     return 0;
 }
 
@@ -1436,9 +1431,16 @@ int HOST_INFO::get_host_info(bool init) {
     if (!init) return 0;
     ::get_memory_info(m_nbytes, m_swap);
     get_os_information(
-        os_name, sizeof(os_name), os_version, sizeof(os_version),
-        os_wsl_enabled, os_wsl_name, sizeof(os_wsl_name), os_wsl_version, sizeof(os_wsl_version)
+        os_name, sizeof(os_name), os_version, sizeof(os_version)
     );
+#ifdef _WIN64
+    if (!cc_config.dont_use_wsl) {
+        OSVERSIONINFOEX osvi;
+        if (get_OSVERSIONINFO(osvi) && osvi.dwMajorVersion >= 10) {
+            get_wsl_information(wsl_available, wsls);
+        }
+    }
+#endif
     if (!cc_config.dont_use_vbox) {
         get_virtualbox_version();
     }

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -326,6 +326,7 @@ int get_wsl_information(bool& wsl_available, WSLS& wsls) {
             if (create_wsl_process(distro, command_uname_s, &handle)) {
                 os_name = read_from_pipe(handle);
                 strip_whitespace(os_name);
+                CloseHandle(handle);
             }
         }
 
@@ -335,6 +336,7 @@ int get_wsl_information(bool& wsl_available, WSLS& wsls) {
             if (create_wsl_process(distro, command_uname_r ,&handle)) {
                 os_version_extra = read_from_pipe(handle);
                 strip_whitespace(os_version_extra);
+                CloseHandle(handle);
             }
         }
 

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -15,27 +15,113 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#ifdef _WIN64
+
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
-#else
-#include "config.h"
-#include <cstdio>
-#include <cstring>
-#if HAVE_UNISTD_H
-#include <unistd.h>
-#endif
-#endif
+
+#include "str_replace.h"
 
 #include "hostinfo.h"
+
+bool get_available_wsls(std::vector<std::string>& wsls, std::string& default_wsl) {
+    const std::string lxss_path = "Software\\Microsoft\\Windows\\CurrentVersion\\Lxss";
+
+    HKEY hKey;
+    
+    default_wsl = "";
+
+    LONG lRet = RegOpenKeyEx(HKEY_CURRENT_USER,
+        lxss_path.c_str(),
+        0, KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS, &hKey);
+    if (lRet != ERROR_SUCCESS)
+        return false;
+
+    const int buf_len = 256;
+    char default_wsl_guid[buf_len];
+    DWORD default_wsl_guid_len = sizeof(default_wsl_guid);
+
+    lRet = RegQueryValueEx(hKey, "DefaultDistribution", NULL, NULL,
+        (LPBYTE)default_wsl_guid, &default_wsl_guid_len);
+    if ((lRet != ERROR_SUCCESS) || (default_wsl_guid_len > buf_len))
+        return false;
+    
+    int i = 0;
+    while(true) {
+        char wsl_guid[buf_len];
+        DWORD wsl_guid_len = sizeof(wsl_guid);
+
+        LONG ret = RegEnumKeyEx(hKey, i++, wsl_guid, &wsl_guid_len,
+            NULL, NULL, NULL, NULL);
+        if (ret != ERROR_SUCCESS) {
+            break;
+        }
+
+        HKEY hSubKey;
+        const std::string sub_key = lxss_path + "\\" + wsl_guid;
+        ret = RegOpenKeyEx(HKEY_CURRENT_USER,
+            sub_key.c_str(),
+            0, KEY_QUERY_VALUE, &hSubKey);
+        if (ret != ERROR_SUCCESS) {
+            break;
+        }
+
+        char wsl_name[buf_len];
+        DWORD wsl_name_len = sizeof(wsl_name);
+        DWORD wsl_state = 0;
+        DWORD wsl_state_len = sizeof(wsl_state);
+
+        ret = RegQueryValueEx(hSubKey, "State", NULL, NULL, (LPBYTE)&wsl_state, &wsl_state_len);
+        if (ret != ERROR_SUCCESS || wsl_state != 1) {
+            continue;
+        }
+
+        ret = RegQueryValueEx(hSubKey, "DistributionName", NULL, NULL,
+            (LPBYTE)wsl_name, &wsl_name_len);
+        if ((ret == ERROR_SUCCESS) && (wsl_name_len < buf_len)) {
+            wsls.push_back(wsl_name);
+            if (std::string(wsl_guid) == std::string(default_wsl_guid)) {
+                default_wsl = wsl_name;
+            }
+
+            RegCloseKey(hSubKey);
+        }        
+    }
+
+    RegCloseKey(hKey);
+
+    return default_wsl != "";
+}
+
+typedef HRESULT(WINAPI *PWslLaunch)(PCWSTR, PCWSTR, BOOL, HANDLE, HANDLE, HANDLE, HANDLE*);
+
+HINSTANCE wsl_lib = NULL;
 
 HANDLE in_read = NULL;
 HANDLE in_write = NULL;
 HANDLE out_read = NULL;
 HANDLE out_write = NULL;
 
-bool CreateWslProcess(const std::string& command, HANDLE& handle) {
+PWslLaunch pWslLaunch = NULL;
+
+
+//convert std::string to PCWSTR
+//taken from https://stackoverflow.com/questions/27220/how-to-convert-stdstring-to-lpcwstr-in-c-unicode
+std::wstring s2ws(const std::string& s)
+{
+    const int slength = (int)s.length() + 1;
+    const int len = MultiByteToWideChar(CP_ACP, 0, s.c_str(), slength, 0, 0);
+    wchar_t* buf = new wchar_t[len];
+    MultiByteToWideChar(CP_ACP, 0, s.c_str(), slength, buf, len);
+    std::wstring r(buf);
+    delete[] buf;
+    return r;
+}
+
+bool create_wsl_process(const std::string& wsl_distro_name, const std::string& command, HANDLE* handle) {
+    return (pWslLaunch(s2ws(wsl_distro_name).c_str(), s2ws(command).c_str(), FALSE, in_read, out_write, out_write, handle) == S_OK);
+}
+
+bool CreateWslProcess(const std::string& wsl_app, const std::string& command, HANDLE& handle) {
     PROCESS_INFORMATION pi;
     STARTUPINFO si;
 
@@ -50,7 +136,7 @@ bool CreateWslProcess(const std::string& command, HANDLE& handle) {
 
     const DWORD dwFlags = CREATE_NO_WINDOW;
 
-    const std::string cmd = "bash -c \"" + command + "\"";
+    const std::string cmd = wsl_app + " " + command;
 
     const bool res = (CreateProcess(NULL, (LPSTR)cmd.c_str(), NULL, NULL, TRUE, dwFlags, NULL, NULL, &si, &pi) == TRUE);
 
@@ -68,16 +154,20 @@ inline void close_handle(HANDLE handle) {
     }
 }
 
-int close_handles_and_exit(const int return_code) {
+int free_resources_and_exit(const int return_code) {
     close_handle(in_read);
     close_handle(in_write);
     close_handle(out_read);
     close_handle(out_write);
 
+    if (wsl_lib) {
+        FreeLibrary(wsl_lib);
+    }
+
     return return_code;
 }
 
-std::string ReadFromPipe(HANDLE handle) {
+std::string read_from_pipe(HANDLE handle) {
     DWORD avail, read, exitcode;
     const int bufsize = 256;
     char buf[bufsize];
@@ -102,17 +192,59 @@ std::string ReadFromPipe(HANDLE handle) {
         }
     }
 
-    close_handle(handle);
-
     return res;
+}
+
+void parse_sysctl_output(const std::vector<std::string>& lines, std::string& ostype, std::string& osrelease) {
+    char buf[256], ostype_found[256], osrelease_found[256];
+    ostype = "";
+    osrelease = "";
+    for (size_t i = 0; i < lines.size(); ++i) {
+        safe_strcpy(buf, lines[i].c_str());
+        strip_whitespace(buf);
+        if (strstr(buf, "kernel.ostype =")) {
+            safe_strcpy(ostype_found, strchr(buf, '=') + 1);
+            ostype = ostype_found;
+            strip_whitespace(ostype);
+            continue;
+        }
+        if (strstr(buf, "kernel.osrelease =")) {
+            safe_strcpy(osrelease_found, strchr(buf, '=') + 1);
+            osrelease = osrelease_found;
+            strip_whitespace(osrelease);
+        }
+    }
 }
 
 // Returns the OS name and version for WSL when enabled
 //
-int get_wsl_information(
-    bool& wsl_enabled, char* wsl_os_name, const int wsl_os_name_size, char* wsl_os_version, const int wsl_os_version_size
-) {
-    wsl_enabled = false;
+int get_wsl_information(bool& wsl_available, WSLS& wsls) {
+    wsl_lib = NULL;
+    in_read = NULL;
+    in_write = NULL;
+    out_read = NULL;
+    out_write = NULL;
+    pWslLaunch = NULL;
+
+    std::vector<std::string> distros;
+    std::string default_distro;
+
+    if (!get_available_wsls(distros, default_distro)) {
+        return 1;
+    }
+
+    wsl_lib = LoadLibrary("wslapi.dll");
+    if (!wsl_lib) {
+        return 1;
+    }
+
+    pWslLaunch = (PWslLaunch) GetProcAddress(wsl_lib, "WslLaunch");
+
+    if (!pWslLaunch) {
+        free_resources_and_exit(1);
+    }
+
+    wsl_available = false;
 
     SECURITY_ATTRIBUTES sa;
     HANDLE handle;
@@ -125,46 +257,103 @@ int get_wsl_information(
         return 1;
     }
     if (!SetHandleInformation(out_read, HANDLE_FLAG_INHERIT, 0)) {
-        return close_handles_and_exit(1);
+        return free_resources_and_exit(1);
     }
     if (!CreatePipe(&in_read, &in_write, &sa, 0)) {
-        return close_handles_and_exit(1);
+        return free_resources_and_exit(1);
     }
     if (!SetHandleInformation(in_write, HANDLE_FLAG_INHERIT, 0)) {
-        return close_handles_and_exit(1);
+        return free_resources_and_exit(1);
     }
 
-    // lsbrelease
-    if (!CreateWslProcess(command_lsbrelease, handle)) {
-        return close_handles_and_exit(1);
-    }
-    wsl_enabled = HOST_INFO::parse_linux_os_info(
-        ReadFromPipe(handle), lsbrelease, wsl_os_name, wsl_os_name_size, wsl_os_version, wsl_os_version_size);
-    if (wsl_enabled) {
-        return close_handles_and_exit(0);
+    for (size_t i = 0; i < distros.size(); ++i) {
+        char wsl_dist_name[256];
+        char wsl_dist_version[256];
+
+        const std::string& distro = distros[i];
+        WSL wsl(distro);
+        if (distro == default_distro) {
+            wsl.is_default = true;
+        }
+
+        // lsbrelease
+        if (!create_wsl_process(distro, command_lsbrelease, &handle)) {
+            continue;
+        }
+        wsl_available = HOST_INFO::parse_linux_os_info(
+            read_from_pipe(handle), lsbrelease, wsl_dist_name, sizeof(wsl_dist_name), wsl_dist_version, sizeof(wsl_dist_version));
+        CloseHandle(handle);
+
+        if (!wsl_available) {
+            //osrelease
+            const std::string command_osrelease = "cat " + std::string(file_osrelease);
+            if (!create_wsl_process(distro, command_osrelease, &handle)) {
+                continue;
+            }
+            wsl_available = HOST_INFO::parse_linux_os_info(
+                read_from_pipe(handle), osrelease, wsl_dist_name, sizeof(wsl_dist_name), wsl_dist_version, sizeof(wsl_dist_version));
+            CloseHandle(handle);
+        }
+
+        //redhatrelease
+        if (!wsl_available) {
+            const std::string command_redhatrelease = "cat " + std::string(file_redhatrelease);
+            if (!create_wsl_process(distro, command_redhatrelease, &handle)) {
+                continue;
+            }
+            wsl_available = HOST_INFO::parse_linux_os_info(
+                read_from_pipe(handle), redhatrelease, wsl_dist_name, sizeof(wsl_dist_name), wsl_dist_version, sizeof(wsl_dist_version));
+            CloseHandle(handle);
+        }
+
+        if (!wsl_available) {
+            continue;
+        }
+
+        std::string os_name = "";
+        std::string os_version_extra = "";
+
+        // sysctl -a
+        const std::string command_sysctl = "sysctl -a";
+        if (create_wsl_process(distro, command_sysctl, &handle)) {
+            parse_sysctl_output(split(read_from_pipe(handle), '\n'), os_name, os_version_extra);
+            CloseHandle(handle);
+        }
+
+        // uname -s
+        if (os_name.empty()) {
+            const std::string command_uname_s = "uname -s";
+            if (create_wsl_process(distro, command_uname_s, &handle)) {
+                os_name = read_from_pipe(handle);
+                strip_whitespace(os_name);
+            }
+        }
+
+        // uname -r
+        if (os_version_extra.empty()) {
+            const std::string command_uname_r = "uname -r";
+            if (create_wsl_process(distro, command_uname_r ,&handle)) {
+                os_version_extra = read_from_pipe(handle);
+                strip_whitespace(os_version_extra);
+            }
+        }
+
+        if (!os_name.empty()) {
+            wsl.name = os_name + " " + wsl_dist_name;
+        }
+        else {
+            wsl.name = wsl_dist_name;
+        }
+        if (!os_version_extra.empty()) {
+            wsl.version = std::string(wsl_dist_version) + " [" + os_version_extra + "]";
+        }
+        else {
+            wsl.version = wsl_dist_version;
+        }
+        wsls.wsls.push_back(wsl);
     }
 
-    //osrelease
-    const std::string command_osrelease = "cat " + std::string(file_osrelease);
-    if (!CreateWslProcess(command_osrelease, handle)) {
-        return close_handles_and_exit(1);
-    }
-    wsl_enabled = HOST_INFO::parse_linux_os_info(
-        ReadFromPipe(handle), osrelease, wsl_os_name, wsl_os_name_size, wsl_os_version, wsl_os_version_size);
-    if (wsl_enabled) {
-        return close_handles_and_exit(0);
-    }
-
-    //redhatrelease
-    const std::string command_redhatrelease = "cat " + std::string(file_redhatrelease);
-    if (!CreateWslProcess(command_redhatrelease, handle)) {
-        return close_handles_and_exit(1);
-    }
-    wsl_enabled = HOST_INFO::parse_linux_os_info(
-        ReadFromPipe(handle), redhatrelease, wsl_os_name, wsl_os_name_size, wsl_os_version, wsl_os_version_size);
-    if (wsl_enabled) {
-        return close_handles_and_exit(0);
-    }
-
-    return close_handles_and_exit(0);
+    return free_resources_and_exit(0);
 }
+
+#endif // _WIN64

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -271,9 +271,12 @@ int get_wsl_information(bool& wsl_available, WSLS& wsls) {
         char wsl_dist_version[256];
 
         const std::string& distro = distros[i];
-        WSL wsl(distro);
+        WSL wsl;
+        wsl.distro_name = distro;
         if (distro == default_distro) {
             wsl.is_default = true;
+        } else {
+            wsl.is_default = false;
         }
 
         // lsbrelease

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -80,13 +80,15 @@ win_sources = \
     procinfo_win.cpp \
     run_app_windows.cpp \
     stackwalker_win.cpp \
-    win_util.cpp
+    win_util.cpp \
+    wslinfo.cpp
 win_headers= \
     boinc_win.h \
     diagnostics_win.h \
     run_app_windows.h \
     stackwalker_win.h \
-    win_util.h
+    win_util.h \
+    wslinfo.h
 else # !OS_WIN32
 if OS_DARWIN
 mac_sources = \

--- a/lib/Makefile.mingw
+++ b/lib/Makefile.mingw
@@ -40,7 +40,8 @@ HEADERS = $(BOINC_SRC)/version.h \
 	$(BOINC_SRC)/lib/opencl_boinc.h \
 	$(BOINC_SRC)/svn_version.h \
 	$(BOINC_SRC)/win_build/config.h \
-	$(BOINC_SRC)/lib/str_util.h
+	$(BOINC_SRC)/lib/str_util.h \
+	$(BOINC_SRC)/lib/wslinfo.h
 
 ZIP_HEADERS = zip/boinc_zip.h
 
@@ -78,7 +79,8 @@ LIB_OBJ = app_ipc.o \
 	stackwalker_win.o \
 	url.o \
 	util.o \
-	win_util.o
+	win_util.o \
+	wslinfo.o
 
 ZIP_OBJ = zip/boinc_zip.o \
 	zip/api.o \

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -220,6 +220,7 @@ void CC_CONFIG::defaults() {
     lower_client_priority = false;
     dont_suspend_nci = false;
     dont_use_vbox = false;
+    dont_use_wsl = false;
     exclude_gpus.clear();
     exclusive_apps.clear();
     exclusive_gpu_apps.clear();
@@ -355,6 +356,7 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
         if (xp.parse_bool("lower_client_priority", lower_client_priority)) continue;
         if (xp.parse_bool("dont_suspend_nci", dont_suspend_nci)) continue;
         if (xp.parse_bool("dont_use_vbox", dont_use_vbox)) continue;
+        if (xp.parse_bool("dont_use_wsl", dont_use_wsl)) continue;
         if (xp.match_tag("exclude_gpu")) {
             EXCLUDE_GPU eg;
             retval = eg.parse(xp);
@@ -561,13 +563,15 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         "        <dont_contact_ref_site>%d</dont_contact_ref_site>\n"
         "        <lower_client_priority>%d</lower_client_priority>\n"
         "        <dont_suspend_nci>%d</dont_suspend_nci>\n"
-        "        <dont_use_vbox>%d</dont_use_vbox>\n",
+        "        <dont_use_vbox>%d</dont_use_vbox>\n"
+        "        <dont_use_wsl>%d</dont_use_wsl>\n",
         disallow_attach,
         dont_check_file_sizes,
         dont_contact_ref_site,
         lower_client_priority,
         dont_suspend_nci,
-        dont_use_vbox
+        dont_use_vbox,
+        dont_use_wsl
     );
 
     for (i=0; i<exclude_gpus.size(); i++) {

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -155,6 +155,7 @@ struct CC_CONFIG {
     bool dont_contact_ref_site;
     bool dont_suspend_nci;
     bool dont_use_vbox;
+    bool dont_use_wsl;
     std::vector<EXCLUDE_GPU> exclude_gpus;
     std::vector<std::string> exclusive_apps;
     std::vector<std::string> exclusive_gpu_apps;

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -205,7 +205,7 @@ int HOST_INFO::write(
         "    <os_name>%s</os_name>\n"
         "    <os_version>%s</os_version>\n"
         "    <n_usable_coprocs>%d</n_usable_coprocs>\n"
-        "    <wsl_available>%d</wsl_available>",
+        "    <wsl_available>%d</wsl_available>\n",
         host_cpid,
         p_ncpus,
         pv,

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -32,6 +32,10 @@
 #include "coproc.h"
 #include "common_defs.h"
 
+#ifdef _WIN64
+#include "wslinfo.h"
+#endif
+
 enum LINUX_OS_INFO_PARSER {
     lsbrelease,
     osrelease,
@@ -73,9 +77,10 @@ public:
     char os_version[256];
 
     // WSL information for Win10 only
-    bool os_wsl_enabled;
-    char os_wsl_name[256];
-    char os_wsl_version[256];
+    bool wsl_available;
+#ifdef _WIN64
+    WSLS wsls;
+#endif
 
     char product_name[256];       // manufacturer and/or model of system
     char mac_address[256];      // MAC addr e.g. 00:00:00:00:00:00
@@ -123,10 +128,8 @@ public:
         char* os_name, const int os_name_size, char* os_version, const int os_version_size);
 };
 
-#ifdef _WIN32
-int get_wsl_information(
-    bool& wsl_enabled, char* wsl_os_name, const int wsl_os_name_size, char* wsl_os_version, const int wsl_os_version_size
-);
+#ifdef _WIN64
+int get_wsl_information(bool& wsl_available, WSLS& wsls);
 #endif
 
 #ifdef __APPLE__

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -1,0 +1,94 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifdef _WIN64
+
+#include "wslinfo.h"
+
+WSL::WSL(const std::string& distro) {
+    clear();
+    distro_name = distro;
+}
+
+void WSL::clear() {
+    name = "";
+    version = "";
+    is_default = false;
+}
+
+void WSL::write_xml(MIOFILE& f) {
+    char dn[256], n[256], v[256];
+    xml_escape(distro_name.c_str(), dn, sizeof(dn));
+    xml_escape(name.c_str(), n, sizeof(n));
+    xml_escape(version.c_str(), v, sizeof(v));
+    f.printf(
+        "   <%s>\n"
+        "       <name>%s</name>\n"
+        "       <version>%s</version>\n"
+        "       <is_default>%d</is_default>\n"
+        "   </%s>\n",
+        dn,
+        n,
+        v,
+        is_default ? 1 : 0,
+        dn
+    );
+}
+
+int WSL::parse(XML_PARSER& xp) {
+    clear();
+    while (!xp.get_tag()) {
+        if (!distro_name.empty() && xp.match_tag(std::string("/" + distro_name).c_str())) {
+            return 0;
+        }
+        if (xp.parse_string("name", name)) continue;
+        if (xp.parse_string("version", version)) continue;
+        if (xp.parse_bool("is_default", is_default)) continue;
+    }
+    return ERR_XML_PARSE;
+}
+
+WSLS::WSLS() {
+    clear();
+}
+
+void WSLS::clear() {
+    wsls.clear();
+}
+
+void WSLS::write_xml(MIOFILE& f) {
+    f.printf("<wsl>\n");
+    for (size_t i = 0; i < wsls.size(); ++i) {
+        wsls[i].write_xml(f);
+    }
+    f.printf("</wsl>\n");
+}
+
+int WSLS::parse(XML_PARSER& xp) {
+    clear();
+    while (!xp.get_tag()) {
+        if (xp.match_tag("/wsl")) {
+            return 0;
+        }
+        WSL wsl(xp.parsed_tag);
+        wsl.parse(xp);
+        wsls.push_back(wsl);
+    }
+    return ERR_XML_PARSE;
+}
+
+#endif // _WIN64

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -31,7 +31,7 @@ struct WSL {
     std::string version;
     bool is_default;
 
-    explicit WSL(const std::string&);
+    WSL();
 
     void clear();
 

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -1,0 +1,55 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef BOINC_WSLINFO_H
+#define BOINC_WSLINFO_H
+
+#ifdef _WIN64
+
+#include "boinc_win.h"
+
+#include "miofile.h"
+#include "parse.h"
+
+struct WSL {
+    std::string distro_name;
+    std::string name;
+    std::string version;
+    bool is_default;
+
+    explicit WSL(const std::string&);
+
+    void clear();
+
+    void write_xml(MIOFILE&);
+    int parse(XML_PARSER&);
+};
+
+struct WSLS {
+    std::vector<WSL> wsls;
+
+    WSLS();
+
+    void clear();
+
+    void write_xml(MIOFILE&);
+    int parse(XML_PARSER&);    
+};
+
+#endif // _WIN64
+
+#endif

--- a/win_build/boinc_os_ss.vcxproj
+++ b/win_build/boinc_os_ss.vcxproj
@@ -381,6 +381,7 @@
     <ClCompile Include="..\lib\url.cpp" />
     <ClCompile Include="..\lib\util.cpp" />
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\base64.h" />
@@ -410,6 +411,7 @@
     <ClInclude Include="..\lib\url.h" />
     <ClInclude Include="..\lib\util.h" />
     <ClInclude Include="..\lib\win_util.h" />
+    <ClInclude Include="..\lib\wslinfo.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\clientscr\res\boinc.bmp" />

--- a/win_build/boinc_os_ss_vs2013.vcxproj
+++ b/win_build/boinc_os_ss_vs2013.vcxproj
@@ -362,6 +362,7 @@
     <ClCompile Include="..\lib\url.cpp" />
     <ClCompile Include="..\lib\util.cpp" />
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\base64.h" />
@@ -391,6 +392,7 @@
     <ClInclude Include="..\lib\url.h" />
     <ClInclude Include="..\lib\util.h" />
     <ClInclude Include="..\lib\win_util.h" />
+    <ClInclude Include="..\lib\wslinfo.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\clientscr\res\boinc.bmp" />

--- a/win_build/boincmgr.vcxproj
+++ b/win_build/boincmgr.vcxproj
@@ -343,6 +343,7 @@
     <ClCompile Include="..\lib\url.cpp" />
     <ClCompile Include="..\lib\util.cpp" />
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
     <ClCompile Include="..\clientgui\AccountInfoPage.cpp" />
     <ClCompile Include="..\clientgui\AccountManagerInfoPage.cpp" />
     <ClCompile Include="..\clientgui\AccountManagerProcessingPage.cpp" />

--- a/win_build/boincmgr_vs2013.vcxproj
+++ b/win_build/boincmgr_vs2013.vcxproj
@@ -328,6 +328,7 @@
     <ClCompile Include="..\lib\url.cpp" />
     <ClCompile Include="..\lib\util.cpp" />
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
     <ClCompile Include="..\clientgui\AccountInfoPage.cpp" />
     <ClCompile Include="..\clientgui\AccountManagerInfoPage.cpp" />
     <ClCompile Include="..\clientgui\AccountManagerProcessingPage.cpp" />

--- a/win_build/libboinc.vcxproj
+++ b/win_build/libboinc.vcxproj
@@ -238,6 +238,7 @@
     <ClInclude Include="..\lib\url.h" />
     <ClInclude Include="..\lib\util.h" />
     <ClInclude Include="..\lib\win_util.h" />
+    <ClInclude Include="..\lib\wslinfo.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\lib\app_ipc.cpp">
@@ -310,6 +311,7 @@
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win_build/libboinc_staticcrt.vcxproj
+++ b/win_build/libboinc_staticcrt.vcxproj
@@ -262,6 +262,7 @@
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\app_ipc.h" />
@@ -294,6 +295,7 @@
     <ClInclude Include="..\lib\str_util.h" />
     <ClInclude Include="..\lib\util.h" />
     <ClInclude Include="..\lib\win_util.h" />
+    <ClInclude Include="..\lib\wslinfo.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win_build/libboinc_staticcrt_vs2013.vcxproj
+++ b/win_build/libboinc_staticcrt_vs2013.vcxproj
@@ -268,6 +268,7 @@
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\app_ipc.h" />
@@ -300,6 +301,7 @@
     <ClInclude Include="..\lib\str_util.h" />
     <ClInclude Include="..\lib\util.h" />
     <ClInclude Include="..\lib\win_util.h" />
+    <ClInclude Include="..\lib\wslinfo.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win_build/libboinc_vs2013.vcxproj
+++ b/win_build/libboinc_vs2013.vcxproj
@@ -243,6 +243,7 @@
     <ClInclude Include="..\lib\url.h" />
     <ClInclude Include="..\lib\util.h" />
     <ClInclude Include="..\lib\win_util.h" />
+    <ClInclude Include="..\lib\wslinfo.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\lib\app_ipc.cpp">
@@ -315,6 +316,7 @@
       <CompileAs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">CompileAsCpp</CompileAs>
     </ClCompile>
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win_build/sim.vcxproj
+++ b/win_build/sim.vcxproj
@@ -392,6 +392,7 @@
     <ClCompile Include="..\lib\str_util.cpp" />
     <ClCompile Include="..\client\time_stats.cpp" />
     <ClCompile Include="..\client\work_fetch.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\client\app.h" />

--- a/win_build/sim_vs2013.vcxproj
+++ b/win_build/sim_vs2013.vcxproj
@@ -396,6 +396,7 @@
     <ClCompile Include="..\lib\str_util.cpp" />
     <ClCompile Include="..\client\time_stats.cpp" />
     <ClCompile Include="..\client\work_fetch.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\client\app.h" />

--- a/win_build/wcg_boinc_os_ss.vcxproj
+++ b/win_build/wcg_boinc_os_ss.vcxproj
@@ -381,6 +381,7 @@
     <ClCompile Include="..\lib\url.cpp" />
     <ClCompile Include="..\lib\util.cpp" />
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\base64.h" />
@@ -409,6 +410,7 @@
     <ClInclude Include="..\lib\url.h" />
     <ClInclude Include="..\lib\util.h" />
     <ClInclude Include="..\lib\win_util.h" />
+    <ClInclude Include="..\lib\wslinfo.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\clientscr\res\boinc.bmp" />

--- a/win_build/wcg_boincmgr.vcxproj
+++ b/win_build/wcg_boincmgr.vcxproj
@@ -337,6 +337,7 @@
     <ClCompile Include="..\lib\url.cpp" />
     <ClCompile Include="..\lib\util.cpp" />
     <ClCompile Include="..\lib\win_util.cpp" />
+    <ClCompile Include="..\lib\wslinfo.cpp" />
     <ClCompile Include="..\clientgui\AccountInfoPage.cpp" />
     <ClCompile Include="..\clientgui\AccountManagerInfoPage.cpp" />
     <ClCompile Include="..\clientgui\AccountManagerProcessingPage.cpp" />


### PR DESCRIPTION
Move WSL detection to get_host_info().
Enumerate available WSLs from registry.
Add wslapi library loading.
Add support of multiple installed wsl distros detection.
Detect only installed and configured distros.
Add extra information parse.
Add wslinfo files to save and parse wsl info.
Add dont_use_wsl param to cc_config.
Add missed hostinfo_wsl.cpp when building win client using gcc.
Fix small issues.
Small refactoring.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>