### PR TITLE
Fix .gitattributes to use LF by default.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 #
 
 # Random stuff
-*                       text=auto
+*                       text=auto eol=lf
 
 # Source files
 #
@@ -45,3 +45,11 @@ checkin_notes_2012      text eol=lf
 *.log                   text eol=lf
 *.rtf                   text eol=lf
 *.rul                   text eol=crlf
+*.png                   binary diff=exif
+*.ttf                   binary 
+*.otf                   binary
+*.woff 	                binary 
+*.woff2                 binary 
+*.exe                   binary 
+*.dll                   binary 
+*.dat                   binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,10 +12,10 @@
 *.rc                    text eol=lf
 *.php                   text eol=lf
 *.xpm                   text eol=lf
-*.cu					text eol=lf
-*.cl					text eol=lf
-*.c					    text eol=lf
-*.hpp					text eol=lf
+*.cu                    text eol=lf
+*.cl                    text eol=lf
+*.c	                    text eol=lf
+*.hpp                   text eol=lf
 
 # Project files
 #


### PR DESCRIPTION
In case that boinc is cloned on Windows, git adds CRLF to files that were not explicitly specified. When those files were copied into a Linux directly, without committing them to git, the line endings were preserved, and compilation failed.

It would be much more convenient to have all files cloned with expected line endings to overcome this issue.

This issue may occur when the development is done on Windows and build on Linux using Docker for example.