### PR TITLE
[Manager] Fix project urls comparison

### DIFF
--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -878,17 +878,21 @@ static void handle_project_attach(GUI_RPC_CONN& grc) {
 	// there is no reason to connect to secure address project
 	// if we're already connected to the non-secure address
 	// or vice versa
+	// also clear last '/' character if present
 
-	const std::string http = "http://";
-	const std::string https = "https://";
+	const string http = "http://";
+	const string https = "https://";
 
 	string new_project_url = url;
 	size_t pos = new_project_url.find(http);
-	if (pos != std::string::npos) {
+	if (pos != string::npos) {
 		new_project_url.erase(pos, http.length());
 	}
-	else if ((pos = new_project_url.find(https)) != std::string::npos) {
+	else if ((pos = new_project_url.find(https)) != string::npos) {
 		new_project_url.erase(pos, https.length());
+	}
+	if (new_project_url.length() >= 1 && new_project_url[new_project_url.length() - 1] == '/') {
+		new_project_url.erase(new_project_url.length() - 1, 1);
 	}
 
     for (i=0; i<gstate.projects.size(); i++) {
@@ -896,11 +900,14 @@ static void handle_project_attach(GUI_RPC_CONN& grc) {
 		string project_url = p->master_url;
 
 		pos = project_url.find(http);
-		if (pos != std::string::npos) {
+		if (pos != string::npos) {
 			project_url.erase(pos, http.length());
 		}
-		else if ((pos = project_url.find(https)) != std::string::npos) {
+		else if ((pos = project_url.find(https)) != string::npos) {
 			project_url.erase(pos, https.length());
+		}
+		if (project_url.length() >= 1 && project_url[project_url.length() - 1] == '/') {
+			project_url.erase(project_url.length() - 1, 1);
 		}
 
 		if (new_project_url == project_url) {

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -874,9 +874,39 @@ static void handle_project_attach(GUI_RPC_CONN& grc) {
         }
     }
 
+	// remove http(s):// at the beginning of project address
+	// there is no reason to connect to secure address project
+	// if we're already connected to the non-secure address
+	// or vice versa
+
+	const std::string http = "http://";
+	const std::string https = "https://";
+
+	string new_project_url = url;
+	size_t pos = new_project_url.find(http);
+	if (pos != std::string::npos) {
+		new_project_url.erase(pos, http.length());
+	}
+	else if ((pos = new_project_url.find(https)) != std::string::npos) {
+		new_project_url.erase(pos, https.length());
+	}
+
     for (i=0; i<gstate.projects.size(); i++) {
         PROJECT* p = gstate.projects[i];
-        if (url == p->master_url) already_attached = true;
+		string project_url = p->master_url;
+
+		pos = project_url.find(http);
+		if (pos != std::string::npos) {
+			project_url.erase(pos, http.length());
+		}
+		else if ((pos = project_url.find(https)) != std::string::npos) {
+			project_url.erase(pos, https.length());
+		}
+
+		if (new_project_url == project_url) {
+			already_attached = true;
+			break;
+		}
     }
 
     if (already_attached) {

--- a/clientgui/ProjectInfoPage.cpp
+++ b/clientgui/ProjectInfoPage.cpp
@@ -814,6 +814,8 @@ void CProjectInfoPage::OnPageChanging( wxWizardExEvent& event ) {
     }
 
     // Check if we are already attached to that project: 
+    const std::string http = "http://";
+    const std::string https = "https://";
  	for (int i = 0; i < pDoc->GetProjectCount(); ++i) { 
  	    PROJECT* project = pDoc->project(i);
         if (project) {
@@ -822,7 +824,25 @@ void CProjectInfoPage::OnPageChanging( wxWizardExEvent& event ) {
 
             canonicalize_master_url(project_url);
             canonicalize_master_url(new_project_url);
-                
+
+            // remove http(s):// at the beginning of project address
+            // there is no reason to connect to secure address project
+            // if we're already connected to the non-secure address
+            // or vice versa
+            size_t pos = project_url.find(http);
+            if (pos != std::string::npos) {
+                project_url.erase(pos, http.length());
+            } else if ((pos = project_url.find(https)) != std::string::npos) {
+                project_url.erase(pos, https.length());
+            }
+
+            if ((pos = new_project_url.find(http)) != std::string::npos) {
+                new_project_url.erase(pos, http.length());
+            }
+            else if ((pos = new_project_url.find(https)) != std::string::npos) {
+                new_project_url.erase(pos, https.length());
+            }
+
             if (project_url == new_project_url) {
                 bAlreadyAttached = true;
                 break;

--- a/clientgui/ProjectInfoPage.cpp
+++ b/clientgui/ProjectInfoPage.cpp
@@ -816,32 +816,39 @@ void CProjectInfoPage::OnPageChanging( wxWizardExEvent& event ) {
     // Check if we are already attached to that project: 
     const std::string http = "http://";
     const std::string https = "https://";
+
+	std::string new_project_url = (const char*)m_strProjectURL.mb_str();
+	canonicalize_master_url(new_project_url);
+	// remove http(s):// at the beginning of project address
+	// there is no reason to connect to secure address project
+	// if we're already connected to the non-secure address
+	// or vice versa
+	// also clear last '/' character if present
+	size_t pos = new_project_url.find(http);
+	if (pos != std::string::npos) {
+		new_project_url.erase(pos, http.length());
+	}
+	else if ((pos = new_project_url.find(https)) != std::string::npos) {
+		new_project_url.erase(pos, https.length());
+	}
+	if (new_project_url.length() >= 1 && new_project_url[new_project_url.length() - 1] == '/') {
+		new_project_url.erase(new_project_url.length() - 1, 1);
+	}
  	for (int i = 0; i < pDoc->GetProjectCount(); ++i) { 
  	    PROJECT* project = pDoc->project(i);
         if (project) {
-            std::string project_url = project->master_url;
-            std::string new_project_url = (const char*)m_strProjectURL.mb_str();
+            std::string project_url = project->master_url;            
 
             canonicalize_master_url(project_url);
-            canonicalize_master_url(new_project_url);
 
-            // remove http(s):// at the beginning of project address
-            // there is no reason to connect to secure address project
-            // if we're already connected to the non-secure address
-            // or vice versa
-            size_t pos = project_url.find(http);
-            if (pos != std::string::npos) {
+            if ((pos = project_url.find(http)) != std::string::npos) {
                 project_url.erase(pos, http.length());
             } else if ((pos = project_url.find(https)) != std::string::npos) {
                 project_url.erase(pos, https.length());
             }
-
-            if ((pos = new_project_url.find(http)) != std::string::npos) {
-                new_project_url.erase(pos, http.length());
-            }
-            else if ((pos = new_project_url.find(https)) != std::string::npos) {
-                new_project_url.erase(pos, https.length());
-            }
+			if (project_url.length() >= 1 && project_url[project_url.length() - 1] == '/') {
+				project_url.erase(project_url.length() - 1, 1);
+			}
 
             if (project_url == new_project_url) {
                 bAlreadyAttached = true;


### PR DESCRIPTION
Remove http(s): at the beginning of project address.
There is no reason to connect to secure address project  if we're already connected to the non-secure address or vice versa.

Partial fix for the issue mentioned in #1043

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>