### PR TITLE
Drupal: Fixed bug in community pref form.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1636,7 +1636,7 @@ function communityprefs_form_submit($form, &$form_state) {
   pm_email_notify_user('submit', $edit, $user);
   
   // Avatar settings - only set if profile_node exists.
-  if (!empty($profile_node)) {
+  if ($profile_node) {
     if (!$edit['field_image']) $edit['field_image'] = array();
     $profile_node->field_image = $edit['field_image'];
     node_save($profile_node);

--- a/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincwork/includes/boincwork.forms.inc
@@ -1635,13 +1635,15 @@ function communityprefs_form_submit($form, &$form_state) {
   // Private message settings
   pm_email_notify_user('submit', $edit, $user);
   
-  // Avatar settings
-  if (!$edit['field_image']) $edit['field_image'] = array();
-  $profile_node->field_image = $edit['field_image'];
-  node_save($profile_node);
-  // Flush this from the node cache or changes won't show up immediately!
-  $profile_node = node_load($profile_node->nid, NULL, TRUE);
-  
+  // Avatar settings - only set if profile_node exists.
+  if (!empty($profile_node)) {
+    if (!$edit['field_image']) $edit['field_image'] = array();
+    $profile_node->field_image = $edit['field_image'];
+    node_save($profile_node);
+    // Flush this from the node cache or changes won't show up immediately!
+    $profile_node = node_load($profile_node->nid, NULL, TRUE);
+  }
+
   // All other settings
   $settings = array(
     'signature' => $edit['signature'],


### PR DESCRIPTION
When saving community preference form: the user_profile is loaded. If it does not exist, there should be no 'node_save()' function call, otherwise empty nodes are created.

https://dev.gridrepublic.org/browse/DBOINCP-437