### PR TITLE
client: prevent a situation where a job is not throttled

### DIFF
--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -891,7 +891,6 @@ int APP_VERSION::parse(XML_PARSER& xp) {
             }
             continue;
         }
-        if (xp.parse_bool("dont_throttle", dont_throttle)) continue;
         if (xp.parse_bool("is_wrapper", is_wrapper)) continue;
         if (xp.parse_bool("needs_network", needs_network)) continue;
         if (log_flags.unparsed_xml) {

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1450,7 +1450,6 @@ int HOST_INFO::get_os_info() {
 
 #if LINUX_LIKE_SYSTEM
     bool found_something = false;
-    char buf2[256];
     char dist_name[256], dist_version[256];
     string os_version_extra("");
     safe_strcpy(dist_name, "");

--- a/version.h
+++ b/version.h
@@ -22,7 +22,7 @@
 #define BOINC_VERSION_STRING "7.13.0"
 
 /* Package is a pre-release (Alpha/Beta) package */
-//#define BOINC_PRERELEASE 1
+#define BOINC_PRERELEASE 1
 
 #if (defined(_WIN32) || defined(__APPLE__))
 /* Name of package */


### PR DESCRIPTION
I noticed an Amicable Numbers 4-CPU job wasn't being throttled,
while other jobs were.
Two types of jobs are exempt from throttling: GPU and non-CPU-intensive.
This app version was neither.
And yet it was marked as <dont_throttle/> in client_state.xml.
This is read at startup, and prevents that app version from being throttled
even if it not GPU and is not non-CPU-intensive.

I'm not sure how this situation arose.
Possibly the project had a temporary misconfiguration
where that plan class (mt) used a GPU.
This set the dont_throttle flag, and it stuck.

Anyway, the fix is to not parse <dont_throttle/> from app versions
in the client state file.
There's no need to - after parsing the app_version record,
dont_throttle is set according to whether it uses a GPU.