### PR TITLE
Mac installer: Changes to avoid Mojave security dialog

### DIFF
--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 45;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -20,10 +20,11 @@
 				DDF9EC0D144EB338005D6144 /* PBXTargetDependency */,
 				DDBD681107FA830E0082C20D /* PBXTargetDependency */,
 				DDB874670C850DB600E0DE1F /* PBXTargetDependency */,
-				DDBD681507FA830E0082C20D /* PBXTargetDependency */,
 				DD791FF10819063C00BE2906 /* PBXTargetDependency */,
+				DDBD681507FA830E0082C20D /* PBXTargetDependency */,
 				DD58247D0B198BDD003B6A2F /* PBXTargetDependency */,
 				DD6178CE1488F09E0042482E /* PBXTargetDependency */,
+				DD3EAAB1216A26C700BC673C /* PBXTargetDependency */,
 				DD127877081F44E5007B5DE1 /* PBXTargetDependency */,
 				DD664F19084321A2009BFB11 /* PBXTargetDependency */,
 				DDA12AD10A369DEC00FBDD12 /* PBXTargetDependency */,
@@ -148,6 +149,10 @@
 		DD3E15310A774397007E0084 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20286C33FDCF999611CA2CEA /* Carbon.framework */; };
 		DD3E15320A774397007E0084 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2552B07C62F3E008E7D6E /* IOKit.framework */; };
 		DD3E15330A774397007E0084 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1929D80918A2F100C31BCF /* Security.framework */; };
+		DD3EAAAD216A262100BC673C /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
+		DD3EAAAF216A268600BC673C /* finish_install.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD3EAAAE216A268500BC673C /* finish_install.cpp */; };
+		DD3EAAB7216A2A7900BC673C /* boinc_finish_install in Resources */ = {isa = PBXBuildFile; fileRef = DD3EAAA6216A25AD00BC673C /* boinc_finish_install */; };
+		DD3EAABA216A2A9B00BC673C /* boinc_finish_install in Resources */ = {isa = PBXBuildFile; fileRef = DD3EAAA6216A25AD00BC673C /* boinc_finish_install */; };
 		DD407A4D07D2FB6500163EF5 /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
 		DD407A4F07D2FB7100163EF5 /* base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344B6307C5ACEB0043025C /* base64.cpp */; };
 		DD407A5307D2FB7C00163EF5 /* diagnostics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BA207C5AE5A0043025C /* diagnostics.cpp */; };
@@ -582,6 +587,27 @@
 			remoteGlobalIDString = DDD74D8607CF482E0065AC9D;
 			remoteInfo = BOINC_Client;
 		};
+		DD3EAAB0216A26C700BC673C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD3EAAA5216A25AD00BC673C;
+			remoteInfo = boinc_finish_install;
+		};
+		DD3EAAB5216A2A6700BC673C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD3EAAA5216A25AD00BC673C;
+			remoteInfo = boinc_finish_install;
+		};
+		DD3EAAB8216A2A8A00BC673C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD3EAAA5216A25AD00BC673C;
+			remoteInfo = boinc_finish_install;
+		};
 		DD45C4A00A53E73500E923D1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
@@ -755,6 +781,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DD3EAAA4216A25AD00BC673C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -856,6 +891,8 @@
 		DD344BEF07C5B1770043025C /* proxy_info.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_info.cpp; sourceTree = "<group>"; };
 		DD35353107E1E05C00C4718D /* libboinc_api.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboinc_api.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3E15420A774397007E0084 /* BOINCManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BOINCManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD3EAAA6216A25AD00BC673C /* boinc_finish_install */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = boinc_finish_install; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD3EAAAE216A268500BC673C /* finish_install.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = finish_install.cpp; path = ../mac_installer/finish_install.cpp; sourceTree = "<group>"; };
 		DD407A4A07D2FB1200163EF5 /* libboinc.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboinc.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD407AB707D2FC7D00163EF5 /* mem_usage.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = mem_usage.cpp; sourceTree = "<group>"; };
 		DD407AB807D2FC7D00163EF5 /* mem_usage.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = mem_usage.h; path = ../lib/mem_usage.h; sourceTree = SOURCE_ROOT; };
@@ -1295,6 +1332,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DD3EAAA3216A25AD00BC673C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD407A4807D2FB1200163EF5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1445,6 +1489,7 @@
 				DDD337021062235D00867C7D /* AddRemoveUser */,
 				DD81C79A144D8DA9000BE61A /* libjpeg.a */,
 				DDF9EC03144EB14B005D6144 /* libboinc_opencl.a */,
+				DD3EAAA6216A25AD00BC673C /* boinc_finish_install */,
 			);
 			name = Products;
 			sourceTree = SOURCE_ROOT;
@@ -1463,6 +1508,7 @@
 				DD81C79E144D8F97000BE61A /* jpeg */,
 				20286C2CFDCF999611CA2CEA /* Resources */,
 				20286C32FDCF999611CA2CEA /* External Frameworks and Libraries */,
+				DD3EAAA7216A25AE00BC673C /* boinc_finish_install */,
 				195DF8C9FE9D4F0611CA2CBB /* Products */,
 				DD96AFFA0811075100A06F22 /* ScreenSaver-Info.plist */,
 				DD1277B5081F3D67007B5DE1 /* PostInstall-Info.plist */,
@@ -1513,6 +1559,7 @@
 			isa = PBXGroup;
 			children = (
 				DD1AFEE70A51301C00EE5B82 /* Installer.cpp */,
+				DD3EAAAE216A268500BC673C /* finish_install.cpp */,
 				DD1277C0081F3E73007B5DE1 /* PostInstall.cpp */,
 				DDF9350F176B0D0C00A2793C /* translate.cpp */,
 				DDF93510176B0D0C00A2793C /* translate.h */,
@@ -1525,6 +1572,13 @@
 			);
 			name = mac_installer;
 			sourceTree = SOURCE_ROOT;
+		};
+		DD3EAAA7216A25AE00BC673C /* boinc_finish_install */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = boinc_finish_install;
+			sourceTree = "<group>";
 		};
 		DD81C3F707C5D03B0098A04D /* clientgui */ = {
 			isa = PBXGroup;
@@ -2069,6 +2123,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DD3EAAB6216A2A6700BC673C /* PBXTargetDependency */,
 				DDAD19DF09090914004E7DD0 /* PBXTargetDependency */,
 			);
 			name = PostInstall;
@@ -2136,6 +2191,23 @@
 			productReference = DD3E15420A774397007E0084 /* BOINCManager.app */;
 			productType = "com.apple.product-type.application";
 		};
