### PR TITLE
[WIP] Mac: fixes to installer for issues under OS 10.13 High Sierra

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -139,6 +139,19 @@ bool CBOINCGUIApp::OnInit() {
     AEInstallEventHandler( kCoreEventClass, kAEQuitApplication, NewAEEventHandlerUPP((AEEventHandlerProcPtr)QuitAppleEventHandler), 0, false );
 #endif
 
+#ifdef __WXMAC__
+    // Don't open main window if we were started automatically at login
+    // We are launched hidden if started from our login item (except if
+    // we had windows open at logout, the system "restores" them.)
+    m_bGUIVisible = IsApplicationVisible();
+
+    if (getTimeSinceBoot() < 30.) {
+        // If the system was just started, we usually get a "Connection
+        // failed" error if we try to connect too soon, so delay a bit.
+        sleep(10);
+    }
+#endif
+
 
     // Commandline parsing is done in wxApp::OnInit()
     if (!wxApp::OnInit()) {
@@ -305,9 +318,9 @@ bool CBOINCGUIApp::OnInit() {
 
 #if (defined(__WXMAC__) && (!defined (_DEBUG)))
         if (!IsApplicationVisible()) {  // If we were (probably) launched from a Login Item
-            wxString launchAgentPath = wxFileName::GetHomeDir() + "/Library/LaunchAgent/edu.berkeley.boinc.plist";
+            wxString launchAgentPath = wxFileName::GetHomeDir() + "/Library/LaunchAgents/edu.berkeley.boinc.plist";
             if (wxFileName::FileExists(launchAgentPath)) {  // If PostInstall app set up a LaunchAgent for this user
-                boinc_sleep(15.);   // Allow time for LaunchAgent to terminate us before complaining
+                boinc_sleep(30.);   // Allow time for LaunchAgent to terminate us before complaining
             }
         }
 #endif
@@ -439,19 +452,6 @@ bool CBOINCGUIApp::OnInit() {
     // Startup the System Idle Detection code
     IdleTrackerAttach();
     
-#ifdef __WXMAC__
-    // Don't open main window if we were started automatically at login
-    // We are launched hidden if started from our login item (except if
-    // we had windows open at logout, the system "restores" them.)
-    m_bGUIVisible = IsApplicationVisible();
-
-    if (getTimeSinceBoot() < 30.) {
-        // If the system was just started, we usually get a "Connection
-        // failed" error if we try to connect too soon, so delay a bit.
-        sleep(10);
-    }
-#endif
-
     // Show the UI
     SetActiveGUI(m_iGUISelected, m_bGUIVisible);
 

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -303,6 +303,14 @@ bool CBOINCGUIApp::OnInit() {
 
     if (iErrorCode) {
 
+#if (defined(__WXMAC__) && (!defined (_DEBUG)))
+        if (!IsApplicationVisible()) {  // If we were (probably) launched from a Login Item
+            wxString launchAgentPath = wxFileName::GetHomeDir() + "/Library/LaunchAgent/edu.berkeley.boinc.plist";
+            if (wxFileName::FileExists(launchAgentPath)) {  // If PostInstall app set up a LaunchAgent for this user
+                boinc_sleep(15.);   // Allow time for LaunchAgent to terminate us before complaining
+            }
+        }
+#endif
         ShowApplication(true);
 
         if (iErrorCode == -1099) {

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -363,6 +363,8 @@
 		DDA850A41207EED900B473A6 /* WizardAttach.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA850A21207EED900B473A6 /* WizardAttach.cpp */; };
 		DDAEB54012F8295800EDEDBE /* LogBOINC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C41407C5D13E0098A04D /* LogBOINC.cpp */; };
 		DDAEC9FF07FA5A5C00A7BC36 /* SetVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDAEC9E707FA58A000A7BC36 /* SetVersion.cpp */; };
+		DDB00FA120E110E000C8ABEF /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
+		DDB00FA220E111F100C8ABEF /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
 		DDB295C9185B0DBD00B9F842 /* MacNotification.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDB295C8185B0DBD00B9F842 /* MacNotification.mm */; };
 		DDB4A91E1411840800032E5D /* proc_control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDB4A91C1411840800032E5D /* proc_control.cpp */; };
 		DDB4A91F1411840800032E5D /* proc_control.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDB4A91C1411840800032E5D /* proc_control.cpp */; };
@@ -3213,6 +3215,8 @@
 			files = (
 				DDF5E23418B86803005DEA6E /* AddRemoveUser.cpp in Sources */,
 				DDE900271E643E3C003728F2 /* mac_util.mm in Sources */,
+				DDB00FA120E110E000C8ABEF /* filesys.cpp in Sources */,
+				DDB00FA220E111F100C8ABEF /* util.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/mac_installer/AddRemoveUser.cpp
+++ b/mac_installer/AddRemoveUser.cpp
@@ -242,6 +242,12 @@ int main(int argc, char *argv[])
             callPosixSpawn(s);
         }
 
+        if (!AddUsers) {
+            // Delete per-user BOINC Manager and screensaver files
+            sprintf(s, "rm -fR \"/Users/%s/Library/Application Support/BOINC\"", pw->pw_name);
+            callPosixSpawn (s);
+        }
+    
         // Set or remove login item for this user
         bool useOSASript = false;
         
@@ -435,11 +441,11 @@ Boolean SetLoginItemOSAScript(long brandID, Boolean deleteLogInItem, char *userN
 #endif
 #if USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS
     if (isHighSierraOrLater) {
-        sprintf(cmd, "su -l \"%s\" -c 'osascript -e \"tell application \\\"System Events\\\" to delete (every login item whose path contains \\\"%s\\\")\"'", userName, appName[i]);
+        sprintf(cmd, "su -l \"%s\" -c 'osascript -e \"tell application \\\"System Events\\\" to delete login item \\\"%s\\\"\"'", userName, appName[i]);
     } else
 #endif
     {
-        sprintf(cmd, "sudo -u \"%s\" osascript -e 'tell application \"System Events\" to delete (every login item whose path contains \"%s\")'", userName, appName[brandID]);
+        sprintf(cmd, "sudo -u \"%s\" osascript -e 'tell application \"System Events\" to delete login item \"%s\"'", userName, appName[i]);
     }
     err = callPosixSpawn(cmd);
 #if VERBOSE
@@ -533,7 +539,8 @@ Boolean SetLoginItemLaunchAgent(long brandID, Boolean deleteLogInItem, passwd *p
     
     // Create a LaunchAgent for the specified user, replacing any LaunchAgent created
     // previously (such as by Uninstaller or by installing a differently branded BOINC.)
-    //
+
+    // Create LaunchAgents directory for this user if it does not yet exist
     snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents", pw->pw_name);
     if (stat(s, &sbuf) != 0) {
         mkdir(s, 0755);

--- a/mac_installer/Installer.cpp
+++ b/mac_installer/Installer.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/mac_installer/Installer.cpp
+++ b/mac_installer/Installer.cpp
@@ -48,6 +48,7 @@ Boolean IsUserMemberOfGroup(const char *userName, const char *groupName);
 Boolean IsRestartNeeded();
 static void GetPreferredLanguages();
 static void LoadPreferredLanguages();
+static long GetOldBrandID(void);
 static void ShowMessage(const char *format, ...);
 static OSErr QuitAppleEventHandler(const AppleEvent *appleEvt, AppleEvent* reply, UInt32 refcon);
 int callPosixSpawn(const char *cmd);
@@ -83,6 +84,8 @@ int main(int argc, char *argv[])
     OSStatus                err = noErr;
     Boolean                 restartNeeded = true;
     FILE                    *restartNeededFile;
+    FILE                    *f;
+    long                    oldBrandID;
 
     if (Initialize() != noErr) {
         return 0;
@@ -142,11 +145,22 @@ int main(int argc, char *argv[])
         // Create an account_data.txt file containing our 
         // installer's filename and put it in our temp directory
         snprintf(temp2, sizeof(temp2), "/tmp/%s/%s", tempDirName, ACCOUNT_DATA_FILENAME);
-        FILE* f = fopen(temp2, "w");
+        f = fopen(temp2, "w");
         fputs(p+1, f);
         fclose(f);
     }
-    
+
+    // Write a temp file to tell our PostInstall.app the previous branding, if any
+    oldBrandID = GetOldBrandID();
+    snprintf(temp, sizeof(temp), "/tmp/%s/OldBranding", tempDirName);
+    f = fopen(temp, "w");
+    if (!f) {
+        REPORT_ERROR(true);
+    } else {
+        fprintf(f, "BrandId=%ld\n", oldBrandID);
+        fclose(f);
+    }
+
     // To allow for branding, assume name of installer package inside bundle corresponds to name of this application
     strlcpy(brand, p+1, sizeof(brand));
     strlcat(pkgPath, p+1, sizeof(pkgPath));
@@ -545,6 +559,22 @@ static void LoadPreferredLanguages(){
         }
     }
     fclose(f);
+}
+
+
+static long GetOldBrandID()
+{
+    long oldBrandId;
+
+    oldBrandId = 0;   // Default value
+    
+    FILE *f = fopen("/Library/Application Support/BOINC Data/Branding", "r");
+    if (f) {
+        fscanf(f, "BrandId=%ld\n", &oldBrandId);
+        fclose(f);
+    }
+    
+    return oldBrandId;
 }
 
 

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -20,7 +20,8 @@
 #define TESTING 0       /* for debugging */
 #define VERBOSE_TEST 0  /* for debugging callPosixSpawn */
 
-    
+#define USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS false
+
 #include <Carbon/Carbon.h>
 
 #include <grp.h>
@@ -43,18 +44,22 @@ using std::string;
 #define SEARCHFORALLBOINCMANAGERS 0
 
 #define MAX_LANGUAGES_TO_TRY 5
-#define MANIPULATE_LOGINITEM_PLIST_FILE 0
+
+#define USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS false
 
 #include "mac_util.h"
 #include "translate.h"
+#include "file_names.h"
 
 
 static OSStatus DoUninstall(void);
 static OSStatus CleanupAllVisibleUsers(void);
 static OSStatus DeleteOurBundlesFromDirectory(CFStringRef bundleID, char *extension, char *dirPath);
-static void DeleteLoginItemOSAScript(char* user, char* appName);
+static void DeleteLoginItemOSAScript(char *userName);
+static Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw);
+long GetBrandID(char *path);
 static char * PersistentFGets(char *buf, size_t buflen, FILE *f);
-OSErr GetCurrentScreenSaverSelection(char *moduleName, size_t maxLen);
+OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen);
 OSErr SetScreenSaverSelection(char *moduleName, char *modulePath, int type);
 static pid_t FindProcessPID(char* name, pid_t thePID);
 static int KillOneProcess(char* name);
