### PR TITLE
[WIP] Fix cs_benchmark.cpp heap destruction

### DIFF
--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -276,7 +276,7 @@ void CLIENT_STATE::start_cpu_benchmarks() {
         benchmark_descs[i].error = false;
 #ifdef _WIN32
         benchmark_descs[i].handle = CreateThread(
-            NULL, 0, win_cpu_benchmarks, &benchmark_descs, 0,
+            NULL, 0, win_cpu_benchmarks, &benchmark_descs[i], 0,
             &benchmark_descs[i].pid
         );
         int n = host_info.p_ncpus;

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -262,15 +262,13 @@ void CLIENT_STATE::start_cpu_benchmarks() {
     remove_benchmark_file(BM_TYPE_INT);
     cpu_benchmarks_start = dtime();
 
-    if (!benchmark_descs.empty()) {
-        benchmark_descs.clear();
-    }
+    benchmark_descs.clear();
+    benchmark_descs.resize(ncpus);
+
     bm_ncpus = ncpus;
     benchmarks_running = true;
 
     for (i=0; i<bm_ncpus; i++) {
-        benchmark_descs.push_back(BENCHMARK_DESC());
-
         benchmark_descs[i].ordinal = i;
         benchmark_descs[i].done = false;
         benchmark_descs[i].error = false;

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -292,7 +292,7 @@ void CLIENT_STATE::start_cpu_benchmarks() {
                 perror("setpriority");
             }
 #endif
-            int retval = cpu_benchmarks(&benchmark_descs);
+            int retval = cpu_benchmarks(&benchmark_descs[i]);
             fflush(NULL);
             _exit(retval);
         } else {

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -68,6 +68,8 @@
 #include "log_flags.h"
 #include "client_state.h"
 
+#include <vector>
+
 // defaults in case benchmarks fail or time out.
 // better to err on the low side so hosts don't get too much work
 
@@ -119,7 +121,7 @@ struct BENCHMARK_DESC {
 #endif
 };
 
-static BENCHMARK_DESC* benchmark_descs=0;
+static std::vector<BENCHMARK_DESC> benchmark_descs;
 static double cpu_benchmarks_start;
 static int bm_ncpus;
     // user might change ncpus during benchmarks.
@@ -260,20 +262,21 @@ void CLIENT_STATE::start_cpu_benchmarks() {
     remove_benchmark_file(BM_TYPE_INT);
     cpu_benchmarks_start = dtime();
 
-    if (benchmark_descs) {
-        free(benchmark_descs);
+    if (!benchmark_descs.empty()) {
+        benchmark_descs.clear();
     }
     bm_ncpus = ncpus;
-    benchmark_descs = (BENCHMARK_DESC*)calloc(bm_ncpus, sizeof(BENCHMARK_DESC));
     benchmarks_running = true;
 
     for (i=0; i<bm_ncpus; i++) {
+        benchmark_descs.push_back(BENCHMARK_DESC());
+
         benchmark_descs[i].ordinal = i;
         benchmark_descs[i].done = false;
         benchmark_descs[i].error = false;
 #ifdef _WIN32
         benchmark_descs[i].handle = CreateThread(
-            NULL, 0, win_cpu_benchmarks, benchmark_descs+i, 0,
+            NULL, 0, win_cpu_benchmarks, &benchmark_descs, 0,
             &benchmark_descs[i].pid
         );
         int n = host_info.p_ncpus;
@@ -289,7 +292,7 @@ void CLIENT_STATE::start_cpu_benchmarks() {
                 perror("setpriority");
             }
 #endif
-            int retval = cpu_benchmarks(benchmark_descs+i);
+            int retval = cpu_benchmarks(&benchmark_descs);
             fflush(NULL);
             _exit(retval);
         } else {


### PR DESCRIPTION
Use std::vector instead of allocated piece of memory to store multiple objects.
This hopefully fixes crash originally described in #2646 with heap destruction while copying data and next stacktrace:

>	msvcr100d.dll!_CrtDbgBreak()  Line 85	C
 	msvcr100d.dll!_VCrtDbgReportW(int nRptType, const wchar_t * szFile, int nLine, const wchar_t * szModule, const wchar_t * szFormat, char * arglist)  Line 502	C
 	msvcr100d.dll!_CrtDbgReportWV(int nRptType, const wchar_t * szFile, int nLine, const wchar_t * szModule, const wchar_t * szFormat, char * arglist)  Line 242	C++
 	msvcr100d.dll!_CrtDbgReportW(int nRptType, const wchar_t * szFile, int nLine, const wchar_t * szModule, const wchar_t * szFormat, ...)  Line 258 + 0x2c bytes	C++
 	msvcp100d.dll!std::_Debug_message(const wchar_t * message, const wchar_t * file, unsigned int line)  Line 13 + 0x22 bytes	C++
 	boinc.exe!std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > >::_Compat(const std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > > & _Right)  Line 239	C++
 	boinc.exe!std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > >::operator==(const std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > > & _Right)  Line 203	C++
 	boinc.exe!std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > >::operator!=(const std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > > & _Right)  Line 208 + 0xf bytes	C++
 	boinc.exe!std::vector<WSL,std::allocator<WSL> >::erase(std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > > * _First_arg, std::_Vector_const_iterator<std::_Vector_val<WSL,std::allocator<WSL> > > * _Last_arg)  Line 1194 + 0xf bytes	C++
 	boinc.exe!std::vector<WSL,std::allocator<WSL> >::clear()  Line 1218 + 0xe1 bytes	C++
 	boinc.exe!std::vector<WSL,std::allocator<WSL> >::operator=(const std::vector<WSL,std::allocator<WSL> > & _Right)  Line 715 + 0xa bytes	C++
 	boinc.exe!WSLS::operator=(const WSLS & __that)  + 0x32 bytes	C++
 	boinc.exe!HOST_INFO::operator=(const HOST_INFO & __that)  + 0x458 bytes	C++
 	boinc.exe!cpu_benchmarks(BENCHMARK_DESC * bdp)  Line 219	C++
 	boinc.exe!win_cpu_benchmarks(void * p)  Line 234	C++
 	kernel32.dll!00000000779d59cd()
 	[Frames below may be incorrect and/or missing, no symbols loaded for kernel32.dll]
 	ntdll.dll!0000000077b0a561()

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>