### PR TITLE
Drupal: Change user profile permissions

### DIFF
--- a/drupal/sites/all/features/user_profiles/user_profiles.views_default.inc
+++ b/drupal/sites/all/features/user_profiles/user_profiles.views_default.inc
@@ -318,6 +318,47 @@ function user_profiles_views_default_views() {
       'field' => 'changed',
       'relationship' => 'none',
     ),
+    'phpcode' => array(
+      'label' => 'Edit Profile',
+      'alter' => array(
+        'alter_text' => 0,
+        'text' => '',
+        'make_link' => 0,
+        'path' => '',
+        'absolute' => 0,
+        'link_class' => '',
+        'alt' => '',
+        'rel' => '',
+        'prefix' => '',
+        'suffix' => '',
+        'target' => '',
+        'help' => '',
+        'trim' => 0,
+        'max_length' => '',
+        'word_boundary' => 1,
+        'ellipsis' => 1,
+        'html' => 0,
+        'strip_tags' => 0,
+      ),
+      'empty' => '',
+      'hide_empty' => 0,
+      'empty_zero' => 0,
+      'hide_alter_empty' => 1,
+      'value' => '<?php
+$uid = $data->users_uid;
+return l(
+bts(\'edit\', array(), NULL, \'boinc:edit-profile\'),
+"/moderate/profile/$uid/edit");
+?>',
+      'exclude' => 0,
+      'id' => 'phpcode',
+      'table' => 'customfield',
+      'field' => 'phpcode',
+      'override' => array(
+        'button' => 'Use default',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('filters', array(
     'moderate' => array(

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -53,7 +53,7 @@ function boincuser_menu() {
     'title' => 'Edit',
     'description' => 'Edit a user profile',
     'page callback' => 'boincuser_edit_profile',
-    'access callback' => 'user_is_logged_in',
+    'access arguments' => array('edit own profile content'),
     'type' => MENU_LOCAL_TASK,
     'weight' => 5
   );

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1472,6 +1472,16 @@ function boincuser_view_profile($account = null) {
     global $user;
     $account = $user;
   }
+
+  $min_credit_to_post = variable_get('boinc_comment_min_credit', 0);
+  $verified_contributor = array_search('verified contributor', user_roles(true));
+  if (!isset($account->roles[$verified_contributor])) {
+    drupal_set_message(bts(
+        'You may only create or modify your user profile after earning @count credits.',
+        array('@count' => $min_credit_to_post), NULL, 'boinc:view-profile'
+    ), 'warning', FALSE);
+  }
+
   // For now, just call the user module profile view function
   user_build_content($account);
   return theme('user_profile', $account);

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.helpers.inc
@@ -91,7 +91,7 @@ function boincuser_check_credit_requirements() {
     }
     else {
       drupal_set_message(bts(
-        'You must earn @count more credits to be able to post comments on this site.',
+        'You must earn @count more credits to be able to post comments on this site and create or modify your user profile.',
         array('@count' => $min_credit_to_post - $account->boincuser_total_credit)
       ), 'warning', FALSE);
       if (isset($account->roles[$unrestricted_role])) {


### PR DESCRIPTION
Only verified contributors, users with at least 1[*] credit, may create or modify user profiles. Also moderators may edit user profiles.

* adjustable in admin interface, but defaults to 1 credit.

Part of
https://dev.gridrepublic.org/browse/DBOINCP-466