### PR TITLE
Drop bashisms in configure.ac and macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -439,20 +439,19 @@ dnl m4/boinc_check_fcgi.m4
 BOINC_CHECK_FCGI
 fi
 dnl ---------- SSL (m4/check_ssl.m4)
-if [[ "x${enable_client}" = "xyes" -o "x${enable_server}" = "xyes" ]]
-then
-    CHECK_SSL
-fi
+AS_IF([test "x${enable_client}" = "xyes" -o "x${enable_server}" = "xyes"],
+  [CHECK_SSL])
 
 dnl ---------- libcurl (m4/libcurl.m4) ------------------------------
 dnl curl is needed for client
 
-if [[ "x${enable_client}" = "xyes" ]]
-then
-LIBCURL_CHECK_CONFIG([yes], [7.17.1], [haveCurl=yes], [haveCurl=no])
+AS_IF([test "x${enable_client}" = "xyes"],
+  [
+    LIBCURL_CHECK_CONFIG([yes], [7.17.1], [haveCurl=yes], [haveCurl=no])
 
-if test "${haveCurl}" != yes; then
-   AC_MSG_ERROR([
+    AS_IF([test "${haveCurl}" != "yes"],
+      [
+        AC_MSG_ERROR([
 ================================================================================
 ERROR: could not find (recent enough) development-libs for libcurl.
 
@@ -463,22 +462,25 @@ ERROR: could not find (recent enough) development-libs for libcurl.
   You can download libcurl from: http://curl.haxx.se/
 
 ================================================================================
-   ])
-else
-   ## add libcurl et al. to the list of statically linked libs
-   STATIC_LIB_LIST="${STATIC_LIB_LIST} curl idn ssh2 crypto ssl krb5 k5crypto gssapi_krb5 com_err resolv lber ldap socket nsl z rt gcrypt gpg-error"
-   CPPFLAGS="${CPPFLAGS} ${LIBCURL_CPPFLAGS}"
-   CURL_LIB_PATHS=`echo $LIBCURL | sed 's/[^[a-zA-Z]]*-l[^ ]*//g'`
+        ])
+      ],
+      [
+        ## add libcurl et al. to the list of statically linked libs
+        STATIC_LIB_LIST="${STATIC_LIB_LIST} curl idn ssh2 crypto ssl krb5 k5crypto gssapi_krb5 com_err resolv lber ldap socket nsl z rt gcrypt gpg-error"
+        CPPFLAGS="${CPPFLAGS} ${LIBCURL_CPPFLAGS}"
+        CURL_LIB_PATHS=`echo $LIBCURL | sed 's/[^[a-zA-Z]]*-l[^ ]*//g'`
 
-   if test "${enable_debug}" = yes; then
-      echo "LIBCURL = ${LIBCURL}"
-      echo "LIBCURL_CPPFLAGS = ${LIBCURL_CPPFLAGS}"
-      echo "CURL_LIB_PATHS = ${CURL_LIB_PATHS}"
-      echo "LDFLAGS = ${LDFLAGS}"
-   fi
-   BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${LIBCURL}"
-fi
-fi
+        AS_IF([test "${enable_debug}" = "yes"],
+          [
+            echo "LIBCURL = ${LIBCURL}"
+            echo "LIBCURL_CPPFLAGS = ${LIBCURL_CPPFLAGS}"
+            echo "CURL_LIB_PATHS = ${CURL_LIB_PATHS}"
+            echo "LDFLAGS = ${LDFLAGS}"
+          ])
+
+        BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${LIBCURL}"
+      ])
+  ])
 
 if test "x${found_ssl}" = "xyes"; then
    BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${SSL_LIBS}"
@@ -617,10 +619,10 @@ fi
 AM_CONDITIONAL(BUILD_GRAPHICS_API, [ test "$have_glut" = yes -a "$have_jpeg" = 1])
 
 dnl check for X screen saver lib (X-based idle detection on Linux)
