### PR TITLE
Eliminate need for installer to rename previous nvc_config.xml to old_nvc_config.xml

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -180,7 +180,7 @@ CLIENT_STATE::CLIENT_STATE()
     gui_rpc_unix_domain = false;
     new_version_check_time = 0;
     all_projects_list_check_time = 0;
-    client_version_check_url = nvc_config.get_default_version_check_url();
+    client_version_check_url = DEFAULT_VERSION_CHECK_URL;
     detach_console = false;
 #ifdef SANDBOX
     g_use_sandbox = true; // User can override with -insecure command-line arg

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -180,6 +180,7 @@ CLIENT_STATE::CLIENT_STATE()
     gui_rpc_unix_domain = false;
     new_version_check_time = 0;
     all_projects_list_check_time = 0;
+    client_version_check_url = nvc_config.get_default_version_check_url();
     detach_console = false;
 #ifdef SANDBOX
     g_use_sandbox = true; // User can override with -insecure command-line arg
@@ -641,7 +642,7 @@ int CLIENT_STATE::init() {
 
     // inform the user if there's a newer version of client
     // NOTE: this must be called AFTER
-    // read_vc_config_file(NVC_CONFIG_FILE, nvc_config)
+    // read_vc_config_file()
     //
     newer_version_startup_check();
 

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -245,11 +245,14 @@ struct CLIENT_STATE {
     double new_version_check_time;
     double all_projects_list_check_time;
         // the time we last successfully fetched the project list
-    string newer_version;
     bool autologin_in_progress;
     bool autologin_fetching_project_list;
     PROJECT_LIST project_list;
     void process_autologin(bool first);
+
+// --------------- current_version.cpp:
+    string newer_version;
+    string client_version_check_url;
 
 // --------------- client_state.cpp:
     CLIENT_STATE();

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -507,6 +507,9 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
         if (xp.parse_string("newer_version", newer_version)) {
             continue;
         }
+        if (xp.parse_string("client_version_check_url", client_version_check_url)) {
+            continue;
+        }
 #ifdef ENABLE_AUTO_UPDATE
         if (xp.match_tag("auto_update")) {
             if (!project) {
@@ -792,6 +795,9 @@ int CLIENT_STATE::write_state(MIOFILE& f) {
     }
     if (newer_version.size()) {
         f.printf("<newer_version>%s</newer_version>\n", newer_version.c_str());
+    }
+    if (client_version_check_url.size()) {
+        f.printf("<client_version_check_url>%s</client_version_check_url>\n", client_version_check_url.c_str());
     }
     for (i=1; i<platforms.size(); i++) {
         f.printf("<alt_platform>%s</alt_platform>\n", platforms[i].name.c_str());

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -39,14 +39,10 @@ NVC_CONFIG::NVC_CONFIG() {
 void NVC_CONFIG::defaults() {
     client_download_url = "https://boinc.berkeley.edu/download.php";
     client_new_version_name = "";
-    client_version_check_url = get_default_version_check_url();
+    client_version_check_url = DEFAULT_VERSION_CHECK_URL;
     network_test_url = "https://www.google.com/";
 };
 
-std::string NVC_CONFIG::get_default_version_check_url() {
-    return "https://boinc.berkeley.edu/download.php?xml=1";
-}
-    
 int NVC_CONFIG::parse(FILE* f) {
     MIOFILE mf;
     XML_PARSER xp(&mf);

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -34,15 +34,19 @@ NVC_CONFIG::NVC_CONFIG() {
     defaults();
 }
 
-// this is called first thing by client
+// this is called first thing by client right after CC_CONFIG::defaults()
 //
 void NVC_CONFIG::defaults() {
     client_download_url = "https://boinc.berkeley.edu/download.php";
     client_new_version_name = "";
-    client_version_check_url = "https://boinc.berkeley.edu/download.php?xml=1";
+    client_version_check_url = get_default_version_check_url();
     network_test_url = "https://www.google.com/";
 };
 
+std::string NVC_CONFIG::get_default_version_check_url() {
+    return "https://boinc.berkeley.edu/download.php?xml=1";
+}
+    
 int NVC_CONFIG::parse(FILE* f) {
     MIOFILE mf;
     XML_PARSER xp(&mf);
@@ -101,13 +105,13 @@ int NVC_CONFIG::parse(FILE* f) {
     return ERR_XML_PARSE;
 }
 
-int read_vc_config_file(const char* fname, NVC_CONFIG& nvc_config_file) {
-    nvc_config_file.defaults();
-    FILE* f = boinc_fopen(fname, "r");
+int read_vc_config_file() {
+    nvc_config.defaults();
+    FILE* f = boinc_fopen(NVC_CONFIG_FILE, "r");
     if (!f) {
         return ERR_FOPEN;
     }
-    nvc_config_file.parse(f);
+    nvc_config.parse(f);
     fclose(f);
     return 0;
 }
@@ -216,20 +220,14 @@ void GET_CURRENT_VERSION_OP::handle_reply(int http_op_retval) {
 
 // called at startup to see if the client state file
 // says there's a new version. This must be called after
-// read_vc_config_file(NVC_CONFIG_FILE, nvc_config)
+// read_vc_config_file()
 //
 void newer_version_startup_check() {
-    NVC_CONFIG old_nvc_config;
-    
-    // This code expects our installer to rename any previous nvc_config.xml 
-    // file to old_nvc_config.xml.
-    //
     // If version check URL has changed (perhaps due to installing a build of
     // BOINC with different branding), reset any past new version information
     //
-    read_vc_config_file(OLD_NVC_CONFIG_FILE, old_nvc_config);
-    boinc_delete_file(OLD_NVC_CONFIG_FILE);
-    if (old_nvc_config.client_version_check_url != nvc_config.client_version_check_url) {
+    if (gstate.client_version_check_url != nvc_config.client_version_check_url) {
+        gstate.client_version_check_url = nvc_config.client_version_check_url;
         gstate.newer_version = "";
         return;
     }

--- a/client/current_version.h
+++ b/client/current_version.h
@@ -20,6 +20,8 @@
 
 #include "gui_http.h"
 
+#define DEFAULT_VERSION_CHECK_URL "https://boinc.berkeley.edu/download.php?xml=1"
+
 struct GET_CURRENT_VERSION_OP: public GUI_HTTP_OP {
     int error_num;
 
@@ -42,7 +44,6 @@ struct NVC_CONFIG {
 
     NVC_CONFIG();
     void defaults();
-    std::string get_default_version_check_url(void);
     int parse(FILE*);
 };
 

--- a/client/current_version.h
+++ b/client/current_version.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2010 University of California
+// Copyright (C) 2018 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -42,11 +42,12 @@ struct NVC_CONFIG {
 
     NVC_CONFIG();
     void defaults();
+    std::string get_default_version_check_url(void);
     int parse(FILE*);
 };
 
 extern NVC_CONFIG nvc_config;
 
-extern int read_vc_config_file(const char* fname, NVC_CONFIG& nvc_config_file);
+extern int read_vc_config_file(void);
 
 #endif

--- a/client/file_names.h
+++ b/client/file_names.h
@@ -71,7 +71,6 @@ extern void send_log_after(const char* filename, double t, MIOFILE& mf);
 #define CLIENT_OPAQUE_FILENAME      "client_opaque.txt"
 #define CONFIG_FILE                 "cc_config.xml"
 #define NVC_CONFIG_FILE             "nvc_config.xml"
-#define OLD_NVC_CONFIG_FILE         "old_nvc_config.xml"
 #define COPROC_INFO_FILENAME        "coproc_info.xml"
 #define CPU_BENCHMARKS_FILE_NAME    "cpu_benchmarks"
 #define CREATE_ACCOUNT_FILENAME     "create_account.xml"

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -237,7 +237,7 @@ static void init_core_client(int argc, char** argv) {
     
     // NOTE: this must be called BEFORE newer_version_startup_check()
     //
-    if (read_vc_config_file(NVC_CONFIG_FILE, nvc_config)) {
+    if (read_vc_config_file()) {
         msg_printf(NULL, MSG_INFO, "nvc_config.xml not found - using defaults");
     }
     

--- a/mac_installer/preinstall
+++ b/mac_installer/preinstall
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ##
-# Pre-Install / Pre-Upgrade Script for Macintosh BOINC Manager for OS X revised 7/15/18
+# Pre-Install / Pre-Upgrade Script for Macintosh BOINC Manager for OS X revised 7/26/18
 ##
 
 # If we are replacing an earlier GridRepublic installation, fix the data directory name before installing
@@ -18,11 +18,4 @@ rm -fR "/Library/Screen Savers/BOINCSaver.saver"
 # Remove any old "BOINC Manager.mo" files before installing "BOINC-Manager.mo" files (or vice-versa)
 rm -fR "/Library/Application Support/BOINC Data/locale/"
 
-# Rename any previous nvc_config.xml file to old_nvc_config.xml to allow
-# newer_version_startup_check() to compare them
-rm -f "/Library/Application Support/BOINC Data/old_nvc_config.xml"
-if [ -e "/Library/Application Support/BOINC Data/nvc_config.xml" ]; then
-    mv -f "/Library/Application Support/BOINC Data/nvc_config.xml" "/Library/Application Support/BOINC Data/old_nvc_config.xml"
-fi
- 
 exit 0

--- a/mac_installer/preinstall
+++ b/mac_installer/preinstall
@@ -18,4 +18,7 @@ rm -fR "/Library/Screen Savers/BOINCSaver.saver"
 # Remove any old "BOINC Manager.mo" files before installing "BOINC-Manager.mo" files (or vice-versa)
 rm -fR "/Library/Application Support/BOINC Data/locale/"
 
+# Remove any previous nvc_config.xml file
+rm -f "/Library/Application Support/BOINC Data/old_nvc_config.xml"
+
 exit 0

--- a/mac_installer/preinstall
+++ b/mac_installer/preinstall
@@ -19,6 +19,6 @@ rm -fR "/Library/Screen Savers/BOINCSaver.saver"
 rm -fR "/Library/Application Support/BOINC Data/locale/"
 
 # Remove any previous nvc_config.xml file
-rm -f "/Library/Application Support/BOINC Data/old_nvc_config.xml"
+rm -f "/Library/Application Support/BOINC Data/nvc_config.xml"
 
 exit 0

--- a/win_build/installerv2/redist/default/nvc_config.xml
+++ b/win_build/installerv2/redist/default/nvc_config.xml
@@ -1,0 +1,2 @@
+<nvc_config>
+</nvc_config>


### PR DESCRIPTION
client: save a copy of nvc_config.client_version_check_url in client_state.xml file, eliminating need for installer to rename previous nvc_config.xml to old_nvc_config.xml.

newer_version_startup_check() compares gstate.client_version_check_url to nvc_config.client_version_check_url. If different, it clears gstate.newer_version and updates gstate.client_version_check_url.

This supersedes part 2 of [this comment](https://github.com/BOINC/boinc/pull/2603#issuecomment-405083071) in my earlier PR #2603.