### PR TITLE
Mac: screensaver fixes for OS 10.14 Mojave

### DIFF
--- a/clientscr/Mac_Saver_ModuleView.h
+++ b/clientscr/Mac_Saver_ModuleView.h
@@ -43,6 +43,7 @@
 - (IBAction)closeSheetCancel:(id) sender;
 
 - (bool) setUpToUseCGWindowList;
+- (void) doPeriodicTasks;
 
 @end
 

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -427,10 +427,12 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
     // For unkown reasons, OS 10.7 Lion screensaver and later delay several seconds
     // after user activity before calling stopAnimation, so we check user activity here
     if ((compareOSVersionTo(10, 7) >= 0) && ((getDTime() - gSS_StartTime) > 2.0)) {
-           double idleTime =  CGEventSourceSecondsSinceLastEventType
-                    (kCGEventSourceStateCombinedSessionState, kCGAnyInputEventType);
-        if (idleTime < 1.5) {
-            [ NSApp terminate:nil ];
+        if (compareOSVersionTo(10, 14) < 0) {
+               double idleTime =  CGEventSourceSecondsSinceLastEventType
+                        (kCGEventSourceStateCombinedSessionState, kCGAnyInputEventType);
+            if (idleTime < 1.5) {
+                [ NSApp terminate:nil ];
+            }
         }
     }
 #endif  // NOT DEBUG_UNDER_XCODE
@@ -770,10 +772,11 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
 
 
 - (void)animateOneFrame {
-    
-    NSRect windowFrame = [ [ self window ] frame ];
-    if ( (windowFrame.origin.x != 0) || (windowFrame.origin.y != 0) ) {
-        return;         // We draw only to main screen
+    if ( ! [ self isPreview ] ) {    
+        NSRect windowFrame = [ [ self window ] frame ];
+        if ( (windowFrame.origin.x != 0) || (windowFrame.origin.y != 0) ) {
+            return;         // We draw only to main screen
+        }
     }
     //  Drawing in animateOneFrame doesn't seem to work under OS 10.14 Mojave
     // but drawing in drawRect: seems slow under erarlier versions of OS X

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -427,7 +427,7 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
     // For unkown reasons, OS 10.7 Lion screensaver and later delay several seconds
     // after user activity before calling stopAnimation, so we check user activity here
     if ((compareOSVersionTo(10, 7) >= 0) && ((getDTime() - gSS_StartTime) > 2.0)) {
-        if (compareOSVersionTo(10, 14) < 0) {
+        if (! mojave) {
                double idleTime =  CGEventSourceSecondsSinceLastEventType
                         (kCGEventSourceStateCombinedSessionState, kCGAnyInputEventType);
             if (idleTime < 1.5) {
@@ -435,9 +435,7 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
             }
         }
     }
-#endif  // NOT DEBUG_UNDER_XCODE
-    
-#if ! DEBUG_UNDER_XCODE
+
     NSRect windowFrame = [ myWindow frame ];
     if ( (windowFrame.origin.x != 0) || (windowFrame.origin.y != 0) ) {
         // Hide window on second display to aid in debugging

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -91,6 +91,7 @@ extern CFStringRef gPathToBundleResources;
 static SaverState saverState = SaverState_Idle;
 // int gQuitCounter = 0;
 
+static long brandId = 0;
 bool IsDualGPUMacbook = false;
 static io_connect_t GPUSelectConnect = IO_OBJECT_NULL;
 static bool OKToRunOnBatteries = false;
@@ -331,6 +332,9 @@ CScreensaver::CScreensaver() {
     // we were displaying using CGWindowListCreateImage under OS X >= 10.13
     pthread_mutexattr_settype(&saver_mutex_attr, PTHREAD_MUTEX_ERRORCHECK);
     pthread_mutex_init(&saver_mutex, &saver_mutex_attr);
+
+    brandId = GetBrandID();
+    m_BrandText = brandName[brandId];
 }
 
 
@@ -409,13 +413,9 @@ OSStatus CScreensaver::initBOINCApp() {
     pid_t myPid;
     int status;
     OSStatus err;
-    long brandId = 0;
 
     saverState = SaverState_CantLaunchCoreClient;
     
-    brandId = GetBrandID();
-    m_BrandText = brandName[brandId];
-
     m_CoreClientPID = FindProcessPID("boinc", 0);
     if (m_CoreClientPID) {
         m_wasAlreadyRunning = true;

--- a/mac_installer/ReadMe.rtf
+++ b/mac_installer/ReadMe.rtf
@@ -1,33 +1,39 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1265\cocoasubrtf210
+{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf600
 \cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;\red217\green11\blue0;\red56\green110\blue255;}
+{\colortbl;\red255\green255\blue255;\red251\green2\blue7;\red251\green2\blue7;\red56\green110\blue255;
+}
+{\*\expandedcolortbl;;\cssrgb\c100000\c14913\c0;\cssrgb\c100000\c14913\c0;\csgenericrgb\c21961\c43137\c100000;
+}
 \margl1440\margr1440\vieww9000\viewh9000\viewkind0
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
 \f0\b\fs28 \cf0 Macintosh BOINCManager Version <VER_NUM> Release Notes\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b0\fs24 \cf0 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 \cf0 http://boinc.berkeley.edu/\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b \cf0 Installing BOINC may take several minutes; please be patient.
 \b0 \
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
-\cf2 CUDA UPGRADE WARNING\cf0 : Do not upgrade to CUDA 6.5 or later if you have an older NVIDIA GPU with Compute Capability 1.3 or less.  You can check your GPU\'92s Compute Capability at {\field{\*\fldinst{HYPERLINK "https://developer.nvidia.com/cuda-gpus"}}{\fldrslt https://developer.nvidia.com/cuda-gpus}}. \
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
+\cf2 New for Mojave\cf0 : If your Mac has more than one user account, each user may see the following dialog upon their first login after you have installed BOINC: "sh" wants to control "System Events...." The BOINC installer needs this access to finish adding or removing its login item for each user; please click "OK".\
+\
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
+\cf3 CUDA UPGRADE WARNING\cf0 : Do not upgrade to CUDA 6.5 or later if you have an older NVIDIA GPU with Compute Capability 1.3 or less.  You can check your GPU\'92s Compute Capability at {\field{\*\fldinst{HYPERLINK "https://developer.nvidia.com/cuda-gpus"}}{\fldrslt https://developer.nvidia.com/cuda-gpus}}. \
 \
 You can find older CUDA drivers at {\field{\*\fldinst{HYPERLINK "http://www.nvidia.com/object/mac-driver-archive.html"}}{\fldrslt http://www.nvidia.com/object/mac-driver-archive.html}}. Note: after mounting the downloaded disk image, you may need to control-click on the CUDA installer package to open it.\
 \
 For more options, please see the BOINC Macintosh administrator tools at:\
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/wiki/Tools_for_Mac_OS_X"}}{\fldrslt \cf0 http://boinc.berkeley.edu/wiki/Tools_for_Mac_OS_X}}\
 \
-BOINC on the Mac now supports processing with your graphics card, or GPU.  Please see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/wiki/GPU_computing"}}{\fldrslt \cf3 \ul \ulc3 http://boinc.berkeley.edu/wiki/GPU_computing\cf0 \ulnone  }}for more information.   If you have a CUDA-capable NVIDIA GPU and you wish to run CUDA applications, you will need to download and install the CUDA driver and libraries for your system from {\field{\*\fldinst{HYPERLINK "http://www.nvidia.com/object/mac-driver-archive.html"}}{\fldrslt http://www.nvidia.com/object/mac-driver-archive.html}}.  BOINC also supports openCL applications on NVIDIA and ATI / AMD graphics processors.  OpenCL support is standard as part of Mac OS 10.6 and later.\
+BOINC on the Mac now supports processing with your graphics card, or GPU.  Please see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/wiki/GPU_computing"}}{\fldrslt \cf4 \ul \ulc4 http://boinc.berkeley.edu/wiki/GPU_computing\cf0 \ulnone  }}for more information.   If you have a CUDA-capable NVIDIA GPU and you wish to run CUDA applications, you will need to download and install the CUDA driver and libraries for your system from {\field{\*\fldinst{HYPERLINK "http://www.nvidia.com/object/mac-driver-archive.html"}}{\fldrslt http://www.nvidia.com/object/mac-driver-archive.html}}.  BOINC also supports openCL applications on NVIDIA and ATI / AMD graphics processors.  OpenCL support is standard as part of Mac OS 10.6 and later.\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b \cf0 Setting BOINC as your screen saver:
 \b0  This installer adds the BOINC screen saver to your system, and optionally changes your screen saver settings to use the BOINC screen saver.  You can also select BOINC as your screen saver later, using the Screen Saver or Screen Effects panel in the System Preferences (accessible from the Apple menu).  \
@@ -39,13 +45,13 @@ Note: on some versions of the Mac OS, you may not be able to exit the BOINC scre
 
 \b Security:\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \b0 \cf0 BOINC Manager for the Macintosh features strong security measures.  This additional security helps protect your computer data from potential theft or accidental or malicious damage by limiting BOINC projects' access to your  system and data.  \
 \
 For more information or technical details of the implementation, please see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/SandboxUser"}}{\fldrslt http://boinc.berkeley.edu/trac/wiki/SandboxUser}} and {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/sandbox.php"}}{\fldrslt http://boinc.berkeley.edu/sandbox.php}}\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 
 \b \cf0 Automatic start:
 \b0 \
@@ -54,7 +60,7 @@ The installer sets BOINCManager as a Login item for
 \b all
 \b0  authorized users, not just the user who ran the installer.  You can add or remove Login Items by using the Accounts Pane in the System Preferences (accessible from the Apple menu).  \
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 
 \b \cf0 Other useful information:
 \b0 \
@@ -77,7 +83,7 @@ You can move (
 \b /Applications
 \b0  folder.\
 \
-\pard\pardeftab720
+\pard\pardeftab720\partightenfactor0
 \cf0 To completely remove (
 \b uninstall
 \b0 ) BOINC from your Macintosh, run the 


### PR DESCRIPTION
I need to do more testing before removing the [WIP]. 

Since OS 10.14 Mojave was released several days ago and we have already received bug reports about this, should we merge this into the 7.12 branch and issue a hot fix for BOINC on the Mac once my testing is complete?