### PR TITLE
Manager: Fix branded link in About Dialog

### DIFF
--- a/clientgui/DlgAbout.cpp
+++ b/clientgui/DlgAbout.cpp
@@ -126,6 +126,9 @@ bool CDlgAbout::Create(wxWindow* parent, wxWindowID id, const wxString& caption,
     m_AboutBOINCURLCtrl->SetLabel(
         pSkinAdvanced->GetOrganizationWebsite().c_str()
     );
+    m_AboutBOINCURLCtrl->SetURL(
+        pSkinAdvanced->GetOrganizationWebsite().c_str()
+    );
 
     GetSizer()->Fit(this);
     GetSizer()->SetSizeHints(this);


### PR DESCRIPTION
Manager: in the About dialog "For more information, visit" hyperlink, set the value of the link to the same string as the text displayed for the link when using a branded skin.

NOTE: Despite the "mac" in the name of this branch, this fix is needed for all platforms.