### PR TITLE
Travis: restructure travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,12 @@
 language: cpp
-os:
-  - linux
-  - osx
 compiler:
   - gcc
-#  - clang
 
 branches:
   only:
     - master
     - coverity_scan
 
-#notifications:
-#  email:
-#    recipients:
-#      - boinc_cvs@ssl.berkeley.edu
-#    on_success: always
-#    on_failure: always
-
-# Use Trusty image and enable sudo to install apt dependencies
 dist: trusty
 sudo: required
 
@@ -49,24 +37,21 @@ env:
     - BOINC_TYPE=manager
     - BOINC_TYPE=libs-mingw
     - BOINC_TYPE=apps-mingw
-    #- BOINC_TYPE=coverity
+    - BOINC_TYPE=integration-test
 
 matrix:
   fast_finish: true
-  exclude:
-# the osx build currently builds everything in one go
-  - os: osx
-    env: BOINC_TYPE=libs
-  - os: osx
-    env: BOINC_TYPE=server
-  - os: osx
-    env: BOINC_TYPE=client
-  - os: osx
-    env: BOINC_TYPE=apps
-  - os: osx
-    env: BOINC_TYPE=libs-mingw
-  - os: osx
-    env: BOINC_TYPE=apps-mingw
+  include:
+    - language: php
+      os: linux
+      php: 7.0
+      env:
+        - BOINC_TYPE=unit-test
+    - language: cpp
+      os: osx
+      env: BOINC_TYPE=manager-osx
+    - language: android
+      env: BOINC_TYPE=manager-android
 
 before_install:
    - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( sudo apt-get -qq update ) fi
