### PR TITLE
Update GAHP version string

### DIFF
--- a/samples/condor/Makefile
+++ b/samples/condor/Makefile
@@ -7,7 +7,7 @@ distclean: clean
 
 distclean-recursive: clean
 
-boinc_gahp: boinc_gahp.cpp ../../lib/remote_submit.h ../../lib/remote_submit.cpp ../../svn_version.h
+boinc_gahp: boinc_gahp.cpp ../../lib/remote_submit.h ../../lib/remote_submit.cpp ../../svn_version.h ../../version.h
 	g++ -g -O2 -I../../lib -I../.. \
 	-o boinc_gahp boinc_gahp.cpp ../../lib/remote_submit.cpp \
 	-L../../lib -lboinc -lpthread -lcurl

--- a/samples/condor/boinc_gahp.cpp
+++ b/samples/condor/boinc_gahp.cpp
@@ -35,8 +35,9 @@
 #include "parse.h"
 #include "remote_submit.h"
 #include "svn_version.h"
+#include "version.h"
 
-#define BOINC_GAHP_VERSION "1.0.1"
+#define BOINC_GAHP_VERSION "1.0.2"
 
 using std::map;
 using std::pair;
@@ -723,7 +724,7 @@ int COMMAND::parse_command() {
 }
 
 void print_version(bool startup) {
-    BPRINTF("%s$GahpVersion: %s %s BOINC\\ GAHP\\ GIT:%x $\n", startup ? "" : "S ", BOINC_GAHP_VERSION, __DATE__, GIT_REVISION);
+    BPRINTF("%s$GahpVersion: %s %s BOINC\\ %s\\ GAHP $\n", startup ? "" : "S ", BOINC_GAHP_VERSION, __DATE__, BOINC_VERSION_STRING);
 }
 
 int n_results() {


### PR DESCRIPTION
The existing code depended on building within a git repository.  It
included the GIT_REVISION in the startup message.  Unfortunately,
if you built from a downloaded tarball, the build fails. I thought
that the version of BOINC that the GAHP was compiled against would
be useful information as it is logged.  The SVN_VERSION is still
available by using the --version command line option.  Because of
the small change in behavior, I also bumped the version number of
the GAHP to 1.0.2.