### PR TITLE
(wip) lib: escape CDATA-section-close delimiter in xml_escape()

### DIFF
--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -371,6 +371,13 @@ void xml_escape(const char* in, char* out, int len) {
                 p += strlen(buf);
                 break;
             }
+        } else if (x == ']') {
+            // two stage check, strncmp() is slow
+            if (!strncmp(in, "]]>", 3)) {
+                strcpy(p, "]]&gt;");
+                p += 6;
+                in += 3;
+            }
         } else {
             *p++ = x;
         }


### PR DESCRIPTION
Per XML standard CDATA-section-close delimiter ']]>' is not allowed to
appear in element content without being escaped. XML tools like libxml
that require well-formed XML refuse to parse text that doesn't follow
this rule.

In particular this bug broke processing database result archives
generated by db_purge.