### PR TITLE
Fix likely bug where nsecs parameter is ignored

### DIFF
--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -489,7 +489,7 @@ int run_program(
     }
 
     if (nsecs) {
-        boinc_sleep(3);
+        boinc_sleep(nsecs);
         if (waitpid(pid, 0, WNOHANG) == pid) {
             return -1;
         }


### PR DESCRIPTION
When waiting for child process to finish with a nonzero timeout, sleep for that timeout instead of a hardcoded 3 seconds, which seems unlikely to be intentional.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
