### PR TITLE
fix bintray deploy

### DIFF
--- a/deploy/deploy_to_bintray.sh
+++ b/deploy/deploy_to_bintray.sh
@@ -86,6 +86,7 @@ if [[ $CI_RUN == "true" ]]; then
         ;;
         *)
         echo "event $TRAVIS_EVENT_TYPE not supported for deployment"
+        exit 0;
         ;;
     esac
 fi

--- a/deploy/deploy_to_bintray.sh
+++ b/deploy/deploy_to_bintray.sh
@@ -34,9 +34,9 @@ fi
 
 ROOTDIR=$(pwd)
 if [[ $# != 1 ]]; then
-  echo "Usage: $0 SOURCE_DIR"
-  echo "SOURCE_DIR : relative path where binaries are, last component is used as BOINC_TYPE"
-  exit 1
+    echo "Usage: $0 SOURCE_DIR"
+    echo "SOURCE_DIR : relative path where binaries are, last component is used as BOINC_TYPE"
+    exit 1
 fi
 
 SOURCE_DIR="$1"
@@ -47,8 +47,8 @@ fi
 
 # for PR's this is set if the PR comes from within the same repository
 if [ "${BINTRAY_API_KEY}" == "" ] ; then
-  echo "BINTRAY_API_KEY is missing; doing nothing"
-  exit 0
+    echo "BINTRAY_API_KEY is missing; doing nothing"
+    exit 0
 fi
 
 CI_RUN="${TRAVIS:-false}"
@@ -74,19 +74,19 @@ VERSION_DESC="Custom build created on ${BUILD_DATE}"
 if [[ $CI_RUN == "true" ]]; then
     case $TRAVIS_EVENT_TYPE in
         pull_request)
-        PKG_NAME="pull-requests"
-        GIT_REV=${TRAVIS_PULL_REQUEST_SHA:0:8}
-        VERSION="PR${TRAVIS_PULL_REQUEST}_${BUILD_DATE}_${GIT_REV}"
-        VERSION_DESC="CI build created from PR #${TRAVIS_PULL_REQUEST} on ${BUILD_DATE}"
+            PKG_NAME="pull-requests"
+            GIT_REV=${TRAVIS_PULL_REQUEST_SHA:0:8}
+            VERSION="PR${TRAVIS_PULL_REQUEST}_${BUILD_DATE}_${GIT_REV}"
+            VERSION_DESC="CI build created from PR #${TRAVIS_PULL_REQUEST} on ${BUILD_DATE}"
         ;;
         cron)
-        PKG_NAME="weekly"
-        VERSION="weekly_${BUILD_DATE}_${GIT_REV}"
-        VERSION_DESC="Weekly CI build created on ${BUILD_DATE}"
+            PKG_NAME="weekly"
+            VERSION="weekly_${BUILD_DATE}_${GIT_REV}"
+            VERSION_DESC="Weekly CI build created on ${BUILD_DATE}"
         ;;
         *)
-        echo "event $TRAVIS_EVENT_TYPE not supported for deployment"
-        exit 0;
+            echo "event $TRAVIS_EVENT_TYPE not supported for deployment"
+            exit 0;
         ;;
     esac
 fi
@@ -122,7 +122,7 @@ if [ "$TRAVIS_BUILD_ID" ] ; then
     BUILD_LOG="https://travis-ci.org/BOINC/boinc/builds/${TRAVIS_BUILD_ID}"
     #BUILD_LOG="https://api.travis-ci.org/jobs/${TRAVIS_JOB_ID}/log.txt?deansi=true"
     data='{
