### PR TITLE
HTCondor boinc_gahp should compile with -O2

### DIFF
--- a/samples/condor/Makefile
+++ b/samples/condor/Makefile
@@ -8,7 +8,7 @@ distclean: clean
 distclean-recursive: clean
 
 boinc_gahp: boinc_gahp.cpp ../../lib/remote_submit.h ../../lib/remote_submit.cpp ../../svn_version.h
-	g++ -g -O0 -I../../lib -I../.. \
+	g++ -g -O2 -I../../lib -I../.. \
 	-o boinc_gahp boinc_gahp.cpp ../../lib/remote_submit.cpp \
 	-L../../lib -lboinc -lpthread -lcurl
 


### PR DESCRIPTION
I was reviewing the builds for the upcoming HTCondor release and noticed the -O0 was chosen for optimization when building HTCondor's bonic_gahp. It should be compiled at -O2.