### PR TITLE
Travis: copy successful builds to bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ addons:
 
 env:
   global:
-    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-    #   via the "travis encrypt" command using the project repo's public key
+    # secret API keys for Coverity and bintray
     - secure: "Rd++Hyurnwd/tvjH0PX2seO3QUZ6WOf8bSB2ZkKPfZCU6+tXVMvloyog6Mlc7vl0m3WFAzw24MDtNLFBUktRsVXOkqDup1s6PdkwwcwG+5wAnydN+kXF9PcqKyOi0xJvl48Wji+r92Y9SCLzPnQGjZg70xHET22bDZHt2FsjP80="
+    - secure: dYJhIQi9mB00HsyjNEbyyeh7ChHxbg9o6dkBvub/4dRwJKN+KAReU7yHshUTpHI+Nn4TdCjpwHcDMDOklRTSeUFz79jGEmCVqvnz0DynZFroryX3rdAnc/kW4QkupgLZk4JKCN0JRPOM/j9RS2zLxkqrDc7gibF7BNgIhu1jUXk=
   matrix:
     - BOINC_TYPE=libs
     - BOINC_TYPE=server
@@ -55,7 +55,7 @@ matrix:
 
 before_install:
    - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( sudo apt-get -qq update ) fi
-   - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( sudo apt-get install -y freeglut3-dev libxmu-dev libxi-dev libfcgi-dev libxss-dev libnotify-dev libxcb-util0-dev libsqlite3-dev libgtk2.0-dev libwebkitgtk-dev mingw-w64 binutils-mingw-w64-i686 binutils-mingw-w64-x86-64 gcc-mingw-w64 gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 g++-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 realpath ) fi
+   - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( sudo apt-get install -y freeglut3-dev libxmu-dev libxi-dev libfcgi-dev libxss-dev libnotify-dev libxcb-util0-dev libsqlite3-dev libgtk2.0-dev libwebkitgtk-dev mingw-w64 binutils-mingw-w64-i686 binutils-mingw-w64-x86-64 gcc-mingw-w64 gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 g++-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 realpath p7zip-full ) fi
    - if [[ "${BOINC_TYPE}" == "integration-test" ]]; then ( sudo apt-get install ansible/trusty-backports; sudo service mysql stop; ) fi
 
 before_script:
@@ -75,3 +75,6 @@ script:
 - if [[ "${BOINC_TYPE}" == "manager-android" ]]; then ( /bin/true ) fi
 - if [[ "${BOINC_TYPE}" == "unit-test" ]]; then ( /bin/true ) fi
 - if [[ "${BOINC_TYPE}" == "integration-test" ]]; then ( ./integration_test/executeTestSuite.sh ) fi
+
+after_success:
+- ./deploy/prepare_deployment.sh ${BOINC_TYPE} deploy/${BOINC_TYPE}/ && ./deploy/deploy_to_bintray.sh deploy/${BOINC_TYPE}/

