### PR TITLE
Drupal: Improve forum ACL to allow new user to post in limited forums.

### DIFF
--- a/drupal/sites/all/features/discussion_forums/discussion_forums.features.user_permission.inc
+++ b/drupal/sites/all/features/discussion_forums/discussion_forums.features.user_permission.inc
@@ -46,8 +46,9 @@ function discussion_forums_user_default_permissions() {
     'name' => 'create forum topics',
     'roles' => array(
       '0' => 'administrator',
-      '1' => 'moderator',
-      '2' => 'verified contributor',
+      '1' => 'community member',
+      '2' => 'moderator',
+      '3' => 'verified contributor',
     ),
   );
 
@@ -81,7 +82,8 @@ function discussion_forums_user_default_permissions() {
     'name' => 'edit own forum topics',
     'roles' => array(
       '0' => 'administrator',
-      '1' => 'verified contributor',
+      '1' => 'community member',
+      '2' => 'verified contributor',
     ),
   );
 
@@ -90,8 +92,9 @@ function discussion_forums_user_default_permissions() {
     'name' => 'post comments',
     'roles' => array(
       '0' => 'administrator',
-      '1' => 'moderator',
-      '2' => 'verified contributor',
+      '1' => 'community member',
+      '2' => 'moderator',
+      '3' => 'verified contributor',
     ),
   );
 
@@ -100,8 +103,9 @@ function discussion_forums_user_default_permissions() {
     'name' => 'post comments without approval',
     'roles' => array(
       '0' => 'administrator',
-      '1' => 'moderator',
-      '2' => 'verified contributor',
+      '1' => 'community member',
+      '2' => 'moderator',
+      '3' => 'verified contributor',
     ),
   );
 

--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.module
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.module
@@ -510,6 +510,33 @@ function boinccore_form_alter(&$form, $form_state, $form_id) {
     
     // Remove redundant name field
     unset($form['_author']);
+
+    // If user is role='community member' only, then user may not post
+    // any comments in non-forum node-types, team_forums are also not
+    // allowed.. This allows users who have site-wide comment
+    // permission to comment on forums in special
+    // circumstances. Additionally, any comments require a captcha.
+    //
+    $node = node_load($form['nid']['#value']);
+    $community_role = array_search('community member', user_roles(true));
+    $unrestricted_role = array_search('verified contributor', user_roles(true));
+    if ( (isset($account->roles[$community_role])) and (!isset($account->roles[$unrestricted_role])) ) {
+      if ($node->type == 'forum') {
+        if (module_exists('captcha')) {
+          $form['comment_captcha'] = array(
+            '#type' => 'captcha',
+            '#weight' => 1000,
+          );
+        }
+      }
+      else {
+        $form = NULL;
+        $form['from'] = array(
+          '#type'  => 'item',
+          '#value' => 'You do not have permission to post comments in this forum.',
+        );
+      }
+    }
     
     break;
     
@@ -545,6 +572,18 @@ function boinccore_form_alter(&$form, $form_state, $form_id) {
       '#value' => '</ul>',
       '#weight' => 1010,
     );
+
+    // Add captcha for role='community member'
+    $community_role = array_search('community member', user_roles(true));
+    $unrestricted_role = array_search('verified contributor', user_roles(true));
+    if ( (isset($account->roles[$community_role])) and (!isset($account->roles[$unrestricted_role])) ) {
+      if (module_exists('captcha')) {
+        $form['comment_captcha'] = array(
+          '#type' => 'captcha',
+          '#weight' => 1000,
+        );
+      }
+    }
 
     break;
   case 'boinccore_delete_confirm':

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1261,25 +1261,6 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
   case 'views_exposed_form':
       $form['submit']['#value'] = bts('Search', array(), NULL, 'boinc:search-user');
     break;
-
-  case 'comment_form':
-      // Additional logic: If the user cannot post due to total credit, make sure they 
-      // cannot post when node type is not forum. This allows users who have site-wide comment 
-      // permission to comment on forums in special circumstances. Thus they can comment on posts they 
-      // created, but not elsewhere on the site, e.g., News.
-      //
-      $min_credit_to_post = variable_get('boinc_comment_min_credit', 0);
-      $node = node_load($form['nid']['#value']);
-      $account = user_load($user->uid);
-      if ( ($account->boincuser_total_credit < $min_credit_to_post) and ($node->type != 'forum') ) {
-        $form = NULL;
-        $form['from'] = array(
-          '#type'  => 'item',
-          '#value' => 'You do not have permission to post comments in this forum.',
-        );
-        dd($form, 'form after');
-      }
-    break;
   }
 }
 
@@ -1294,7 +1275,7 @@ function boincuser_profile_node_form_after_build($form, &$form_state) {
   return $form;
 }
 
