### PR TITLE
user: set show_host default to false.

### DIFF
--- a/html/inc/user_util.inc
+++ b/html/inc/user_util.inc
@@ -92,6 +92,13 @@ function is_valid_user_name($name, &$reason) {
     return true;
 }
 
+function default_show_hosts() {
+    global $config;
+    // If enable privacy by default is TRUE, then show_hosts' default
+    // is FALSE.
+    return parse_bool($config, "enable_privacy_by_default") ? 0 : 1;
+}
+
 // the following DB-escapes its args
 //
 function make_user(
@@ -114,14 +121,8 @@ function make_user(
     $country = BoincDb::escape_string($country);
     $postal_code = sanitize_tags(BoincDb::escape_string($postal_code));
 
-    //show_hosts defaults to TRUE (1), but config option
-    //'enable_privacy_by_default' will set the default to FALSE(0).
-    $default_show_hosts = 1;
-    $config = get_config();
-    if (parse_bool($config, "enable_privacy_by_default")) {
-        $default_show_hosts = 0;
-    }
-    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  venue, send_email, show_hosts, posts, seti_id, seti_nresults, seti_last_result_time, seti_total_cpu, has_profile, cross_project_id, passwd_hash, email_validated, donated) values($now, '$email_addr', '$name', '$authenticator', '$country', '$postal_code', 0, 0, unix_timestamp(), '$project_prefs', $teamid, '', 1, $default_show_hosts, 0, 0, 0, 0, 0, 0, '$cross_project_id', '$database_passwd_hash', 0, 0)");
+    $show_hosts = default_show_hosts();
+    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  venue, send_email, show_hosts, posts, seti_id, seti_nresults, seti_last_result_time, seti_total_cpu, has_profile, cross_project_id, passwd_hash, email_validated, donated) values($now, '$email_addr', '$name', '$authenticator', '$country', '$postal_code', 0, 0, unix_timestamp(), '$project_prefs', $teamid, '', 1, $show_hosts, 0, 0, 0, 0, 0, 0, '$cross_project_id', '$database_passwd_hash', 0, 0)");
 
     if (!$uid) {
         return null;
@@ -144,14 +145,8 @@ function make_user_ldap($email_addr, $name) {
     $passwd_hash = random_string();
     $now = time();
 
-    //show_hosts defaults to TRUE (1), but config option
-    //'enable_privacy_by_default' will set the default to FALSE(0).
-    $default_show_hosts = 1;
-    $config = get_config();
-    if (parse_bool($config, "enable_privacy_by_default")) {
-        $default_show_hosts = 0;
-    }
-    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  send_email, show_hosts, cross_project_id, passwd_hash) values($now, '$email_addr', '$name', '$authenticator', '', '', 0, 0, unix_timestamp(), '', 0, 1, $default_show_hosts, '$cross_project_id', '$passwd_hash')");
+    $show_hosts = default_show_hosts();
+    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  send_email, show_hosts, cross_project_id, passwd_hash) values($now, '$email_addr', '$name', '$authenticator', '', '', 0, 0, unix_timestamp(), '', 0, 1, $show_hosts, '$cross_project_id', '$passwd_hash')");
 
     if ($uid) {
         return BoincUser::lookup_id($uid);

--- a/html/inc/user_util.inc
+++ b/html/inc/user_util.inc
@@ -114,7 +114,14 @@ function make_user(
     $country = BoincDb::escape_string($country);
     $postal_code = sanitize_tags(BoincDb::escape_string($postal_code));
 
-    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  venue, send_email, show_hosts, posts, seti_id, seti_nresults, seti_last_result_time, seti_total_cpu, has_profile, cross_project_id, passwd_hash, email_validated, donated) values($now, '$email_addr', '$name', '$authenticator', '$country', '$postal_code', 0, 0, unix_timestamp(), '$project_prefs', $teamid, '', 1, 0, 0, 0, 0, 0, 0, 0, '$cross_project_id', '$database_passwd_hash', 0, 0)");
+    //show_hosts defaults to TRUE (1), but config option
+    //'enable_privacy_by_default' will set the default to FALSE(0).
+    $default_show_hosts = 1;
+    $config = get_config();
+    if (parse_bool($config, "enable_privacy_by_default")) {
+        $default_show_hosts = 0;
+    }
+    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  venue, send_email, show_hosts, posts, seti_id, seti_nresults, seti_last_result_time, seti_total_cpu, has_profile, cross_project_id, passwd_hash, email_validated, donated) values($now, '$email_addr', '$name', '$authenticator', '$country', '$postal_code', 0, 0, unix_timestamp(), '$project_prefs', $teamid, '', 1, $default_show_hosts, 0, 0, 0, 0, 0, 0, '$cross_project_id', '$database_passwd_hash', 0, 0)");
 
     if (!$uid) {
         return null;
@@ -136,7 +143,14 @@ function make_user_ldap($email_addr, $name) {
     $cross_project_id = random_string();
     $passwd_hash = random_string();
     $now = time();
-    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  send_email, show_hosts, cross_project_id, passwd_hash) values($now, '$email_addr', '$name', '$authenticator', '', '', 0, 0, unix_timestamp(), '', 0, 1, 0, '$cross_project_id', '$passwd_hash')");
+
+    //show_hosts defaults to TRUE (1), but config option
+    //'enable_privacy_by_default' will set the default to FALSE(0).
+    $config = get_config();
+    if (parse_bool($config, "enable_privacy_by_default")) {
+        $default_show_hosts = 0;
+    }
+    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  send_email, show_hosts, cross_project_id, passwd_hash) values($now, '$email_addr', '$name', '$authenticator', '', '', 0, 0, unix_timestamp(), '', 0, 1, $default_show_hosts, '$cross_project_id', '$passwd_hash')");
 
     if ($uid) {
         return BoincUser::lookup_id($uid);

--- a/html/inc/user_util.inc
+++ b/html/inc/user_util.inc
@@ -146,6 +146,7 @@ function make_user_ldap($email_addr, $name) {
 
     //show_hosts defaults to TRUE (1), but config option
     //'enable_privacy_by_default' will set the default to FALSE(0).
+    $default_show_hosts = 1;
     $config = get_config();
     if (parse_bool($config, "enable_privacy_by_default")) {
         $default_show_hosts = 0;

--- a/html/inc/user_util.inc
+++ b/html/inc/user_util.inc
@@ -114,7 +114,7 @@ function make_user(
     $country = BoincDb::escape_string($country);
     $postal_code = sanitize_tags(BoincDb::escape_string($postal_code));
 
-    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  venue, send_email, show_hosts, posts, seti_id, seti_nresults, seti_last_result_time, seti_total_cpu, has_profile, cross_project_id, passwd_hash, email_validated, donated) values($now, '$email_addr', '$name', '$authenticator', '$country', '$postal_code', 0, 0, unix_timestamp(), '$project_prefs', $teamid, '', 1, 1, 0, 0, 0, 0, 0, 0, '$cross_project_id', '$database_passwd_hash', 0, 0)");
+    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  venue, send_email, show_hosts, posts, seti_id, seti_nresults, seti_last_result_time, seti_total_cpu, has_profile, cross_project_id, passwd_hash, email_validated, donated) values($now, '$email_addr', '$name', '$authenticator', '$country', '$postal_code', 0, 0, unix_timestamp(), '$project_prefs', $teamid, '', 1, 0, 0, 0, 0, 0, 0, 0, '$cross_project_id', '$database_passwd_hash', 0, 0)");
 
     if (!$uid) {
         return null;
@@ -136,7 +136,7 @@ function make_user_ldap($email_addr, $name) {
     $cross_project_id = random_string();
     $passwd_hash = random_string();
     $now = time();
-    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  send_email, show_hosts, cross_project_id, passwd_hash) values($now, '$email_addr', '$name', '$authenticator', '', '', 0, 0, unix_timestamp(), '', 0, 1, 1, '$cross_project_id', '$passwd_hash')");
+    $uid = BoincUser::insert("(create_time, email_addr, name, authenticator, country, postal_code, total_credit, expavg_credit, expavg_time, project_prefs, teamid,  send_email, show_hosts, cross_project_id, passwd_hash) values($now, '$email_addr', '$name', '$authenticator', '', '', 0, 0, unix_timestamp(), '', 0, 1, 0, '$cross_project_id', '$passwd_hash')");
 
     if ($uid) {
         return BoincUser::lookup_id($uid);

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -489,6 +489,7 @@ class Project:
         config.daily_result_quota = 500
         config.disable_account_creation = 0
         config.disable_web_account_creation = 0
+        config.enable_privacy_by_default = 0
         config.show_results = 1
         config.cache_md5_info = 1
         config.sched_debug_level = 3


### PR DESCRIPTION
This PR changes a single flag the BoincUser::insert statement, setting the flag `show_host` to false. Thus by default a user's hosts are not in publicly view.

Part of #2449