--- a/deploy/deploy_to_bintray.sh
+++ b/deploy/deploy_to_bintray.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+# This file is part of BOINC.
+# http://boinc.berkeley.edu
+# Copyright (C) 2018 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+## Push binaries to Bintray (https://bintray.com/docs/api/)
+## Creates a 7z archive from the content of $1
+
+# be carefull with set -x in this script because of ${BINTRAY_API_KEY} which needs to stay secret
+set -e # Exit on errors
+trap 'exit 1' ERR
+
+# check working directory because the script needs to be called like: ./deploy/deploy_to_bintray.sh
+if [ ! -d "deploy" ]; then
+    echo "start this script in the source root directory"
+    exit 1
+fi
+
+ROOTDIR=$(pwd)
+if [[ $# != 1 ]]; then
+  echo "Usage: $0 SOURCE_DIR"
+  echo "SOURCE_DIR : relative path where binaries are, last component is used as BOINC_TYPE"
+  exit 1
+fi
+
+SOURCE_DIR="$1"
+if [[ ! -d "${SOURCE_DIR}" || $(ls -A "${SOURCE_DIR}" | wc -l) -eq 0 ]]; then
+    echo "Directory '$SOURCE_DIR' doesn't exist or is empty";
+    exit 1;
+fi
+
+# for PR's this is set if the PR comes from within the same repository
+if [ "${BINTRAY_API_KEY}" == "" ] ; then
+  echo "BINTRAY_API_KEY is missing; doing nothing"
+  exit 0
+fi
+
+CI_RUN="${TRAVIS:-false}"
+BOINC_TYPE="$(basename "${SOURCE_DIR}")"
+API=https://api.bintray.com
+BINTRAY_USER="${BINTRAY_USER:-ChristianBeer}"
+BINTRAY_API_KEY="$BINTRAY_API_KEY" # env
+BINTRAY_REPO="${BINTRAY_REPO:-boinc-ci}"
+BINTRAY_REPO_OWNER="${BINTRAY_REPO_OWNER:-boinc}" # owner and user not always the same
+WEBSITE_URL="${WEBSITE_URL:-http://boinc.berkeley.edu}"
+ISSUE_TRACKER_URL="${ISSUE_TRACKER_URL:-https://github.com/BOINC/boinc/issues}"
+VCS_URL="${VCS_URL:-https://github.com/BOINC/boinc.git}" # Mandatory for packages in free Bintray repos
+
+CURL="curl -u${BINTRAY_USER}:${BINTRAY_API_KEY} -H Accept:application/json -w \n"
+#CURL="echo " # use this for local debugging
+
+BUILD_DATE=$(date "+%Y-%m-%d")
+GIT_REV=$(git rev-parse --short HEAD)
+PKG_NAME="custom"
+PKG_DESC="Automated CI build of BOINC components"
+VERSION="custom_${BUILD_DATE}_${GIT_REV}"
+VERSION_DESC="Custom build created on ${BUILD_DATE}"
+if [[ $CI_RUN == "true" ]]; then
+    case $TRAVIS_EVENT_TYPE in
+        pull_request)
+        PKG_NAME="pull-requests"
+        VERSION="PR${TRAVIS_PULL_REQUEST}_${BUILD_DATE}_${GIT_REV}"
+        VERSION_DESC="CI build created from PR #${TRAVIS_PULL_REQUEST} on ${BUILD_DATE}"
+        ;;
+        cron)
+        PKG_NAME="weekly"
+        VERSION="weekly_${BUILD_DATE}_${GIT_REV}"
+        VERSION_DESC="Weekly CI build created on ${BUILD_DATE}"
+        ;;
+        *)
+        echo "event $TRAVIS_EVENT_TYPE not supported for deployment"
+        ;;
+    esac
+fi
+
+echo "Creating package ${PKG_NAME}..."
+data="{
+    \"name\": \"${PKG_NAME}\",
+    \"desc\": \"${PKG_DESC}\",
+    \"desc_url\": \"auto\",
+    \"website_url\": [\"${WEBSITE_URL}\"],
+    \"vcs_url\": [\"${VCS_URL}\"],
+    \"issue_tracker_url\": [\"${ISSUE_TRACKER_URL}\"],
+    \"licenses\": [\"LGPL-3.0\"]
+    }"
+${CURL} -H Content-Type:application/json -X POST -d "${data}" "${API}/packages/${BINTRAY_REPO_OWNER}/${BINTRAY_REPO}"
+
+echo "Creating version ${VERSION}"
+data="{
+    \"name\": \"${VERSION}\",
+    \"desc\": \"${VERSION_DESC}\"
+}"
+set +x
+${CURL} -H Content-Type:application/json -X POST -d "${data}" "${API}/packages/${BINTRAY_REPO_OWNER}/${BINTRAY_REPO}/${PKG_NAME}/versions"
+
+echo "Uploading and publishing ${SOURCE_DIR}..."
+PKG_DIR=$(dirname "${SOURCE_DIR}")
+cd "${PKG_DIR}"
+7z a "${BOINC_TYPE}.7z" "${BOINC_TYPE}/"  &>/dev/null
+if [ $? -gt 1 ]; then # an exit code of 1 is still a success says 7z
+    cd ..
+    echo "error while creating 7z archive; files not uploaded"
+    return 1
+fi
+cd "${ROOTDIR}"
+if [ -f "${PKG_DIR}/${BOINC_TYPE}.7z" ]; then
+    set +x
+    ${CURL} -H Content-Type:application/octet-stream -T "${PKG_DIR}/${BOINC_TYPE}.7z" "${API}/content/${BINTRAY_REPO_OWNER}/${BINTRAY_REPO}/${PKG_NAME}/${VERSION}/${BOINC_TYPE}_${VERSION}.7z?publish=1&override=1"
+fi
+
+if [ "$TRAVIS_BUILD_ID" ] ; then
+    echo "Adding Travis CI log to release notes..."
+    BUILD_LOG="https://travis-ci.org/BOINC/boinc/builds/${TRAVIS_BUILD_ID}"
+    #BUILD_LOG="https://api.travis-ci.org/jobs/${TRAVIS_JOB_ID}/log.txt?deansi=true"
+    data='{
+  "bintray": {
+    "syntax": "markdown",
+    "content": "'${BUILD_LOG}'"
+  }
+}'
+    set +x
+    ${CURL} -H Content-Type:application/json -X POST -d "${data}" "${API}/packages/${BINTRAY_REPO_OWNER}/${BINTRAY_REPO}/${PKG_NAME}/versions/${VERSION}/release_notes"
+fi

