### PR TITLE
Web: Eliminate PHP warning

### DIFF
--- a/html/user/add_venue.php
+++ b/html/user/add_venue.php
@@ -35,6 +35,8 @@ if ($action) {
     if ($subset == "global") {
         $prefs = prefs_parse_global($user->global_prefs);
         $prefs->$venue = $prefs;
+
+        $new_prefs = new stdClass();
         $error = prefs_global_parse_form($new_prefs);
         if ($error != false) {
             $title = tra("Edit %1 preferences", subset_name($subset));
@@ -56,7 +58,8 @@ if ($action) {
     } else {
         $prefs = prefs_parse_project($user->project_prefs);
         $prefs->$venue = $prefs;
-
+ 
+        $new_prefs = new stdClass();
         $project_error = prefs_project_parse_form($new_prefs);
         $error = prefs_resource_parse_form($new_prefs);
 


### PR DESCRIPTION
While testing and allowing PHP to report warnings, attempts to create a venue resulted in the following being shown on the page:

Warning: Creating default object from empty value in /root/project/html/inc/prefs_project.inc on line 395

This is because the variable $new_prefs was not defined before being passed into prefs_project_parse_form and the application was relying on implicit object creation.

This change initializes $new_prefs before passing it in so that the warning is not triggered.
