### PR TITLE
NeedRunDaemon option should be applied when connecting to localhost o…

### DIFF
--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -586,19 +586,17 @@ int CMainDocument::OnPoll() {
                     pFrame->OnExit(event); // Exit if Select Computer dialog cancelled
                 }
             }
-        }
-
-        if (wxGetApp().GetNeedRunDaemon()) {
-            if (IsComputerNameLocal(hostName)) {
+            if (wxGetApp().GetNeedRunDaemon()) {
                 if (m_pClientManager->StartupBOINCCore()) {
                     Connect(wxT("localhost"), portNum, password, TRUE, TRUE);
-                } else {
+                }
+                else {
                     m_pNetworkConnection->ForceDisconnect();
                     pFrame->ShowDaemonStartFailedAlert();
                 }
-            } else {
-                Connect(hostName, portNum, password, TRUE, password.IsEmpty());
             }
+        } else {
+            Connect(hostName, portNum, password, TRUE, password.IsEmpty());
         }
     }
 

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -651,7 +651,7 @@ int CMainDocument::ResetState() {
 
 
 int CMainDocument::Connect(const wxString& szComputer, int iPort, const wxString& szComputerPassword, const bool bDisconnect, const bool bUseDefaultPassword) {
-    if (IsComputerNameLocal(szComputer)) {
+    if (wxGetApp().GetNeedRunDaemon() && IsComputerNameLocal(szComputer)) {
         // Restart client if not already running
         m_pClientManager->AutoRestart();
     }

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -586,14 +586,15 @@ int CMainDocument::OnPoll() {
                     pFrame->OnExit(event); // Exit if Select Computer dialog cancelled
                 }
             }
-            if (wxGetApp().GetNeedRunDaemon()) {
-                if (m_pClientManager->StartupBOINCCore()) {
-                    Connect(wxT("localhost"), portNum, password, TRUE, TRUE);
-                }
-                else {
-                    m_pNetworkConnection->ForceDisconnect();
-                    pFrame->ShowDaemonStartFailedAlert();
-                }
+        }
+
+        if (wxGetApp().GetNeedRunDaemon() && IsComputerNameLocal(hostName)) {
+            if (m_pClientManager->StartupBOINCCore()) {
+                Connect(wxT("localhost"), portNum, password, TRUE, TRUE);
+            }
+            else {
+                m_pNetworkConnection->ForceDisconnect();
+                pFrame->ShowDaemonStartFailedAlert();
             }
         } else {
             Connect(hostName, portNum, password, TRUE, password.IsEmpty());


### PR DESCRIPTION
…nly.

This commit fixes a situation when trying to connect to remote client with option 'Run client' on leads to unability to connect to selected client.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>