### PR TITLE
added default project value disable_account_creation_rpc

### DIFF
--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -514,7 +514,7 @@ class Project:
         config.max_wus_to_send = 50
         config.daily_result_quota = 500
         config.disable_account_creation = 0
-        config.disable_account_creation_rpc = 1
+        config.disable_account_creation_rpc = 0
         config.disable_web_account_creation = 0
         config.enable_login_mustagree_termsofuse = 0
         config.enable_privacy_by_default = 0

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -514,6 +514,7 @@ class Project:
         config.max_wus_to_send = 50
         config.daily_result_quota = 500
         config.disable_account_creation = 0
+        config.disable_account_creation_rpc = 0
         config.disable_web_account_creation = 0
         config.enable_login_mustagree_termsofuse = 0
         config.enable_privacy_by_default = 0

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -514,7 +514,7 @@ class Project:
         config.max_wus_to_send = 50
         config.daily_result_quota = 500
         config.disable_account_creation = 0
-        config.disable_account_creation_rpc = 0
+        config.disable_account_creation_rpc = 1
         config.disable_web_account_creation = 0
         config.enable_login_mustagree_termsofuse = 0
         config.enable_privacy_by_default = 0


### PR DESCRIPTION
While testing [GDPR compliance](https://boinc.berkeley.edu/trac/wiki/GdprCompliance) I have noticed that in `project/config.xml` the attribute `disable_account_creation_rpc` was missing