@@ -82,6 +67,9 @@ script:
 - if [[ "${BOINC_TYPE}" == "apps" ]]; then ( ./configure --enable-apps --disable-server --disable-client --disable-manager && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( ./3rdParty/buildLinuxDependencies.sh && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux && make ) fi
 - if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "linux" ]]; then ( make distclean && ./3rdParty/buildLinuxDependencies.sh --disable-webview --cache_dir ${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && ./configure --disable-server --disable-client --with-wx-prefix=${TRAVIS_BUILD_DIR}/3rdParty/buildCache/linux2 && make ) fi
-- if [[ "${BOINC_TYPE}" == "manager" && "${TRAVIS_OS_NAME}" == "osx" ]]; then ( ./3rdParty/buildMacDependencies.sh -q && ./mac_build/buildMacBOINC-CI.sh --no_shared_headers ) fi
 - if [[ "${BOINC_TYPE}" == "libs-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw ) fi
 - if [[ "${BOINC_TYPE}" == "apps-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw wrapper ) fi
+- if [[ "${BOINC_TYPE}" == "manager-osx" ]]; then ( ./3rdParty/buildMacDependencies.sh -q && ./mac_build/buildMacBOINC-CI.sh --no_shared_headers ) fi
+- if [[ "${BOINC_TYPE}" == "manager-android" ]]; then ( /bin/true ) fi
+- if [[ "${BOINC_TYPE}" == "unit-test" ]]; then ( /bin/true ) fi
+- if [[ "${BOINC_TYPE}" == "integration-test" ]]; then ( /bin/true ) fi

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -165,16 +165,17 @@ if [ ${retval} -ne 0 ]; then
     cd ..; exit 1;
 fi
 
-libSearchPath="./build/Deployment"
-if [ "${style}" == "Development" ]; then
-    libSearchPath="./build/Development"
-fi
-target="ss_app"
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../api/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "${libSearchPath} ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
-    cd ..; exit 1;
-fi
+# screensaver disabled because Travis can't build some library correctly, see https://github.com/BOINC/boinc/issues/2662
+#libSearchPath="./build/Deployment"
+#if [ "${style}" == "Development" ]; then
+#    libSearchPath="./build/Development"
+#fi
+#target="ss_app"
+#source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../api/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "${libSearchPath} ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+#if [ ${retval} -ne 0 ]; then
+#    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+#    cd ..; exit 1;
+#fi
 
 target="ScreenSaver"
 source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting GCC_ENABLE_OBJC_GC "unsupported" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -84,9 +84,10 @@ if [ ${share_paths} = "yes" ]; then
     if [ "${style}" == "Development" ]; then
         libSearchPathDbg="./build/Development  ${cache_dir}/lib/debug"
     fi
-    source BuildMacBOINC.sh ${config} -all -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "$libSearchPathDbg ${cache_dir}/lib ../lib" | $beautifier; retval=${PIPESTATUS[0]}
-    if [ $retval -ne 0 ]; then cd ..; exit 1; fi
-
+    source BuildMacBOINC.sh ${config} -all -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "$libSearchPathDbg ${cache_dir}/lib ../lib" | tee xcodebuild_all.log | $beautifier; retval=${PIPESTATUS[0]}
+    if [ $retval -ne 0 ]; then
+        curl --upload-file ./xcodebuild_all.log https://transfer.sh/xcodebuild_all.log
+        cd ..; exit 1; fi
     return 0
 fi
 
@@ -107,58 +108,121 @@ libSearchPathDbg=""
 if [ "${style}" == "Development" ]; then
     libSearchPathDbg="${cache_dir}/lib/debug"
 fi
-source BuildMacBOINC.sh ${config} -noclean -target mgr_boinc -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include" -setting LIBRARY_SEARCH_PATHS "${libSearchPathDbg} ${cache_dir}/lib" | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then cd ..; exit 1; fi
+target="mgr_boinc"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include" -setting LIBRARY_SEARCH_PATHS "${libSearchPathDbg} ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
 ## Target gfx2libboinc also build dependent target jpeg
-source BuildMacBOINC.sh ${config} -noclean -target gfx2libboinc -setting HEADER_SEARCH_PATHS "../samples/jpeglib" | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="gfx2libboinc"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../samples/jpeglib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target libboinc | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="libboinc"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target api_libboinc | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="api_libboinc"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target PostInstall | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="PostInstall"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target switcher | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="switcher"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target gfx_switcher | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="gfx_switcher"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target Install_BOINC | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="Install_BOINC"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-# screensaver disabled because Travis can't build the 32bit FTGL library currently
-#libSearchPath="./build/Deployment"
-#if [ "${style}" == "Development" ]; then
-#    libSearchPath="./build/Development"
-#fi
-#source BuildMacBOINC.sh ${config} -noclean -target ss_app -setting HEADER_SEARCH_PATHS "../api/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "${libSearchPath} ${cache_dir}/lib" | $beautifier; retval=${PIPESTATUS[0]}
-#if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+libSearchPath="./build/Deployment"
+if [ "${style}" == "Development" ]; then
+    libSearchPath="./build/Development"
+fi
+target="ss_app"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../api/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "${libSearchPath} ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target ScreenSaver -setting GCC_ENABLE_OBJC_GC "unsupported" | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="ScreenSaver"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting GCC_ENABLE_OBJC_GC "unsupported" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target boinc_opencl | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="boinc_opencl"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target setprojectgrp | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="setprojectgrp"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target cmd_boinc | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="cmd_boinc"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target Uninstaller | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="Uninstaller"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target SetUpSecurity | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="SetUpSecurity"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
-source BuildMacBOINC.sh ${config} -noclean -target AddRemoveUser | $beautifier; retval=${PIPESTATUS[0]}
-if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+target="AddRemoveUser"
+source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+if [ ${retval} -ne 0 ]; then
+    curl --upload-file ./xcodebuild_${target}.log https://transfer.sh/xcodebuild_${target}.log
+    cd ..; exit 1;
+fi
 
 cd ..

--- a/mac_build/buildcurl.sh
+++ b/mac_build/buildcurl.sh
@@ -140,7 +140,7 @@ if [ "x${lprefix}" != "x" ]; then
     export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64"
     export CPPFLAGS="-isysroot ${SDKPATH} -arch x86_64"
     export CFLAGS="-isysroot ${SDKPATH} -arch x86_64"
-    PKG_CONFIG_PATH="${lprefix}/lib/pkgconfig" ./configure --prefix=${lprefix} --enable-ares --enable-shared=NO --host=x86_64
+    PKG_CONFIG_PATH="${lprefix}/lib/pkgconfig" ./configure --prefix=${lprefix} --enable-ares --enable-shared=NO --without-libidn --without-libidn2 --host=x86_64
     if [ $? -ne 0 ]; then return 1; fi
 else
     # Get the names of the current versions of c-ares and openssl from
@@ -163,7 +163,7 @@ else
     export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64 -L${CURL_DIR}/../${opensslDirName} "
     export CPPFLAGS="-isysroot ${SDKPATH} -arch x86_64 -I${CURL_DIR}/../${opensslDirName}/include"
     export CFLAGS="-isysroot ${SDKPATH} -arch x86_64 -I${CURL_DIR}/../${opensslDirName}/include"
-    ./configure --enable-shared=NO --enable-ares="${libcares}" --host=x86_64
+    ./configure --enable-shared=NO --enable-ares="${libcares}" --without-libidn --without-libidn2 --host=x86_64
     if [ $? -ne 0 ]; then return 1; fi
     echo ""
 fi


### PR DESCRIPTION
Instead of excluding unwanted jobs this now specifically includes the jobs needed. This allows to run multiple environments or languages within a single repository. This is not fully documented but was confirmed to be supported by Travis via email.

Configuration can be tested on this page: http://config.travis-ci.org/
Original idea came from this blog entry: http://axelnilsson.tech/2017/08/04/travisci-with-multi-language-repository/

A problem with `libcurl` and the updated Travis CI OSX VM occurred because the buildcache needed to be rebuilt. Therefore I added some code to get more information from failed builds and fixed the problem with `libcurl`.