@@ -66,17 +71,19 @@ static Boolean ShowMessage(Boolean allowCancel, Boolean continueButton, Boolean 
 int callPosixSpawn(const char *cmd, bool delayForResult=false);
 void print_to_log_file(const char *format, ...);
 
-#if MANIPULATE_LOGINITEM_PLIST_FILE
-static void DeleteLoginItemFromPListFile(void);
-int GetCountOfLoginItemsFromPlistFile(void);
-OSErr GetLoginItemNameAtIndexFromPlistFile(int index, char *name, size_t maxLen);
-OSErr DeleteLoginItemNameAtIndexFromPlistFile(int index);
-#endif
-
 static char gAppName[256];
 static char gBrandName[256];
 static char gCatalogsDir[MAXPATHLEN];
 static char * gCatalog_Name = (char *)"BOINC-Setup";
+static char loginName[256];
+
+
+#define NUMBRANDS 5
+static char *appName[NUMBRANDS];
+static char *appPath[NUMBRANDS];
+static char *brandName[NUMBRANDS];
+static char *saverName[NUMBRANDS];
+static char *receiptName[NUMBRANDS];
 
 
 /* BEGIN TEMPORARY ITEMS TO ALLOW TRANSLATORS TO START WORK */
@@ -94,6 +101,39 @@ int main(int argc, char *argv[])
     pid_t                       activeAppPID = 0;
     struct stat                 sbuf;
     OSStatus                    err = noErr;
+    
+    appName[0] = "BOINCManager";
+    appPath[0] = "/Applications/BOINCManager.app";
+    brandName[0] = "BOINC";
+    saverName[0] = "BOINCSaver";
+    receiptName[0] = "/Library/Receipts/BOINC Installer.pkg";
+
+    appName[1] = "GridRepublic Desktop";
+    appPath[1] = "/Applications/GridRepublic Desktop.app";
+    brandName[1] = "GridRepublic";
+    saverName[1] = "GridRepublic";
+    receiptName[1] = "/Library/Receipts/GridRepublic Installer.pkg";
+
+    appName[2] = "Progress Thru Processors Desktop";
+    appPath[2] = "/Applications/Progress Thru Processors Desktop.app";
+    brandName[2] = "Progress Thru Processors";
+    saverName[2] = "Progress Thru Processors";
+    receiptName[2] = "/Library/Receipts/Progress Thru Processors Installer.pkg";
+
+    appName[3] = "Charity Engine Desktop";
+    appPath[3] = "/Applications/Charity Engine Desktop.app";
+    brandName[3] = "Charity Engine";
+    saverName[3] = "Charity Engine";
+    receiptName[3] = "/Library/Receipts/Charity Engine Installer.pkg";
+
+    appName[4] = "World Community Grid";
+    appPath[4] = "/Applications/World Community Grid.app";
+    brandName[4] = "World Community Grid";
+    saverName[4] = "World Community Grid";
+    receiptName[4] = "/Library/Receipts/World Community Grid Installer.pkg";
+
+    // getlogin() gives unreliable results under OS 10.6.2, so use environment
+    strncpy(loginName, getenv("USER"), sizeof(loginName)-1);
 
     pathToSelf[0] = '\0';
     // Get the full path to our executable inside this application's bundle
@@ -126,7 +166,7 @@ int main(int argc, char *argv[])
 
     strlcpy(gBrandName, p, sizeof(gBrandName));
         
-    // Determine whether this is the intial launch or the relaunch with privileges
+    // Determine whether this is the initial launch or the relaunch with privileges
     if ( (argc == 3) && (strcmp(argv[1], "--privileged") == 0) ) {
         // Prevent displaying "OSAScript" in menu bar on newer versions of OS X
         activeAppPID = (pid_t)atol(argv[2]);
@@ -184,7 +224,6 @@ int main(int argc, char *argv[])
     CFStringRef CFBOINCDataPath, CFUserPrefsPath;
     char BOINCDataPath[MAXPATHLEN], temp[MAXPATHLEN], PathToPrefs[MAXPATHLEN];
     Boolean success = false;
-    char * loginName = getlogin();
     
     CFURLRef urlref = CFURLCreateWithFileSystemPath(NULL, CFSTR("/Library"),
                                                     kCFURLPOSIXPathStyle, true);
@@ -344,6 +383,7 @@ int main(int argc, char *argv[])
 static OSStatus DoUninstall(void) {
     pid_t                   coreClientPID = 0;
     pid_t                   BOINCManagerPID = 0;
+    int                     i;
     char                    cmd[1024];
     char                    *p;
     passwd                  *pw;
@@ -353,46 +393,21 @@ static OSStatus DoUninstall(void) {
     char                    notBoot[] = "/Volumes/";
     CFStringRef             cfPath;
     CFURLRef                appURL;
-    int                     pathOffset, i;
+    int                     pathOffset;
 #endif
 
 #if TESTING
     ShowMessage(false, false, false, "Permission OK after relaunch");
 #endif
 
-    //TODO: It would be nice to get the app name from the bundle ID or signature
-    // so we don't have to try all 4 and to allow for future branded versions
+    // getlogin() gives unreliable results under OS 10.6.2, so use environment
+    strncpy(loginName, getenv("USER"), sizeof(loginName)-1);
 
-    for (;;) {
-        BOINCManagerPID = FindProcessPID("BOINCManager", 0);
+    // With fast user switching, each logged in user can 
+    // be running a separate copy of the Manager
+    for (i=0; i<100; ++i) { // Limit iterations for safety
+        BOINCManagerPID = getPidIfRunning("edu.berkeley.boinc");
         if (BOINCManagerPID == 0) break;
-        kill(BOINCManagerPID, SIGTERM);
-        sleep(2);
-    }
-    
-    for (;;) {
-        BOINCManagerPID = FindProcessPID("GridRepublic Desktop", 0);
-        if (BOINCManagerPID == 0) break;
-        kill(BOINCManagerPID, SIGTERM);
-        sleep(2);
-    }
-    
-    for (;;) {
-        BOINCManagerPID = FindProcessPID("Progress Thru Processors Desktop", 0);
-        if (BOINCManagerPID == 0) break;
-        kill(BOINCManagerPID, SIGTERM);
-        sleep(2);
-    }
-    
-    for (;;) {
-        BOINCManagerPID = FindProcessPID("Charity Engine Desktop", 0);
-        if (BOINCManagerPID == 0) break;
-        kill(BOINCManagerPID, SIGTERM);
-        sleep(2);
-    }
-    
-    BOINCManagerPID = getPidIfRunning("edu.berkeley.boinc");
-    if (BOINCManagerPID) {
         kill(BOINCManagerPID, SIGTERM);
     }
     sleep(2);
@@ -465,43 +480,30 @@ static OSStatus DoUninstall(void) {
     err = DeleteOurBundlesFromDirectory(CFSTR("edu.berkeley.boincsaver"), "saver", "/Library/Screen Savers");
 
     // Phase 4: Delete our files and directories at our installer's default locations
-    // Remove everything we've installed, whether BOINC, GridRepublic, Progress Thru Processors or
-    // Charity Engine
+    // Remove everything we may have installed, though the above 2 calls already deleted some
     
-    //TODO: It would be nice to get the app name from the bundle ID or signature
-    // so we don't have to try all 4 and to allow for future branded versions
-    
-    // These first 4 should already have been deleted by the above code, but do them anyway for safety
-    callPosixSpawn ("rm -rf /Applications/BOINCManager.app");
-    callPosixSpawn ("rm -rf \"/Library/Screen Savers/BOINCSaver.saver\"");
-    
-    callPosixSpawn ("rm -rf \"/Applications/GridRepublic Desktop.app\"");
-    callPosixSpawn ("rm -rf \"/Library/Screen Savers/GridRepublic.saver\"");
-    
-    callPosixSpawn ("rm -rf \"/Applications/Progress Thru Processors Desktop.app\"");
-    callPosixSpawn ("rm -rf \"/Library/Screen Savers/Progress Thru Processors.saver\"");
-    
-    callPosixSpawn ("rm -rf \"/Applications/Charity Engine Desktop.app\"");
-    callPosixSpawn ("rm -rf \"/Library/Screen Savers/Charity Engine.saver\"");
-    
-    callPosixSpawn ("rm -rf \"/Applications/World Community Grid.app\"");
-    callPosixSpawn ("rm -rf \"/Library/Screen Savers/World Community Grid.saver\"");
+    for (i=0; i<NUMBRANDS; ++i) {
+        sprintf(cmd, "rm -rf \"%s\"", appPath[i]);
+        callPosixSpawn(cmd);
+        sprintf(cmd, "rm -rf \"/Library/Screen Savers/%s.saver\"", saverName[i]);
+        callPosixSpawn(cmd);
+    }
 
-    // Delete any receipt from an older installer (which had 
-    // a wrapper application around the installer package.)
-    callPosixSpawn ("rm -rf /Library/Receipts/GridRepublic.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/Progress\\ Thru\\ Processors.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/Charity\\ Engine.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/World\\ Community\\ Grid.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/BOINC.pkg");
+    for (i=0; i<NUMBRANDS; ++i) {
+        // NOTE: the following work for older versions of OS X, but newer versions 
+        // of OS X store the receipts elsewhere. However, this step is probably 
+        // not needed to allow installing older versions of BOINC over newer ones
+        // with more recent versions of OS X.
+        // Delete any receipt from a very old BOINC Installer
+        sprintf(cmd, "rm -rf \"/Library/Receipts/%s\".pkg", brandName[i]);
+        callPosixSpawn(cmd);
 
-    // Delete any receipt from a newer installer (a bare package.) 
-    callPosixSpawn ("rm -rf /Library/Receipts/GridRepublic\\ Installer.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/Progress\\ Thru\\ Processors\\ Installer.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/Charity\\ Engine\\ Installer.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/World\\ Community\\ Grid\\ Installer.pkg");
-    callPosixSpawn ("rm -rf /Library/Receipts/BOINC\\ Installer.pkg");
-
+        // Delete any receipt from a newer BOINC installer (which has 
+        // a wrapper application around the installer package.)
+        sprintf(cmd, "rm -rf \"%s\"", receiptName[i]);
+        callPosixSpawn(cmd);
+    }
+    
     // Phase 5: Set BOINC Data owner and group to logged in user
     // We don't customize BOINC Data directory name for branding
 //    callPosixSpawn ("rm -rf \"/Library/Application Support/BOINC Data\"");
@@ -628,7 +630,8 @@ char *systemEventsAppName = "System Events";
 // For now, don't delete user's BOINC Preferences file.
 static OSStatus CleanupAllVisibleUsers(void)
 {
-    passwd              *pw;
+    long                brandID = 0;
+   passwd              *pw;
     vector<string>      human_user_names;
     vector<uid_t>       human_user_IDs;
     uid_t               saved_uid, saved_euid;
@@ -653,6 +656,8 @@ static OSStatus CleanupAllVisibleUsers(void)
     err = noErr;
     systemEventsPath[0] = '\0';
 
+    brandID = GetBrandID("/Library/Application Support/BOINC Data/Branding");
+    
     err = GetPathToAppFromID(kSystemEventsCreator, kSystemEventsBundleID,  systemEventsPath, sizeof(systemEventsPath));
 
 #if TESTING
@@ -706,24 +711,28 @@ static OSStatus CleanupAllVisibleUsers(void)
             while (PersistentFGets(buf, sizeof(buf), f)) {
                 p = strrchr(buf, ' ');
                 if (p) {
-                    if (strstr(p, "/var/empty") != NULL) flag = 1;
+                    if (strstr(p, "/var/empty") != NULL) {
+                        flag = 1;
+                        break;
+                    }
                 }
             }
             pclose(f);
         }
 
-        sprintf(s, "dscl . -read \"/Users/%s\" UserShell", human_user_name);    
-        f = popen(s, "r");
-        if (f) {
-            while (PersistentFGets(buf, sizeof(buf), f)) {
-                p = strrchr(buf, ' ');
-                if (p) {
-                    if (strstr(p, "/usr/bin/false") != NULL) flag |= 2;
+        if (flag) {
+            sprintf(s, "dscl . -read \"/Users/%s\" UserShell", human_user_name);    
+            f = popen(s, "r");
+            if (f) {
+                while (PersistentFGets(buf, sizeof(buf), f)) {
+                    p = strrchr(buf, ' ');
+                    if (p) {
+                        if (strstr(p, "/usr/bin/false") != NULL) flag |= 2;
+                    }
                 }
+                pclose(f);
             }
-            pclose(f);
         }
-        
         // Skip all non-human (non-login) users
         if (flag == 3) { // if (Home Directory == "/var/empty") && (UserShell == "/usr/bin/false")
 #if TESTING
@@ -748,85 +757,35 @@ static OSStatus CleanupAllVisibleUsers(void)
         sprintf(s, "dscl . -delete /groups/boinc_project users \"%s\"", human_user_name);
         callPosixSpawn (s);
 
-#if TESTING
-//    ShowMessage(false, false, false, "Before seteuid(%d) for user %s, euid = %d", pw->pw_uid, human_user_name, geteuid());
-#endif
-        setuid(0);
-        // Delete our login item(s) for this user
-#if MANIPULATE_LOGINITEM_PLIST_FILE
-       if (compareOSVersionTo(10, 8) >= 0) {
-            seteuid(pw->pw_uid);    // Temporarily set effective uid to this user
-            DeleteLoginItemFromPListFile();
-            seteuid(saved_euid);    // Set effective uid back to privileged user
-        } else {            // OS 10.7.x
-#endif
-            // We must leave effective user ID as privileged user (root)
-            // because the target user may not be in the sudoers file.
-
-            // We must launch the System Events application for the target user
-
-#if TESTING
-            ShowMessage(false, false, false, "Telling System Events to quit (before DeleteLoginItemOSAScript)");
-#endif
-            // Find SystemEvents process.  If found, quit it in case 
-            // it is running under a different user.
-            systemEventsPID = FindProcessPID(systemEventsAppName, 0);
-            if (systemEventsPID != 0) {
-                err = kill(systemEventsPID, SIGKILL);
-            }
-#if TESTING
-            if (err != noErr) {
-                ShowMessage(false, false, false, "kill(systemEventsPID, SIGKILL) returned error %d ", (int) err);
-            }
-#endif
-            // Wait for the process to be gone
-            for (i=0; i<50; ++i) {      // 5 seconds max delay
-                SleepSeconds(0.1);      // 1/10 second
-                systemEventsPID = FindProcessPID(systemEventsAppName, 0);
-                if (systemEventsPID == 0) break;
-            }
-#if TESTING
-            if (i >= 50) {
-                ShowMessage(false, false, false, "Failed to make System Events quit");
-            }
-#endif
-            sleep(2);
-
-            if (systemEventsPath[0] != '\0') {
-#if TESTING
-                ShowMessage(false, false, false, "Launching SystemEvents for user %s", pw->pw_name);
-#endif
-                sprintf(cmd, "sudo -u \"%s\" -b \"%s/Contents/MacOS/System Events\"", pw->pw_name, systemEventsPath);
-                err = callPosixSpawn(cmd);
-                if (err == noErr) {
-                    // Wait for the process to start
-                    for (i=0; i<50; ++i) {      // 5 seconds max delay
-                        SleepSeconds(0.1);      // 1/10 second
-                        systemEventsPID = FindProcessPID(systemEventsAppName, 0);
-                        if (systemEventsPID != 0) break;
-                    }
-#if TESTING
-                    if (i >= 50) {
-                        ShowMessage(false, false, false, "Failed to launch System Events for user %s", pw->pw_name);
-                    }
-#endif
-                    sleep(2);
-
-                    DeleteLoginItemOSAScript(pw->pw_name, "BOINCManager");
-                    DeleteLoginItemOSAScript(pw->pw_name, "GridRepublic Desktop");
-                    DeleteLoginItemOSAScript(pw->pw_name, "Progress Thru Processors Desktop");
-                    DeleteLoginItemOSAScript(pw->pw_name, "Charity Engine Desktop");
-                    DeleteLoginItemOSAScript(pw->pw_name, "World Community Grid");
-
-#if TESTING
-                } else {
-                    ShowMessage(false, false, false, "[2] Command: %s returned error %d", cmd, (int) err);
-#endif
-                }
-            }
-#if MANIPULATE_LOGINITEM_PLIST_FILE
+       // Set login item for this user
+        bool useOSASript = false;
+        
+        if ((compareOSVersionTo(10, 13) < 0)
+            || (strcmp(loginName, human_user_name) == 0) 
+                || (strcmp(loginName, pw->pw_name) == 0) 
+                    || (strcmp(loginName, pw->pw_gecos) == 0)) {
+            useOSASript = true;
+        }
+#if USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS
+        if (! useOSASript) {
+            useOSASript = IsUserLoggedIn(pw->pw_name);
         }
 #endif
+       if (useOSASript) {
+            snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist", pw->pw_name);
+            boinc_delete_file(s);
+#if TESTING
+            ShowMessage(false, false, false, "calling DeleteLoginItemOSAScript for user %s, euid = %d\n", 
+                pw->pw_name, geteuid());
+#endif
+            DeleteLoginItemOSAScript(pw->pw_name);
+        } else {
+#if TESTING
+            ShowMessage(false, false, false, "calling DeleteLoginItemLaunchAgent for user %s, euid = %d\n", 
+                pw->pw_name, geteuid());
+#endif
+            DeleteLoginItemLaunchAgent(brandID, pw);
+        }
 
         // We don't delete the user's BOINC Manager preferences
 //        sprintf(s, "rm -f \"/Users/%s/Library/Preferences/BOINC Manager Preferences\"", human_user_name);
@@ -839,71 +798,28 @@ static OSStatus CleanupAllVisibleUsers(void)
         //  Set screensaver to "Computer Name" default screensaver only 
         //  if it was BOINC, GridRepublic, Progress Thru Processors or Charity Engine.
         changeSaver = false;
-        seteuid(pw->pw_uid);    // Temporarily set effective uid to this user
-        if (compareOSVersionTo(10, 6) < 0) {
-            f = popen("defaults -currentHost read com.apple.screensaver moduleName", "r");
-            if (f) {
-                while (PersistentFGets(s, sizeof(s), f)) {
-                    if (strstr(s, "BOINCSaver")) {
-                        changeSaver = true;
-                        break;
-                    }
-                    if (strstr(s, "GridRepublic")) {
-                        changeSaver = true;
-                        break;
-                    }
-                    if (strstr(s, "Progress Thru Processors")) {
-                        changeSaver = true;
-                        break;
-                    }
-                    if (strstr(s, "Charity Engine")) {
-                        changeSaver = true;
-                        break;
-                    }
 
-                    if (strstr(s, "World Community Grid")) {
-                        changeSaver = true;
-                        break;
-                    }
-                }
-                pclose(f);
-            }
-        } else {
-            err = GetCurrentScreenSaverSelection(s, sizeof(s) -1);
-            if (err == noErr) {
-                if (strstr(s, "BOINCSaver")) {
-                    changeSaver = true;
-                }
-                if (strstr(s, "GridRepublic")) {
-                    changeSaver = true;
-                }
-                if (strstr(s, "Progress Thru Processors")) {
-                    changeSaver = true;
-                }
-                if (strstr(s, "Charity Engine")) {
-                    changeSaver = true;
-                }
-                if (strstr(s, "World Community Grid")) {
+        err = GetCurrentScreenSaverSelection(pw, s, sizeof(s) -1);
+        if (err == noErr) {
+            for (i=0; i<NUMBRANDS; ++i) {
+                if (strcmp(s, saverName[i]) == 0) {
                     changeSaver = true;
                 }
             }
         }
         
         if (changeSaver) {
-            if (compareOSVersionTo(10, 6) < 0) {
-                callPosixSpawn ("defaults -currentHost write com.apple.screensaver moduleName \"Computer Name\"");
-                callPosixSpawn ("defaults -currentHost write com.apple.screensaver modulePath \"/System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/Computer Name.saver\"");
-            } else {
-                err = SetScreenSaverSelection("Computer Name",
-                    "/System/Library/Frameworks/ScreenSaver.framework/Versions/A/Resources/Computer Name.saver", 0);
-            }
-        }
-
-        seteuid(saved_euid);    // Set effective uid back to privileged user
-        
+            seteuid(pw->pw_uid);    // Temporarily set effective uid to this user
+            err = SetScreenSaverSelection("Computer Name",
+                "/System/Library/Frameworks/ScreenSaver.framework/Resources/Computer Name.saver", 0);
+            seteuid(saved_euid);    // Set effective uid back to privileged user
 #if TESTING
 //    ShowMessage(false, false, false, "After seteuid(%d) for user %s, euid = %d, saved_uid = %d", pw->pw_uid, human_user_name, geteuid(), saved_uid);
 #endif
+            // This seems to work also:
+            // sprintf(s, "su -l \"%s\" -c 'defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName \"Computer Name\" path \"/System/Library/Frameworks/ScreenSaver.framework/Resources/Computer Name.saver"\" type 0'");
+            // callPosixSpawn(s);
+        }
     }       // End userIndex loop
     
     sleep(1);
@@ -925,59 +841,230 @@ static OSStatus CleanupAllVisibleUsers(void)
 }
 
 
-// Used for OS <= 10.7
-static void DeleteLoginItemOSAScript(char* user, char* appName)
+static void DeleteLoginItemOSAScript(char *userName)
 {
+    int                     i, j;
     char                    cmd[2048];
-    OSErr                   err;
+    char                    systemEventsPath[1024];
+    pid_t                   systemEventsPID;
+    OSErr                   err, err2;
+#if USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS
+    Boolean                 isHighSierraOrLater = (compareOSVersionTo(10, 13) >= 0);
+    // NOTE: It may not be necessary to kill and relaunch the
+    // System Events application for each logged in user under High Sierra 
+#endif
 
-    sprintf(cmd, "sudo -u \"%s\" osascript -e 'tell application \"System Events\"' -e 'delete (every login item whose name contains \"%s\")' -e 'end tell'", user, appName);
-    err = callPosixSpawn(cmd);
 #if TESTING
-    if (err) {
-        ShowMessage(false, false, false, "Command: %s returned error %d", cmd, err);
+    ShowMessage(false, false, false, "Adjusting login items for user %s\n", userName);
+#endif
+
+    // We must launch the System Events application for the target user
+    err = noErr;
+    systemEventsPath[0] = '\0';
+
+    err = GetPathToAppFromID(kSystemEventsCreator, kSystemEventsBundleID, systemEventsPath, sizeof(systemEventsPath));
+
+#if TESTING
+    if (err == noErr) {
+        ShowMessage(false, false, false, "SystemEvents is at %s\n", systemEventsPath);
+    } else {
+        ShowMessage(false, false, false, "GetPathToAppFromID(kSystemEventsCreator, kSystemEventsBundleID) returned error %d ", (int) err);
     }
 #endif
-}
-    
 
-#if MANIPULATE_LOGINITEM_PLIST_FILE
-// Used for OS >= 10.8
-static void DeleteLoginItemFromPListFile(void)
-{
-    Boolean                 success;
-    int                     numberOfLoginItems, counter;
-    char                    theName[256], *q;
-
-    success = false;
-
-    numberOfLoginItems = GetCountOfLoginItemsFromPlistFile();
-    
-    // Search existing login items in reverse order, deleting ours
-    for (counter = numberOfLoginItems ; counter > 0 ; counter--)
-    {
-        GetLoginItemNameAtIndexFromPlistFile(counter-1, theName, sizeof(theName));
-        q = theName;
-        while (*q)
-        {
-            // It is OK to modify the returned string because we "own" it
-            *q = toupper(*q);	// Make it case-insensitive
-            q++;
+    if (err == noErr) {
+        // Find SystemEvents process.  If found, quit it in case 
+        // it is running under a different user.
+#if TESTING
+        ShowMessage(false, false, false, "Telling System Events to quit (at start of SetLoginItemOSAScript)\n");
+#endif
+        systemEventsPID = FindProcessPID(systemEventsAppName, 0);
+        if (systemEventsPID != 0) {
+            err = kill(systemEventsPID, SIGKILL);
         }
-            
-        if (strstr(theName, "BOINCMANAGER"))
-            success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
-        if (strstr(theName, "GRIDREPUBLIC DESKTOP"))
-            success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
-        if (strstr(theName, "PROGRESS THRU PROCESSORS DESKTOP"))
-            success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
-        if (strstr(theName, "CHARITY ENGINE DESKTOP"))
-            success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
-        if (strstr(theName, "World Community Grid"))
-            success = DeleteLoginItemNameAtIndexFromPlistFile(counter-1);
+#if TESTING
+        if (err != noErr) {
+            ShowMessage(false, false, false, "(systemEventsPID, SIGKILL) returned error %d \n", (int) err);
+        }
+#endif
+        // Wait for the process to be gone
+        for (i=0; i<50; ++i) {      // 5 seconds max delay
+            SleepSeconds(0.1);      // 1/10 second
+            systemEventsPID = FindProcessPID(systemEventsAppName, 0);
+            if (systemEventsPID == 0) break;
+        }
+        if (i >= 50) {
+#if TESTING
+            ShowMessage(false, false, false, "Failed to make System Events quit\n");
+#endif
+            err = noErr;
+            goto cleanupSystemEvents;
+        }
+        sleep(4);
     }
+    
+    if (systemEventsPath[0] != '\0') {
+ #if TESTING
+        ShowMessage(false, false, false, "Launching SystemEvents for user %s\n", userName);
+#endif
+
+        for (j=0; j<5; ++j) {
+            sprintf(cmd, "sudo -u \"%s\" -b \"%s/Contents/MacOS/System Events\" &", userName, systemEventsPath);
+            err = callPosixSpawn(cmd);
+            if (err) {
+ #if TESTING
+                ShowMessage(false, false, false, "Command: %s returned error %d (try %d of 5)\n", cmd, (int) err, j);
+#endif
+            }
+            // Wait for the process to start
+            for (i=0; i<50; ++i) {      // 5 seconds max delay
+                SleepSeconds(0.1);      // 1/10 second
+                systemEventsPID = FindProcessPID(systemEventsAppName, 0);
+                if (systemEventsPID != 0) break;
+            }
+            if (i < 50) break;  // Exit j loop on success
+        }
+        if (j >= 5) {
+#if TESTING
+            ShowMessage(false, false, false, "Failed to launch System Events for user %s\n", userName);
+#endif
+            err = noErr;
+            goto cleanupSystemEvents;
+        }
+    }
+    sleep(2);
+    
+    for (i=0; i<NUMBRANDS; i++) {
+        ShowMessage(false, false, false, "Deleting any login items containing %s for user %s\n", appName[i], userName);
+#if USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS
+        if (isHighSierraOrLater) {
+            sprintf(cmd, "su -l \"%s\" -c 'osascript -e \"tell application \\\"System Events\\\" to delete (every login item whose path contains \\\"%s\\\")\"'", userName, appName[i]);
+        } else
+#endif
+        {
+            sprintf(cmd, "sudo -u \"%s\" osascript -e 'tell application \"System Events\" to delete (every login item whose path contains \"%s\")'", userName, appName[i]);
+        }
+        err = callPosixSpawn(cmd);
+#if TESTING
+        if (err) {
+            ShowMessage(false, false, false, "Command: %s\n", cmd);
+            ShowMessage(false, false, false, "Delete login item containing %s returned error %d\n", appName[i], err);
+        }
+#endif
+    }
+
+cleanupSystemEvents:
+    // Clean up in case this was our last user
+    fprintf(stdout, "Telling System Events to quit (at end of SetLoginItemOSAScript)\n");
+    fflush(stdout);
+    systemEventsPID = FindProcessPID(systemEventsAppName, 0);
+    err2 = noErr;
+    if (systemEventsPID != 0) {
+        err2 = kill(systemEventsPID, SIGKILL);
+    }
+    if (err2 != noErr) {
+#if TESTING
+        ShowMessage(false, false, false, "kill(systemEventsPID, SIGKILL) returned error %d \n", (int) err2);
+#endif
+    }
+    // Wait for the process to be gone
+    for (i=0; i<50; ++i) {      // 5 seconds max delay
+        SleepSeconds(0.1);      // 1/10 second
+        systemEventsPID = FindProcessPID(systemEventsAppName, 0);
+        if (systemEventsPID == 0) break;
+    }
+    if (i >= 50) {
+#if TESTING
+        ShowMessage(false, false, false, "Failed to make System Events quit\n");
+#endif
+    }
+    
+    sleep(4);
 }
-#endif // MANIPULATE_LOGINITEM_PLIST_FILE
+
+
+// Under OS 10.13 High Sierra, telling System Events to modify Login Items for 
+// users who are not currently logged in no longer works, even when System Events 
+// is running as that user. 
+// So we create a LaunchAgent for that user. The next time that user logs in, the 
+// LaunchAgent will make the desired changes to that user's Login Items, launch 
+// BOINC Manager if appropriate, and delete itself.
+//
+// While we could just use a LaunchAgent to launch BOINC Manager on every login 
+// instead of using it to create a Login Item, I prefer Login Items because:
+//  * they are more readily visible to a less technically aware user through 
+//    System Preferences, and
+//  * they are more easily added or removed through System Preferences, and
+//  * continuing to use them is consistent with older versions of BOINC Manager.
+//
+Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
+{
+    struct stat             sbuf;
+    int                     i;
+    char                    s[2048];
+    
+    // Create a LaunchAgent for the specified user, replacing any LaunchAgent created
+    // previously (such as by Uninstaller or by installing a differently branded BOINC.)
+    //
+    snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents", pw->pw_name);
+    if (stat(s, &sbuf) != 0) {
+        mkdir(s, 0755);
+        chown(s, pw->pw_uid, pw->pw_gid);
+    }
+
+    snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist", pw->pw_name);
+    FILE* f = fopen(s, "w");
+    if (!f) return false;
+    fprintf(f, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    fprintf(f, "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n");
+    fprintf(f, "<plist version=\"1.0\">\n");
+    fprintf(f, "<dict>\n");
+    fprintf(f, "\t<key>Label</key>\n");
+    fprintf(f, "\t<string>edu.berkeley.test</string>\n");
+    fprintf(f, "\t<key>ProgramArguments</key>\n");
+    fprintf(f, "\t<array>\n");
+    fprintf(f, "\t\t<string>sh</string>\n");
+    fprintf(f, "\t\t<string>-c</string>\n");
+    fprintf(f, "\t\t<string>");
+    for (i=0; i<NUMBRANDS; i++) {
+        fprintf(f, "osascript -e 'tell application \"System Events\" to delete login item \"%s\"';", appName[i]);
+    }
+    // If this user was previously authorized to run the Manager, there 
+    // may still be a Login Item for this user, and the Login Item may
+    // launch the Manager before the LaunchAgent deletes the Login Item.
+    // To guard against this, we have the LaunchAgent kill the Manager
+    // (for this user only) if it is running.
+    //
+    fprintf(f, "pkill -9 -U %d \"%s\";", pw->pw_uid, appName[brandID]);
+    fprintf(f, "rm -f ~/Library/LaunchAgents/edu.berkeley.boinc.plist</string>\n");
+    fprintf(f, "\t</array>\n");
+    fprintf(f, "\t<key>RunAtLoad</key>\n");
+    fprintf(f, "\t<true/>\n");
+    fprintf(f, "</dict>\n");
+    fprintf(f, "</plist>\n");
+    fclose(f);
+
+    chmod(s, 0644);
+    chown(s, pw->pw_uid, pw->pw_gid);
+
+    return true;
+}
+
+
+long GetBrandID(char *path)
+{
+    long iBrandId;
+
+    iBrandId = 0;   // Default value
+    
+    FILE *f = fopen(path, "r");
+    if (f) {
+        fscanf(f, "BrandId=%ld\n", &iBrandId);
+        fclose(f);
+    }
+    
+    return iBrandId;
+}
 
 
 static char * PersistentFGets(char *buf, size_t buflen, FILE *f) {
@@ -999,37 +1086,44 @@ static char * PersistentFGets(char *buf, size_t buflen, FILE *f) {
 }
 
 
-OSErr GetCurrentScreenSaverSelection(char *moduleName, size_t maxLen) {
-    OSErr err = noErr;
-    CFStringRef nameKey = CFStringCreateWithCString(NULL,"moduleName",kCFStringEncodingASCII);
-    CFStringRef moduleNameAsCFString;
-    CFDictionaryRef theData;
-    
-    theData = (CFDictionaryRef)CFPreferencesCopyValue(CFSTR("moduleDict"), 
-                CFSTR("com.apple.screensaver"), 
-                kCFPreferencesCurrentUser,
-                kCFPreferencesCurrentHost
-                );
-    if (theData == NULL) {
-        CFRelease(nameKey);
-        return (-1);
+OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen) {
+    char                buf[1024];
+    FILE                *f;
+    char                *p, *q;
+    int                 i;
+
+    *moduleName = '\0';
+    sprintf(buf, "su -l \"%s\" -c 'defaults -currentHost read com.apple.screensaver moduleDict'", pw->pw_name);
+    f = popen(buf, "r");
+    if (f == NULL) {
+#if TESTING
+        ShowMessage(false, false, false, "Could not get current screensaver selection for user %s\n", pw->pw_name);
+#endif
+        return fnfErr;
     }
     
-    if (CFDictionaryContainsKey(theData, nameKey)  == false) 	
-	{
-        moduleName[0] = 0;
-        CFRelease(nameKey);
-        CFRelease(theData);
-	    return(-1);
-	}
+    while (PersistentFGets(buf, sizeof(buf), f))
+    {
+        p = strstr(buf, "moduleName = ");
+        if (p) {
+            p += 13;    // Point past "moduleName = "
+            q = moduleName;
+            for (i=0; i<maxLen-1; ++i) {
+                if (*p == '"') {
+                    ++p;
+                    continue;
+                }
+                if (*p == ';') break;
+                *q++ = *p++;
+            }
+            *q = '\0';
+            pclose(f);
+            return 0;
+        }
+    }
     
-    moduleNameAsCFString = CFStringCreateCopy(NULL, (CFStringRef)CFDictionaryGetValue(theData, nameKey));
-    CFStringGetCString(moduleNameAsCFString, moduleName, maxLen, kCFStringEncodingASCII);		    
-
-    CFRelease(nameKey);
-    CFRelease(theData);
-    CFRelease(moduleNameAsCFString);
-    return err;
+    pclose(f);
+    return fnfErr;
 }
 
 
@@ -1097,147 +1191,6 @@ OSErr SetScreenSaverSelection(char *moduleName, char *modulePath, int type) {
 
     return err;
 }
-
-
-#if MANIPULATE_LOGINITEM_PLIST_FILE
-
-int GetCountOfLoginItemsFromPlistFile() {
-    CFArrayRef	arrayOfLoginItemsFixed;
-    int valueToReturn = -1;
-    CFStringRef loginItemArrayKeyName = CFSTR("CustomListItems");
-    CFDictionaryRef topLevelDict;
-
-    topLevelDict = (CFDictionaryRef)CFPreferencesCopyValue(CFSTR("SessionItems"), CFSTR("com.apple.loginitems"), kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    if (topLevelDict == NULL) {
-        return (0);
-    }
-
-    if (CFDictionaryContainsKey(topLevelDict, loginItemArrayKeyName)  == false) 	
-	{
-        CFRelease(topLevelDict);
-	    return(0);
-	}
-    
-    arrayOfLoginItemsFixed = (CFArrayRef)CFDictionaryGetValue(topLevelDict, loginItemArrayKeyName);
-    if( arrayOfLoginItemsFixed == NULL)
-	{
-        CFRelease(topLevelDict);
-	    return(0); 
-	}
-	
-    valueToReturn = (int) CFArrayGetCount(arrayOfLoginItemsFixed);
-
-    CFRelease(topLevelDict);
-    return(valueToReturn);    
-}
-
-
-// Returns empty string on failure
-OSErr GetLoginItemNameAtIndexFromPlistFile(int index, char *name, size_t maxLen) {
-    CFArrayRef	arrayOfLoginItemsFixed = NULL;
-    CFStringRef loginItemArrayKeyName = CFSTR("CustomListItems");
-    CFDictionaryRef topLevelDict = NULL;
-    CFDictionaryRef loginItemDict = NULL;
-    CFStringRef nameKey = CFSTR("Name");
-    CFStringRef nameAsCFString = NULL;
-    
-    *name = 0;  // Prepare for failure
-
-    topLevelDict = (CFDictionaryRef)CFPreferencesCopyValue(CFSTR("SessionItems"), CFSTR("com.apple.loginitems"), kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    if (topLevelDict == NULL) {
-        return (-1);
-    }
-
-    if (CFDictionaryContainsKey(topLevelDict, loginItemArrayKeyName)  == false) 	
-	{
-        CFRelease(topLevelDict);
-	    return(-1);
-	}
-    
-    arrayOfLoginItemsFixed = (CFArrayRef) CFDictionaryGetValue(topLevelDict, loginItemArrayKeyName);
-    if( arrayOfLoginItemsFixed == NULL)
-	{
-        CFRelease(topLevelDict);
-	    return(-1); 
-	}
-    
-    loginItemDict = (CFDictionaryRef) CFArrayGetValueAtIndex(arrayOfLoginItemsFixed, (CFIndex)index);
-    if (loginItemDict == NULL)
-    {
-        CFRelease(topLevelDict);
-        return(-1); 
-    }
-
-	if (CFDictionaryContainsKey(loginItemDict, nameKey) == false) 	
-	{
-        CFRelease(topLevelDict);
-        return(-1); 
-	}
-
-    nameAsCFString = CFStringCreateCopy(NULL, (CFStringRef)CFDictionaryGetValue(loginItemDict, nameKey));
-    CFStringGetCString(nameAsCFString, name, maxLen, kCFStringEncodingASCII);		    
-
-    CFRelease(topLevelDict);
-    CFRelease(nameAsCFString);
-    return(noErr);
-}
-
-
-OSErr DeleteLoginItemNameAtIndexFromPlistFile(int index){
-    CFArrayRef	arrayOfLoginItemsFixed = NULL;
-    CFMutableArrayRef arrayOfLoginItemsModifiable;
-    CFStringRef topLevelKeyName = CFSTR("SessionItems");
-    CFStringRef preferenceName = CFSTR("com.apple.loginitems");
-    CFStringRef loginItemArrayKeyName = CFSTR("CustomListItems");
-    CFDictionaryRef oldTopLevelDict = NULL;
-    CFMutableDictionaryRef newTopLevelDict = NULL;
-    Boolean success;
-    OSErr err = noErr;
-
-    oldTopLevelDict = (CFDictionaryRef)CFPreferencesCopyValue(topLevelKeyName, preferenceName, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    if (oldTopLevelDict == NULL) {
-        return (-1);
-    }
-
-    if (CFDictionaryContainsKey(oldTopLevelDict, loginItemArrayKeyName)  == false) 	
-	{
-        CFRelease(oldTopLevelDict);
-	    return(-1);
-	}
-    
-    arrayOfLoginItemsFixed = (CFArrayRef) CFDictionaryGetValue(oldTopLevelDict, loginItemArrayKeyName);
-    if( arrayOfLoginItemsFixed == NULL)
-	{
-        CFRelease(oldTopLevelDict);
-	    return(-1); 
-	}
-
-    arrayOfLoginItemsModifiable = CFArrayCreateMutableCopy(NULL, 0, arrayOfLoginItemsFixed);
-    if( arrayOfLoginItemsModifiable == NULL)
-	{
-        CFRelease(oldTopLevelDict);
-	    return(-1); 
-	}
-
-    CFArrayRemoveValueAtIndex(arrayOfLoginItemsModifiable, (CFIndex) index);    
-
-    newTopLevelDict = CFDictionaryCreateMutableCopy(NULL, 0, oldTopLevelDict);
-    CFDictionaryReplaceValue(newTopLevelDict, loginItemArrayKeyName, arrayOfLoginItemsModifiable);
-
-    CFPreferencesSetValue(topLevelKeyName, newTopLevelDict, preferenceName, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-    success = CFPreferencesSynchronize(preferenceName, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-
-    if (!success) {
-        err = -1;
-    }
- 
-    CFRelease(oldTopLevelDict);
-    CFRelease(newTopLevelDict);
-   
-    return(err);
-
-}
-#endif // MANIPULATE_LOGINITEM_PLIST_FILE
 
 
 static pid_t FindProcessPID(char* name, pid_t thePID)
@@ -1352,7 +1305,6 @@ static void GetPreferredLanguages() {
     char * language;
     char *uscore;
     FILE *f;
-    char loginName[256];
     char tempFileName[MAXPATHLEN];
 
     // Create an array of all our supported languages
@@ -1399,7 +1351,6 @@ static void GetPreferredLanguages() {
     closedir(dirp);
 
     // Write a temp file to tell our PostInstall.app our preferred languages
-    strncpy(loginName, getenv("USER"), sizeof(loginName)-1);
     snprintf(tempFileName, sizeof(tempFileName), "/tmp/UninstallBOINC-%s", loginName);
     mkdir(tempFileName, 0777);
     chmod(tempFileName, 0777);  // Needed because mkdir sets permissions restricted by umask (022)
@@ -1471,13 +1422,11 @@ static void LoadPreferredLanguages(){
     int i;
     char *p;
     char language[32];
-    char loginName[256];
     char tempFileName[MAXPATHLEN];
 
     BOINCTranslationInit();
 
     // First pass wrote a list of our preferred languages to a temp file
-    strncpy(loginName, getenv("USER"), sizeof(loginName)-1);
     snprintf(tempFileName, sizeof(tempFileName), "/tmp/UninstallBOINC-%s/BOINC_preferred_languages", loginName);
     f = fopen(tempFileName, "r");
     if (!f) return;


### PR DESCRIPTION
Fixes to installer for issues under OS 10.13 High Sierra when multiple users are to be allowed to run BOINC Manager

 - fix setting or deleting Login Items for users other than the one running the installer
 - fix setting the screensaver for users other than the one running the installer

This situation probably occurs fairly infrequently, but I recently noticed these problems when running the Mac installer, Uninstaller, and AddRemoveUser utility under OS 10.13. As far as I have been able to determine, these problems do not occur on earlier versions of OS X.

It may be desirable to back port these fixes to BOINC 7.10 once they are complete.