### PR TITLE
run_program() fixes

### DIFF
--- a/client/gpu_detect.cpp
+++ b/client/gpu_detect.cpp
@@ -598,7 +598,6 @@ int COPROCS::launch_child_process_to_detect_gpus() {
 #else
     int prog;
 #endif
-    char quoted_client_path[MAXPATHLEN];
     char quoted_data_dir[MAXPATHLEN+2];
     char data_dir[MAXPATHLEN];
     int retval = 0;
@@ -625,22 +624,17 @@ int COPROCS::launch_child_process_to_detect_gpus() {
     boinc_getcwd(data_dir);
 
 #ifdef _WIN32
-    strlcpy(quoted_client_path, "\"", sizeof(quoted_client_path));
-    strlcat(quoted_client_path, client_path, sizeof(quoted_client_path));
-    strlcat(quoted_client_path, "\"", sizeof(quoted_client_path));
-
     strlcpy(quoted_data_dir, "\"", sizeof(quoted_data_dir));
     strlcat(quoted_data_dir, data_dir, sizeof(quoted_data_dir));
     strlcat(quoted_data_dir, "\"", sizeof(quoted_data_dir));
 #else
-    strlcpy(quoted_client_path, client_path, sizeof(quoted_client_path));
     strlcpy(quoted_data_dir, data_dir, sizeof(quoted_data_dir));
 #endif
 
     if (log_flags.coproc_debug) {
         msg_printf(0, MSG_INFO,
             "[coproc] launching child process at %s",
-            quoted_client_path
+            client_path
         );
         if (!is_path_absolute(client_path)) {
             msg_printf(0, MSG_INFO,
@@ -656,7 +650,7 @@ int COPROCS::launch_child_process_to_detect_gpus() {
             
     int argc = 4;
     char* const argv[5] = {
-         const_cast<char *>(quoted_client_path),
+         const_cast<char *>(client_path),
          const_cast<char *>("--detect_gpus"), 
          const_cast<char *>("--dir"), 
          const_cast<char *>(quoted_data_dir),

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1582,18 +1582,18 @@ void CAdvancedFrame::OnLaunchNewInstance(wxCommandEvent& WXUNUSED(event)) {
 #else
     int prog;
 #endif
+    wxString strExecutable = wxGetApp().GetRootDirectory() + wxGetApp().GetExecutableName();
+    wxCharBuffer mbStrExecutable = strExecutable.mb_str();
     int argc = 2;
     char* const argv[3] = {
-         const_cast<char *>("boincmgr"), 
+         mbStrExecutable.data(),
          const_cast<char *>("--multiple"), 
          NULL
     }; 
 
-    wxString strExecutable = wxGetApp().GetRootDirectory() + wxGetApp().GetExecutableName();
-
     run_program(
         wxGetApp().GetRootDirectory().mb_str(),
-        strExecutable.mb_str(),
+        mbStrExecutable,
         argc,
         argv, 
         2.0,

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -1793,17 +1793,19 @@ int CMainDocument::WorkShowGraphics(RESULT* rp) {
             );
         }
 #else
-        char* argv[2];
-
         // If graphics app is already running, don't launch a second instance
         //
         if (previous_gfx_app) return 0;
-        argv[0] = 0;
+
+        char* argv[2] = {
+            rp->graphics_exec_path,
+            NULL
+        };
 
         iRetVal = run_program(
             rp->slot_path,
             rp->graphics_exec_path,
-            0,
+            1,
             argv,
             0,
             id

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -243,7 +243,7 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
     }
 #else
         char* argv[3];
-        argv[0] = "app_graphics";   // not used
+        argv[0] = rp->graphics_exec_path;
         argv[1] = "--fullscreen";
         argv[2] = 0;
         retval = run_program(
@@ -392,10 +392,6 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
     BOINCTRACE(_T("launch_default_screensaver returned %d\n"), retval);
     
 #else
-    // For unknown reasons, the graphics application exits with 
-    // "RegisterProcess failed (error = -50)" unless we pass its 
-    // full path twice in the argument list to execv on Macs.
-
     char* argv[4];
     char full_path[1024];
 
@@ -403,7 +399,7 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
     strlcat(full_path, PATH_SEPARATOR, sizeof(full_path));
     strlcat(full_path, THE_DEFAULT_SS_EXECUTABLE, sizeof(full_path));
 
-    argv[0] = full_path;   // not used
+    argv[0] = full_path;
     argv[1] = "--fullscreen";
     argv[2] = 0;
     argv[3] = 0;

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -414,7 +414,7 @@ int read_file_string(
 
 #ifdef _WIN32
 int run_program(
-    const char* dir, const char* /*file*/, int argc, char *const argv[], double nsecs, HANDLE& id
+    const char* dir, const char* file, int argc, char *const argv[], double nsecs, HANDLE& id
 ) {
     int retval;
     PROCESS_INFORMATION process_info;
@@ -427,12 +427,13 @@ int run_program(
     memset(&startup_info, 0, sizeof(startup_info));
     startup_info.cb = sizeof(startup_info);
 
-    safe_strcpy(cmdline, "");
-    for (int i=0; i<argc; i++) {
+    // lpApplicationName needs to be NULL for CreateProcess to search path
+    // but argv[0] may be full path or just filename
+    // 'file' should be something runnable so use that as program name
+    snprintf(cmdline, sizeof(cmdline), "\"%s\"", file);
+    for (int i=1; i<argc; i++) {
+        safe_strcat(cmdline, " ");
         safe_strcat(cmdline, argv[i]);
-        if (i<argc-1) {
-            safe_strcat(cmdline, " ");
-        }
     }
 
     retval = CreateProcessA(


### PR DESCRIPTION
lib: change `run_program()` to use `file` parameter as program name on Windows
mgr,scr: fix `argv`s in calls to `run_program()`
client: remove quoting client path in launching GPU detection

See commit messages for details.

Fixes launching graphics apps with Manager and screensaver as reported on boinc_alpha.