-if test "$enable_xss" == yes; then
+if test "$enable_xss" = yes; then
     AC_CHECK_LIB([Xss], [XScreenSaverAllocInfo], [have_Xss="yes"], [have_Xss="no"])
     AC_CHECK_HEADER([X11/extensions/scrnsaver.h], [have_Xss="yes"], [have_Xss="no"])
-    if test "$have_Xss" == no; then
+    if test "$have_Xss" = no; then
         AC_MSG_WARN([libxss missing, disabling X ScreenSaver user idle detection])
     fi
 fi
@@ -1177,7 +1179,7 @@ if test "${ac_cv_func_res_init}" != "yes" ; then
 fi
 LIBS=$svlibs
 
-if (test "$enable_xss" == yes) && (test "$have_Xss" == yes); then
+if (test "$enable_xss" = yes) && (test "$have_Xss" = yes); then
     SAH_CHECK_LIB([Xss],[XScreenSaverAllocInfo],[
         AC_DEFINE([HAVE_XSS],[1],[Define to 1 if you have xss library])
         CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])

--- a/configure.ac
+++ b/configure.ac
@@ -369,7 +369,7 @@ SAH_OPTION_BITNESS
 dnl Determine the BOINC platform given the target arch-platform-os.
 BOINC_PLATFORM
 
-if ( test "${enable_client_release}" = yes ) && ( test "${enable_client}" != yes ); then
+if test "${enable_client_release}" = yes -a "${enable_client}" != yes; then
    AC_MSG_WARN([--enable-client-release ignored.
 --------------------------------------------------
 The switch --enable-client-release is only useful for building the client and will be ignored
@@ -1179,7 +1179,7 @@ if test "${ac_cv_func_res_init}" != "yes" ; then
 fi
 LIBS=$svlibs
 
-if (test "$enable_xss" = yes) && (test "$have_Xss" = yes); then
+if test "$enable_xss" = yes -a "$have_Xss" = yes; then
     SAH_CHECK_LIB([Xss],[XScreenSaverAllocInfo],[
         AC_DEFINE([HAVE_XSS],[1],[Define to 1 if you have xss library])
         CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
@@ -1194,7 +1194,7 @@ SAH_CHECK_LIB([resolv],[res_query],[
     CLIENTLIBS="${sah_lib_last} ${CLIENTLIBS}"])
    echo DEBUG: CLIENTLIBS=${CLIENTLIBS} >&5
 
-if ( test "${disable_static_linkage}" != yes ) && ( test "${enable_client_release}" = yes ); then
+if test "${disable_static_linkage}" != yes -a "${enable_client_release}" = yes; then
 
    echo "----------"
    echo "NOTE: Building portable client binaries"
@@ -1210,7 +1210,7 @@ fi
 
 fi
 
-AM_CONDITIONAL([ENABLE_CLIENT_RELEASE],[ ( test "${disable_static_linkage}" != yes ) && ( test "${enable_client_release}" = yes ) ])
+AM_CONDITIONAL([ENABLE_CLIENT_RELEASE],[ test "${disable_static_linkage}" != yes -a "${enable_client_release}" = yes ])
 AM_CONDITIONAL([BUILD_STATIC_LIBS],[test "x${enable_static}" != xno])
 
 AC_SUBST(CLIENTLIBS)

--- a/m4/boinc_check_fcgi.m4
+++ b/m4/boinc_check_fcgi.m4
@@ -1,5 +1,5 @@
 AC_DEFUN([BOINC_CHECK_FCGI],[
-if ( test "x${enable_server}" = "xyes" ) || ( test "x${enable_libraries}" = "xyes" ) ; then
+if test "x${enable_server}" = "xyes" -o "x${enable_libraries}" = "xyes" ; then
   if test "x${enable_fcgi}" = "xyes" ; then
     AC_MSG_CHECKING([if CFLAG '-include fcgi_stdio.h' works])
     AC_LANG_PUSH(C)


### PR DESCRIPTION
Most platforms ship bash nowadays but it's still bad practice to rely on it as far as autotools go.
This can be tested using `CONFIG_SHELL=/bin/dash ./configure` for example which produces errors like `./configure: 36970: test: yes: unexpected operator`.