### PR TITLE
lib: fix xml_escape(), again

### DIFF
--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -376,7 +376,9 @@ void xml_escape(const char* in, char* out, int len) {
             if (!strncmp(in, "]]>", 3)) {
                 strcpy(p, "]]&gt;");
                 p += 6;
-                in += 3;
+                in += 2;  // +1 from for loop
+            } else {
+                *p++ = x;
             }
         } else {
             *p++ = x;


### PR DESCRIPTION
Commit ff0b8d08985707f089f934816b0d28841b709c80 (fix CDATA escaping) introduced two bugs to xml_escape():

- it eats ']' characters that are not part of ']]>'
- it eats the next character after ']]>'

Fixes #2809