### PR TITLE
Drupal: Fixed bug- in emails sent to user when email address changes

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -495,7 +495,7 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
             if ($changing_email) {
               // reload account
               $account = user_load($account->uid);
-              _boincuser_send_emailchange($account, $email_addr, $prev_email);
+              _boincuser_send_emailchange($account, $email_addr, $prev_email, user_access('administer users'));
             }
           }
           break;

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
@@ -212,7 +212,7 @@ function boincuser_select_user_of_the_day() {
  * this function is called, it may be called with optional parameters
  * new and prev email.
  */
-function _boincuser_send_emailchange($account, $new_email=NULL, $prev_email=NULL) {
+function _boincuser_send_emailchange($account, $new_email=NULL, $prev_email=NULL, $adminuser=FALSE) {
   require_boinc('token');
   module_load_include('inc', 'rules', 'modules/system.rules');
 
@@ -228,20 +228,27 @@ function _boincuser_send_emailchange($account, $new_email=NULL, $prev_email=NULL
 
   // @todo - set constant in drupal, or use BOINC contsants
   $duration = TOKEN_DURATION_ONE_WEEK;
-  $changedate = date('F j, Y \a\t G:i T', $account->boincuser_email_addr_change_time);
+  $changedate = date('F j, Y \a\t G:i T', time());
   $newdate = date('F j, Y \a\t G:i T', $account->boincuser_email_addr_change_time + $duration);
-
   $token = create_token($account->boincuser_id, TOKEN_TYPE_CHANGE_EMAIL, $duration);
+  if ($adminuser) {
+    $graf1 = "Your email address was changed from {$prev_email} to {$new_email} "
+      . "on {$changedate}. If you need to reverse this change, please look for "
+      . "an email send to the email address: {$prev_email}.\n";
+  }
+  else {
+    $graf1 = "Your email address was changed from {$prev_email} to {$new_email} "
+      . "on {$changedate}. You will not be able to change your email address "
+      . "until {$newdate}. If you need to reverse this change, please look for "
+      . "an email send to the email address: {$prev_email}.\n";
+  }
 
   // Send email #1 to current address
   $mysubject = "Notification of email change at {$site_name}";
   $mymessage = ''
       . "{$account->boincuser_name},\n"
       . "\n"
-      . "Your email address was changed from {$prev_email} to {$new_email} "
-      . "on {$changedate}. You will not be able to change your email address "
-      . "until {$newdate}. If you need to reverse this change, please look for "
-      . "an email send to the email address: {$prev_email}.\n"
+      . $graf1
       . "\n"
       . "Thanks, \n"
       . "{$site_name} support team\n";


### PR DESCRIPTION
When admin user changing email address, email sent to user contains correct time.

Part of https://dev.gridrepublic.org/browse/DBOINCP-436