### PR TITLE
Travis Bintray: add attributes to versions for better cleanup

### DIFF
--- a/deploy/deploy_to_bintray.sh
+++ b/deploy/deploy_to_bintray.sh
@@ -111,6 +111,15 @@ data="{
 set +x
 ${CURL} -H Content-Type:application/json -X POST -d "${data}" "${API}/packages/${BINTRAY_REPO_OWNER}/${BINTRAY_REPO}/${PKG_NAME}/versions"
 
+echo "Adding attributes to version ${VERSION}"
+# this can be used to cleanup old versions
+pr="${TRAVIS_PULL_REQUEST:-0}"
+created=$(date -Is)
+data="[{\"name\": \"PR\", \"values\": [\"${pr}\"], \"type\": \"string\"},
+            {\"name\": \"create_time\", \"values\": [\"${created}\"], \"type\": \"date\"}]"
+echo $data
+${CURL} -H Content-Type:application/json -X POST -d "${data}" "${API}/packages/${BINTRAY_REPO_OWNER}/${BINTRAY_REPO}/${PKG_NAME}/versions/${VERSION}/attributes"
+
 echo "Uploading and publishing ${SOURCE_DIR}/${BOINC_TYPE}.7z..."
 if [ -f "${SOURCE_DIR}/${BOINC_TYPE}.7z" ]; then
     set +x


### PR DESCRIPTION
**Description of the Change**
Attributes can be used to easily delete old versions. A script can check if a PR is closed and delete all versions for this PR on bintray. Or it could delete all versions older than a threshold.
Attribtes only need to be added once. Currently this is done in the Travis build because this is running for every PR.

**Alternate Designs**
None

**Release Notes**
N/A
