### PR TITLE
client: parse and store user and team name from account manager.

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -894,15 +894,14 @@ int ACCT_MGR_INFO::write_info() {
             no_project_notices?1:0,
             dynamic?1:0
         );
+        char buf[4096];
         if (strlen(user_name)) {
-            string x = user_name;
-            xml_unescape(x);
-            fprintf(f,    "<user_name>%s</user_name>\n", x.c_str());
+            xml_escape(user_name, buf, sizeof(buf));
+            fprintf(f,    "<user_name>%s</user_name>\n", buf);
         }
         if (strlen(team_name)) {
-            string x = team_name;
-            xml_unescape(x);
-            fprintf(f,    "<team_name>%s</team_name>\n", x.c_str());
+            xml_escape(team_name, buf, sizeof(buf));
+            fprintf(f,    "<team_name>%s</team_name>\n", buf);
         }
 
 

--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -402,6 +402,14 @@ int ACCT_MGR_OP::parse(FILE* f) {
         }
         if (xp.match_tag("/acct_mgr_reply")) return 0;
         if (xp.parse_str("name", ami.project_name, 256)) continue;
+        if (xp.parse_str("user_name", ami.user_name, sizeof(ami.user_name))) {
+            xml_unescape(ami.user_name);
+            continue;
+        }
+        if (xp.parse_str("team_name", ami.team_name, sizeof(ami.team_name))) {
+            xml_unescape(ami.team_name);
+            continue;
+        }
         if (xp.parse_str("authenticator", ami.authenticator, 256)) continue;
         if (xp.parse_int("error_num", error_num)) continue;
         if (xp.parse_string("error", error_str)) continue;
@@ -796,6 +804,8 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
         ::rss_feeds.update_feed_list();
     }
 
+    safe_strcpy(gstate.acct_mgr_info.user_name, ami.user_name);
+    safe_strcpy(gstate.acct_mgr_info.team_name, ami.team_name);
     safe_strcpy(
         gstate.acct_mgr_info.previous_host_cpid, gstate.host_info.host_cpid
     );
@@ -884,6 +894,18 @@ int ACCT_MGR_INFO::write_info() {
             no_project_notices?1:0,
             dynamic?1:0
         );
+        if (strlen(user_name)) {
+            string x = user_name;
+            xml_unescape(x);
+            fprintf(f,    "<user_name>%s</user_name>\n", x.c_str());
+        }
+        if (strlen(team_name)) {
+            string x = team_name;
+            xml_unescape(x);
+            fprintf(f,    "<team_name>%s</team_name>\n", x.c_str());
+        }
+
+
         user_keywords.write(f);
         fprintf(f,
             "</acct_mgr_login>\n"
@@ -898,6 +920,7 @@ void ACCT_MGR_INFO::clear() {
     safe_strcpy(master_url, "");
     safe_strcpy(login_name, "");
     safe_strcpy(user_name, "");
+    safe_strcpy(team_name, "");
     safe_strcpy(password_hash, "");
     safe_strcpy(authenticator, "");
     safe_strcpy(signing_key, "");
@@ -938,12 +961,12 @@ int ACCT_MGR_INFO::parse_login_file(FILE* p) {
             continue;
         }
         if (xp.match_tag("/acct_mgr_login")) break;
-        else if (xp.parse_str("login", login_name, 256)) continue;
-        else if (xp.parse_str("password_hash", password_hash, 256)) continue;
-        else if (xp.parse_str("authenticator", authenticator, 256)) continue;
-        else if (xp.parse_str("previous_host_cpid", previous_host_cpid, sizeof(previous_host_cpid))) continue;
-        else if (xp.parse_double("next_rpc_time", next_rpc_time)) continue;
-        else if (xp.match_tag("opaque")) {
+        if (xp.parse_str("login", login_name, 256)) continue;
+        if (xp.parse_str("password_hash", password_hash, 256)) continue;
+        if (xp.parse_str("authenticator", authenticator, 256)) continue;
+        if (xp.parse_str("previous_host_cpid", previous_host_cpid, sizeof(previous_host_cpid))) continue;
+        if (xp.parse_double("next_rpc_time", next_rpc_time)) continue;
+        if (xp.match_tag("opaque")) {
             retval = xp.element_contents("</opaque>", opaque, sizeof(opaque));
             if (retval) {
                 msg_printf(NULL, MSG_INFO,
@@ -952,9 +975,17 @@ int ACCT_MGR_INFO::parse_login_file(FILE* p) {
             }
             continue;
         }
-        else if (xp.parse_bool("no_project_notices", no_project_notices)) continue;
-        else if (xp.parse_bool("dynamic", dynamic)) continue;
-        else if (xp.match_tag("user_keywords")) {
+        if (xp.parse_str("user_name", user_name, sizeof(user_name))) {
+            xml_unescape(user_name);
+            continue;
+        }
+        if (xp.parse_str("team_name", team_name, sizeof(team_name))) {
+            xml_unescape(team_name);
+            continue;
+        }
+        if (xp.parse_bool("no_project_notices", no_project_notices)) continue;
+        if (xp.parse_bool("dynamic", dynamic)) continue;
+        if (xp.match_tag("user_keywords")) {
             retval = user_keywords.parse(xp);
             if (retval) {
                 msg_printf(NULL, MSG_INFO,

--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -45,6 +45,7 @@ struct ACCT_MGR_INFO : PROJ_AM {
     //
     char login_name[256];   // unique name (could be email addr)
     char user_name[256];    // non-unique name
+    char team_name[256];
     char password_hash[256];
         // md5 of password.lowercase(login_name)
     char authenticator[256];

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -238,7 +238,7 @@ static void init_core_client(int argc, char** argv) {
     // NOTE: this must be called BEFORE newer_version_startup_check()
     //
     if (read_vc_config_file()) {
-        msg_printf(NULL, MSG_INFO, "nvc_config.xml not found - using defaults");
+       // msg_printf(NULL, MSG_INFO, "nvc_config.xml not found - using defaults");
     }
     
     // Win32 - detach from console if requested

--- a/client/project.cpp
+++ b/client/project.cpp
@@ -362,8 +362,19 @@ int PROJECT::write_state(MIOFILE& out, bool gui_rpc) {
         "<project>\n"
     );
 
-    xml_escape(user_name, un, sizeof(un));
-    xml_escape(team_name, tn, sizeof(tn));
+    // if this project was attached via SU, show the SU user and team names
+    //
+    if (gstate.acct_mgr_info.using_am()
+        && attached_via_acct_mgr
+        && gstate.acct_mgr_info.dynamic
+        && strlen(gstate.acct_mgr_info.user_name)
+    ) {
+        xml_escape(gstate.acct_mgr_info.user_name, un, sizeof(un));
+        xml_escape(gstate.acct_mgr_info.team_name, tn, sizeof(tn));
+    } else {
+        xml_escape(user_name, un, sizeof(un));
+        xml_escape(team_name, tn, sizeof(tn));
+    }
     out.printf(
         "    <master_url>%s</master_url>\n"
         "    <project_name>%s</project_name>\n"


### PR DESCRIPTION
If the AM is "dynamic", show those for projects attached via AM,
rather than e.g. "Science United user 123456".