### PR TITLE
Locale: enhance translation update script

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,6 +1,6 @@
 [main]
 host = https://www.transifex.com
-minimum_perc = 100
+minimum_perc = 97
 
 [boinc.manager]
 file_filter = locale/<lang>/BOINC-Manager.po
@@ -44,4 +44,3 @@ lang_map = it_IT:it-rIT,pt_BR:pt-rBR,pt_PT:pt-rPT,zh_CN:zh-rCN,zh_TW:zh-rTW,fa_I
 source_file = android/BOINC/app/src/main/res/values/strings.xml
 source_lang = en
 type = ANDROID
-


### PR DESCRIPTION
- No testmode anymore as this was unpractical
- added instructions what to check since not everything is automatable
- translations are pulled from transifex when 97% complete. This proved practical in the last release.
- added simple po file check to prevent incorrect tabs and printf problems from translations (potential to break the manager)