### PR TITLE
web: if a thread or post creation fails...

### DIFF
--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -25,6 +25,10 @@ require_once("../inc/text_transform.inc");
 
 define('THREADS_PER_PAGE', 50);
 
+$forum_error = "";
+    // for functions that return null on error,
+    // look here for an explanation
+
 // sorting styles (for both threads and posts)
 //
 define('MODIFIED_NEW', 1);
@@ -876,18 +880,23 @@ function notify_subscribers($thread, $user) {
 // Don't do these things directly - use these functions
 //
 function create_post($content, $parent_id, $user, $forum, $thread, $signature) {
+    global $forum_error;
     if (POST_MAX_LINKS
         && link_count($content) > POST_MAX_LINKS
         && !is_moderator($user, $forum)
     ) {
-        return 0;
+        $forum_error = "Too many links.";
+        return null;
     }
     $content = substr($content, 0, 64000);
     $content = BoincDb::escape_string($content);
     $now = time();
     $sig = $signature?1:0;
     $id = BoincPost::insert("(thread, user, timestamp, content, modified, parent_post, score, votes, signature, hidden) values ($thread->id, $user->id, $now, '$content', 0, $parent_id, 0, 0, $sig, 0)");
-    if (!$id) return null;
+    if (!$id) {
+        $forum_error = "Failed to add post to DB.";
+        return null;
+    }
 
     notify_subscribers($thread, $user);
 
@@ -917,11 +926,13 @@ function update_forum_timestamp($forum) {
 }
 
 function create_thread($title, $content, $user, $forum, $signature, $export) {
+    global $forum_error;
     if (POST_MAX_LINKS
         && link_count($content) > POST_MAX_LINKS
         && !is_moderator($user, $forum)
     ) {
-        return 0;
+        $forum_error = "Too many links.";
+        return null;
     }
     $title = trim($title);
     $title = sanitize_tags($title);
@@ -932,7 +943,10 @@ function create_thread($title, $content, $user, $forum, $signature, $export) {
         $status = 1;
     }
     $id  = BoincThread::insert("(forum, owner, status, title, timestamp, views, replies, activity, sufferers, score, votes, create_time, hidden, sticky, locked) values ($forum->id, $user->id, $status, '$title', $now, 0, -1, 0, 0, 0, 0, $now, 0, 0, 0)");
-    if (!$id) return null;
+    if (!$id) {
+        $forum_error = "Failed to add thread to DB.";
+        return null;
+    }
     $thread = BoincThread::lookup_id($id);
     create_post($content, 0, $user, $forum, $thread, $signature);
     $forum->update("threads=threads+1");

--- a/html/user/forum_post.php
+++ b/html/user/forum_post.php
@@ -70,7 +70,7 @@ if ($content && $title && (!$preview)){
         if ($thread) {
             header('Location: forum_thread.php?id=' . $thread->id);
         } else {
-            error_page("Can't create thread");
+            error_page("Can't create thread.  $forum_error");
         }
     }
 }

--- a/html/user/forum_reply.php
+++ b/html/user/forum_reply.php
@@ -83,7 +83,7 @@ if ($content && (!$preview)){
         if ($post_id) {
             header("Location: forum_thread.php?id=$thread->id&postid=$post_id");
         } else {
-            error_page("Can't create post.");
+            error_page("Can't create post.  $forum_error");
         }
     }
 }


### PR DESCRIPTION
(e.g. because it has too many links) show the user an explanation.

Aside: the forum code (which was written by students a long time ago)
uses a hodge-podge of return conventions.
At some point we should standardize on 0 = success, nonzero = error code