### PR TITLE
[Android] Changed the RESTART_PACKAGES to KILL_BACKGROUND_PROCESSES

### DIFF
--- a/android/BOINC/app/src/main/AndroidManifest.xml
+++ b/android/BOINC/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.RESTART_PACKAGES" />
+    <uses-permission android:name="android.permission.KILL_BACKGROUND_PROCESSES" />
 
     <!-- Features required for Android TV, consoles, and set-top boxes like Nexus Player, OUYA,
          Razer Forge TV, Nvidia SHIELD, etc -->


### PR DESCRIPTION
**Description of the Change**
RESTART_PACKAGES constant was deprecated in API level 8. The ActivityManager.restartPackage(String) API is no longer supported.

Replacement constant is KILL_BACKGROUND_PROCESSES.

**Release Notes**
N/A
