### PR TITLE
db_dump: Add support for dumping straight to gzip.

### DIFF
--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -213,22 +213,22 @@ int DUMP_SPEC::parse(FILE* in) {
 //
 // File streams
 //
-class OutputStream {
+class OUTPUT_STREAM {
 public:
-    virtual ~OutputStream() {}
+    virtual ~OUTPUT_STREAM() {}
     virtual bool is_open() const = 0;
     virtual bool open(const char* filename) = 0;
     virtual void close() = 0;
     virtual void write(const void* buf, int size) = 0;
 };
 
-class UncompressedFile : public OutputStream
+class UNCOMPRESSED_FILE : public OUTPUT_STREAM
 {
 private:
     FILE* f;
 
 public:
-    UncompressedFile()
+    UNCOMPRESSED_FILE()
         : f(0) {}
 
     bool is_open() const{
@@ -250,10 +250,10 @@ public:
     }
 };
 
-class ZipFile : public OutputStream
+class ZIP_FILE : public OUTPUT_STREAM
 {
 private:
-    UncompressedFile f;
+    UNCOMPRESSED_FILE f;
     char current_path[MAXPATHLEN];
 
 public:
@@ -289,13 +289,13 @@ public:
     }
 };
 
-class GzipFile : public OutputStream
+class GZIP_FILE : public OUTPUT_STREAM
 {
 private:
     gzFile gz;
 
 public:
-    GzipFile()
+    GZIP_FILE()
         : gz(0) {}
 
     bool is_open() const {
@@ -324,18 +324,18 @@ public:
 class ZFILE {
 protected:
     string tag;     // enclosing XML tag
-    OutputStream* stream;
+    OUTPUT_STREAM* stream;
 public:    
     ZFILE(string tag_, int comp): tag(tag_) {
         switch(comp) {
         case COMPRESSION_NONE:
-            stream = new UncompressedFile;
+            stream = new UNCOMPRESSED_FILE;
             break;
         case COMPRESSION_ZIP:
-            stream = new ZipFile;
+            stream = new ZIP_FILE;
             break;
         case COMPRESSION_GZIP:
-            stream = new GzipFile;
+            stream = new GZIP_FILE;
             break;
         }
     }

--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -218,7 +218,7 @@ public:
     virtual ~OutputStream() {}
     virtual bool is_open() const = 0;
     virtual bool open(const char* filename) = 0;
-    virtual bool close() = 0;
+    virtual void close() = 0;
     virtual void write(const void* buf, int size) = 0;
 };
 
@@ -240,10 +240,9 @@ public:
         return f != 0;
     }
 
-    bool close() {
+    void close() {
         fclose(f);
         f = 0;
-        return true;
     }
 
     void write(const void* buf, int size) {
@@ -270,9 +269,8 @@ public:
         return true;
     }
 
-    bool close() {
-        if(!f.close())
-            return false;
+    void close() {
+        f.close();
 
         // Do zip
         char buf[256];
@@ -284,8 +282,6 @@ public:
             );
             exit(retval);
         }
-
-        return true;
     }
 
     void write(const void* buf, int size) {
@@ -313,10 +309,9 @@ public:
         return gz != 0;
     }
 
-    bool close() {
+    void close() {
         gzclose(gz);
         gz = 0;
-        return true;
     }
 
     void write(const void* buf, int size) {

--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -313,8 +313,8 @@ public:
     }
 
     bool open(const char* filename) {
-        char buf[256];
-        sprintf(buf, "%s.gz", filename);
+        char buf[MAXPATHLEN];
+        snprintf(buf, sizeof(buf), "%s.gz", filename);
         gz = gzopen(buf, "wb");
         return gz != 0;
     }

--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -329,7 +329,20 @@ public:
     }
 
     void write(const char* fmt, va_list args) {
-        gzvprintf(gz, fmt, args);
+        if(!is_open())
+            return;
+
+        char* ptr;
+        int retval = vasprintf(&ptr, fmt, args);
+        if(retval < 0) {
+            log_messages.printf(MSG_CRITICAL,
+                "Error allocating gzip memory buffer\n"
+            );
+            exit(ERR_MALLOC);
+        }
+
+        gzwrite(gz, ptr, retval);
+        free(ptr);
     }
 };
 

--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -328,14 +328,15 @@ protected:
 public:    
     ZFILE(string tag_, int comp): tag(tag_) {
         switch(comp) {
-        case COMPRESSION_NONE:
-            stream = new UNCOMPRESSED_FILE;
-            break;
         case COMPRESSION_ZIP:
             stream = new ZIP_FILE;
             break;
         case COMPRESSION_GZIP:
             stream = new GZIP_FILE;
+            break;
+        case COMPRESSION_NONE:
+        default:
+            stream = new UNCOMPRESSED_FILE;
             break;
         }
     }


### PR DESCRIPTION
A refactor of db_dump which splits the compression logic out of ZFILE and into separate output stream classes. This opens up for on-the-fly gzip compression for #694.

I have tested this in the VM image but it could be good if someone with a larger database tries an export to see if there are any concrete time gains.