### PR TITLE
[Android] Update Android Gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
     - language: android
       android:
         components:
-            - build-tools-28.0.2
+            - build-tools-28.0.3
             - android-26
             - extra-google-m2repository
             - extra-android-m2repository    

--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -48,7 +48,7 @@ def buildVersionName() {
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "28.0.2"
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "edu.berkeley.boinc"

--- a/android/BOINC/app/src/main/AndroidManifest.xml
+++ b/android/BOINC/app/src/main/AndroidManifest.xml
@@ -29,10 +29,6 @@
         android:smallScreens="true"
         android:xlargeScreens="true" />
 
-    <uses-sdk
-        android:minSdkVersion="19"
-        android:targetSdkVersion="26" />
-
     <!-- Required Permissions -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />

--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -6,9 +6,10 @@ buildscript {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 

--- a/android/BOINC/gradle/wrapper/gradle-wrapper.properties
+++ b/android/BOINC/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 04 13:02:41 UTC 2018
+#Fri Nov 23 11:36:09 CET 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
**Description of the Change**
To take advantage of the latest features, improvements, and security fixes, Google strongly recommends updating the Android Gradle plugin to version 3.2.1 and Gradle to version 4.6. 

Android plugin 3.2.0 and higher now support building the Android App Bundle—a new upload format that defers APK generation and signing to compatible app stores, such as Google Play. With app bundles, we no longer have to build, sign, and manage multiple APKs, and users get smaller, more optimized downloads.

**Release Notes**
APK optimization.
