### PR TITLE
script_validator segfault fix

### DIFF
--- a/sched/script_validator.cpp
+++ b/sched/script_validator.cpp
@@ -76,9 +76,9 @@ int validate_handler_init(int argc, char** argv) {
         }
     }
 
-    if (!init_script.size() && !compare_script.size()) {
+    if (!init_script.size() || !compare_script.size()) {
         log_messages.printf(MSG_CRITICAL,
-            "script names missing from command line\n"
+            "init_script and/or compare_script names are missing from command line\n"
         );
         return 1;
     }

--- a/sched/script_validator.cpp
+++ b/sched/script_validator.cpp
@@ -112,7 +112,7 @@ int init_result(RESULT& result, void*&) {
     }
 
     if (init_script.size() == 0) {
-        fprintf(stderr, "init_result() failed: init_script parameter was not specified\n")
+        fprintf(stderr, "init_result() failed: init_script parameter was not specified\n");
         return 1;
     }
 
@@ -158,7 +158,7 @@ int compare_results(RESULT& r1, void*, RESULT const& r2, void*, bool& match) {
     }
 
     if (compare_script.size() == 0) {
-        fprintf(stderr, "compare_results() failed: compare_script parameter was not specified\n")
+        fprintf(stderr, "compare_results() failed: compare_script parameter was not specified\n");
         return 1;
     }
 

--- a/sched/script_validator.cpp
+++ b/sched/script_validator.cpp
@@ -110,6 +110,12 @@ int init_result(RESULT& result, void*&) {
         fprintf(stderr, "get_output_file_paths() returned %d\n", retval);
         return retval;
     }
+
+    if (init_script.size() == 0) {
+        fprintf(stderr, "init_result() failed: init_script parameter was not specified\n")
+        return 1;
+    }
+
     char cmd[4096];
     sprintf(cmd, "../bin/%s", init_script[0].c_str());
     for (i=1; i<init_script.size(); i++) {
@@ -150,6 +156,12 @@ int compare_results(RESULT& r1, void*, RESULT const& r2, void*, bool& match) {
         fprintf(stderr, "get_output_file_paths() returned %d\n", retval);
         return retval;
     }
+
+    if (compare_script.size() == 0) {
+        fprintf(stderr, "compare_results() failed: compare_script parameter was not specified\n")
+        return 1;
+    }
+
     char cmd[4096];
     sprintf(cmd, "../bin/%s", compare_script[0].c_str());
     for (i=1; i<compare_script.size(); i++) {


### PR DESCRIPTION
Current script_validator implementation contains next statements:

`sprintf(cmd, "../bin/%s", init_script[0].c_str());`

and

`sprintf(cmd, "../bin/%s", compare_script[0].c_str());`

It is dangerous to use this arrays
that are filled by parsing command line
without validating whether they contain any elements
and leads to next behavior:

Program received signal SIGSEGV, Segmentation fault.
```
0x000000000040f838 in compare_results (r1=..., r2=..., match=match@entry=@0x7ffffffb6c17: false) at script_validator.cpp:154
154	script_validator.cpp: No such file or directory.
(gdb) bt
#0  0x000000000040f838 in compare_results (r1=..., r2=..., match=match@entry=@0x7ffffffb6c17: false) at script_validator.cpp:154
#1  0x000000000040e85d in check_set (results=std::vector of length 2, capacity 2 = {...}, wu=..., canonicalid=@0x7ffffffb6dd0: 0,
    retry=@0x7ffffffb6dcf: false) at validate_util2.cpp:134
#2  0x000000000040944e in handle_wu (validator=..., items=std::vector of length 3, capacity 4 = {...}) at validator.cpp:411
#3  0x000000000040a9f2 in do_validate_scan () at validator.cpp:730
#4  0x000000000040aae4 in main_loop () at validator.cpp:756
#5  0x00000000004039f6 in main (argc=5, argv=0x7fffffffdd48) at validator.cpp:929
```

This fix checks whether these arrays contain some elements
and output a readable error of missed inout parameter.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>