### PR TITLE
Client, Win: Fix WSL-related crash

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -252,26 +252,6 @@ void CLIENT_STATE::show_host_info() {
         tz<0?"":"+", tz
     );
 
-#ifdef _WIN64
-    if (host_info.wsl_available) {
-        msg_printf(NULL, MSG_INFO, "WSL detected:");
-        for (size_t i = 0; i < host_info.wsls.wsls.size(); ++i) {
-            const WSL& wsl = host_info.wsls.wsls[i];
-            if (wsl.is_default) {
-                msg_printf(NULL, MSG_INFO,
-                    "   [%s] (default): %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
-                );
-            } else {
-                msg_printf(NULL, MSG_INFO,
-                    "   [%s]: %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
-                );
-            }
-        }
-    } else {
-        msg_printf(NULL, MSG_INFO, "No WSL found.");
-    }
-#endif
-
     if (strlen(host_info.virtualbox_version)) {
         msg_printf(NULL, MSG_INFO,
             "VirtualBox version: %s",
@@ -287,6 +267,28 @@ void CLIENT_STATE::show_host_info() {
 #endif
     }
 }
+
+#ifdef _WIN64
+void WSLS::show() {
+    if (available) {
+        msg_printf(NULL, MSG_INFO, "WSL detected:");
+        for (size_t i = 0; i < wsls.size(); ++i) {
+            const WSL& wsl = wsls[i];
+            if (wsl.is_default) {
+                msg_printf(NULL, MSG_INFO,
+                    "   [%s] (default): %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
+                );
+            } else {
+                msg_printf(NULL, MSG_INFO,
+                    "   [%s]: %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
+                );
+            }
+        }
+    } else {
+        msg_printf(NULL, MSG_INFO, "No WSL found.");
+    }
+}
+#endif
 
 int rsc_index(const char* name) {
     const char* nm = strcmp(name, "CUDA")?name:GPU_TYPE_NVIDIA;
@@ -625,6 +627,12 @@ int CLIENT_STATE::init() {
     host_info.get_host_info(true);
     set_ncpus();
     show_host_info();
+#ifdef _WIN64
+    if (!cc_config.dont_use_wsl) {
+        wsls.get_information();
+        wsls.show();
+    }
+#endif
 
     // this follows parse_state_file() because that's where we read project names
     //

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -109,7 +109,9 @@ struct CLIENT_STATE {
     NET_STATS net_stats;
     ACTIVE_TASK_SET active_tasks;
     HOST_INFO host_info;
+#ifdef _WIN64
     WSLS wsls;
+#endif
 
     // the following used only on Android
     DEVICE_STATUS device_status;

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -55,6 +55,7 @@ using std::vector;
 #include "project_list.h"
 #include "scheduler_op.h"
 #include "time_stats.h"
+#include "wslinfo.h"
 
 #ifdef SIM
 #include "../sched/edf_sim.h"
@@ -108,6 +109,7 @@ struct CLIENT_STATE {
     NET_STATS net_stats;
     ACTIVE_TASK_SET active_tasks;
     HOST_INFO host_info;
+    WSLS wsls;
 
     // the following used only on Android
     DEVICE_STATUS device_status;

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -421,6 +421,11 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
             }
             continue;
         }
+#ifdef _WIN64
+        if (xp.match_tag("wsls")) {
+            wsls.parse(xp);
+        }
+#endif
         if (xp.match_tag("time_stats")) {
             retval = time_stats.parse(xp);
             if (retval) {
@@ -721,6 +726,9 @@ int CLIENT_STATE::write_state(MIOFILE& f) {
     f.printf("<client_state>\n");
     retval = host_info.write(f, true, true);
     if (retval) return retval;
+#ifdef _WIN64
+    wsls.write_xml(f);
+#endif
     retval = time_stats.write(f, false);
     if (retval) return retval;
     retval = net_stats.write(f);

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -524,11 +524,12 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
         }
 
 #if defined(__aarch64__) || defined(__arm__)
-        if (
-            // Hardware is specifying the board this CPU is on, store it in product_name while we parse /proc/cpuinfo
-            strstr(buf, "Hardware\t: ")
-        ) {
-            // this makes sure we only ever copy as much bytes as we can still store in host.product_name
+        if (strstr(buf, "Hardware\t: ")) {
+            // Hardware is specifying the board this CPU is on,
+            // store it in product_name while we parse /proc/cpuinfo
+            // This makes sure we only ever copy as much bytes
+            // as we can still store in host.product_name
+            //
             int t = sizeof(host.product_name) - strlen(host.product_name) - 2;
             strlcpy(buf2, strchr(buf, ':') + 2, ((t<sizeof(buf2))?t:sizeof(buf2)));
             strip_whitespace(buf2);
@@ -545,7 +546,9 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
 #elif __powerpc__ || __sparc__
             strstr(buf, "cpu\t\t: ")
 #elif defined(__aarch64__) || defined(__arm__)
-            // Hardware is a fallback specifying the board this CPU is on (not ideal but better than nothing)
+            // Hardware is a fallback specifying the board this CPU is on
+            // (not ideal but better than nothing)
+            //
             strstr(buf, "model name") || strstr(buf, "Processor") || strstr(buf, "Hardware")
 #else
             strstr(buf, "model name\t: ") || strstr(buf, "cpu model\t\t: ")
@@ -554,9 +557,10 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
             if (!model_hack && !model_found) {
                 model_found = true;
 #ifdef __powerpc__
-                char *coma = NULL;
-                if ((coma = strrchr(buf, ','))) {   /* we have ", altivec supported" */
-                    *coma = '\0';    /* strip the unwanted line */
+                char *comma = NULL;
+                if ((comma = strrchr(buf, ','))) {
+                    // we have ", altivec supported"
+                    *comma = '\0';    / strip the unwanted line
                     strcpy(features, "altivec");
                     features_found = true;
                 }
@@ -564,9 +568,10 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
                 strlcpy(host.p_model, strchr(buf, ':') + 2, sizeof(host.p_model));
             } else if (!model_found) {
 #ifdef __ia64__
-                /* depending on kernel version, family can be either
-                a number or a string. If number, we have a model name,
-                else we don't */
+                // depending on kernel version, family can be either
+                // a number or a string.
+                // If number, we have a model name, else we don't
+                //
                 char *testc = NULL;
                 testc = strrchr(buf, ':')+2;
                 if (isdigit(*testc)) {
@@ -1454,7 +1459,6 @@ int HOST_INFO::get_os_info() {
 
 #if LINUX_LIKE_SYSTEM
     bool found_something = false;
-    char buf2[256];
     char dist_name[256], dist_version[256];
     string os_version_extra("");
     strcpy(dist_name, "");
@@ -1462,18 +1466,24 @@ int HOST_INFO::get_os_info() {
 
     // see: http://refspecs.linuxbase.org/LSB_4.1.0/LSB-Core-generic/LSB-Core-generic/lsbrelease.html
     // although the output is not clearly specified it seems to be constant
+    //
     FILE* f = popen(command_lsbrelease, "r");
     if (f) {
-        found_something = parse_linux_os_info(f, lsbrelease, dist_name, sizeof(dist_name),
-            dist_version, sizeof(dist_version));
+        found_something = parse_linux_os_info(
+            f, lsbrelease, dist_name, sizeof(dist_name),
+            dist_version, sizeof(dist_version)
+        );
         pclose(f);
     }
     if (!found_something) {
         // see: https://www.freedesktop.org/software/systemd/man/os-release.html
+        //
         f = fopen(file_osrelease, "r");
         if (f) {
-            found_something = parse_linux_os_info(f, osrelease, dist_name, sizeof(dist_name),
-                dist_version, sizeof(dist_version));
+            found_something = parse_linux_os_info(
+                f, osrelease, dist_name, sizeof(dist_name),
+                dist_version, sizeof(dist_version)
+            );
             fclose(f);
         }
     }
@@ -1482,8 +1492,10 @@ int HOST_INFO::get_os_info() {
         // last ditch effort for older redhat releases
         f = fopen(file_redhatrelease, "r");
         if (f) {
-            found_something = parse_linux_os_info(f, redhatrelease, dist_name, sizeof(dist_name),
-                dist_version, sizeof(dist_version));
+            found_something = parse_linux_os_info(
+                f, redhatrelease, dist_name, sizeof(dist_name),
+                dist_version, sizeof(dist_version)
+            );
             fclose(f);
         }
     }
@@ -1500,10 +1512,13 @@ int HOST_INFO::get_os_info() {
     string libc_version(""), libc_extra_info("");
     if (!get_libc_version(libc_version, libc_extra_info)) {
         // This will be part of the normal startup messages to show to the user
+        //
         msg_printf(NULL, MSG_INFO,
-                "[libc detection] gathered: %s, %s", libc_version.c_str(), libc_extra_info.c_str()
-            );
+            "[libc detection] gathered: %s, %s",
+            libc_version.c_str(), libc_extra_info.c_str()
+        );
         // add info to os_version_extra
+        //
         if (!os_version_extra.empty()) {
             os_version_extra += "|";
         }
@@ -1592,10 +1607,15 @@ vector<string> get_tty_list() {
         if (dev) {
             do {
                 // get next file
+                //
+
                 done=dir_scan(devname,dev,1024);
+
                 // does it match our tty pattern? If so, add it to the tty list.
+                //
                 if (!done && (strstr(devname,tty_patterns[i].dev) == devname)) {
                     // don't add anything starting with .
+                    //
                     if (devname[0] != '.') {
                         sprintf(fullname,"%s/%s",tty_patterns[i].dir,devname);
                         tty_list.push_back(fullname);

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -1433,14 +1433,6 @@ int HOST_INFO::get_host_info(bool init) {
     get_os_information(
         os_name, sizeof(os_name), os_version, sizeof(os_version)
     );
-#ifdef _WIN64
-    if (!cc_config.dont_use_wsl) {
-        OSVERSIONINFOEX osvi;
-        if (get_OSVERSIONINFO(osvi) && osvi.dwMajorVersion >= 10) {
-            get_wsl_information(wsl_available, wsls);
-        }
-    }
-#endif
     if (!cc_config.dont_use_vbox) {
         get_virtualbox_version();
     }

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -693,7 +693,7 @@ struct MSG_FROM_HOST {
     int create_time;
     DB_ID_TYPE hostid;
     char variety[256];              // project-defined; what kind of msg
-    bool handled;                   // message handler has processed this
+    int handled;                    // message handler has processed this
     char xml[MSG_FROM_HOST_BLOB_SIZE];
     void clear();
 };
@@ -703,7 +703,7 @@ struct MSG_TO_HOST {
     int create_time;
     DB_ID_TYPE hostid;
     char variety[256];              // project-defined; what kind of msg
-    bool handled;                   // scheduler has sent this
+    int handled;                    // scheduler has sent this
     char xml[MSG_TO_HOST_BLOB_SIZE];      // text to include in sched reply
     void clear();
 };

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -70,11 +70,6 @@ void HOST_INFO::clear_host_info() {
     safe_strcpy(os_name, "");
     safe_strcpy(os_version, "");
 
-    wsl_available = false;
-#ifdef _WIN64
-    wsls.clear();
-#endif
-
     safe_strcpy(product_name, "");
     safe_strcpy(mac_address, "");
 
@@ -130,13 +125,7 @@ int HOST_INFO::parse(XML_PARSER& xp, bool static_items_only) {
         if (xp.parse_double("d_free", d_free)) continue;
         if (xp.parse_str("os_name", os_name, sizeof(os_name))) continue;
         if (xp.parse_str("os_version", os_version, sizeof(os_version))) continue;
-#ifdef _WIN64
-        if (xp.parse_bool("os_wsl_enabled", wsl_available)) continue;
-        if (xp.match_tag("wsl")) {
-            this->wsls.parse(xp);
-            continue;
-        }
-#endif
+
         if (xp.parse_str("product_name", product_name, sizeof(product_name))) continue;
         if (xp.parse_str("virtualbox_version", virtualbox_version, sizeof(virtualbox_version))) continue;
         if (xp.match_tag("coprocs")) {
@@ -204,8 +193,7 @@ int HOST_INFO::write(
         "    <d_free>%f</d_free>\n"
         "    <os_name>%s</os_name>\n"
         "    <os_version>%s</os_version>\n"
-        "    <n_usable_coprocs>%d</n_usable_coprocs>\n"
-        "    <wsl_available>%d</wsl_available>\n",
+        "    <n_usable_coprocs>%d</n_usable_coprocs>\n",
         host_cpid,
         p_ncpus,
         pv,
@@ -223,18 +211,8 @@ int HOST_INFO::write(
         d_free,
         osn,
         osv,
-        coprocs.ndevs(),
-#ifdef _WIN64
-        wsl_available ? 1 : 0
-#else
-        0
-#endif
+        coprocs.ndevs()
     );
-#ifdef _WIN64
-    if (wsl_available) {
-        wsls.write_xml(out);
-    }
-#endif
     if (strlen(product_name)) {
         xml_escape(product_name, pn, sizeof(pn));
         out.printf(

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -32,10 +32,6 @@
 #include "coproc.h"
 #include "common_defs.h"
 
-#ifdef _WIN64
-#include "wslinfo.h"
-#endif
-
 enum LINUX_OS_INFO_PARSER {
     lsbrelease,
     osrelease,
@@ -75,12 +71,6 @@ public:
 
     char os_name[256];
     char os_version[256];
-
-    // WSL information for Win10 only
-    bool wsl_available;
-#ifdef _WIN64
-    WSLS wsls;
-#endif
 
     char product_name[256];       // manufacturer and/or model of system
     char mac_address[256];      // MAC addr e.g. 00:00:00:00:00:00
@@ -128,10 +118,6 @@ public:
         char* os_name, const int os_name_size, char* os_version, const int os_version_size);
 };
 
-#ifdef _WIN64
-int get_wsl_information(bool& wsl_available, WSLS& wsls);
-#endif
-
 #ifdef __APPLE__
     int get_system_uptime();
 
@@ -155,6 +141,10 @@ typedef double (*nxIdleTimeProc)(NXEventHandle handle);
 #endif
 
 extern NXEventHandle gEventHandle;
+#endif
+
+#ifdef _WIN64
+extern BOOL get_OSVERSIONINFO(OSVERSIONINFOEX& osvi);
 #endif
 
 #endif

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -36,12 +36,12 @@ void WSL::write_xml(MIOFILE& f) {
     xml_escape(name.c_str(), n, sizeof(n));
     xml_escape(version.c_str(), v, sizeof(v));
     f.printf(
-        "        <distro>\n"
-        "            <distro_name>%s</distro_name>\n"
-        "            <name>%s</name>\n"
-        "            <version>%s</version>\n"
-        "            <is_default>%d</is_default>\n"
-        "        </distro>\n",
+        "    <distro>\n"
+        "        <distro_name>%s</distro_name>\n"
+        "        <name>%s</name>\n"
+        "        <version>%s</version>\n"
+        "        <is_default>%d</is_default>\n"
+        "    </distro>\n",
         dn,
         n,
         v,
@@ -68,15 +68,17 @@ WSLS::WSLS() {
 }
 
 void WSLS::clear() {
+    available = false;
     wsls.clear();
 }
 
 void WSLS::write_xml(MIOFILE& f) {
-    f.printf("    <wsl>\n");
+    f.printf("<wsl>\n");
+    if (available) f.printf("    <available/>\n");
     for (size_t i = 0; i < wsls.size(); ++i) {
         wsls[i].write_xml(f);
     }
-    f.printf("    </wsl>\n");
+    f.printf("</wsl>\n");
 }
 
 int WSLS::parse(XML_PARSER& xp) {
@@ -85,8 +87,8 @@ int WSLS::parse(XML_PARSER& xp) {
         if (xp.match_tag("/wsl")) {
             return 0;
         }
-        if (xp.match_tag("distro"))
-        {
+        if (xp.parse_bool("available", available)) continue;
+        if (xp.match_tag("distro")) {
             WSL wsl;
             wsl.parse(xp);
             wsls.push_back(wsl);

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -40,11 +40,13 @@ struct WSL {
 };
 
 struct WSLS {
+    bool available;
     std::vector<WSL> wsls;
 
     WSLS();
-
+    int get_information();
     void clear();
+    void show();
 
     void write_xml(MIOFILE&);
     int parse(XML_PARSER&);    

--- a/sched/trickle_handler.cpp
+++ b/sched/trickle_handler.cpp
@@ -20,12 +20,14 @@
 //
 //  --variety variety
 //  [--d debug_level]
-//  [--one_pass]     // make one pass through table, then exit
+//  [--one_pass]        // make one pass through table, then exit
 //
-// This program must be linked with an app-specific function:
+// This program must be linked with an app-specific functions:
 //
+// int handle_trickle_init(int argc, char** argv);
+//      initialize
 // int handle_trickle(MSG_FROM_HOST&)
-//    handle a trickle message
+//      handle a trickle message
 //
 // return nonzero on error
 
@@ -46,7 +48,12 @@
 
 char variety[256];
 
-// make one pass through trickle_ups with handled == 0
+// can change the following in handle_trickle_init()
+//
+int handled_enum = 0;
+int handled_set = 1;
+
+// make one pass through trickle_ups with handled == handled_enum
 // return true if there were any
 //
 bool do_trickle_scan() {
@@ -55,7 +62,7 @@ bool do_trickle_scan() {
     bool found=false;
     int retval;
 
-    sprintf(buf, "where variety='%s' and handled=0", variety);
+    sprintf(buf, "where variety='%s' and handled=%d", variety, handled_enum);
     while (1) {
         retval = mfh.enumerate(buf);
         if (retval) {
@@ -71,7 +78,7 @@ bool do_trickle_scan() {
                 "handle_trickle(): %s", boincerror(retval)
             );
         }
-        mfh.handled = true;
+        mfh.handled = handled_set;
         mfh.update();
         found = true;
     }

--- a/sched/trickle_handler.h
+++ b/sched/trickle_handler.h
@@ -21,3 +21,4 @@
 
 extern int handle_trickle(MSG_FROM_HOST&);
 extern int handle_trickle_init(int argc, char** argv);
+extern int handled_enum, handled_set;


### PR DESCRIPTION
The client was crashing in cs_benchmark.cpp on the line
    bdp->host_info = host_info;
... in something involving copying WSL info.

I don't know why this was happening, but I fixed it by moving WSLS out of HOST_INFO.
It's probably better this way in any case.