### PR TITLE
Sandboxing tools installation fixes

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -24,7 +24,7 @@ endif
 
 bin_PROGRAMS = boinc_client boinccmd
 if !OS_WIN32
-bin_PROGRAMS += switcher
+pkglibexec_PROGRAMS = switcher
 endif
 
 boinccmd_SOURCES = boinc_cmd.cpp
@@ -106,7 +106,17 @@ else
 if OS_DARWIN
 boinc_client_LDFLAGS += -Wl,-flat_namespace,-undefined,dynamic_lookup
 else
-boinc_client_SOURCES += hostinfo_unix.cpp
+boinc_client_SOURCES += \
+	hostinfo_unix.cpp \
+	file_names_unix.h
+
+edit = $(SED) -e 's|@pkglibexecdir[@]|$(pkglibexecdir)|g'
+
+file_names_unix.h: file_names_unix.h.in Makefile
+	$(AM_V_GEN)$(edit) $@.in > $@
+
+BUILT_SOURCES = file_names_unix.h
+CLEANFILES = file_names_unix.h
 endif
 endif
 boinc_client_LDADD = $(LIBBOINC) $(LIBBOINC_CRYPT) $(BOINC_EXTRA_LIBS) $(PTHREAD_LIBS)

--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -24,7 +24,7 @@ endif
 
 bin_PROGRAMS = boinc_client boinccmd
 if !OS_WIN32
-pkglibexec_PROGRAMS = switcher
+pkglibexec_PROGRAMS = switcher setprojectgrp
 endif
 
 boinccmd_SOURCES = boinc_cmd.cpp
@@ -136,6 +136,10 @@ endif
 switcher_SOURCES = switcher.cpp
 switcher_LDFLAGS = $(AM_LDFLAGS) -L../lib
 switcher_LDADD = $(LIBBOINC)
+
+setprojectgrp_SOURCES = setprojectgrp.cpp
+setprojectgrp_LDFLAGS = $(AM_LDFLAGS) -L../lib
+setprojectgrp_LDADD = $(LIBBOINC)
 
 ## since we are using libtool we need some magic to get boinc and boinc_client
 ## to both be installed properly.  The next two rules do that...

--- a/client/file_names.h
+++ b/client/file_names.h
@@ -97,7 +97,11 @@ extern void send_log_after(const char* filename, double t, MIOFILE& mf);
 #define STATE_FILE_PREV             "client_state_prev.xml"
 #define STDERR_FILE_NAME            "stderr.txt"
 #define STDOUT_FILE_NAME            "stdout.txt"
+#if defined(_WIN32) || defined(__APPLE__)
 #define SWITCHER_DIR                "switcher"
+#else
+#include "file_names_unix.h"
+#endif
 #define SWITCHER_FILE_NAME          "switcher"
 #define TASK_STATE_FILENAME         "boinc_task_state.xml"
 #define TEMP_ACCT_FILE_NAME         "temp_acct.xml"

--- a/client/file_names_unix.h.in
+++ b/client/file_names_unix.h.in
@@ -1,0 +1,23 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2018 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef BOINC_FILE_NAMES_UNIX_H
+#define BOINC_FILE_NAMES_UNIX_H
+
+#define SWITCHER_DIR                "@pkglibexecdir@"
+
+#endif

--- a/client/setprojectgrp.cpp
+++ b/client/setprojectgrp.cpp
@@ -23,6 +23,8 @@
 //
 // setprojectgrp runs setuid boinc_master and setgid boinc_project
 
+#include "config.h"
+
 #include <unistd.h>
 #include <grp.h>
 #include <cstdio>


### PR DESCRIPTION
While comparing packaging in Debian and Gentoo, I came across the `switcher` tool. Haven't really found it if it is ever used but the following modifications would make it install in a FHS compatible location. Also switcher makes calls to `setprojectgrp` which wasn't installed at all so I added some changes for that as well as adding missing config.h include to it.