### PR TITLE
Add indexes to host table

### DIFF
--- a/db/constraints.sql
+++ b/db/constraints.sql
@@ -83,6 +83,10 @@ alter table msg_to_host
 alter table host
     add index host_user (userid),
         -- html_user/host_user.php
+    add index host_cpid (host_cpid),
+        -- scheduler request for user with many hosts
+    add index host_domain_name (domain_name),
+        -- scheduler request for user with many hosts
     add index host_avg (expavg_credit desc),
         -- db_dump.C
     add index host_tot (total_credit desc);

--- a/db/constraints.sql
+++ b/db/constraints.sql
@@ -81,12 +81,11 @@ alter table msg_to_host
         -- for scheduler
 
 alter table host
-    add index host_user (userid),
+    add index host_userid_cpid (userid, host_cpid),
         -- html_user/host_user.php
-    add index host_cpid (host_cpid),
-        -- scheduler request for user with many hosts
+        -- sched/handle_request.cpp for user with many hosts
     add index host_domain_name (domain_name),
-        -- scheduler request for user with many hosts
+        -- sched/handle_request.cpp for user with many hosts
     add index host_avg (expavg_credit desc),
         -- db_dump.C
     add index host_tot (total_credit desc);

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1162,6 +1162,12 @@ function update_5_9_2018() {
     ");
 }
 
+function update_8_23_2018() {
+    $retval = do_query("alter table host add index host_cpid (host_cpid)");
+    return $retval && do_query("alter table host add index host_domain_name (domain_name)");
+}
+
+
 // Updates are done automatically if you use "upgrade".
 //
 // If you need to do updates manually,
@@ -1219,7 +1225,8 @@ $db_updates = array (
     array(27023, "update_4_6_2018"),
     array(27024, "update_4_18_2018"),
     array(27025, "update_4_19_2018"),
-    array(27026, "update_5_9_2018")
+    array(27026, "update_5_9_2018"),
+    array(27027, "update_8_23_2018")
 );
 
 ?>

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1163,7 +1163,8 @@ function update_5_9_2018() {
 }
 
 function update_8_23_2018() {
-    $retval = do_query("alter table host add index host_cpid (host_cpid)");
+    $retval = do_query("alter table host add index host_userid_cpid (userid, host_cpid)");
+    $retval = $retval && do_query("alter table host drop index host_user");
     return $retval && do_query("alter table host add index host_domain_name (domain_name)");
 }
 


### PR DESCRIPTION
When a user has a very large number of hosts attached to a project (i.e. at least 50k), the scheduler requests can slow down as the existing index on userid still returns a significant number of records that have to be checked.  These two indexes address the issues associated with this situation.

See discussion in boinc-projects: https://groups.google.com/a/ssl.berkeley.edu/forum/#!topic/boinc_projects/Z59_4zIrSXE