+		DD3EAAA5216A25AD00BC673C /* boinc_finish_install */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD3EAAAC216A25AE00BC673C /* Build configuration list for PBXNativeTarget "boinc_finish_install" */;
+			buildPhases = (
+				DD3EAAA2216A25AD00BC673C /* Sources */,
+				DD3EAAA3216A25AD00BC673C /* Frameworks */,
+				DD3EAAA4216A25AD00BC673C /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = boinc_finish_install;
+			productName = boinc_finish_install;
+			productReference = DD3EAAA6216A25AD00BC673C /* boinc_finish_install */;
+			productType = "com.apple.product-type.tool";
+		};
 		DD407A4907D2FB1200163EF5 /* libboinc */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD9E2351091CBDAE0048316E /* Build configuration list for PBXNativeTarget "libboinc" */;
@@ -2166,6 +2238,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DD3EAAB9216A2A8A00BC673C /* PBXTargetDependency */,
 			);
 			name = Uninstaller;
 			productName = Uninstaller;
@@ -2405,6 +2478,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0620;
+				TargetAttributes = {
+					DD3EAAA5216A25AD00BC673C = {
+						CreatedOnToolsVersion = 9.4.1;
+					};
+				};
 			};
 			buildConfigurationList = DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc" */;
 			compatibilityVersion = "Xcode 3.0";
@@ -2434,6 +2512,7 @@
 				DD7748970A356C880025D05E /* SetUpSecurity */,
 				DDD0953E0A3EDD2500C95BA4 /* switcher */,
 				DD1AFEA40A512D8700EE5B82 /* Install_BOINC */,
+				DD3EAAA5216A25AD00BC673C /* boinc_finish_install */,
 				DDFF2ACA0A53D4AE002BC19D /* setprojectgrp */,
 				DD3E14D30A774397007E0084 /* mgr_boinc */,
 				DD4688400C165F3C0089F500 /* Uninstaller */,
@@ -2449,6 +2528,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD3EAAB7216A2A7900BC673C /* boinc_finish_install in Resources */,
 				DD00F554176C081500850424 /* MacInstaller.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2475,6 +2555,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD3EAABA216A2A9B00BC673C /* boinc_finish_install in Resources */,
 				DD531BC80C193D5200742E50 /* MacUninstaller.icns in Resources */,
 				DD74B686177074AF005CF7DC /* PutInTrash.icns in Resources */,
 			);
@@ -2951,6 +3032,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DD3EAAA2216A25AD00BC673C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD3EAAAF216A268600BC673C /* finish_install.cpp in Sources */,
+				DD3EAAAD216A262100BC673C /* mac_branding.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD407A4707D2FB1200163EF5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3413,6 +3503,21 @@
 			target = DDD74D8607CF482E0065AC9D /* BOINC_Client */;
 			targetProxy = DD3E14D70A774397007E0084 /* PBXContainerItemProxy */;
 		};
+		DD3EAAB1216A26C700BC673C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD3EAAA5216A25AD00BC673C /* boinc_finish_install */;
+			targetProxy = DD3EAAB0216A26C700BC673C /* PBXContainerItemProxy */;
+		};
+		DD3EAAB6216A2A6700BC673C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD3EAAA5216A25AD00BC673C /* boinc_finish_install */;
+			targetProxy = DD3EAAB5216A2A6700BC673C /* PBXContainerItemProxy */;
+		};
+		DD3EAAB9216A2A8A00BC673C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD3EAAA5216A25AD00BC673C /* boinc_finish_install */;
+			targetProxy = DD3EAAB8216A2A8A00BC673C /* PBXContainerItemProxy */;
+		};
 		DD45C4A10A53E73500E923D1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDFF2ACA0A53D4AE002BC19D /* setprojectgrp */;
@@ -3678,6 +3783,119 @@
 					"-Wno-unknown-pragmas",
 					"-Wno-write-strings",
 				);
+			};
+			name = Deployment;
+		};
+		DD3EAAAA216A25AE00BC673C /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Development;
+		};
+		DD3EAAAB216A25AE00BC673C /* Deployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 			};
 			name = Deployment;
 		};
@@ -4329,6 +4547,15 @@
 			buildConfigurations = (
 				DD3E153E0A774397007E0084 /* Development */,
 				DD3E15410A774397007E0084 /* Deployment */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Development;
+		};
+		DD3EAAAC216A25AE00BC673C /* Build configuration list for PBXNativeTarget "boinc_finish_install" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD3EAAAA216A25AE00BC673C /* Development */,
+				DD3EAAAB216A25AE00BC673C /* Deployment */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Development;

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		DD130E740820C422001A0291 /* ScreenSaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD7C5E7508110AE3002FCE1E /* ScreenSaver.framework */; };
 		DD130F320820C47C001A0291 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2552B07C62F3E008E7D6E /* IOKit.framework */; };
 		DD16BF7C099D6C90003E4B69 /* cpu_sched.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD16BF7B099D6C90003E4B69 /* cpu_sched.cpp */; };
+		DD19D2C0216E0211004A5E0D /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20286C33FDCF999611CA2CEA /* Carbon.framework */; };
 		DD1AFEAF0A512D8700EE5B82 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20286C33FDCF999611CA2CEA /* Carbon.framework */; };
 		DD1AFEB00A512D8700EE5B82 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD1929D80918A2F100C31BCF /* Security.framework */; };
 		DD1AFEE80A51301C00EE5B82 /* Installer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD1AFEE70A51301C00EE5B82 /* Installer.cpp */; };
