### PR TITLE
Update HTCondor sample code

### DIFF
--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -513,7 +513,7 @@ void handle_fetch_output(COMMAND& c) {
             sprintf(buf, "get_output_file()\\ returned\\ %d\\ ", retval);
             s = string(buf) + escape_str(error_msg);
         } else {
-            sprintf(buf, "cd %s; unzip %s_output.zip", req.dir, req.job_name);
+            sprintf(buf, "cd %s; unzip -o %s_output.zip >/dev/null", req.dir, req.job_name);
             retval = system(buf);
             if (retval) {
                 s = string("unzip\\ failed");


### PR DESCRIPTION
In our BOINC adapter, we made a change so that the unzip command
does not produce any output and will not stop to ask questions.
This is appropriate for the HTCondor batch system. We have been using
this change since April 18, 2014.