### PR TITLE
Remove the default content type

### DIFF
--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -600,10 +600,6 @@ int HTTP_OP::libcurl_exec(
     //
     setup_proxy_session(no_proxy_for_url(url));
 
-
-    // set the content type in the header
-    //
-
     if (strlen(gstate.language)) {
         snprintf(buf, sizeof(buf), "Accept-Language: %s", gstate.language);
         pcurlList = curl_slist_append(pcurlList, buf);

--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -62,7 +62,6 @@ using std::vector;
 
 static CURLM* g_curlMulti = NULL;
 static char g_user_agent_string[256] = {""};
-static const char g_content_type[] = {"Content-Type: application/x-www-form-urlencoded"};
 static unsigned int g_trace_count = 0;
 static bool got_expectation_failed = false;
     // Whether we've got a 417 HTTP error.
@@ -604,7 +603,6 @@ int HTTP_OP::libcurl_exec(
 
     // set the content type in the header
     //
-    pcurlList = curl_slist_append(pcurlList, g_content_type);
 
     if (strlen(gstate.language)) {
         snprintf(buf, sizeof(buf), "Accept-Language: %s", gstate.language);
@@ -694,7 +692,6 @@ int HTTP_OP::libcurl_exec(
         curl_formadd(&pcurlFormStart, &pcurlFormEnd,
            CURLFORM_FILECONTENT, infile,
            CURLFORM_CONTENTSLENGTH, content_length,
-           CURLFORM_CONTENTTYPE, g_content_type,
            CURLFORM_END
         );
         curl_formadd(&post, &last,


### PR DESCRIPTION
The content type for HTTP operations is always set to the default (application/x-www-form-urlencoded). This breaks the signature used by S3/Ceph as described in issue #2764. This change has been tested by building the client without these lines and running a few tasks that download input files from S3/Ceph.