### PR TITLE
scheduler: linking db_dump requires -lz

### DIFF
--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -260,7 +260,7 @@ script_validator_SOURCES = $(VALIDATOR_SOURCES) \
 script_validator_LDADD = $(SERVERLIBS)
 
 db_dump_SOURCES = db_dump.cpp
-db_dump_LDADD = $(SERVERLIBS)
+db_dump_LDADD = $(SERVERLIBS) -lz
 
 db_purge_SOURCES = db_purge.cpp
 db_purge_LDADD = $(SERVERLIBS) -lz


### PR DESCRIPTION
This is a minor fix for #2767. On my Debian 8.11 `db_dump` doesn't build without that.