### PR TITLE
mac installer: change pkill() calls to killall()

### DIFF
--- a/mac_installer/AddRemoveUser.cpp
+++ b/mac_installer/AddRemoveUser.cpp
@@ -543,7 +543,7 @@ Boolean SetLoginItemLaunchAgent(long brandID, Boolean deleteLogInItem, passwd *p
         // To guard against this, we have the LaunchAgent kill the Manager
         // (for this user only) if it is running.
         //
-        fprintf(f, "pkill -9 -U %d \"%s\";", pw->pw_uid, appName[brandID]);
+        fprintf(f, "killall -u %d -9 \"%s\";", pw->pw_uid, appName[brandID]);
     } else {
         fprintf(f, "osascript -e 'tell application \"System Events\" to make login item at end with properties {path:\"%s\", hidden:true, name:\"%s\"}';", appPath[brandID], appName[brandID]);
         fprintf(f, "open -jg \"%s\";", appPath[brandID]);

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -236,7 +236,7 @@ int main(int argc, char *argv[])
     }
 
     for (i=0; i< NUMBRANDS; i++) {
-        snprintf(s, sizeof(s), "pkill \"%s\"", appName[i]);
+        snprintf(s, sizeof(s), "killall \"%s\"", appName[i]);
         callPosixSpawn (s);
     }
     sleep(2);
@@ -1120,7 +1120,7 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
         // To guard against this, we have the LaunchAgent kill the Manager
         // (for this user only) if it is running.
         //
-        fprintf(f, "pkill -9 -U %d \"%s\";", pw->pw_uid, appName[oldBrandID]);
+        fprintf(f, "killall -u %d -9 \"%s\";", pw->pw_uid, appName[oldBrandID]);
     } else {
         fprintf(f, "osascript -e 'tell application \"System Events\" to make login item at end with properties {path:\"%s\", hidden:true, name:\"%s\"}';", appPath[brandID], appName[brandID]);
         fprintf(f, "open -jg \"%s\";", appPath[brandID]);

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -386,12 +386,12 @@ static OSStatus DoUninstall(void) {
     }
     
     // With fast user switching, each logged in user can be running
-    // a separate copy of the Manager; pkill terminates all of them
+    // a separate copy of the Manager; killall terminates all of them
     for (i=0; i<NUMBRANDS; ++i) {
 #if TESTING
         showDebugMsg("killing any running instances of %s", appName[i]);
 #endif
-        sprintf(cmd, "pkill -KILL \"%s\"", appName[i]);
+        snprintf(cmd, sizeof(cmd), "killall \"%s\"", appName[i]);
         callPosixSpawn(cmd);
     }
 
@@ -997,7 +997,7 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     // To guard against this, we have the LaunchAgent kill the Manager
     // (for this user only) if it is running.
     //
-    fprintf(f, "pkill -9 -U %d \"%s\";", pw->pw_uid, appName[brandID]);
+    fprintf(f, "killall -u %d -9 \"%s\";", pw->pw_uid, appName[brandID]);
     fprintf(f, "rm -f ~/Library/LaunchAgents/edu.berkeley.boinc.plist</string>\n");
     fprintf(f, "\t</array>\n");
     fprintf(f, "\t<key>RunAtLoad</key>\n");


### PR DESCRIPTION
mac installer: change pkill() calls to killall() because pkill() was not available before OS 10.8.

When installing BOINC on OS 10.6 or OS 10.7, using pkill() to kill the previous instance of BOINC Manager failed. Changing pkill() calls to killall() fixes this bug.