### PR TITLE
Improve .gitignore by adding .vscode folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 
+#Visual Studio Code options directory
+.vscode/
+
 # Installshield build directories
 /win_build/installerv2/BOINC
 /win_build/installerv2/BOINC_vbox


### PR DESCRIPTION
Microsoft Visual Studio Code is a very useful and popular IDE.
This commit adds .vscode folder to .gitignore.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>