--- a/deploy/prepare_deployment.sh
+++ b/deploy/prepare_deployment.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# This file is part of BOINC.
+# http://boinc.berkeley.edu
+# Copyright (C) 2018 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+## support script to put all build artefacts into a defined location
+## BOINC_TYPE should always be consistent with content in .travis.yml and appveyor.yml
+## Change artefacts in each prepare_*() function below.
+## Don't hardlink files because this can be run on a filesystem without hardlinks
+## Don't put files into a zip as this is done by the actual deployment script
+## On error always exit non-zero so the deploy script does not run
+
+# check working directory because the script needs to be called like: ./deploy/prepare_deployment.sh
+if [ ! -d "deploy" ]; then
+    echo "start this script in the source root directory"
+    exit 1
+fi
+
+# main funtion is at the end
+
+cp_if_exists() {
+    if [ -e "${1}" ]; then
+        cp -f "${1}" "${2}"
+    fi
+}
+
+prepare_client() {
+    mkdir -p "${TARGET_DIR}"
+    cp_if_exists client/boinc "${TARGET_DIR}"
+    cp_if_exists client/boinccmd "${TARGET_DIR}"
+    cp_if_exists client/switcher "${TARGET_DIR}"
+}
+
+prepare_apps() {
+  mkdir -p "${TARGET_DIR}"
+  cp_if_exists samples/condor/boinc_gahp "${TARGET_DIR}"
+  cp_if_exists samples/example_app/uc2 "${TARGET_DIR}"
+  cp_if_exists samples/example_app/ucn "${TARGET_DIR}"
+  cp_if_exists samples/example_app/uc2_graphics "${TARGET_DIR}"
+  cp_if_exists samples/example_app/slide_show "${TARGET_DIR}"
+  cp_if_exists samples/multi_thread/multi_thread "${TARGET_DIR}"
+  cp_if_exists samples/sleeper/sleeper "${TARGET_DIR}"
+  cp_if_exists samples/vboxmonitor/vboxmonitor "${TARGET_DIR}"
+  cp_if_exists samples/vboxwrapper/vboxwrapper "${TARGET_DIR}"
+  cp_if_exists samples/worker/worker "${TARGET_DIR}"
+  cp_if_exists samples/wrapper/wrapper "${TARGET_DIR}"
+}
+
+prepare_manager() {
+    mkdir -p "${TARGET_DIR}"
+    cp_if_exists clientgui/boincmgr "${TARGET_DIR}"
+}
+
+prepare_apps_mingw() {
+  mkdir -p "${TARGET_DIR}"
+}
+
+prepare_osx() {
+  mkdir -p "${TARGET_DIR}"
+}
+
+prepare_android() {
+  mkdir -p "${TARGET_DIR}"
+}
+
+ROOTDIR=$(pwd)
+if [[ $# -eq 0 || $# -gt 2 ]]; then
+  echo "Usage: $0 BOINC_TYPE [TARGET_DIR]"
+  echo "BOINC_TYPE : [client | apps | manager | apps-mingw | manager-osx | manager-android]"
+  echo "TARGET_DIR : relative path where binaries should be copied to (default: deploy/BOINC_TYPE/)"
+  exit 1
+fi
+
+TYPE="$1"
+TARGET_DIR="${2:-deploy/$TYPE/}"
+
+case $TYPE in
+    client)
+    prepare_client
+    ;;
+    apps)
+    prepare_apps
+    ;;
+    manager)
+    prepare_manager
+    ;;
+    apps-mingw)
+    prepare_apps_mingw
+    ;;
+    manager-osx)
+    prepare_osx
+    ;;
+    manager-android)
+    prepare_android
+    ;;
+    *)
+    echo "unrecognized BOINC_TYPE $key"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Copy a weekly build from master to https://bintray.com/boinc/boinc-ci so it is available for testers. Only specified build artefacts are copied (see deploy/prepare_deploy.sh). The copy operation is triggered via a Travis CI cronjob or a pull request from within the BOINC/boinc gitub repository.
Pull requests from forks are ignored because they can not have access to the bintray API key, this is a security restriction enforced by Travis CI.