### PR TITLE
Mac: Fix truncated tabs in Computing Preferences dialog under OS 10.14 Mojave

### DIFF
--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -29,12 +29,7 @@
 #include "version.h"
 #include "DlgAdvPreferences.h"
 
-#include "res/usage.xpm"
-#include "res/xfer.xpm"
-#include "res/proj.xpm"
-#include "res/clock.xpm"
 #include "res/warning.xpm"
-
 
 using std::string;
 
@@ -55,26 +50,6 @@ CDlgAdvPreferences::CDlgAdvPreferences(wxWindow* parent) : CDlgAdvPreferencesBas
     m_arrTabPageIds.Add(ID_TABPAGE_DISK);
     m_arrTabPageIds.Add(ID_TABPAGE_SCHED);
     
-    //setting tab page images (not handled by generated code)
-    int iImageIndex = 0;
-    wxImageList* pImageList = m_Notebook->GetImageList();
-    if (!pImageList) {
-        pImageList = new wxImageList(ADJUSTFORXDPI(16), ADJUSTFORYDPI(16), true, 0);
-        wxASSERT(pImageList != NULL);
-        m_Notebook->SetImageList(pImageList);
-    }
-    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(proj_xpm));
-    m_Notebook->SetPageImage(0,iImageIndex);
-
-    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(xfer_xpm));
-    m_Notebook->SetPageImage(1,iImageIndex);
-
-    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(usage_xpm));
-    m_Notebook->SetPageImage(2,iImageIndex);
-
-    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(clock_xpm));
-    m_Notebook->SetPageImage(3,iImageIndex);
-
     //setting warning bitmap
     if (m_bmpWarning) {
         m_bmpWarning->SetBitmap(GetScaledBitmapFromXPMData(warning_xpm));

--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -33,6 +33,11 @@
 
 #include "DlgAdvPreferencesBase.h"
 
+#include "res/usage.xpm"
+#include "res/xfer.xpm"
+#include "res/proj.xpm"
+#include "res/clock.xpm"
+
 #define STATICBOXBORDERSIZE 8
 #define STATICBOXVERTICALSPACER 10
 #define DAYOFWEEKBORDERSIZE 10
@@ -45,7 +50,9 @@
 CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxString title, wxPoint pos, wxSize size, int style ) :
     wxDialog( parent, id, title, pos, size, style )
 {
+    int iImageIndex = 0;
     wxString strCaption = title;
+    
     if (strCaption.IsEmpty()) {
         CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
         wxASSERT(pSkinAdvanced);
@@ -59,7 +66,6 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
     this->SetTitle(strCaption);
 
     wxBoxSizer* dialogSizer = new wxBoxSizer( wxVERTICAL );
-
 
     m_bUsingLocalPrefs = doesLocalPrefsFileExist();
     if (web_prefs_url->IsEmpty()) {
@@ -134,19 +140,27 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
     m_Notebook = new wxNotebook( m_panelControls, ID_DEFAULT, wxDefaultPosition, wxDefaultSize, wxNB_FLAT|wxNB_TOP );
     m_Notebook->SetExtraStyle( wxWS_EX_VALIDATE_RECURSIVELY );
 
+    wxImageList* pImageList = new wxImageList(ADJUSTFORXDPI(16), ADJUSTFORYDPI(16), true, 0);
+    wxASSERT(pImageList != NULL);
+    m_Notebook->SetImageList(pImageList);
+
     // Note: we must set the third AddPage argument ("select") to
     // true for each page or ToolTips won't initialize properly.
     m_panelProcessor = createProcessorTab(m_Notebook);
-    m_Notebook->AddPage( m_panelProcessor, _("Computing"), true );
+    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(proj_xpm));
+    m_Notebook->AddPage( m_panelProcessor, _("Computing"), true, iImageIndex );
 
     m_panelNetwork = createNetworkTab(m_Notebook);
-    m_Notebook->AddPage( m_panelNetwork, _("Network"), true );
+    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(xfer_xpm));
+    m_Notebook->AddPage( m_panelNetwork, _("Network"), true, iImageIndex );
 
     m_panelDiskAndMemory = createDiskAndMemoryTab(m_Notebook);
-    m_Notebook->AddPage( m_panelDiskAndMemory, _("Disk and memory"), true );
+    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(usage_xpm));
+    m_Notebook->AddPage( m_panelDiskAndMemory, _("Disk and memory"), true, iImageIndex );
 
     m_panelDailySchedules = createDailySchedulesTab(m_Notebook);
-    m_Notebook->AddPage( m_panelDailySchedules, _("Daily schedules"), true );
+    iImageIndex = pImageList->Add(GetScaledBitmapFromXPMData(clock_xpm));
+    m_Notebook->AddPage( m_panelDailySchedules, _("Daily schedules"), true, iImageIndex );
 
     notebookSizer->Add( m_Notebook, 1, wxEXPAND | wxALL, 1 );
 
@@ -181,7 +195,7 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
     m_panelButtons->SetSizer( buttonSizer );
     m_panelButtons->Layout();
     buttonSizer->Fit( m_panelButtons );
-    dialogSizer->Add( m_panelButtons, 0, wxALIGN_BOTTOM|wxALIGN_CENTER_HORIZONTAL|wxALL, 1 );
+    dialogSizer->Add( m_panelButtons, 0, wxALIGN_CENTER_HORIZONTAL|wxALL, 1 );
 
     dialogSizer->Fit( this );
     this->SetSizer( dialogSizer );


### PR DESCRIPTION
Under OS 10.14 Mojave, the _Computing Preferences_ panel's tab buttons are not wide enough to fit the text. This fixes that issue.
<img width="567" alt="mojave computing prefs" src="https://user-images.githubusercontent.com/10470356/47266570-5e588f80-d4ed-11e8-86ec-e465a28b6953.png">

Is this bug significant enough to justify releasing a hot fix 7.14.3 for the Mac?