@@ -1336,6 +1337,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD19D2C0216E0211004A5E0D /* Carbon.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3818,8 +3820,8 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "-";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -3878,8 +3880,8 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "-";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;

--- a/mac_installer/AddRemoveUser.cpp
+++ b/mac_installer/AddRemoveUser.cpp
@@ -523,7 +523,7 @@ Boolean SetLoginItemLaunchAgent(long brandID, Boolean deleteLogInItem, passwd *p
         chown(s, pw->pw_uid, pw->pw_gid);
     }
     
-    snprintf(s, sizeof(s), "/Library/Application Support/BOINC/%s_Finish_Install", appName[brandID]);
+    snprintf(s, sizeof(s), "/Library/Application Support/BOINC Data/%s_Finish_Install", appName[brandID]);
     if (stat(s, &sbuf) != 0) {
         return SetLoginItemLaunchAgentShellScript(brandID, deleteLogInItem, pw);
     } else {
@@ -591,8 +591,7 @@ Boolean SetLoginItemLaunchAgentFinishInstallApp(long brandID, Boolean deleteLogI
     fprintf(f, "\t<string>edu.berkeley.fix_login_items</string>\n");
     fprintf(f, "\t<key>ProgramArguments</key>\n");
     fprintf(f, "\t<array>\n");
-    fprintf(f, "\t\t<string>\"/Library/Application Support/BOINC/%s_Finish_Install\"</string>\n", appName[brandID]);
-    fprintf(f, "\t\t<string>");
+    fprintf(f, "\t\t<string>/Library/Application Support/BOINC Data/%s_Finish_Install</string>\n", appName[brandID]);
     if (deleteLogInItem) {
         // If this user was previously authorized to run the Manager, there 
         // may still be a Login Item for this user, and the Login Item may
@@ -600,9 +599,11 @@ Boolean SetLoginItemLaunchAgentFinishInstallApp(long brandID, Boolean deleteLogI
         // To guard against this, we have the LaunchAgent kill the Manager
         // (for this user only) if it is running.
         //
-        fprintf(f, "-d \"%s\" ", appName[brandID]);
+        fprintf(f, "\t\t<string>-d</string>\n");
+        fprintf(f, "\t\t<string>%s</string>\n", appName[brandID]);
     } else  {
-        fprintf(f, "-a \"%s\"", appName[brandID]);
+        fprintf(f, "\t\t<string>-a</string>\n");
+        fprintf(f, "\t\t<string>%s</string>\n", appName[brandID]);
     }
     fprintf(f, "</string>\n");
     fprintf(f, "\t</array>\n");

--- a/mac_installer/AddRemoveUser.cpp
+++ b/mac_installer/AddRemoveUser.cpp
@@ -39,6 +39,8 @@
 void printUsage(long brandID);
 Boolean SetLoginItemOSAScript(long brandID, Boolean deleteLogInItem, char *userName);
 Boolean SetLoginItemLaunchAgent(long brandID, Boolean deleteLogInItem, passwd *pw);
+Boolean SetLoginItemLaunchAgentShellScript(long brandID, Boolean deleteLogInItem, passwd *pw);
+Boolean SetLoginItemLaunchAgentFinishInstallApp(long brandID, Boolean deleteLogInItem, passwd *pw);
 OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen);
 OSErr SetScreenSaverSelection(passwd *pw, char *moduleName, char *modulePath, int type);
 pid_t FindProcessPID(char* name, pid_t thePID);
@@ -510,9 +512,9 @@ Boolean SetLoginItemLaunchAgent(long brandID, Boolean deleteLogInItem, passwd *p
 {
     struct stat             sbuf;
     char                    s[2048];
-    
+
     // Create a LaunchAgent for the specified user, replacing any LaunchAgent created
-    // previously (such as by Uninstaller or by installing a differently branded BOINC.)
+    // previously (such as by Ininstaller or by installing a differently branded BOINC.)
 
     // Create LaunchAgents directory for this user if it does not yet exist
     snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents", pw->pw_name);
@@ -520,6 +522,18 @@ Boolean SetLoginItemLaunchAgent(long brandID, Boolean deleteLogInItem, passwd *p
         mkdir(s, 0755);
         chown(s, pw->pw_uid, pw->pw_gid);
     }
+    
+    snprintf(s, sizeof(s), "/Library/Application Support/BOINC/%s_Finish_Install", appName[brandID]);
+    if (stat(s, &sbuf) != 0) {
+        return SetLoginItemLaunchAgentShellScript(brandID, deleteLogInItem, pw);
+    } else {
+        return SetLoginItemLaunchAgentFinishInstallApp(brandID, deleteLogInItem, pw);    
+    }
+}
+
+
+Boolean SetLoginItemLaunchAgentShellScript(long brandID, Boolean deleteLogInItem, passwd *pw) {
+    char                    s[2048];
 
     snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist", pw->pw_name);
     FILE* f = fopen(s, "w");
@@ -560,6 +574,50 @@ Boolean SetLoginItemLaunchAgent(long brandID, Boolean deleteLogInItem, passwd *p
     chown(s, pw->pw_uid, pw->pw_gid);
 
     return true;
+}
+
+
+Boolean SetLoginItemLaunchAgentFinishInstallApp(long brandID, Boolean deleteLogInItem, passwd *pw){
+    char                    s[2048];
+    
+    snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist", pw->pw_name);
+    FILE* f = fopen(s, "w");
+    if (!f) return false;
+    fprintf(f, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    fprintf(f, "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n");
+    fprintf(f, "<plist version=\"1.0\">\n");
+    fprintf(f, "<dict>\n");
+    fprintf(f, "\t<key>Label</key>\n");
+    fprintf(f, "\t<string>edu.berkeley.fix_login_items</string>\n");
+    fprintf(f, "\t<key>ProgramArguments</key>\n");
+    fprintf(f, "\t<array>\n");
+    fprintf(f, "\t\t<string>\"/Library/Application Support/BOINC/%s_Finish_Install\"</string>\n", appName[brandID]);
+    fprintf(f, "\t\t<string>");
+    if (deleteLogInItem) {
+        // If this user was previously authorized to run the Manager, there 
+        // may still be a Login Item for this user, and the Login Item may
+        // launch the Manager before the LaunchAgent deletes the Login Item.
+        // To guard against this, we have the LaunchAgent kill the Manager
+        // (for this user only) if it is running.
+        //
+        fprintf(f, "-d \"%s\" ", appName[brandID]);
+    } else  {
+        fprintf(f, "-a \"%s\"", appName[brandID]);
+    }
+    fprintf(f, "</string>\n");
+    fprintf(f, "\t</array>\n");
+    fprintf(f, "\t<key>RunAtLoad</key>\n");
+    fprintf(f, "\t<true/>\n");
+    fprintf(f, "</dict>\n");
+    fprintf(f, "</plist>\n");
+    fclose(f);
+
+    chmod(s, 0644);
+    chown(s, pw->pw_uid, pw->pw_gid);
+
+    return true;
+
+
 }
 
 

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -1104,9 +1104,13 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
             alreadyCopied = true;
         }
 
-        snprintf(s, sizeof(s), "Users/%s/Library/LaunchAgents/%s_Finish_Install\"</string>\n", pw->pw_name, appName[brandID]);
+        snprintf(s, sizeof(s), "/Library/Application Support/BOINC Data/%s_Finish_Install\"</string>\n", appName[brandID]);
         chmod(s, 0755);
-        chown(s, pw->pw_uid, pw->pw_gid);
+        group *bmgrp = getgrnam(boinc_master_group_name);
+        passwd *bmpw = getpwnam(boinc_master_user_name);
+        if (bmgrp && bmpw) {
+            chown(s, bmpw->pw_uid, bmgrp->gr_gid);
+        }
     }
 
     // Create a LaunchAgent for the specified user, replacing any LaunchAgent created

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -1093,11 +1093,9 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
     OSErr                   err;
     
     if (!alreadyCopied) {
-        mkdir("\"/Library/Application Support/BOINC\"", 0755);
         getPathToThisApp(path, sizeof(path));
-        strncat(path, "/Contents/Resources/boinc_finish_install", sizeof(s)-1);
-
-        snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC/%s_Finish_Install\"", path, appName[brandID]);
+        strncat(path, "/Contents/Resources/boinc_Finish_Install", sizeof(s)-1);
+        snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC Data/%s_Finish_Install\"", path, appName[brandID]);
         err = callPosixSpawn(s);
          if (err) {
             printf("[2] Command %s returned error %d\n", s, err);
@@ -1132,8 +1130,7 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
     fprintf(f, "\t<string>edu.berkeley.fix_login_items</string>\n");
     fprintf(f, "\t<key>ProgramArguments</key>\n");
     fprintf(f, "\t<array>\n");
-    fprintf(f, "\t\t<string>\"/Library/Application Support/BOINC/%s_Finish_Install\"</string>\n", appName[brandID]);
-    fprintf(f, "\t\t<string>");
+    fprintf(f, "\t\t<string>/Library/Application Support/BOINC Data/%s_Finish_Install</string>\n", appName[brandID]);
     if (deleteLogInItem || (brandID != oldBrandID)) {
         // If this user was previously authorized to run the Manager, there 
         // may still be a Login Item for this user, and the Login Item may
@@ -1141,10 +1138,12 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
         // To guard against this, we have the LaunchAgent kill the Manager
         // (for this user only) if it is running.
         //
-        fprintf(f, "-d \"%s\" ", appName[oldBrandID]);
+        fprintf(f, "\t\t<string>-d</string>\n");
+        fprintf(f, "\t\t<string>%s</string>\n", appName[oldBrandID]);
     }
     if (!deleteLogInItem) {
-        fprintf(f, "-a \"%s\"", appName[brandID]);
+        fprintf(f, "\t\t<string>-a</string>\n");
+        fprintf(f, "\t\t<string>%s</string>\n", appName[brandID]);
     }
     fprintf(f, "</string>\n");
     fprintf(f, "\t</array>\n");

--- a/mac_installer/ReadMe.rtf
+++ b/mac_installer/ReadMe.rtf
@@ -1,9 +1,7 @@
 {\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf600
 \cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;\red251\green2\blue7;\red251\green2\blue7;\red56\green110\blue255;
-}
-{\*\expandedcolortbl;;\cssrgb\c100000\c14913\c0;\cssrgb\c100000\c14913\c0;\csgenericrgb\c21961\c43137\c100000;
-}
+{\colortbl;\red255\green255\blue255;\red251\green2\blue7;\red56\green110\blue255;}
+{\*\expandedcolortbl;;\cssrgb\c100000\c14913\c0;\csgenericrgb\c21961\c43137\c100000;}
 \margl1440\margr1440\vieww9000\viewh9000\viewkind0
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\qc\partightenfactor0
 
@@ -20,10 +18,9 @@
 \b0 \
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
-\cf2 New for Mojave\cf0 : If your Mac has more than one user account, each user may see the following dialog upon their first login after you have installed BOINC: "sh" wants to control "System Events...." The BOINC installer needs this access to finish adding or removing its login item for each user; please click "OK".\
+\cf2 New for Mojave\cf0 : If your Mac has more than one user account, each user may see the following dialog upon their first login after you have installed BOINC: "BOINC_Finish_install" wants to control "System Events...." The BOINC installer needs this access to finish adding or removing its login item for each user; please click "OK".\
 \
-\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
-\cf3 CUDA UPGRADE WARNING\cf0 : Do not upgrade to CUDA 6.5 or later if you have an older NVIDIA GPU with Compute Capability 1.3 or less.  You can check your GPU\'92s Compute Capability at {\field{\*\fldinst{HYPERLINK "https://developer.nvidia.com/cuda-gpus"}}{\fldrslt https://developer.nvidia.com/cuda-gpus}}. \
+\cf2 CUDA UPGRADE WARNING\cf0 : Do not upgrade to CUDA 6.5 or later if you have an older NVIDIA GPU with Compute Capability 1.3 or less.  You can check your GPU\'92s Compute Capability at {\field{\*\fldinst{HYPERLINK "https://developer.nvidia.com/cuda-gpus"}}{\fldrslt https://developer.nvidia.com/cuda-gpus}}. \
 \
 You can find older CUDA drivers at {\field{\*\fldinst{HYPERLINK "http://www.nvidia.com/object/mac-driver-archive.html"}}{\fldrslt http://www.nvidia.com/object/mac-driver-archive.html}}. Note: after mounting the downloaded disk image, you may need to control-click on the CUDA installer package to open it.\
 \
@@ -31,7 +28,7 @@ For more options, please see the BOINC Macintosh administrator tools at:\
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/wiki/Tools_for_Mac_OS_X"}}{\fldrslt \cf0 http://boinc.berkeley.edu/wiki/Tools_for_Mac_OS_X}}\
 \
-BOINC on the Mac now supports processing with your graphics card, or GPU.  Please see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/wiki/GPU_computing"}}{\fldrslt \cf4 \ul \ulc4 http://boinc.berkeley.edu/wiki/GPU_computing\cf0 \ulnone  }}for more information.   If you have a CUDA-capable NVIDIA GPU and you wish to run CUDA applications, you will need to download and install the CUDA driver and libraries for your system from {\field{\*\fldinst{HYPERLINK "http://www.nvidia.com/object/mac-driver-archive.html"}}{\fldrslt http://www.nvidia.com/object/mac-driver-archive.html}}.  BOINC also supports openCL applications on NVIDIA and ATI / AMD graphics processors.  OpenCL support is standard as part of Mac OS 10.6 and later.\
+BOINC on the Mac now supports processing with your graphics card, or GPU.  Please see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/wiki/GPU_computing"}}{\fldrslt \cf3 \ul \ulc3 http://boinc.berkeley.edu/wiki/GPU_computing\cf0 \ulnone  }}for more information.   If you have a CUDA-capable NVIDIA GPU and you wish to run CUDA applications, you will need to download and install the CUDA driver and libraries for your system from {\field{\*\fldinst{HYPERLINK "http://www.nvidia.com/object/mac-driver-archive.html"}}{\fldrslt http://www.nvidia.com/object/mac-driver-archive.html}}.  BOINC also supports openCL applications on NVIDIA and ATI / AMD graphics processors.  OpenCL support is standard as part of Mac OS 10.6 and later.\
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -1,0 +1,386 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  main.cpp
+//  boinc_Finish_Install
+
+// Usage: boinc_Finish_Install [-d] [appName]
+//
+// * Deletes Login Items of all possible branded and unbranded BOINC Managers for current user.
+// * If first argument is -d then also kills the application specified by the second argument.
+// * If first argument is the name of a branded or unbranded BOINC Manager, adds it as a Login
+//   Item for the current user and launches it.
+//
+// TODO: Do we ned to code sign this app?
+//
+
+#define VERBOSE_TEST 0  /* for debugging callPosixSpawn */
+#if VERBOSE_TEST
+#define CREATE_LOG 1    /* for debugging */
+#else
+#define CREATE_LOG 0    /* for debugging */
+#endif
+#define USE_SPECIAL_LOG_FILE 1
+
+
+#include <Carbon/Carbon.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/wait.h>    // waitpid
+#include <sys/param.h>  // for MAXPATHLEN
+#include <string.h>
+#include <ctype.h>
+#include <cerrno>
+#include <sys/time.h>
+#include <stdarg.h>
+#include <unistd.h>
+#include <pwd.h>    // getpwname, getpwuid, getuid
+#include <spawn.h>
+
+#include "mac_branding.h"
+
+int callPosixSpawn(const char *cmd);
+long GetBrandID(char *path);
+static void FixLaunchServicesDataBase(void);
+void print_to_log_file(const char *format, ...);
+void strip_cr(char *buf);
+
+int main(int argc, const char * argv[]) {
+    int                     i, err;
+    char                    cmd[2048];
+    passwd                  *pw;
+
+    for (i=0; i<NUMBRANDS; i++) {
+        snprintf(cmd, sizeof(cmd), "osascript -e 'tell application \"System Events\" to delete login item \"%s\"'", appName[i]);
+        err = callPosixSpawn(cmd);
+        if (err) {
+            fprintf(stderr, "Command: %s\n", cmd);
+            fprintf(stderr, "Delete login item containing %s returned error %d\n", appName[i], err);
+            fflush(stderr);
+        }
+    }
+    for (i=1; i<argc; i+=2) {
+        if (strcmp(argv[i], "-d") == 0) {
+            // If this user was previously authorized to run the Manager, the Login Item
+            // may have launched the Manager before this app deleted that Login Item. To
+            // guard against this, we kill the Manager (for this user only) if it is running.
+            // 
+            snprintf(cmd, sizeof(cmd), "killall -u %d -9 \"%s\"", getuid(), argv[i+1]);
+            err = callPosixSpawn(cmd);
+            if (err) {
+                fprintf(stderr, "Command: %s\n", cmd);
+                fprintf(stderr, "killall %s returned error %d\n", argv[i+1], err);
+                fflush(stderr);
+            }
+        } else if (strcmp(argv[i], "-a") == 0) {
+            snprintf(cmd, sizeof(cmd), "osascript -e 'tell application \"System Events\" to make new login item at end with properties {path:\"/Applications/%s.app\", hidden:true, name:\"%s\"}'", argv[i+1], argv[i+1]);
+            err = callPosixSpawn(cmd);
+            if (err) {
+                fprintf(stderr, "Command: %s\n", cmd);
+                fprintf(stderr, "Make new login item for %s returned error %d\n", argv[i+1], err);
+                fflush(stderr);
+            }
+        
+            snprintf(cmd, sizeof(cmd), "open -jg \"/Applications/%s.app\"", argv[i+1]);
+            err = callPosixSpawn(cmd);
+            if (err) {
+                fprintf(stderr, "Command: %s\n", cmd);
+                fprintf(stderr, "Make login item for %s returned error %d\n", argv[i+1], err);
+                fflush(stderr);
+            }
+        }   // end if (strcmp(argv[i], "-a") == 0)
+    }   // end for (i=i; i<argc; i+=2)
+    
+    FixLaunchServicesDataBase();
+
+    pw = getpwuid(getuid());
+    
+    snprintf(cmd, sizeof(cmd), "rm -f \"/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist\"", pw->pw_name);
+    callPosixSpawn(cmd);
+    
+    return 0;
+}
+
+
+long GetBrandID(char *path)
+{
+    long iBrandId;
+
+    iBrandId = 0;   // Default value
+    
+    FILE *f = fopen(path, "r");
+    if (f) {
+        fscanf(f, "BrandId=%ld\n", &iBrandId);
+        fclose(f);
+    }
+    if ((iBrandId < 0) || (iBrandId > (NUMBRANDS-1))) {
+        iBrandId = 0;
+    }
+    return iBrandId;
+}
+
+
+// If there are other copies of BOINC Manager with different branding
+// on the system, Noitifications may display the icon for the wrong
+// branding, due to the Launch Services database having one of the
+// other copies of BOINC Manager as the first entry. Each user has
+// their own copy of the Launch Services database, so this must be
+// done for each user.
+//
+// This probably will happen only on BOINC development systems where
+// Xcode has generated copies of BOINC Manager.
+static void FixLaunchServicesDataBase() {
+    long brandID = 0;
+    char boincPath[MAXPATHLEN];
+    char cmd[MAXPATHLEN+250];
+    long i, n;
+    CFArrayRef appRefs = NULL;
+    OSStatus err;
+
+    brandID = GetBrandID("/Library/Application Support/BOINC Data/Branding");
+
+    CFStringRef bundleID = CFSTR("edu.berkeley.boinc");
+
+    // LSCopyApplicationURLsForBundleIdentifier is not available before OS 10.10,
+    // but this app is used only for OS 10.13 and later
+        appRefs = LSCopyApplicationURLsForBundleIdentifier(bundleID, NULL);
+        if (appRefs == NULL) {
+            print_to_log_file("Call to LSCopyApplicationURLsForBundleIdentifier returned NULL");
+            goto registerOurApp;
+        }
+        n = CFArrayGetCount(appRefs);   // Returns all results at once, in database order
+        print_to_log_file("LSCopyApplicationURLsForBundleIdentifier returned %ld results", n);
+
+    for (i=0; i<n; ++i) {     // Prevent infinite loop
+        CFURLRef appURL = (CFURLRef)CFArrayGetValueAtIndex(appRefs, i);
+        boincPath[0] = '\0';
+        if (appURL) {
+            CFRetain(appURL);
+            CFStringRef CFPath = CFURLCopyFileSystemPath(appURL, kCFURLPOSIXPathStyle);
+            CFStringGetCString(CFPath, boincPath, sizeof(boincPath), kCFStringEncodingUTF8);
+            if (CFPath) CFRelease(CFPath);
+            CFRelease(appURL);
+            appURL = NULL;
+        }
+        if (strncmp(boincPath, appPath[brandID], sizeof(boincPath)) == 0) {
+            print_to_log_file("**** Keeping %s", boincPath);
+            if (appRefs) CFRelease(appRefs);
+            return;     // Our (possibly branded) BOINC Manager app is now at top of database
+        }
+        print_to_log_file("Unregistering %3ld: %s", i, boincPath);
+        // Remove this entry from the Launch Services database
+        sprintf(cmd, "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister -u \"%s\"", boincPath);
+        err = callPosixSpawn(cmd);
+        if (err) {
+            print_to_log_file("*** lsregister -u call returned error %d for %s", err, boincPath);
+        }
+    }
+
+registerOurApp:
+    if (appRefs) CFRelease(appRefs);
+
+    // We have exhausted the Launch Services database without finding our
+    // (possibly branded) BOINC Manager app, so add it to the dataabase
+    print_to_log_file("%s was not found in Launch Services database; registering it now", appPath[brandID]);
+    sprintf(cmd, "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Versions/Current/Support/lsregister \"%s\"", appPath[brandID]);
+    err = callPosixSpawn(cmd);
+    if (err) {
+        print_to_log_file("*** lsregister call returned error %d for %s", err, appPath[brandID]);
+        fflush(stdout);
+    }
+}
+
+
+#define NOT_IN_TOKEN                0
+#define IN_SINGLE_QUOTED_TOKEN      1
+#define IN_DOUBLE_QUOTED_TOKEN      2
+#define IN_UNQUOTED_TOKEN           3
+
+static int parse_posic_spawn_command_line(char* p, char** argv) {
+    int state = NOT_IN_TOKEN;
+    int argc=0;
+
+    while (*p) {
+        switch(state) {
+        case NOT_IN_TOKEN:
+            if (isspace(*p)) {
+            } else if (*p == '\'') {
+                p++;
+                argv[argc++] = p;
+                state = IN_SINGLE_QUOTED_TOKEN;
+                break;
+            } else if (*p == '\"') {
+                p++;
+                argv[argc++] = p;
+                state = IN_DOUBLE_QUOTED_TOKEN;
+                break;
+            } else {
+                argv[argc++] = p;
+                state = IN_UNQUOTED_TOKEN;
+            }
+            break;
+        case IN_SINGLE_QUOTED_TOKEN:
+            if (*p == '\'') {
+                if (*(p-1) == '\\') break;
+                *p = 0;
+                state = NOT_IN_TOKEN;
+            }
+            break;
+        case IN_DOUBLE_QUOTED_TOKEN:
+            if (*p == '\"') {
+                if (*(p-1) == '\\') break;
+                *p = 0;
+                state = NOT_IN_TOKEN;
+            }
+            break;
+        case IN_UNQUOTED_TOKEN:
+            if (isspace(*p)) {
+                *p = 0;
+                state = NOT_IN_TOKEN;
+            }
+            break;
+        }
+        p++;
+    }
+    argv[argc] = 0;
+    return argc;
+}
+
+
+int callPosixSpawn(const char *cmdline) {
+    char command[1024];
+    char progName[1024];
+    char progPath[MAXPATHLEN];
+    char* argv[100];
+    int argc = 0;
+    char *p;
+    pid_t thePid = 0;
+    int result = 0;
+    int status = 0;
+    extern char **environ;
+    
+    // Make a copy of cmdline because parse_posic_spawn_command_line modifies it
+    strlcpy(command, cmdline, sizeof(command));
+    argc = parse_posic_spawn_command_line(const_cast<char*>(command), argv);
+    strlcpy(progPath, argv[0], sizeof(progPath));
+    strlcpy(progName, argv[0], sizeof(progName));
+    p = strrchr(progName, '/');
+    if (p) {
+        argv[0] = p+1;
+    } else {
+        argv[0] = progName;
+    }
+    
+#if VERBOSE_TEST
+    print_to_log_file("***********");
+    for (int i=0; i<argc; ++i) {
+        print_to_log_file("argv[%d]=%s", i, argv[i]);
+    }
+    print_to_log_file("***********\n");
+#endif
+
+    errno = 0;
+
+    result = posix_spawnp(&thePid, progPath, NULL, NULL, argv, environ);
+#if VERBOSE_TEST
+    print_to_log_file("callPosixSpawn command: %s", cmdline);
+    print_to_log_file("callPosixSpawn: posix_spawnp returned %d: %s", result, strerror(result));
+#endif
+    if (result) {
+        return result;
+    }
+// CAF    int val =
+    waitpid(thePid, &status, WUNTRACED);
+// CAF        if (val < 0) printf("first waitpid returned %d\n", val);
+    if (status != 0) {
+#if VERBOSE_TEST
+        print_to_log_file("waitpid() returned status=%d", status);
+#endif
+        result = status;
+    } else {
+        if (WIFEXITED(status)) {
+            result = WEXITSTATUS(status);
+            if (result == 1) {
+#if VERBOSE_TEST
+                print_to_log_file("WEXITSTATUS(status) returned 1, errno=%d: %s", errno, strerror(errno));
+#endif
+                result = errno;
+            }
+#if VERBOSE_TEST
+            else if (result) {
+                print_to_log_file("WEXITSTATUS(status) returned %d", result);
+            }
+#endif
+        }   // end if (WIFEXITED(status)) else
+    }       // end if waitpid returned 0 sstaus else
+    
+    return result;
+}
+
+
+void print_to_log_file(const char *format, ...) {
+#if CREATE_LOG
+    va_list args;
+    char buf[256];
+    time_t t;
+#if USE_SPECIAL_LOG_FILE
+    strlcpy(buf, getenv("HOME"), sizeof(buf));
+    strlcat(buf, "/Documents/test_log.txt", sizeof(buf));
+    FILE *f;
+    f = fopen(buf, "a");
+    if (!f) return;
+
+//  freopen(buf, "a", stdout);
+//  freopen(buf, "a", stderr);
+#else
+    #define f stderr
+#endif
+    time(&t);
+    strlcpy(buf, asctime(localtime(&t)), sizeof(buf));
+
+    strip_cr(buf);
+
+    fputs(buf, f);
+    fputs("   ", f);
+
+    va_start(args, format);
+    vfprintf(f, format, args);
+    va_end(args);
+    
+    fputs("\n", f);
+#if USE_SPECIAL_LOG_FILE
+    fflush(f);
+    fclose(f);
+#endif
+#endif
+}
+
+#if CREATE_LOG
+void strip_cr(char *buf)
+{
+    char *theCR;
+
+    theCR = strrchr(buf, '\n');
+    if (theCR)
+        *theCR = '\0';
+    theCR = strrchr(buf, '\r');
+    if (theCR)
+        *theCR = '\0';
+}
+#endif    // CREATE_LOG

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -75,6 +75,9 @@ int main(int argc, const char * argv[]) {
             fflush(stderr);
         }
     }
