### PR TITLE
Fix .gitignore by adding .vs folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 # Visual Studio build directories
 /win_build/Build/
 
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
 # Installshield build directories
 /win_build/installerv2/BOINC
 /win_build/installerv2/BOINC_vbox


### PR DESCRIPTION
Visual Studio 2015/2017 use new cache/options directory .vs in the root of solution directory and should be ignored

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>