### PR TITLE
Remove unused utmp variables

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1756,17 +1756,8 @@ inline bool user_idle(time_t t, struct utmp* u) {
   //
   struct utmp *getutent() {
       if (ufp == NULL) {
-#if defined(UTMP_LOCATION)
           if ((ufp = fopen(UTMP_LOCATION, "r")) == NULL)
-#elif defined(UTMP_FILE)
-          if ((ufp = fopen(UTMP_FILE, "r")) == NULL)
-#elif defined(_PATH_UTMP)
-          if ((ufp = fopen(_PATH_UTMP, "r")) == NULL)
-#else
-          if ((ufp = fopen("/etc/utmp", "r")) == NULL)
-#endif
-          { // Please keep all braces balanced in source files; repeated
-            // open braces in conditional compiles confuse Xcode's editor.
+          {
               return((struct utmp *)NULL);
           }
       }


### PR DESCRIPTION
We also don't need a default as we already do
for for f in /etc/utmp /var/adm/utmp /var/run/utmp; during build.
And the default that we used /etc/utmp is deprecated everywhere I
could find anyway.

In the event a UTMP_LOCATION doesn't exist, I think it would more
sense just to disable utmp in the build.