### PR TITLE
[Android] Update vagrant

### DIFF
--- a/android/Vagrant.README.md
+++ b/android/Vagrant.README.md
@@ -6,6 +6,7 @@ Provide a turn-key VM for Android development
 
 * [Vagrant](https://www.vagrantup.com/downloads.html)
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads) for USB 3.0 support.
 * Host:
   * 4 CPU cores (2 used by VM)
   * ~18 GB disk space
@@ -15,7 +16,7 @@ Provide a turn-key VM for Android development
 ## HOWTO
 
 1. On your host: open a terminal
-   1. `cd <BOINC_REPO>/android`
+   1. Clone the [BOINC repo](https://github.com/BOINC/boinc) and `cd <BOINC_REPO>/android` or just dowload the [Vagrantfile from GitHub](https://github.com/BOINC/boinc/blob/master/android/Vagrantfile)
    1. `vagrant up`
    1. Wait until the final reboot finished
    1. **From this point on you don't need Vagrant anymore**

--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
**Description of the Change**
The Vagrant readme has to be updated because under Windows 10 there are extra requirements. Without the VirtualBox Extension Pack Vagrant drops error, it misses the USB 3.0 port capability.

The base image also updated to Ubuntu 18.04. Tested and Android Studio builds the project.

**Alternate Designs**
Ubuntu 18.10 is the latest image, but not LTS.

**Release Notes**
N/A