### PR TITLE
web: Fix string that included a variable but needs to be translated s…

### DIFF
--- a/html/user/delete_account_confirm.php
+++ b/html/user/delete_account_confirm.php
@@ -82,7 +82,7 @@ function delete_account_confirm_action() {
     
     page_head(tra("Account Deleted"));
     
-    echo "<p>".tra("Your account has been deleted.  If you want to contribute to ".PROJECT." in the future you will need to create a new account.")."</p>";
+    echo "<p>".tra("Your account has been deleted.  If you want to contribute to %1 in the future you will need to create a new account.",PROJECT)."</p>";
     
     page_tail();
 }


### PR DESCRIPTION
Fix string that included a variable but needs to be translated so that it uses a placeholder instead of the variable in the string.

Fixes #2573 