### PR TITLE
add virtualization info to host info page

### DIFF
--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -251,15 +251,26 @@ function host_nresults($host) {
     return BoincResult::count("hostid=$host->id");
 }
 
+
+// Parse the Virtualbox version information from inside the serialnum field.
+// Prior to BOINC commit 6121ce1, the DB entry looked like e.g. "[vbox|5.0.0]"
+// where Virtualbox 5.0.0 gave the version number. After 6121ce1, the entry was
+// "[vbox|5.0.0|1|1]", where now two additional flags give information about
+// hardware virtualization support. Older clients may have the old-style
+// serialnum in the DB despite the server being upgraded.
 function vbox_desc($x){
-    if (preg_match("/\[vbox\|(.*)\|([01])\|([01])\]/",$x,$matches)){
-        $desc = "Virtualbox [".$matches[1]."] ".tra("installed").", ";
-        if ($matches[2]=="1" and $matches[3]=="1") {
-            return $desc.tra("CPU has hardware virtualization support and it is enabled");
-        } elseif ($matches[2]=="1" and $matches[3]=="0") {
-            return $desc.tra("CPU has hardware virtualization support but it is disabled");
-        } elseif ($matches[2]=="0") {
-            return $desc.tra("CPU does not have hardware virtualization support");
+    if (preg_match("/\[vbox\|(.*?)(\|([01])\|([01]))?\]/",$x,$matches)){
+        $desc = "Virtualbox (".$matches[1].") ".tra("installed");
+        if (sizeof($matches)>2){
+            if ($matches[3]=="1" and $matches[4]=="1") {
+                return $desc.tra(", CPU has hardware virtualization support and it is enabled");
+            } elseif ($matches[3]=="1" and $matches[4]=="0") {
+                return $desc.tra(", CPU has hardware virtualization support but it is disabled");
+            } elseif ($matches[3]=="0") {
+                return $desc.tra(", CPU does not have hardware virtualization support");
+            }
+        } else {
+            return $desc;
         }
     } else {
         return tra("None");

--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -122,6 +122,7 @@ function show_host($host, $user, $ipprivate) {
     if ($host->serialnum) {
         row2(tra("Coprocessors"), gpu_desc($host->serialnum));
     }
+    row2(tra("Virtualization"), vbox_desc($host->serialnum));
     row2(tra("Operating System"), "$host->os_name <br> $host->os_version");
     $v = boinc_version($host->serialnum);
     if ($v) {
@@ -248,6 +249,21 @@ function top_host_table_start($sort_by) {
 
 function host_nresults($host) {
     return BoincResult::count("hostid=$host->id");
+}
+
+function vbox_desc($x){
+    if (preg_match("/\[vbox\|(.*)\|([01])\|([01])\]/",$x,$matches)){
+        $desc = "Virtualbox [".$matches[1]."] ".tra("installed").", ";
+        if ($matches[2]=="1" and $matches[3]=="1") {
+            return $desc.tra("CPU has hardware virtualization support and it is enabled");
+        } elseif ($matches[2]=="1" and $matches[3]=="0") {
+            return $desc.tra("CPU has hardware virtualization support but it is disabled");
+        } elseif ($matches[2]=="0") {
+            return $desc.tra("CPU does not have hardware virtualization support");
+        }
+    } else {
+        return tra("None");
+    }
 }
 
 // Given string of the form [BOINC|vers][type|model|count|RAM|driver-vers][vbox|vers],

--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -254,7 +254,7 @@ function host_nresults($host) {
 
 // Parse the Virtualbox version information from inside the serialnum field.
 // Prior to BOINC commit 6121ce1, the DB entry looked like e.g. "[vbox|5.0.0]"
-// where Virtualbox 5.0.0 gave the version number. After 6121ce1, the entry was
+// where 5.0.0 gave the Virtualbox version number. After 6121ce1, the entry was
 // "[vbox|5.0.0|1|1]", where now two additional flags give information about
 // hardware virtualization support. Older clients may have the old-style
 // serialnum in the DB despite the server being upgraded.


### PR DESCRIPTION
This adds a row to the host info page that tells the user what version of Virtualbox they have, if they have hardware virtualization support available and whether it is enabled. Having this should make it much easier for users to debug problems stemming from the fact that their CPU doesn't have hardware support or they have it disabled. 