### PR TITLE
Mac: In ReadMe.rtf file, fix broken link to sandbox design document

### DIFF
--- a/mac_installer/ReadMe.rtf
+++ b/mac_installer/ReadMe.rtf
@@ -46,7 +46,7 @@ Note: on some versions of the Mac OS, you may not be able to exit the BOINC scre
 
 \b0 \cf0 BOINC Manager for the Macintosh features strong security measures.  This additional security helps protect your computer data from potential theft or accidental or malicious damage by limiting BOINC projects' access to your  system and data.  \
 \
-For more information or technical details of the implementation, please see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/SandboxUser"}}{\fldrslt http://boinc.berkeley.edu/trac/wiki/SandboxUser}} and {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/sandbox.php"}}{\fldrslt http://boinc.berkeley.edu/sandbox.php}}\
+For more information or technical details of the implementation, please see {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/trac/wiki/SandboxUser"}}{\fldrslt http://boinc.berkeley.edu/trac/wiki/SandboxUser}} and {\field{\*\fldinst{HYPERLINK "http://boinc.berkeley.edu/sandbox_design.php"}}{\fldrslt http://boinc.berkeley.edu/sandbox_design.php}}\
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
 


### PR DESCRIPTION
Several links to the sandbox design diagram document _sandbox.php_ were broken due to another file named _sandbox.php_. The duplicate name was fixed by renaming the sandbox design diagram document to _sandbox_design.php_. This PR updates the broken link in the Mac installer ReadMe file to the [new URL](http://boinc.berkeley.edu/sandbox_design.php).

This PR is ready to be merged into master.