### PR TITLE
web rpc: Added global scope to master_url variable.

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -37,6 +37,7 @@ require_once("../inc/bootstrap.inc");
 // parse some stuff from config (do it here for efficiency)
 //
 $config = get_config();
+global $master_url;
 $master_url = parse_config($config , "<master_url>");
 $recaptcha_public_key = parse_config($config, "<recaptcha_public_key>");
 $recaptcha_private_key = parse_config($config, "<recaptcha_private_key>");

--- a/html/user/get_project_config.php
+++ b/html/user/get_project_config.php
@@ -48,6 +48,7 @@ function show_platforms() {
 }
 
 $config = get_config();
+global $master_url;
 $long_name = parse_config($config, "<long_name>");
 
 $min_passwd_length = parse_config($config, "<min_passwd_length>");


### PR DESCRIPTION
BOINC web code [refactored `$master_url` into a global variable](https://github.com/BOINC/boinc/commit/5ea948224ea15ea53bd8167c78e331951d9e1ece). The E@H Drupal installation breaks due to this change. This is due to the scope of the variable not being explicitly set  as global. The functional result is that get_project_rpc does not return the master_url for the E@H project. We believe we're the only ones affected due to our Drupal Web front-end.

If these two small changes are made, this should fix the get_project_config RPC for us. I doubt this will negatively affect the rest of the BOINC html web code, but if someone could check that would be great.