### PR TITLE
Mac screensaver: If no application graphics running, don't display bad message

### DIFF
--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -169,7 +169,7 @@ static bool mojave;
 #define MAXDELTA 16
 
 // On OS 10.13+, assume graphics app is not compatible if no MachO connection after 5 seconds
-#define MAXWAITFORCONNECTION 5.0
+#define MAXWAITFORCONNECTION 8.0
 #define MAX_CGWINDOWLIST_TRIES 3
 
 int signof(float x) {

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -347,10 +347,12 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
     [ super stopAnimation ];
 
     if ([ self isPreview ]) return;
+#if ! DEBUG_UNDER_XCODE
     NSRect windowFrame = [ [ self window ] frame ];
     if ( (windowFrame.origin.x != 0) || (windowFrame.origin.y != 0) ) {
         return;         // We draw only to main screen
     }
+#endif
     if (imageView) {
         useCGWindowList = false;
         // removeFromSuperview must be called from main thread
@@ -548,7 +550,9 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
         // and IOSurfaceBuffer support, so try to use CGWindowListCreateImage 
         // method. If that fails MAX_CGWINDOWLIST_TRIES times then assume 
         // the graphics app is not compatible with OS 10.13+ and kill it.
-        if (gfxAppStartTime) {
+        //
+        // taskSlot<0 if no worker app is running, so launching default graphics
+        if (gfxAppStartTime && (taskSlot >= 0)) { 
             if ((getDTime() - gfxAppStartTime)> MAXWAITFORCONNECTION) {
                 if (++CGWindowListTries > MAX_CGWINDOWLIST_TRIES) {
                     // After displaying message for 5 seconds, incompatibleGfxApp
@@ -770,12 +774,14 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
 
 
 - (void)animateOneFrame {
+#if ! DEBUG_UNDER_XCODE
     if ( ! [ self isPreview ] ) {    
         NSRect windowFrame = [ [ self window ] frame ];
         if ( (windowFrame.origin.x != 0) || (windowFrame.origin.y != 0) ) {
             return;         // We draw only to main screen
         }
     }
+#endif
     //  Drawing in animateOneFrame doesn't seem to work under OS 10.14 Mojave
     // but drawing in drawRect: seems slow under erarlier versions of OS X
     if (mojave) {


### PR DESCRIPTION
Under OS 10.13 and later, there was a bug in the Mac screensaver coordinator when the default (overview) screensaver _boincscr_ took longer than 5 seconds to open its window. This incorrectly triggered the message "Screensaver of application _XXX_ is not compatible with this version of OS X" where _XXX_ is normally the name of the worker application associated with the faulty graphics app. 

But instead of substituting one worker app name for _XXX_ in the displayed string, it appended the names of all inactive apps (all those with slot set to -1) up to the buffer size limit of 1024 characters.

Probably the worst problem created by this bug is that it caused the logic to decide that _boincscr_ was defective and stop trying to use it. 

Fortunately, none of these problems persisted once the screensaver coordinator was dismissed. The next time the screensaver coordinator was invoked _boincscr_ was again able to run (though the problem would recur if _boincscr_ again took too long to display its window.)

Also fortunately, the fix involved a very small change to just one file. However, I needed to add `#if  DEBUG_UNDER_XCODE` in a few more places to allow the debugging logic to work properly so that I could diagnose the problem, and I have included them in this PR.