### PR TITLE
Avoid project.inc including itself

### DIFF
--- a/html/project.sample/project.inc
+++ b/html/project.sample/project.inc
@@ -8,7 +8,7 @@
 // see inc/translation.inc and
 // https://boinc.berkeley.edu/trac/wiki/TranslateProject for details
 
-require_once("../inc/util.inc");
+require_once("../inc/util_basic.inc");
 
 //-------------- Project name and owner
 


### PR DESCRIPTION
Include only the function we need to avoid pulling in other stuff.

**Description of the Change**
util.inc includes project.inc but only the function parse_config that is required and this can be found int util_basic.inc

