### PR TITLE
Adds ability for a Brand to define the string for boinc help in the h…

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -661,11 +661,11 @@ bool CAdvancedFrame::CreateMenu() {
 
     strMenuName.Printf(
         _("&%s help"), 
-        pSkinAdvanced->GetApplicationName().c_str()
+        pSkinAdvanced->GetApplicationHelpName().c_str()
     );
     strMenuDescription.Printf(
         _("Show information about the %s"), 
-        pSkinAdvanced->GetApplicationName().c_str()
+        pSkinAdvanced->GetApplicationHelpName().c_str()
     );
     menuHelp->Append(
         ID_HELPBOINCMANAGER,

--- a/clientgui/SkinManager.cpp
+++ b/clientgui/SkinManager.cpp
@@ -476,6 +476,7 @@ void CSkinAdvanced::Clear() {
     m_bIsBranded = false;
     m_strApplicationName = wxEmptyString;
     m_strApplicationShortName = wxEmptyString;
+    m_strApplicationHelpName = wxEmptyString;
     m_iconApplicationIcon.Clear();
     m_iconApplicationDisconnectedIcon.Clear();
     m_iconApplicationSnoozeIcon.Clear();
@@ -501,6 +502,9 @@ int CSkinAdvanced::Parse(MIOFILE& in) {
             continue;
         } else if (parse_str(buf, "<application_short_name>", strBuffer)) {
             m_strApplicationShortName = wxString(strBuffer.c_str(), wxConvUTF8);
+            continue;
+        } else if (parse_str(buf, "<application_help_name>", strBuffer)) {
+            m_strApplicationHelpName = wxString(strBuffer.c_str(), wxConvUTF8);
             continue;
         } else if (match_tag(buf, "<application_icon>")) {
             m_iconApplicationIcon.Parse(in);
@@ -575,6 +579,14 @@ wxString CSkinAdvanced::GetApplicationShortName() {
 }
 
 
+wxString CSkinAdvanced::GetApplicationHelpName() {
+    if (m_strApplicationHelpName.IsEmpty()) {
+        return m_strApplicationName;
+    }
+    return m_strApplicationHelpName;
+}
+
+
 wxIconBundle* CSkinAdvanced::GetApplicationIcon() {
     return m_iconApplicationIcon.GetIcon();
 }
@@ -639,6 +651,11 @@ bool CSkinAdvanced::InitializeDelayedValidation() {
         }
         m_strApplicationShortName = wxT("BOINC");
         wxASSERT(!m_strApplicationShortName.IsEmpty());
+    }
+    if (m_strApplicationHelpName.IsEmpty()) {
+        if (show_error_msgs) {
+            fprintf(stderr, "Skin Manager: Application help name was not defined. Using application name.\n");
+        }
     }
 #ifdef _WIN32
     m_iconApplicationIcon.SetDefaults(wxT("application"), wxT("boinc"));

--- a/clientgui/SkinManager.h
+++ b/clientgui/SkinManager.h
@@ -190,6 +190,7 @@ public:
 
     wxString      GetApplicationName();
     wxString      GetApplicationShortName();
+    wxString      GetApplicationHelpName();
     wxIconBundle* GetApplicationIcon();
     wxIconBundle* GetApplicationDisconnectedIcon();
     wxIconBundle* GetApplicationSnoozeIcon();
@@ -205,6 +206,7 @@ private:
     bool          m_bIsBranded;
     wxString      m_strApplicationName;
     wxString      m_strApplicationShortName;
+    wxString      m_strApplicationHelpName;
     CSkinIcon     m_iconApplicationIcon;
     CSkinIcon     m_iconApplicationIcon32;
     CSkinIcon     m_iconApplicationDisconnectedIcon;

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -232,12 +232,12 @@ CSimpleFrame::CSimpleFrame(wxString title, wxIconBundle* icons, wxPoint position
     );
 
     strMenuName.Printf(
-        _("&%s"), 
-        pSkinAdvanced->GetApplicationName().c_str()
+        _("&%s help"), 
+        pSkinAdvanced->GetApplicationHelpName().c_str()
     );
     strMenuDescription.Printf(
         _("Show information about the %s"), 
-        pSkinAdvanced->GetApplicationName().c_str()
+        pSkinAdvanced->GetApplicationHelpName().c_str()
     );
     menuHelp->Append(
         ID_HELPBOINCMANAGER,


### PR DESCRIPTION
…elp menu through the skin. This is code from Charlie Fenton that allows brands to define the string used in the help menu for boinc help. The definition goes in the xml for the branded skin <application_help_name>.