-  "bintray": {
+    "bintray": {
     "syntax": "markdown",
     "content": "'${BUILD_LOG}'"
   }

--- a/deploy/prepare_deployment.bat
+++ b/deploy/prepare_deployment.bat
@@ -4,6 +4,11 @@ for /f "tokens=2-4 delims=/ "  %%a in ("%date%") do (set MM=%%a& set DD=%%b& set
 set build_date=%YYYY%-%MM%-%DD%
 set git_rev=%APPVEYOR_REPO_COMMIT:~0,8%
 
+rem Default values because %bintray_deploy% is currently unused
+set pkg_name=master
+set git_rev=%APPVEYOR_REPO_COMMIT:~0,8%
+set pkg_version=master_%build_date%_%git_rev%
+
 if defined APPVEYOR_PULL_REQUEST_NUMBER (
     set pkg_name=pull-requests
     set git_rev=%APPVEYOR_PULL_REQUEST_HEAD_COMMIT:~0,8%

--- a/deploy/prepare_deployment.sh
+++ b/deploy/prepare_deployment.sh
@@ -62,19 +62,19 @@ prepare_client() {
 }
 
 prepare_apps() {
-  mkdir -p "${TARGET_DIR}"
-  cp_if_exists samples/condor/boinc_gahp "${TARGET_DIR}"
-  cp_if_exists samples/example_app/uc2 "${TARGET_DIR}"
-  cp_if_exists samples/example_app/ucn "${TARGET_DIR}"
-  cp_if_exists samples/example_app/uc2_graphics "${TARGET_DIR}"
-  cp_if_exists samples/example_app/slide_show "${TARGET_DIR}"
-  cp_if_exists samples/multi_thread/multi_thread "${TARGET_DIR}"
-  cp_if_exists samples/sleeper/sleeper "${TARGET_DIR}"
-  cp_if_exists samples/vboxmonitor/vboxmonitor "${TARGET_DIR}"
-  cp_if_exists samples/vboxwrapper/vboxwrapper "${TARGET_DIR}"
-  cp_if_exists samples/worker/worker "${TARGET_DIR}"
-  cp_if_exists samples/wrapper/wrapper "${TARGET_DIR}"
-  prepare_7z_archive
+    mkdir -p "${TARGET_DIR}"
+    cp_if_exists samples/condor/boinc_gahp "${TARGET_DIR}"
+    cp_if_exists samples/example_app/uc2 "${TARGET_DIR}"
+    cp_if_exists samples/example_app/ucn "${TARGET_DIR}"
+    cp_if_exists samples/example_app/uc2_graphics "${TARGET_DIR}"
+    cp_if_exists samples/example_app/slide_show "${TARGET_DIR}"
+    cp_if_exists samples/multi_thread/multi_thread "${TARGET_DIR}"
+    cp_if_exists samples/sleeper/sleeper "${TARGET_DIR}"
+    cp_if_exists samples/vboxmonitor/vboxmonitor "${TARGET_DIR}"
+    cp_if_exists samples/vboxwrapper/vboxwrapper "${TARGET_DIR}"
+    cp_if_exists samples/worker/worker "${TARGET_DIR}"
+    cp_if_exists samples/wrapper/wrapper "${TARGET_DIR}"
+    prepare_7z_archive
 }
 
 prepare_manager() {
@@ -84,23 +84,23 @@ prepare_manager() {
 }
 
 prepare_apps_mingw() {
-  mkdir -p "${TARGET_DIR}"
+    mkdir -p "${TARGET_DIR}"
 }
 
 prepare_osx() {
-  mkdir -p "${TARGET_DIR}"
+    mkdir -p "${TARGET_DIR}"
 }
 
 prepare_android() {
-  mkdir -p "${TARGET_DIR}"
+    mkdir -p "${TARGET_DIR}"
 }
 
 ROOTDIR=$(pwd)
 if [[ $# -eq 0 || $# -gt 2 ]]; then
-  echo "Usage: $0 BOINC_TYPE [TARGET_DIR]"
-  echo "BOINC_TYPE : [client | apps | manager | apps-mingw | manager-osx | manager-android]"
-  echo "TARGET_DIR : relative path where binaries should be copied to (default: deploy/BOINC_TYPE/)"
-  exit 1
+    echo "Usage: $0 BOINC_TYPE [TARGET_DIR]"
+    echo "BOINC_TYPE : [client | apps | manager | apps-mingw | manager-osx | manager-android]"
+    echo "TARGET_DIR : relative path where binaries should be copied to (default: deploy/BOINC_TYPE/)"
+    exit 1
 fi
 
 TYPE="$1"
@@ -108,25 +108,25 @@ TARGET_DIR="${2:-deploy/$TYPE/}"
 
 case $TYPE in
     client)
-    prepare_client
+        prepare_client
     ;;
     apps)
-    prepare_apps
+        prepare_apps
     ;;
     manager)
-    prepare_manager
+        prepare_manager
     ;;
     apps-mingw)
-    prepare_apps_mingw
+        prepare_apps_mingw
     ;;
     manager-osx)
-    prepare_osx
+        prepare_osx
     ;;
     manager-android)
-    prepare_android
+        prepare_android
     ;;
     *)
-    echo "unrecognized BOINC_TYPE $key"
-    exit 1
+        echo "unrecognized BOINC_TYPE $key"
+        exit 1
     ;;
 esac


### PR DESCRIPTION
- provide sensible defaults for AppVeyor deploy to bintray; Until there is a better mechanism to control deployments on AppVeyor a deployment will happen for every merge into master. This will prevent it from failing.
- stop Travis deploy script when unsupported event happens
- fix intendation

Follow up hotfix for #2712 