### PR TITLE
Mac: Consolidate branding strings

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -34,6 +34,8 @@
 #endif
 
 #ifdef __APPLE__                            // If Mac BOINC Manager
+#include "mac_branding.h"
+
 bool IsUserInGroup(char* groupName);
 #endif
 
@@ -78,14 +80,6 @@ int use_sandbox, int isManager, char* path_to_error, int len
     struct stat         sbuf;
     int                 retval;
     int                 useFakeProjectUserAndGroup = 0;
-
-#define NUMBRANDS 3
-
-char *saverName[NUMBRANDS];
-
-saverName[0] = "BOINCSaver";
-saverName[1] = "GridRepublic";
-saverName[2] = "Progress Thru Processors";
 
     useFakeProjectUserAndGroup = ! use_sandbox;
 #ifdef _DEBUG

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2016 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -22,6 +22,8 @@
 #ifdef __APPLE__
 #include "mac/MacGUI.pch"
 #include "mac_util.h"
+
+#include "mac_branding.h"
 #endif
 
 #include "stdwx.h"
@@ -1839,7 +1841,7 @@ void CAdvancedFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
                 fscanf(f, "BrandId=%ld\n", &iBrandID);
                 fclose(f);
             }
-            if ((iBrandID > 0) && (iBrandID < 5))
+            if ((iBrandID > 0) && (iBrandID < NUMBRANDS))
 #endif
             {
                 // If successful, hide the main window if we showed it

--- a/clientgui/mac/SecurityUtility.cpp
+++ b/clientgui/mac/SecurityUtility.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2016 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -29,10 +29,16 @@
 #include <Carbon/Carbon.h>
 
 #include "SetupSecurity.h"
+#include "mac_branding.h"
 
 int main(int argc, char *argv[]) {
     OSStatus            err;
     char boincPath[MAXPATHLEN];
+
+    if (!check_branding_arrays(boincPath, sizeof(boincPath))) {
+        printf("Branding array has too few entries: %s\n", boincPath);
+        return -1;
+    }
     
     err = CreateBOINCUsersAndGroups();
     if (err != noErr)

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -31,6 +31,8 @@
 #include "file_names.h"
 #include "mac_util.h"
 #include "SetupSecurity.h"
+
+#include "mac_branding.h"
 
 // Set VERBOSE_TEST to 1 for debugging DoSudoPosixSpawn()
 #define VERBOSE_TEST 0
@@ -126,16 +128,6 @@ int SetBOINCAppOwnersGroupsAndPermissions(char *path) {
     Boolean                 isDirectory;
     OSStatus                err = noErr;
     
-#define NUMBRANDS 5
-
-char *saverName[NUMBRANDS];
-
-saverName[0] = "BOINCSaver";
-saverName[1] = "GridRepublic";
-saverName[2] = "Progress Thru Processors";
-saverName[3] = "Charity Engine";
-saverName[4] = "World Community Grid";
-
     if (geteuid() != 0) {
         ShowSecurityError("SetBOINCAppOwnersGroupsAndPermissions must be called as root");
     }
@@ -153,7 +145,7 @@ saverName[4] = "World Community Grid";
         // Get the full path to our executable inside this application's bundle
         getPathToThisApp(dir_path, sizeof(dir_path));
         if (!dir_path[0]) {
-            ShowSecurityError(false, false, false, "Couldn't get path to self.");
+            ShowSecurityError("Couldn't get path to self.");
             return -1;
         }
         

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -53,6 +53,8 @@
 #ifdef __WXMAC__
 #include "util.h"
 #include "mac_util.h"
+
+#include "mac_branding.h"
 #endif
 
 // Workaround for Linux refresh problem
@@ -817,7 +819,7 @@ void CSimpleFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
                 fscanf(f, "BrandId=%ld\n", &iBrandID);
                 fclose(f);
             }
-            if ((iBrandID > 0) && (iBrandID < 5))
+            if ((iBrandID > 0) && (iBrandID < NUMBRANDS))
 #endif
             {
                 // If successful, hide the main window if we showed it

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -52,6 +52,7 @@ extern "C" {
 #include "diagnostics.h"
 #include "str_replace.h"
 #include "mac_util.h"
+#include "mac_branding.h"
 
 //#include <drivers/event_status_driver.h>
 
@@ -301,7 +302,6 @@ CScreensaver::CScreensaver() {
     m_CurrentBannerMessage = 0;
     m_bQuitDataManagementProc = false;
     m_bDataManagementProcStopped = false;
-    m_BrandText = "BOINC";
     
     m_hDataManagementThread = NULL;
     m_hGraphicsApplication = NULL;
@@ -400,23 +400,7 @@ OSStatus CScreensaver::initBOINCApp() {
     saverState = SaverState_CantLaunchCoreClient;
     
     brandId = GetBrandID();
-    switch(brandId) {
-    case 1:
-        m_BrandText = "GridRepublic Desktop";
-         break;
-    case 2:
-        m_BrandText = "Progress Thru Processors Desktop";
-         break;
-    case 3:
-        m_BrandText = "Charity Engine Desktop";
-         break;
-    case 4:
-        m_BrandText = "World Community Grid";
-         break;
-    default:
-        m_BrandText = "BOINC";
-        break;
-    }
+    m_BrandText = brandName[brandId];
 
     m_CoreClientPID = FindProcessPID("boinc", 0);
     if (m_CoreClientPID) {
@@ -433,13 +417,8 @@ OSStatus CScreensaver::initBOINCApp() {
 
     // Find boinc client within BOINCManager.app
     // First, try default path
-    strcpy(boincPath, "/Applications/");
-    if (brandId) {
-        strcat(boincPath, m_BrandText);
-    } else {
-        strcat(boincPath, "BOINCManager");
-    }
-    strcat(boincPath, ".app/Contents/Resources/boinc");
+    strcpy(boincPath, appPath[brandId]);
+    strcat(boincPath, "/Contents/Resources/boinc");
 
     // If not at default path, search for it by creator code and bundle identifier
     if (!boinc_file_exists(boincPath)) {
@@ -878,7 +857,9 @@ int CScreensaver::GetBrandID()
         fscanf(f, "BrandId=%ld\n", &iBrandId);
         fclose(f);
     }
-        
+    if ((iBrandId < 0) || (iBrandId > (NUMBRANDS-1))) {
+        iBrandId = 0;
+    }
     return iBrandId;
 }
 

--- a/clientscr/ss_app.cpp
+++ b/clientscr/ss_app.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -28,6 +28,7 @@
 #include <vector>
 #ifdef __APPLE__
 #include "boinc_api.h"
+#include "mac_branding.h"
 #include <sys/socket.h>
 #endif
 
@@ -78,13 +79,6 @@ CC_STATE cc_state;
 CC_STATUS cc_status;
 
 #ifdef __APPLE__
-// Possible values of brandId (determined at run time on Mac):
-#define BOINC_BRAND_ID 0
-#define GRIDREPUBLIC_BRAND_ID 1
-#define PROGRESSTHRUPROCESSORS_BRAND_ID 2
-#define CHARITYENGINE_BRAND_ID 3
-#define WORLDCOMMUNITYGRID_BRAND_ID 4
-
 char* brand_name = "BOINC";
 char* logo_file = "boinc_logo_black.jpg";
 # else
@@ -524,23 +518,18 @@ int main(int argc, char** argv) {
     }
     
 #ifdef __APPLE__
-    long brandId = BOINC_BRAND_ID;
-    // For GridRepublic or CharityEngine, the installer put a branding file in our data directory
+    long brandId = 0;
+    // For branded installs, the installer put a branding file in our data directory
     FILE *f = fopen("/Library/Application Support/BOINC Data/Branding", "r");
     if (f) {
         fscanf(f, "BrandId=%ld\n", &brandId);
         fclose(f);
-        if (brandId == GRIDREPUBLIC_BRAND_ID) {
-            brand_name = "GridRepublic";
-            logo_file = "gridrepublic_ss_logo.jpg";
-        } else if (brandId == CHARITYENGINE_BRAND_ID) {
-            brand_name = "Charity Engine";
-            logo_file = "CE_ss_logo.jpg";
-        } else if (brandId == WORLDCOMMUNITYGRID_BRAND_ID) {
-            brand_name = "World Community Grid";
-            logo_file = "wcg_ss_logo.jpg";
-        }
     }
+    if ((brandId < 0) || (brandId > (NUMBRANDS-1))) {
+        brandId = 0;
+    }
+    brand_name = brandName[brandId];
+    logo_file = logoFile[brandId];
 #endif
 
     boinc_graphics_loop(argc, argv, "BOINC screensaver");

--- a/lib/mac/mac_branding.cpp
+++ b/lib/mac/mac_branding.cpp
@@ -1,0 +1,126 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  mac_branding.cpp
+//
+
+#include <string.h>
+#include "mac_branding.h"
+
+// The strings for these arrays are initialized here rather than in mac_branding.h, to avoid
+// duplicate definition errors when mac_branding.h is included from multiple source files.
+
+// appName[] is used by PostInstall.cpp, uninstall.cpp and AddRemoveuser.cpp
+char *appName[] = {
+                "BOINCManager", 
+                "GridRepublic Desktop",
+                "Progress Thru Processors Desktop",
+                "Charity Engine Desktop",
+                "World Community Grid"
+                };
+
+// appPath[] is used by PostInstall.cpp, uninstall.cpp, AddRemoveUser.cpp and mac_saver_module.cpp
+char *appPath[] =  {
+                "/Applications/BOINCManager.app",
+                "/Applications/GridRepublic Desktop.app",
+                "/Applications/Progress Thru Processors Desktop.app",
+                "/Applications/Charity Engine Desktop.app",
+                "/Applications/World Community Grid.app"
+                };
+
+// brandName[] is used by PostInstall.cpp, uninstall.cpp and AddRemoveuser.cpp
+char *brandName[] = {
+                "BOINC",
+                "GridRepublic",
+                "Progress Thru Processors",
+                "Charity Engine",
+                "World Community Grid"
+                };
+
+// saverName[] is used by PostInstall.cpp, uninstall.cpp, AddRemoveuser.cpp, 
+// check_security.cpp and SetupSecurity.cpp
+char *saverName[] = {
+                "BOINCSaver",
+                "GridRepublic",
+                "Progress Thru Processors",
+                "Charity Engine",
+                "World Community Grid"
+                };
+
+// receiptName[] is used by PostInstall.cpp and uninstall.cpp
+char *receiptName[] = {
+                "/Library/Receipts/BOINC Installer.pkg",
+                "/Library/Receipts/GridRepublic Installer.pkg",
+                "/Library/Receipts/Progress Thru Processors Installer.pkg",
+                "/Library/Receipts/Charity Engine Installer.pkg",
+                "/Library/Receipts/World Community Grid Installer.pkg"
+                };
+
+// skinName[] is used by PostInstall.cpp
+char *skinName[] = {
+                "Default",
+                "GridRepublic",
+                "Progress Thru Processors",
+                "Charity Engine",
+                "World Community Grid"
+                };
+
+// logoFile[] is used by ss_app.cpp
+char *logoFile[] = {
+                "boinc_logo_black.jpg",
+                "gridrepublic_ss_logo.jpg",
+                "progress_ss_logo.jpg",
+                "CE_ss_logo.jpg",
+                "wcg_ss_logo.jpg"
+                };
+
+// Returns false if any of these arrays has < NUMBRANDS entries
+bool check_branding_arrays(char* badArrayNames, int len) {
+    bool isOK = true;
+    *badArrayNames = '\0';
+    
+    if(appName[NUMBRANDS-1]==NULL) {
+        isOK = false;
+        strlcat(badArrayNames, "appName ", len);
+    }
+    if(appPath[NUMBRANDS-1]==NULL) {
+        isOK = false;
+        strlcat(badArrayNames, "appPath ", len);
+    }
+    if(brandName[NUMBRANDS-1]==NULL) {
+        isOK = false;
+        strlcat(badArrayNames, "brandName ", len);
+    }
+    if(saverName[NUMBRANDS-1]==NULL) {
+        isOK = false;
+        strlcat(badArrayNames, "saverName ", len);
+    }
+    if(receiptName[NUMBRANDS-1]==NULL) {
+        isOK = false;
+        strlcat(badArrayNames, "receiptName ", len);
+    }
+    if(skinName[NUMBRANDS-1]==NULL) {
+        isOK = false;
+        strlcat(badArrayNames, "skinName ", len);
+    }
+    if(logoFile[NUMBRANDS-1]==NULL) {
+        isOK = false;
+        strlcat(badArrayNames, "logoFile ", len);
+    }
+    
+    return isOK;
+}

--- a/lib/mac/mac_branding.h
+++ b/lib/mac/mac_branding.h
@@ -1,0 +1,40 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  mac_branding.h
+//
+
+#ifndef mac_branding_h
+#define mac_branding_h
+
+#define NUMBRANDS 5
+
+extern char *appName[NUMBRANDS];
+extern char *appPath[NUMBRANDS];
+extern char *brandName[NUMBRANDS];
+extern char *saverName[NUMBRANDS];
+extern char *receiptName[NUMBRANDS];
+extern char *skinName[NUMBRANDS];
+extern char *logoFile[NUMBRANDS];
+
+// The strings for these arrays are initialized in mac_branding.cpp, not here to avoid
+// duplicate definition errors when mac_branding.h is included from multiple source files.
+//
+
+extern bool check_branding_arrays(char* badArrayNames, int len);
+
+#endif /* mac_branding_h */

--- a/lib/procinfo_mac.cpp
+++ b/lib/procinfo_mac.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -31,18 +31,11 @@
 #endif
 
 #include "error_numbers.h"
-
 #include "procinfo.h"
 
+#include "mac_branding.h"
+
 using std::vector;
-
-// Possible values of iBrandId:
-#define BOINC_BRAND_ID 0
-#define GRIDREPUBLIC_BRAND_ID 1
-#define PROGRESSTHRUPROCESSORS_BRAND_ID 2
-#define CHARITYENGINE_BRAND_ID 3
-#define WORLDCOMMUNITYGRID_BRAND_ID 4
-
 
 // build table of all processes in system
 //
@@ -54,16 +47,14 @@ int procinfo_setup(PROC_MAP& pm) {
     char* lf;
     static long iBrandID = -1;
     
-    if (iBrandID < 0) {
-        iBrandID = BOINC_BRAND_ID;
-
-        // For GridRepublic or ProgressThruProcessors, the Mac 
-        // installer put a branding file in our data directory
-        FILE *f = fopen("/Library/Application Support/BOINC Data/Branding", "r");
-        if (f) {
-            fscanf(f, "BrandId=%ld\n", &iBrandID);
-            fclose(f);
-        }
+    // For branded installs, the Mac installer put a branding file in our data directory
+    FILE *f = fopen("/Library/Application Support/BOINC Data/Branding", "r");
+    if (f) {
+        fscanf(f, "BrandId=%ld\n", &iBrandID);
+        fclose(f);
+    }
+    if ((iBrandID < 0) || (iBrandID > (NUMBRANDS-1))) {
+        iBrandID = 0;
     }
 
 #if SHOW_TIMING
@@ -149,28 +140,10 @@ int procinfo_setup(PROC_MAP& pm) {
         // incorrect results for the % CPU used.
         p.is_low_priority = false;
 
-        switch (iBrandID) {
-        case GRIDREPUBLIC_BRAND_ID:
-            if (!strcasestr(p.command, "GridRepublic")) {
-                p.is_boinc_app = true;
-            }
-            break;
-        case PROGRESSTHRUPROCESSORS_BRAND_ID:
-            if (!strcasestr(p.command, "Progress Thru Processors")) {
-                p.is_boinc_app = true;
-            }
-            break;
-        case CHARITYENGINE_BRAND_ID:
-            if (!strcasestr(p.command, "Charity Engine")) {
-                p.is_boinc_app = true;
-            }
-            break;
-         case WORLDCOMMUNITYGRID_BRAND_ID:
-            if (!strcasestr(p.command, "World Community Grid")) {
-                p.is_boinc_app = true;
-            }
-            break;
+        if (!strcasestr(p.command, brandName[iBrandID])) {
+            p.is_boinc_app = true;
         }
+
         pm.insert(std::pair<int, PROCINFO>(p.id, p));
     }
     

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -321,6 +321,16 @@
 		DD8917E90F3B216000DE5B1C /* gutil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD40825507D3076400163EF5 /* gutil.cpp */; };
 		DD8917EE0F3B21CE00DE5B1C /* macglutfix.m in Sources */ = {isa = PBXBuildFile; fileRef = DD6D82DA08131AB1008F7200 /* macglutfix.m */; };
 		DD8917F00F3B21DA00DE5B1C /* mac_icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6381450870DB78007A2F8E /* mac_icon.cpp */; };
+		DD93854520F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854620F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854720F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854820F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854920F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854A20F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854B20F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854C20F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854D20F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD93854E20F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
 		DD957E5B181B908800ECA34E /* thumbnail.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E59181B908800ECA34E /* thumbnail.png */; };
 		DD957E5C181B908800ECA34E /* thumbnail@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E5A181B908800ECA34E /* thumbnail@2x.png */; };
 		DD9917251E69A4F100555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
@@ -1060,6 +1070,8 @@
 		DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
 		DD8DD4A509D9432F0043019E /* BOINCDialupManager.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = BOINCDialupManager.cpp; path = ../clientgui/BOINCDialupManager.cpp; sourceTree = SOURCE_ROOT; };
 		DD8DD4A609D9432F0043019E /* BOINCDialupManager.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = BOINCDialupManager.h; path = ../clientgui/BOINCDialupManager.h; sourceTree = SOURCE_ROOT; };
+		DD93854320F609C7008EDE5A /* mac_branding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mac_branding.cpp; path = ../lib/mac/mac_branding.cpp; sourceTree = "<group>"; };
+		DD93854420F609C8008EDE5A /* mac_branding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = mac_branding.h; path = ../lib/mac/mac_branding.h; sourceTree = "<group>"; };
 		DD957E59181B908800ECA34E /* thumbnail.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = thumbnail.png; path = ../clientscr/res/thumbnail.png; sourceTree = "<group>"; };
 		DD957E5A181B908800ECA34E /* thumbnail@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "thumbnail@2x.png"; path = "../clientscr/res/thumbnail@2x.png"; sourceTree = "<group>"; };
 		DD96AFF90811075000A06F22 /* BOINCSaver.saver */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BOINCSaver.saver; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1747,6 +1759,8 @@
 				DDBAA9B41DF1902B004C48FD /* mac_util.mm */,
 				DDA6BD040BD4551F008F7921 /* mac_backtrace.cpp */,
 				DDA6BD050BD4551F008F7921 /* mac_backtrace.h */,
+				DD93854320F609C7008EDE5A /* mac_branding.cpp */,
+				DD93854420F609C8008EDE5A /* mac_branding.h */,
 				DDA6BD060BD4551F008F7921 /* QBacktrace.c */,
 				DDA6BD070BD4551F008F7921 /* QBacktrace.h */,
 				DDA6BD080BD4551F008F7921 /* QCrashReport.c */,
@@ -2786,6 +2800,7 @@
 				DDA12AA20A369B5500FBDD12 /* SetupSecurity.cpp in Sources */,
 				DD51DC8F0A4943A300BD24E6 /* check_security.cpp in Sources */,
 				DD728D45175DD3B900A1CE23 /* url.cpp in Sources */,
+				DD93854820F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DDD0CEAC1E1E15B2003BD920 /* mac_util.mm in Sources */,
 				DD728D47175DD41B00A1CE23 /* str_util.cpp in Sources */,
 				DDF93511176B0D0C00A2793C /* translate.cpp in Sources */,
@@ -2802,6 +2817,7 @@
 				DD5FE1B517828887003339DF /* translate.cpp in Sources */,
 				DDB9EA9917BE2C1E00651B07 /* filesys.cpp in Sources */,
 				DDB9EA9B17BE2C6F00651B07 /* util.cpp in Sources */,
+				DD93854A20F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DDE289661E1F985C00A17A36 /* mac_util.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2826,6 +2842,7 @@
 				DD3E14E30A774397007E0084 /* AccountManagerPropertiesPage.cpp in Sources */,
 				DD3E14E50A774397007E0084 /* AlreadyExistsPage.cpp in Sources */,
 				DDBAA9B51DF1902B004C48FD /* mac_util.mm in Sources */,
+				DD93854B20F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DD3E14E60A774397007E0084 /* BOINCBaseView.cpp in Sources */,
 				DD3E14E70A774397007E0084 /* BOINCBaseWizard.cpp in Sources */,
 				DD3E14E80A774397007E0084 /* BOINCGUIApp.cpp in Sources */,
@@ -2961,6 +2978,7 @@
 				DD407A6707D2FBBD00163EF5 /* prefs.cpp in Sources */,
 				DD2B6C8E131491B8005D6F3E /* procinfo.cpp in Sources */,
 				DD2B6C8D131491B7005D6F3E /* procinfo_mac.cpp in Sources */,
+				DD93854620F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DD407A6907D2FBC200163EF5 /* proxy_info.cpp in Sources */,
 				DD407A6B07D2FBC700163EF5 /* shmem.cpp in Sources */,
 				DD4329910BA63DEC007CDF2A /* str_util.cpp in Sources */,
@@ -2991,6 +3009,7 @@
 				DDB9EA9C17BE2C7100651B07 /* util.cpp in Sources */,
 				DDF5E23318B8673E005DEA6E /* uninstall.cpp in Sources */,
 				DD83028D1E07F87400B53CAC /* mac_util.mm in Sources */,
+				DD93854C20F609C8008EDE5A /* mac_branding.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3013,6 +3032,7 @@
 			files = (
 				DD7748B50A356D6C0025D05E /* SetupSecurity.cpp in Sources */,
 				DDD0CEAE1E1E36AE003BD920 /* mac_util.mm in Sources */,
+				DD93854920F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DDA12AAE0A369C5800FBDD12 /* SecurityUtility.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3093,6 +3113,7 @@
 				DD89169C0F3B1C0900DE5B1C /* QTaskMemory.c in Sources */,
 				DD89179B0F3B206600DE5B1C /* app_ipc.cpp in Sources */,
 				DD8917A30F3B207800DE5B1C /* diagnostics.cpp in Sources */,
+				DD93854D20F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DD8917A50F3B207E00DE5B1C /* filesys.cpp in Sources */,
 				DD8917A70F3B208500DE5B1C /* gui_rpc_client.cpp in Sources */,
 				DD8917AB0F3B209500DE5B1C /* hostinfo.cpp in Sources */,
@@ -3155,6 +3176,7 @@
 				DDB8739A0C85072500E0DE1F /* Mac_Saver_ModuleView.m in Sources */,
 				DD7AEB4A0C87CE1300AC3B5C /* screensaver.cpp in Sources */,
 				DD6803440E70A61D0067D009 /* diagnostics.cpp in Sources */,
+				DD93854720F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DDD9C5AC10CCF6AB00A1E4CD /* coproc.cpp in Sources */,
 				DDF5F85B10DD05E4006A50CD /* notice.cpp in Sources */,
 				DD262C821366D35D00C9A187 /* cc_config.cpp in Sources */,
@@ -3217,6 +3239,7 @@
 				DDE900271E643E3C003728F2 /* mac_util.mm in Sources */,
 				DDB00FA120E110E000C8ABEF /* filesys.cpp in Sources */,
 				DDB00FA220E111F100C8ABEF /* util.cpp in Sources */,
+				DD93854E20F609C8008EDE5A /* mac_branding.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3308,6 +3331,7 @@
 				DD1CB233154F5BF700BFF282 /* result.cpp in Sources */,
 				DD25F72815914F8C007845B5 /* gpu_nvidia.cpp in Sources */,
 				DD25F72915914F8C007845B5 /* gpu_amd.cpp in Sources */,
+				DD93854520F609C8008EDE5A /* mac_branding.cpp in Sources */,
 				DD25F72A15914F8C007845B5 /* gpu_opencl.cpp in Sources */,
 				DD25F72B15914F8C007845B5 /* gpu_detect.cpp in Sources */,
 				DDE17420166746F70059083A /* app_config.cpp in Sources */,

--- a/mac_installer/AddRemoveUser.cpp
+++ b/mac_installer/AddRemoveUser.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2009 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -34,6 +34,7 @@
 #include "mac_util.h"
 #include "filesys.h"
 #include "util.h"
+#include "mac_branding.h"
 
 void printUsage(long brandID);
 Boolean SetLoginItemOSAScript(long brandID, Boolean deleteLogInItem, char *userName);
@@ -49,13 +50,6 @@ static void SleepSeconds(double seconds);
 long GetBrandID(void);
 static int parse_posic_spawn_command_line(char* p, char** argv);
 int callPosixSpawn(const char *cmd);
-
-
-#define NUMBRANDS 5
-static char *appName[NUMBRANDS];
-static char *appPath[NUMBRANDS];
-static char *brandName[NUMBRANDS];
-static char *saverName[NUMBRANDS];
 
 
 int main(int argc, char *argv[])
@@ -79,31 +73,6 @@ int main(int argc, char *argv[])
     char                s[1024], buf[1024];
     OSStatus            err;
     
-    appName[0] = "BOINCManager";
-    appPath[0] = "/Applications/BOINCManager.app";
-    brandName[0] = "BOINC";
-    saverName[0] = "BOINCSaver";
-
-    appName[1] = "GridRepublic Desktop";
-    appPath[1] = "/Applications/GridRepublic Desktop.app";
-    brandName[1] = "GridRepublic";
-    saverName[1] = "GridRepublic";
-
-    appName[2] = "Progress Thru Processors Desktop";
-    appPath[2] = "/Applications/Progress Thru Processors Desktop.app";
-    brandName[2] = "Progress Thru Processors";
-    saverName[2] = "Progress Thru Processors";
-
-    appName[3] = "Charity Engine Desktop";
-    appPath[3] = "/Applications/Charity Engine Desktop.app";
-    brandName[3] = "Charity Engine";
-    saverName[3] = "Charity Engine";
-
-    appName[4] = "World Community Grid";
-    appPath[4] = "/Applications/World Community Grid.app";
-    brandName[4] = "World Community Grid";
-    saverName[4] = "World Community Grid";
-
     brandID = GetBrandID();
 
 #ifndef _DEBUG
@@ -131,6 +100,11 @@ int main(int argc, char *argv[])
     }
 
     printf("\n");
+
+    if (!check_branding_arrays(s, sizeof(s))) {
+        printf("Branding array has too few entries: %s\n", s);
+        return -1;
+    }
 
     loginName[0] = '\0';
     strncpy(loginName, getenv("USER"), sizeof(loginName)-1);
@@ -805,7 +779,9 @@ long GetBrandID()
         fscanf(f, "BrandId=%ld\n", &iBrandId);
         fclose(f);
     }
-    
+    if ((iBrandId < 0) || (iBrandId > (NUMBRANDS-1))) {
+        iBrandId = 0;
+    }
     return iBrandId;
 }
 

--- a/mac_installer/Installer.cpp
+++ b/mac_installer/Installer.cpp
@@ -36,6 +36,7 @@
 #include "mac_util.h"
 #include "translate.h"
 #include "file_names.h"
+#include "mac_branding.h"
 
 #define boinc_master_user_name "boinc_master"
 #define boinc_master_group_name "boinc_master"
@@ -86,6 +87,11 @@ int main(int argc, char *argv[])
     FILE                    *restartNeededFile;
     FILE                    *f;
     long                    oldBrandID;
+
+    if (!check_branding_arrays(temp, sizeof(temp))) {
+        ShowMessage((char *)_("Branding array has too few entries: %s"), temp);
+        return -1;
+    }
 
     if (Initialize() != noErr) {
         return 0;
@@ -573,7 +579,9 @@ static long GetOldBrandID()
         fscanf(f, "BrandId=%ld\n", &oldBrandId);
         fclose(f);
     }
-    
+    if ((oldBrandId < 0) || (oldBrandId > (NUMBRANDS-1))) {
+        oldBrandId = 0;
+    }
     return oldBrandId;
 }
 

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -52,6 +52,7 @@ using std::string;
 #include "mac_util.h"
 #include "translate.h"
 #include "file_names.h"
+#include "mac_branding.h"
 
 
 static OSStatus DoUninstall(void);
@@ -81,14 +82,6 @@ static char * gCatalog_Name = (char *)"BOINC-Setup";
 static char loginName[256];
 
 
-#define NUMBRANDS 5
-static char *appName[NUMBRANDS];
-static char *appPath[NUMBRANDS];
-static char *brandName[NUMBRANDS];
-static char *saverName[NUMBRANDS];
-static char *receiptName[NUMBRANDS];
-
-
 /* BEGIN TEMPORARY ITEMS TO ALLOW TRANSLATORS TO START WORK */
 void notused() {
     ShowMessage(true, false, false, (char *)_("OK"));
@@ -106,36 +99,6 @@ int main(int argc, char *argv[])
     FILE                        *f;
     OSStatus                    err = noErr;
     
-    appName[0] = "BOINCManager";
-    appPath[0] = "/Applications/BOINCManager.app";
-    brandName[0] = "BOINC";
-    saverName[0] = "BOINCSaver";
-    receiptName[0] = "/Library/Receipts/BOINC Installer.pkg";
-
-    appName[1] = "GridRepublic Desktop";
-    appPath[1] = "/Applications/GridRepublic Desktop.app";
-    brandName[1] = "GridRepublic";
-    saverName[1] = "GridRepublic";
-    receiptName[1] = "/Library/Receipts/GridRepublic Installer.pkg";
-
-    appName[2] = "Progress Thru Processors Desktop";
-    appPath[2] = "/Applications/Progress Thru Processors Desktop.app";
-    brandName[2] = "Progress Thru Processors";
-    saverName[2] = "Progress Thru Processors";
-    receiptName[2] = "/Library/Receipts/Progress Thru Processors Installer.pkg";
-
-    appName[3] = "Charity Engine Desktop";
-    appPath[3] = "/Applications/Charity Engine Desktop.app";
-    brandName[3] = "Charity Engine";
-    saverName[3] = "Charity Engine";
-    receiptName[3] = "/Library/Receipts/Charity Engine Installer.pkg";
-
-    appName[4] = "World Community Grid";
-    appPath[4] = "/Applications/World Community Grid.app";
-    brandName[4] = "World Community Grid";
-    saverName[4] = "World Community Grid";
-    receiptName[4] = "/Library/Receipts/World Community Grid Installer.pkg";
-
     pathToSelf[0] = '\0';
     // Get the full path to our executable inside this application's bundle
     getPathToThisApp(pathToSelf, sizeof(pathToSelf));
@@ -145,6 +108,11 @@ int main(int argc, char *argv[])
     }
     strlcpy(pathToVBoxUninstallTool, pathToSelf, sizeof(pathToVBoxUninstallTool));
     strlcat(pathToVBoxUninstallTool, "/Contents/Resources/VirtualBox_Uninstall.tool", sizeof(pathToVBoxUninstallTool));
+
+    if (!check_branding_arrays(cmd, sizeof(cmd))) {
+        ShowMessage(false, false, false, (char *)_("Branding array has too few entries: %s"), cmd);
+        return -1;
+    }
 
     // To allow for branding, assume name of executable inside bundle is same as name of bundle
     p = strrchr(pathToSelf, '/');         // Assume name of executable inside bundle is same as name of bundle
@@ -1056,7 +1024,9 @@ long GetBrandID(char *path)
         fscanf(f, "BrandId=%ld\n", &iBrandId);
         fclose(f);
     }
-    
+    if ((iBrandId < 0) || (iBrandId > (NUMBRANDS-1))) {
+        iBrandId = 0;
+    }
     return iBrandId;
 }
 


### PR DESCRIPTION
Mac: Consolidate branding strings in one source file and one header file shared among all files which use them; add checks for missing branding strings.