### PR TITLE
server: add the ability to have > 1 stages of trickle handling

### DIFF
--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -693,7 +693,7 @@ struct MSG_FROM_HOST {
     int create_time;
     DB_ID_TYPE hostid;
     char variety[256];              // project-defined; what kind of msg
-    bool handled;                   // message handler has processed this
+    int handled;                    // message handler has processed this
     char xml[MSG_FROM_HOST_BLOB_SIZE];
     void clear();
 };
@@ -703,7 +703,7 @@ struct MSG_TO_HOST {
     int create_time;
     DB_ID_TYPE hostid;
     char variety[256];              // project-defined; what kind of msg
-    bool handled;                   // scheduler has sent this
+    int handled;                    // scheduler has sent this
     char xml[MSG_TO_HOST_BLOB_SIZE];      // text to include in sched reply
     void clear();
 };

--- a/html/ops/purge_trickles.php
+++ b/html/ops/purge_trickles.php
@@ -40,7 +40,7 @@ if ($argc == 1) {
     $n = (int)$argv[2];
     $db->do_query("delete from msg_to_host where handled = $n");
 } else {
-    echo "usage\n";
+    echo "echo "usage: purge_trickles.php [msg_from_host | msg_to_host]\n";
 }
 
 ?>

--- a/html/ops/purge_trickles.php
+++ b/html/ops/purge_trickles.php
@@ -19,11 +19,28 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // purge already-handled trickle messages from the DB
+//
+// no args: delete both up and down messages with handled != 0
+// msg_from_host N
+//    delete trickle ups with handled==N
+// msg_to_host N
+//    same, trickle down
 
 require_once("../inc/boinc_db.inc");
 $db = BoincDb::get();
 if (!$db) die("no DB connection");
-$db->do_query("delete from msg_from_host where handled <> 0");
-$db->do_query("delete from msg_to_host where handled <> 0");
+
+if ($argc == 1) {
+    $db->do_query("delete from msg_from_host where handled <> 0");
+    $db->do_query("delete from msg_to_host where handled <> 0");
+} else if ($argv[1] == "msg_from_host") {
+    $n = (int)$argv[2];
+    $db->do_query("delete from msg_from_host where handled = $n");
+} else if ($argv[1] == "msg_to_host") {
+    $n = (int)$argv[2];
+    $db->do_query("delete from msg_to_host where handled = $n");
+} else {
+    echo "usage\n";
+}
 
 ?>

--- a/sched/trickle_handler.cpp
+++ b/sched/trickle_handler.cpp
@@ -48,10 +48,15 @@
 
 char variety[256];
 
-// can change the following in handle_trickle_init()
+// values of mhf.handled.
+// Can change the following in handle_trickle_init()
 //
 int handled_enum = 0;
+    // enumerate messages with this
 int handled_set = 1;
+    // if successful, set to this
+int handled_error = 1;
+    // if handling error, set to this
 
 // make one pass through trickle_ups with handled == handled_enum
 // return true if there were any
@@ -73,12 +78,12 @@ bool do_trickle_scan() {
             break;
         }
         retval = handle_trickle(mfh);
-        if (!retval) {
+        if (retval) {
             log_messages.printf(MSG_CRITICAL,
                 "handle_trickle(): %s", boincerror(retval)
             );
         }
-        mfh.handled = handled_set;
+        mfh.handled = retval?handled_error:handled_set;
         mfh.update();
         found = true;
     }

--- a/sched/trickle_handler.cpp
+++ b/sched/trickle_handler.cpp
@@ -20,12 +20,14 @@
 //
 //  --variety variety
 //  [--d debug_level]
-//  [--one_pass]     // make one pass through table, then exit
+//  [--one_pass]        // make one pass through table, then exit
 //
-// This program must be linked with an app-specific function:
+// This program must be linked with an app-specific functions:
 //
+// int handle_trickle_init(int argc, char** argv);
+//      initialize
 // int handle_trickle(MSG_FROM_HOST&)
-//    handle a trickle message
+//      handle a trickle message
 //
 // return nonzero on error
 
@@ -46,7 +48,12 @@
 
 char variety[256];
 
-// make one pass through trickle_ups with handled == 0
+// can change the following in handle_trickle_init()
+//
+int handled_enum = 0;
+int handled_set = 1;
+
+// make one pass through trickle_ups with handled == handled_enum
 // return true if there were any
 //
 bool do_trickle_scan() {
@@ -55,7 +62,7 @@ bool do_trickle_scan() {
     bool found=false;
     int retval;
 
-    sprintf(buf, "where variety='%s' and handled=0", variety);
+    sprintf(buf, "where variety='%s' and handled=%d", variety, handled_enum);
     while (1) {
         retval = mfh.enumerate(buf);
         if (retval) {
@@ -71,7 +78,7 @@ bool do_trickle_scan() {
                 "handle_trickle(): %s", boincerror(retval)
             );
         }
-        mfh.handled = true;
+        mfh.handled = handled_set;
         mfh.update();
         found = true;
     }

--- a/sched/trickle_handler.h
+++ b/sched/trickle_handler.h
@@ -21,4 +21,4 @@
 
 extern int handle_trickle(MSG_FROM_HOST&);
 extern int handle_trickle_init(int argc, char** argv);
-extern int handled_enum, handled_set;
+extern int handled_enum, handled_set, handled_error;

--- a/sched/trickle_handler.h
+++ b/sched/trickle_handler.h
@@ -21,3 +21,4 @@
 
 extern int handle_trickle(MSG_FROM_HOST&);
 extern int handle_trickle_init(int argc, char** argv);
+extern int handled_enum, handled_set;


### PR DESCRIPTION
Some projects (namely CPDN) need to process trickle-up messages
with two different daemons.
We do this as follows:
- daemon 1 enumerates messages with handled==0, and sets handled=1
- daemon 2 enumerates messages with handled==1, and sets handled=2
You can then purge records with handled==2

To implement this, trickle_handler.cpp has two global vars,
int handled_enum and int handled_set.
By default these are 0 and 1.
For daemon 2, set them to 1 and 2 in trickle_handler_init()