### PR TITLE
client: fixes for launching GPU detection

### DIFF
--- a/client/gpu_detect.cpp
+++ b/client/gpu_detect.cpp
@@ -661,8 +661,6 @@ int COPROCS::launch_child_process_to_detect_gpus() {
          NULL
     }; 
 
-    chdir(client_dir);
-    
     retval = run_program(
         client_dir,
         client_path,
@@ -672,8 +670,6 @@ int COPROCS::launch_child_process_to_detect_gpus() {
         prog
     );
 
-    chdir(data_dir);
-    
     if (retval) {
         if (log_flags.coproc_debug) {
             msg_printf(0, MSG_INFO,

--- a/client/gpu_detect.cpp
+++ b/client/gpu_detect.cpp
@@ -642,10 +642,12 @@ int COPROCS::launch_child_process_to_detect_gpus() {
             "[coproc] launching child process at %s",
             quoted_client_path
         );
-        msg_printf(0, MSG_INFO,
-            "[coproc] relative to directory %s",
-            client_dir
-        );
+        if (!is_path_absolute(client_path)) {
+            msg_printf(0, MSG_INFO,
+                "[coproc] relative to directory %s",
+                client_dir
+            );
+        }
         msg_printf(0, MSG_INFO,
             "[coproc] with data directory %s",
             quoted_data_dir

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -463,12 +463,17 @@ int main(int argc, char** argv) {
         ) {
             int i, len=1024;
             char commandLine[1024];
+            char execpath[MAXPATHLEN];
             STARTUPINFO si;
             PROCESS_INFORMATION pi;
 
+            if (get_real_executable_path(execpath, sizeof(execpath))) {
+                strlcpy(execpath, argv[0], sizeof(execpath));
+            }
+
             argv[index] = "-detach_phase_two";
 
-            sprintf(commandLine, "\"%s\"", CLIENT_EXEC_FILENAME);
+            snprintf(commandLine, sizeof(commandLine), "\"%s\"", execpath);
             for (i = 1; i < argc; i++) {
                 strlcat(commandLine, " ", len);
                 strlcat(commandLine, argv[i], len);

--- a/configure.ac
+++ b/configure.ac
@@ -993,11 +993,6 @@ if test -e "/proc/self/stat"; then
     AC_DEFINE(HAVE__PROC_SELF_STAT, 1, [Define to 1 if /proc/self/stat exists])
 fi
 
-dnl Check for /proc/self/exe (Linux)
-if test -e "/proc/self/exe"; then
-    AC_DEFINE(HAVE__PROC_SELF_EXE, 1, [Define to 1 if /proc/self/exe exists])
-fi
-
 dnl Check for /proc/meminfo (Linux)
 if test -e "/proc/meminfo"; then
     AC_DEFINE(HAVE__PROC_MEMINFO, 1, [Define to 1 if /proc/meminfo exists])

--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -977,3 +977,20 @@ int get_filesystem_info(double &total_space, double &free_space, char* path) {
 #endif
     return 0;
 }
+
+bool is_path_absolute(const std::string path) {
+#ifdef _WIN32
+    if (path.length() >= 3 && isalpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/')) {
+        // c:\file
+        return true;
+    }
+    if (path.length() >= 2 && (path[0] == '\\' || path[0] == '/') && (path[1] == '\\' || path[1] == '/')) {
+        // \\server\file
+        // \\?\c:\file
+        return true;
+    }
+    return false;
+#else
+    return path.length() >= 1 && path[0] == '/';
+#endif
+}

--- a/lib/filesys.h
+++ b/lib/filesys.h
@@ -93,6 +93,7 @@ extern int file_size(const char*, double&);
 extern int clean_out_dir(const char*);
 extern int dir_size(const char* dirpath, double&, bool recurse=true);
 extern int get_filesystem_info(double& total, double& free, char* path=const_cast<char *>("."));
+extern bool is_path_absolute(const std::string path);
 
 // TODO TODO TODO
 // remove this code - the DirScanner class does the same thing.

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -41,8 +41,14 @@
 
 #ifndef _WIN32
 #include "config.h"
+#if defined(__APPLE__)
+#include <mach-o/dyld.h>
+#endif
 #if HAVE_UNISTD_H
 #include <unistd.h>
+#endif
+#if HAVE_SYS_SYSCTL_H
+#include <sys/sysctl.h>
 #endif
 #include <sys/types.h>
 #include <sys/time.h>
@@ -629,23 +635,50 @@ double rand_normal() {
 // determines the real path and filename of the current process
 // not the current working directory
 //
-#ifdef HAVE__PROC_SELF_EXE
 int get_real_executable_path(char* path, size_t max_len) {
-    int ret = readlink("/proc/self/exe", path, max_len - 1);
-    if ( ret >= 0) {
-        path[ret] = '\0'; // readlink does not null terminate
-        return 0;
-    } else {
-#ifdef _USING_FCGI_
-        FCGI::perror("readlink");
-#else
-        perror("readlink");
-#endif
-        return ERR_PROC_PARSE;
+#if defined(__APPLE__)
+    uint32_t size = (uint32_t)max_len;
+    if (_NSGetExecutablePath(path, &size)) {
+        return ERR_BUFFER_OVERFLOW;
     }
-}
+    return BOINC_SUCCESS;
+#elif (defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)) && defined(KERN_PROC_PATHNAME)
+#if defined(__DragonFly__) || defined(__FreeBSD__)
+    int name[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
 #else
-int get_real_executable_path(char* , size_t ) {
-    return ERR_NOT_IMPLEMENTED;
-}
+    int name[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
 #endif
+    if (sysctl(name, 4, path, &max_len, NULL, 0)) {
+        return errno == ENOMEM ? ERR_BUFFER_OVERFLOW : ERR_PROC_PARSE;
+    }
+    return BOINC_SUCCESS;
+#elif defined(_WIN32)
+    DWORD length = GetModuleFileNameA(NULL, path, (DWORD)max_len);
+    if (!length) {
+        return ERR_PROC_PARSE;
+    } else if (length == (DWORD)max_len) {
+        return ERR_BUFFER_OVERFLOW;
+    }
+    return BOINC_SUCCESS;
+#else
+    const char* links[] = { "/proc/self/exe", "/proc/curproc/exe", "/proc/self/path/a.out", "/proc/curproc/file" };
+    for (unsigned int i = 0; i < sizeof(links) / sizeof(links[0]); ++i) {
+        ssize_t ret = readlink(links[i], path, max_len - 1);
+        if (ret < 0) {
+            if (errno != ENOENT) {
+#ifdef _USING_FCGI_
+                FCGI::perror("readlink");
+#else
+                perror("readlink");
+#endif
+            }
+            continue;
+        } else if ((size_t)ret == max_len - 1) {
+            return ERR_BUFFER_OVERFLOW;
+        }
+        path[ret] = '\0'; // readlink does not null terminate
+        return BOINC_SUCCESS;
+    }
+    return ERR_NOT_IMPLEMENTED;
+#endif
+}

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -414,7 +414,7 @@ int read_file_string(
 
 #ifdef _WIN32
 int run_program(
-    const char* dir, const char* file, int argc, char *const argv[], double nsecs, HANDLE& id
+    const char* dir, const char* /*file*/, int argc, char *const argv[], double nsecs, HANDLE& id
 ) {
     int retval;
     PROCESS_INFORMATION process_info;
@@ -436,7 +436,7 @@ int run_program(
     }
 
     retval = CreateProcessA(
-        file,
+        NULL,
         cmdline,
         NULL,
         NULL,
@@ -479,11 +479,11 @@ int run_program(
             retval = chdir(dir);
             if (retval) return retval;
         }
-        execv(file, argv);
+        execvp(file, argv);
 #ifdef _USING_FCGI_
-        FCGI::perror("execv");
+        FCGI::perror("execvp");
 #else
-        perror("execv");
+        perror("execvp");
 #endif
         exit(errno);
     }


### PR DESCRIPTION
Launching GPU detection has a few issues.
- doesn't work reliably with `--detach_console`
- doesn't work if client is run from `$PATH`
- if it fails the user is presented with hard to understand error code
- the code throws compiler warnings

This PR fixes those issues. To support the fixes `get_real_executable_path()` is implemented for several more operating systems and `run_program()` is changed to use `$PATH`. See individual commit messages for details.

Fixes #2657.