### PR TITLE
Update apache configuration in make_project

### DIFF
--- a/tools/make_project
+++ b/tools/make_project
@@ -360,53 +360,40 @@ print >>open(httpd_conf_template_filename,'w'), '''
     Alias /%(project_shortname)s_ops %(proot)s/html/ops
     ScriptAlias /%(project_shortname)s_cgi %(proot)s/cgi-bin
 
-    # in the following, the "Order" and "Allow" lines are for Apache 2.2;
-    # for Apache 2.4, replace them with the single line
-    # Require all granted
-    #        or
-    # Require all denied
-
     # NOTE: Turn off access to certain default directories
     <Directory "%(proot)s/keys">
-        Order deny,allow
-        Deny from all
+        Require all denied
     </Directory>
     <Directory "%(proot)s/upload">
-        Order deny,allow
-        Deny from all
+        Require all denied
     </Directory>
 
     # NOTE: Allow access but disable PHP script execution
     <Directory "%(proot)s/download">
         RemoveType .php .phtml
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
     <Directory "%(proot)s/html/stats">
         RemoveType .php .phtml
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
     <Directory "%(proot)s/html/user_profile">
         RemoveType .php .phtml
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     # NOTE: Allow access and allow PHP script execution
     <Directory "%(proot)s/html">
         Options Indexes MultiViews
         AllowOverride AuthConfig
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
     # NOTE: Allow access and allow CGI execution
     <Directory "%(proot)s/cgi-bin">
         Options ExecCGI
         AllowOverride AuthConfig
-        Order allow,deny
-        Allow from all
+        Require all granted
     </Directory>
 
 ''' %locals()

--- a/tools/make_project
+++ b/tools/make_project
@@ -359,7 +359,15 @@ print >>open(httpd_conf_template_filename,'w'), '''
 
     Alias /%(project_shortname)s_ops %(proot)s/html/ops
     ScriptAlias /%(project_shortname)s_cgi %(proot)s/cgi-bin
-
+    
+    # In the following, the "denied" and "granted" lines are for Apache 2.4
+    # For Apache 2.2, replace them with the lines
+    # Order deny,allow
+    # Deny from all
+    #      or
+    # Order allow,deny
+    # Allow from all
+    
     # NOTE: Turn off access to certain default directories
     <Directory "%(proot)s/keys">
         Require all denied


### PR DESCRIPTION
Making Apache v2.4 the default as v2.2 is not longer supported.