-/**
+/*12*
  * Implementation of hook_elements()
  * @see http://api.drupal.org/api/drupal/developer--hooks--core.php/function/hook_elements/6
  */

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1275,7 +1275,7 @@ function boincuser_profile_node_form_after_build($form, &$form_state) {
   return $form;
 }
 
-/*12*
+/**
  * Implementation of hook_elements()
  * @see http://api.drupal.org/api/drupal/developer--hooks--core.php/function/hook_elements/6
  */

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1261,6 +1261,25 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
   case 'views_exposed_form':
       $form['submit']['#value'] = bts('Search', array(), NULL, 'boinc:search-user');
     break;
+
+  case 'comment_form':
+      // Additional logic: If the user cannot post due to total credit, make sure they 
+      // cannot post when node type is not forum. This allows users who have site-wide comment 
+      // permission to comment on forums in special circumstances. Thus they can comment on posts they 
+      // created, but not elsewhere on the site, e.g., News.
+      //
+      $min_credit_to_post = variable_get('boinc_comment_min_credit', 0);
+      $node = node_load($form['nid']['#value']);
+      $account = user_load($user->uid);
+      if ( ($account->boincuser_total_credit < $min_credit_to_post) and ($node->type != 'forum') ) {
+        $form = NULL;
+        $form['from'] = array(
+          '#type'  => 'item',
+          '#value' => 'You do not have permission to post comments in this forum.',
+        );
+        dd($form, 'form after');
+      }
+    break;
   }
 }
 

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.info
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.info
@@ -7,7 +7,7 @@ core = 6.x
 
 
 ; Information added by drupal.org packaging script on 2012-05-04
-version = "6.x-1.8-boinc-2-dev"
+version = "6.x-1.8-boinc-3-dev"
 core = "6.x"
 project = "forum_access"
-datestamp = "1476375513"
+datestamp = "1533061263"

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.module
@@ -417,7 +417,7 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
   }
   if (empty($comment)) {
     // Check links for the node.
-    if ($tid && isset($links['comment_add']) && !forum_access_access($tid, 'comment_create')) {
+    if ($tid && isset($links['comment_add']) && !forum_access_access($tid, 'comment_create') && !(forum_access_access($tid, 'create') and ($node->uid==$user->uid)) ) {
       unset($links['comment_add']);
       // Hack to manually remove quote link
       if ( isset($links['quote']) ) {
@@ -433,7 +433,7 @@ function forum_access_link_alter(&$links, $node, $comment = NULL) {
       'delete' => 'comment_delete',
     );
     foreach ($required_keys as $access => $key) {
-      if (!forum_access_access($tid, $access) && !($access == 'update' && comment_access('edit', $comment))) {
+      if (!forum_access_access($tid, $access) && !($access == 'update' && comment_access('edit', $comment)) && !($access == 'comment_create' && forum_access_access($tid, 'create') && ($node->uid==$user->uid)) ) {
         unset($links[$required_keys[$access]]);
         unset($required_keys[$access]);
       }

--- a/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
+++ b/drupal/sites/default/boinc/modules/contrib/forum_access/forum_access.node.inc
@@ -118,7 +118,7 @@ function _forum_access_comment_form(&$form, &$form_state) {
   if ($user->uid != 1 && isset($form['nid']['#value'])) {
     $node = node_load($form['nid']['#value']);
     if ($tid = _forum_access_get_tid($node)) {
-      if (!forum_access_access($tid, 'comment_create')) {
+      if (!forum_access_access($tid, 'comment_create') and !(forum_access_access($tid, 'create') and ($node->uid==$user->uid)) ) {
         switch (arg(0)) {
           case 'node':
               // Remove the in-line comment form, replace with text message to user.

--- a/drupal/sites/default/boinc/themes/boinc/templates/views-view--boinc-team-forum-topics.tpl.php
+++ b/drupal/sites/default/boinc/themes/boinc/templates/views-view--boinc-team-forum-topics.tpl.php
@@ -103,7 +103,7 @@
   <ul class="links">
     <li class="forum first last">
       <?php $account=user_load($user->uid); ?>
-      <?php if ($account->team AND $account->team == $team_forum->nid): ?>
+      <?php if ($account->team AND $account->team == $team_forum->nid AND (user_access('create team_forum content'))): ?>
         <?php print l(bts('Post new topic', array(), NULL, 'boinc:forum-post-new-topic'), "node/add/team-forum/{$team_forum_id}"); ?>
       <?php endif; ?>
     </li>


### PR DESCRIPTION
Modified module to add feature: user may comment on own topics.
If a user has permission to create a new forum topic, s/he has permission to write comments on that forum topic only. They will not have permission to add comments elsewhere.

Feature updated with new site-wide permissions to allow 'community member' role to create forum topics and make comments.

Forum ACL will need to be set to restrict the 'community member' role to specific forums.

https://dev.gridrepublic.org/browse/DBOINCP-455