### PR TITLE
Add Hyper-V support to Vagrant

### DIFF
--- a/android/Vagrant.README.md
+++ b/android/Vagrant.README.md
@@ -30,7 +30,7 @@ Provide a turn-key VM for Android development
    1. Wait until the final reboot finished
    1. **From this point on you don't need Vagrant anymore**
       1. Don't run `vagrant up` again!
-      1. Just use VirtualBox to stop/start your new shiny VM
+      1. Just use VirtualBox/Hyper-V to stop/start your new shiny VM
 1. In the VM:
    1. Log in with `vagrant/vagrant`
    1. Open a terminal
@@ -43,6 +43,13 @@ Provide a turn-key VM for Android development
    1. Ignore potential Gradle Plugin warning: *Don't remind me again*
 1. Hook up your Android device via USB (and remember to attach it to VirtualBox)
 1. Happy hacking :-)
+
+#### Android Virtual Device Manager
+Hyper-V can run Android Virtual Device Manager, but you have to install KVM and add vagrant user to KVM Group.
+1. Open a terminal
+   1. `apt install qemu-kvm`
+   1. `adduser vagrant kvm`
+1. Reboot the VM.
 
 ### Known limitations
 

--- a/android/Vagrant.README.md
+++ b/android/Vagrant.README.md
@@ -4,6 +4,7 @@ Provide a turn-key VM for Android development
 
 ## Requirements
 
+### On Linux, MacOS or Windows with VirtualBox
 * [Vagrant](https://www.vagrantup.com/downloads.html)
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 * [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads) for USB 3.0 support.
@@ -13,7 +14,15 @@ Provide a turn-key VM for Android development
   * 4 GB RAM (2 used by VM)
 * Download volume (once): ~3.5 GB
 
-## HOWTO
+### On Windows with Hyper-V
+* [Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v)
+* Host:
+  * 4 CPU cores (2 used by VM)
+  * ~18 GB disk space
+  * 4 GB RAM (2 used by VM)
+* Download volume (once): ~3.5 GB
+
+### HOWTO
 
 1. On your host: open a terminal
    1. Clone the [BOINC repo](https://github.com/BOINC/boinc) and `cd <BOINC_REPO>/android` or just dowload the [Vagrantfile from GitHub](https://github.com/BOINC/boinc/blob/master/android/Vagrantfile)
@@ -35,7 +44,8 @@ Provide a turn-key VM for Android development
 1. Hook up your Android device via USB (and remember to attach it to VirtualBox)
 1. Happy hacking :-)
 
-## Known limitations
+### Known limitations
 
 * The Android Virtual Device Manager might not work properly as it needs virtualization
   which isn't possible within a virtual machine (at least not using VirtualBox).
+* On Windows it seems the VirtualBox manage GPU acceleration a little better on Ubuntu 18.04, than Hyper-V, despite the fact that Windows added [Enhanced Session Mode to Ubuntu 18.04](https://blogs.technet.microsoft.com/virtualization/2018/02/28/sneak-peek-taking-a-spin-with-enhanced-linux-vms/).

--- a/android/Vagrant.README.md
+++ b/android/Vagrant.README.md
@@ -6,6 +6,7 @@ Provide a turn-key VM for Android development
 
 * [Vagrant](https://www.vagrantup.com/downloads.html)
 * [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads) for USB 3.0 support.
 * Host:
   * 4 CPU cores (2 used by VM)
   * ~18 GB disk space
@@ -15,7 +16,7 @@ Provide a turn-key VM for Android development
 ## HOWTO
 
 1. On your host: open a terminal
-   1. `cd <BOINC_REPO>/android`
+   1. Clone the [BOINC repo](https://github.com/BOINC/boinc) and `cd <BOINC_REPO>/android` or just dowload the [Vagrantfile from GitHub](https://github.com/BOINC/boinc/blob/master/android/Vagrantfile)
    1. `vagrant up`
    1. Wait until the final reboot finished
    1. **From this point on you don't need Vagrant anymore**

--- a/android/Vagrant.README.md
+++ b/android/Vagrant.README.md
@@ -19,7 +19,7 @@ Provide a turn-key VM for Android development
 * Host:
   * 4 CPU cores (2 used by VM)
   * ~18 GB disk space
-  * 4 GB RAM (2 used by VM)
+  * 8 GB RAM (4 used by VM)
 * Download volume (once): ~3.5 GB
 
 ### HOWTO
@@ -47,5 +47,5 @@ Provide a turn-key VM for Android development
 ### Known limitations
 
 * The Android Virtual Device Manager might not work properly as it needs virtualization
-  which isn't possible within a virtual machine (at least not using VirtualBox).
+  which isn't possible within a virtual machine (at least not using VirtualBox). Although Hyper-V can run Android Virtual Device Manager.
 * On Windows it seems the VirtualBox manage GPU acceleration a little better on Ubuntu 18.04, than Hyper-V, despite the fact that Windows added [Enhanced Session Mode to Ubuntu 18.04](https://blogs.technet.microsoft.com/virtualization/2018/02/28/sneak-peek-taking-a-spin-with-enhanced-linux-vms/).

--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -38,7 +38,8 @@ Vagrant.configure("2") do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
-
+  config.vm.synced_folder ".", "/vagrant_data", disabled: true
+  
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:

--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -79,7 +79,7 @@ Vagrant.configure("2") do |config|
       hv.cpus = 2
 
       # Customize the amount of memory on the VM:
-      hv.memory = "2048"
+      hv.memory = "4096"
       
       # Enable virtualization extensions for the virtual CPUs. 
       hv.enable_virtualization_extensions = true

--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/ubuntu-18.04"
+  config.vm.box = "bento/ubuntu-16.04"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -66,6 +66,35 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--usb", "on"]
       vb.customize ["modifyvm", :id, "--usbxhci", "on"]
   end
+
+  # Example of Hyper-V:
+  #
+  config.vm.provider "hyperv" do |hv, override|
+
+      # Set VM name
+      hv.vmname = "BOINC-Android-Development"
+
+      # Customize the number of CPU cores on the VM:
+      hv.cpus = 2
+
+      # Customize the amount of memory on the VM:
+      hv.memory = "2048"
+      
+      # Enable virtualization extensions for the virtual CPUs. 
+      hv.enable_virtualization_extensions = true
+
+      hv.vm_integration_services = {
+        guest_service_interface: true,
+        heartbeat: false,
+        shutdown: true,
+        time_synchronization: true
+      }
+
+      override.ssh.username = "vagrant"
+      config.ssh.password =  "vagrant"
+
+  end
+
   #
   # View the documentation for the provider you are using for more
   # information on available options.

--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "bento/ubuntu-16.04"
+  config.vm.box = "bento/ubuntu-18.04"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
This PR is based on #2842, please merge that first.

**Description of the Change**
On Windows, the [VirtualBox can't be used](https://forums.virtualbox.org/viewtopic.php?f=6&t=85438) if someone uses Hyper-V by default.

The user doesn't have to do anything differently. If VirtualBox is installed, the Vagrant detects it and use it as default.

**Release Notes**
N/A