+
+    FixLaunchServicesDataBase();
+
     for (i=1; i<argc; i+=2) {
         if (strcmp(argv[i], "-d") == 0) {
             // If this user was previously authorized to run the Manager, the Login Item
@@ -107,8 +110,6 @@ int main(int argc, const char * argv[]) {
         }   // end if (strcmp(argv[i], "-a") == 0)
     }   // end for (i=i; i<argc; i+=2)
     
-    FixLaunchServicesDataBase();
-
     pw = getpwuid(getuid());
     
     snprintf(cmd, sizeof(cmd), "rm -f \"/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist\"", pw->pw_name);

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -500,7 +500,8 @@ static OSStatus DoUninstall(void) {
     // Phase 6: step through all users and do user-specific cleanup
     CleanupAllVisibleUsers();
     
-    // This directory contains only the BOINC_Finish_Install command-line utility
+    // This directory contains only the BOINC_Finish_Install and
+    // BOINC_Finish_Uninstall command-line utilities
     snprintf(cmd, sizeof(cmd), "rm -rf \"/Library/Application Support/BOINC/\"");
     err = callPosixSpawn(cmd);
      if (err) {
@@ -977,7 +978,7 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     if (!alreadyCopied) {
         mkdir("\"/Library/Application Support/BOINC\"", 0755);
         getPathToThisApp(path, sizeof(path));
-        strncat(path, "/Contents/Resources/boinc_finish_install", sizeof(s)-1);
+        strncat(path, "/Contents/Resources/boinc_Finish_Uninstall", sizeof(s)-1);
 
         snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC/%s_Finish_Install\"", path, appName[brandID]);
         err = callPosixSpawn(s);
@@ -1014,7 +1015,7 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     fprintf(f, "\t<string>edu.berkeley.fix_login_items</string>\n");
     fprintf(f, "\t<key>ProgramArguments</key>\n");
     fprintf(f, "\t<array>\n");
-    fprintf(f, "\t\t<string>\"/Library/Application Support/BOINC/%s_Finish_Install\"</string>\n", appName[brandID]);
+    fprintf(f, "\t\t<string>\"/Library/Application Support/BOINC/%s_Finish_Uninstall\"</string>\n", appName[brandID]);
     // If this user was previously authorized to run the Manager, there 
     // may still be a Login Item for this user, and the Login Item may
     // launch the Manager before the LaunchAgent deletes the Login Item.

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -500,6 +500,14 @@ static OSStatus DoUninstall(void) {
     // Phase 6: step through all users and do user-specific cleanup
     CleanupAllVisibleUsers();
     
+    // This directory contains only the BOINC_Finish_Install command-line utility
+    snprintf(cmd, sizeof(cmd), "rm -rf \"/Library/Application Support/BOINC/\"");
+    err = callPosixSpawn(cmd);
+     if (err) {
+        printf("[2] Command %s returned error %d\n", cmd, err);
+       fflush(stdout);
+    }
+    
     callPosixSpawn ("dscl . -delete /users/boinc_master");
     callPosixSpawn ("dscl . -delete /groups/boinc_master");
     callPosixSpawn ("dscl . -delete /users/boinc_project");
@@ -960,12 +968,33 @@ cleanupSystemEvents:
 //
 Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
 {
+    static bool             alreadyCopied = false;
     struct stat             sbuf;
-    int                     i;
+    char                    path[MAXPATHLEN];
     char                    s[2048];
+    OSErr                   err;
+   
+    if (!alreadyCopied) {
+        mkdir("\"/Library/Application Support/BOINC\"", 0755);
+        getPathToThisApp(path, sizeof(path));
+        strncat(path, "/Contents/Resources/boinc_finish_install", sizeof(s)-1);
+
+        snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC/%s_Finish_Install\"", path, appName[brandID]);
+        err = callPosixSpawn(s);
+         if (err) {
+            printf("[2] Command %s returned error %d\n", s, err);
+            fflush(stdout);
+        } else {
+            alreadyCopied = true;
+        }
+
+        snprintf(s, sizeof(s), "Users/%s/Library/LaunchAgents/%s_Finish_Install\"</string>\n", pw->pw_name, appName[brandID]);
+        chmod(s, 0755);
+        chown(s, pw->pw_uid, pw->pw_gid);
+    }
     
     // Create a LaunchAgent for the specified user, replacing any LaunchAgent created
-    // previously (such as by Uninstaller or by installing a differently branded BOINC.)
+    // previously (such as by Installer or by installing a differently branded BOINC.)
 
     // Create LaunchAgents directory for this user if it does not yet exist
     snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents", pw->pw_name);
@@ -982,23 +1011,20 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     fprintf(f, "<plist version=\"1.0\">\n");
     fprintf(f, "<dict>\n");
     fprintf(f, "\t<key>Label</key>\n");
-    fprintf(f, "\t<string>edu.berkeley.test</string>\n");
+    fprintf(f, "\t<string>edu.berkeley.fix_login_items</string>\n");
     fprintf(f, "\t<key>ProgramArguments</key>\n");
     fprintf(f, "\t<array>\n");
-    fprintf(f, "\t\t<string>sh</string>\n");
-    fprintf(f, "\t\t<string>-c</string>\n");
-    fprintf(f, "\t\t<string>");
-    for (i=0; i<NUMBRANDS; i++) {
-        fprintf(f, "osascript -e 'tell application \"System Events\" to delete login item \"%s\"';", appName[i]);
-    }
+    fprintf(f, "\t\t<string>\"/Library/Application Support/BOINC/%s_Finish_Install\"</string>\n", appName[brandID]);
     // If this user was previously authorized to run the Manager, there 
     // may still be a Login Item for this user, and the Login Item may
     // launch the Manager before the LaunchAgent deletes the Login Item.
     // To guard against this, we have the LaunchAgent kill the Manager
     // (for this user only) if it is running.
     //
-    fprintf(f, "killall -u %d -9 \"%s\";", pw->pw_uid, appName[brandID]);
-    fprintf(f, "rm -f ~/Library/LaunchAgents/edu.berkeley.boinc.plist</string>\n");
+    // Actually, the uninstaller should have deleted the Manager before 
+    // that could happen, so this step is probably unnecessary.
+    //
+    fprintf(f, "\t\t<string>-d \"%s\"</string>\n", appName[brandID]);
     fprintf(f, "\t</array>\n");
     fprintf(f, "\t<key>RunAtLoad</key>\n");
     fprintf(f, "\t<true/>\n");

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -500,15 +500,6 @@ static OSStatus DoUninstall(void) {
     // Phase 6: step through all users and do user-specific cleanup
     CleanupAllVisibleUsers();
     
-    // This directory contains only the BOINC_Finish_Install and
-    // BOINC_Finish_Uninstall command-line utilities
-    snprintf(cmd, sizeof(cmd), "rm -rf \"/Library/Application Support/BOINC/\"");
-    err = callPosixSpawn(cmd);
-     if (err) {
-        printf("[2] Command %s returned error %d\n", cmd, err);
-       fflush(stdout);
-    }
-    
     callPosixSpawn ("dscl . -delete /users/boinc_master");
     callPosixSpawn ("dscl . -delete /groups/boinc_master");
     callPosixSpawn ("dscl . -delete /users/boinc_project");
@@ -976,11 +967,9 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     OSErr                   err;
    
     if (!alreadyCopied) {
-        mkdir("\"/Library/Application Support/BOINC\"", 0755);
         getPathToThisApp(path, sizeof(path));
-        strncat(path, "/Contents/Resources/boinc_Finish_Uninstall", sizeof(s)-1);
-
-        snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC/%s_Finish_Install\"", path, appName[brandID]);
+        strncat(path, "/Contents/Resources/boinc_finish_install", sizeof(s)-1);
+        snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC Data/%s_Finish_Uninstall\"", path, appName[brandID]);
         err = callPosixSpawn(s);
          if (err) {
             printf("[2] Command %s returned error %d\n", s, err);
@@ -989,7 +978,7 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
             alreadyCopied = true;
         }
 
-        snprintf(s, sizeof(s), "Users/%s/Library/LaunchAgents/%s_Finish_Install\"</string>\n", pw->pw_name, appName[brandID]);
+        snprintf(s, sizeof(s), "Users/%s/Library/LaunchAgents/%s_Finish_Uninstall\"</string>\n", pw->pw_name, appName[brandID]);
         chmod(s, 0755);
         chown(s, pw->pw_uid, pw->pw_gid);
     }
@@ -1015,7 +1004,7 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     fprintf(f, "\t<string>edu.berkeley.fix_login_items</string>\n");
     fprintf(f, "\t<key>ProgramArguments</key>\n");
     fprintf(f, "\t<array>\n");
-    fprintf(f, "\t\t<string>\"/Library/Application Support/BOINC/%s_Finish_Uninstall\"</string>\n", appName[brandID]);
+    fprintf(f, "\t\t<string>/Library/Application Support/BOINC Data/%s_Finish_Uninstall</string>\n", appName[brandID]);
     // If this user was previously authorized to run the Manager, there 
     // may still be a Login Item for this user, and the Login Item may
     // launch the Manager before the LaunchAgent deletes the Login Item.
@@ -1025,7 +1014,8 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     // Actually, the uninstaller should have deleted the Manager before 
     // that could happen, so this step is probably unnecessary.
     //
-    fprintf(f, "\t\t<string>-d \"%s\"</string>\n", appName[brandID]);
+    fprintf(f, "\t\t<string>-d</string>\n");
+    fprintf(f, "\t\t<string>%s</string>\n", appName[brandID]);
     fprintf(f, "\t</array>\n");
     fprintf(f, "\t<key>RunAtLoad</key>\n");
     fprintf(f, "\t<true/>\n");

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -978,7 +978,7 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
             alreadyCopied = true;
         }
 
-        snprintf(s, sizeof(s), "Users/%s/Library/LaunchAgents/%s_Finish_Uninstall\"</string>\n", pw->pw_name, appName[brandID]);
+        snprintf(s, sizeof(s), "/Library/Application Support/BOINC Data/%s_Finish_Install\"</string>\n", appName[brandID]);
         chmod(s, 0755);
         chown(s, pw->pw_uid, pw->pw_gid);
     }


### PR DESCRIPTION
OS 10.14 Mojave has added some new security safeguards. As a result, Macs who have multiple user accounts will see a scary warning when each user other than the one running the installer logs in, and asks for permission to proceed. As a temporary measure, I added the following to the installer's ReadMe file for generic (unbranded) BOINC:

> New for Mojave: If your Mac has more than one user account, each user may see the following dialog upon their first login after you have installed BOINC: "sh" wants to control "System Events...." The BOINC installer needs this access to finish adding or removing its login item for each user; please click "OK".

With the changes in this PR I am trying to either avoid that warning or at least make it easier to understand.

The reason for this problem is that the installer needs to adjust the Login Items for each user. (The Login Item causes BOINC Manager to be launched at login.)

For users authorized to manage BOINC, the installer deletes any old Login Items for branded / unbranded Managers other than the branded / unbranded one being installed, and adds the Login Item for the one being installed. 

For users NOT authorized to manage BOINC, the installer deletes any old Login Items for all branded / unbranded Managers.

The method the installer had been using to do this prior to OS 10.13 High Sierra no longer worked as of OS 10.13. My fix was for the installer to add a LaunchAgent in each user's account which runs the next time the user logs in. It runs a shell script to update the Login Items (which requires the use of the SystemEvents app) and then the LaunchAgent deletes itself. Since the app executing the shell script is _sh_, that is the application named in the warning dialog:
> "sh" wants to control "System Events....

Since the warning dialog says _sh_ rather than _BOINC_, it is not obviously associated with the BOINC installer, this PR adds a small CLI app named something like "BOINC_Finish_Install" to do be run by the LaunchAgent, in the hope that the warning dialog will then say something like 

> BOINC_Finish_Install" wants to control "System Events...."

substituting the branded name for _BOINC_ in the case of a branded Manager.

My early testing found that this approach seems to completely eliminate the warning dialog. If that holds true, then this is an even better solution than I had expected.

In addition to the BOINC installer, I will need make the corresponding changes to the _uninstaller_ and the _AddRemoveUser_ utility (all for Macintosh only.)