### PR TITLE
Fix issues to build android release

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -20,7 +20,7 @@ def buildVersionCode() {
 
 // Derive version name from release tag and add commit SHA1
 def buildVersionName() {
-    def pattern = /client_release\/\d+\.\d+\/(?<major>\d+)\.(?<minor>\d+)\.(?<revision>\d+)(?<suffix>[-_\.].*)/
+    def pattern = /client_release\/\d+\.\d+\/(?<major>\d+)\.(?<minor>\d+)\.(?<revision>\d+)(?<suffix>[-_\.]?.*)/
     def version = ': DEVELOPMENT'
 
     def head = versionDetails()

--- a/android/BOINC/app/src/main/AndroidManifest.xml
+++ b/android/BOINC/app/src/main/AndroidManifest.xml
@@ -38,7 +38,6 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.READ_LOGS" />
     <uses-permission android:name="android.permission.RESTART_PACKAGES" />
 
     <!-- Features required for Android TV, consoles, and set-top boxes like Nexus Player, OUYA,


### PR DESCRIPTION
While trying to create an unsigned release apk for Android, the following issues were found.

Attempt to use system only permission:
```
 > Lint found errors in the project; aborting build.
  
  Fix the issues identified by lint, or add the following to your build script to proceed with errors:
  ...
  android {
      lintOptions {
          abortOnError false
      }
  }
  ...
  
  Errors found:
  
  /home/knreed/BOINC/android/BOINC/app/src/main/AndroidManifest.xml:41: Error: Permission is only granted to system apps [ProtectedPermissions]
      <uses-permission android:name="android.permission.READ_LOGS"/>
```

Version regex in gradle build file required a seperator character for the suffix in all cases.  Added a ? to indicate that it was not required.