### PR TITLE
Alternative approach for server versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ py/Boinc/version.py
 py/setup.py
 stamp-h1
 test/version.inc
+html/inc/release.inc
 
 ## files created by make:
 *.o

--- a/generate_svn_version.sh
+++ b/generate_svn_version.sh
@@ -19,6 +19,7 @@ elif [ -d .git ]; then
     fi
     URL=`git config --get remote.$remote.url`
     DATE=`git log -n1 --pretty="format:%ct"`
+    SERVER_VERSION=`git describe --abbrev=0 --match server_release/*` 
 elif [ -d .svn ]; then
     CMD="svn info"
 else
@@ -60,4 +61,17 @@ if cmp "$HEADER" "$TMPFILE" >/dev/null 2>&1; then
 	rm -f "$TMPFILE"
 else
 	mv "$TMPFILE" "$HEADER"
+fi
+
+if [ ! -z ${SERVER_VERSION} ]; then
+    SERVER_VERSION=`echo ${SERVER_VERSION} | sed 's#.*/##'`
+    cat << EOF > html/inc/release.inc
+<?php
+
+global \$server_version ;
+\$server_version = "${SERVER_VERSION}";
+
+?>
+EOF
+
 fi

--- a/html/user/get_project_config.php
+++ b/html/user/get_project_config.php
@@ -19,8 +19,8 @@
 require_once("../inc/consent.inc");
 require_once("../inc/util.inc");
 require_once("../inc/xml.inc");
-if(file_exists('../../release.inc'))
-    include '../../release.inc';
+if(file_exists('../inc/release.inc'))
+    include '../inc/release.inc';
 
 BoincDb::get(true);
 xml_header();
@@ -65,10 +65,6 @@ echo "<project_config>
     <master_url>$master_url</master_url>
     <web_rpc_url_base>".secure_url_base()."</web_rpc_url_base>
 ";
-
-if ( isset($git_commit) ) {
-    echo "<git_commit>$git_commit</git_commit>\n";
-}
 
 if ( isset($server_version) ) {
     echo "<server_version>$server_version</server_version>\n";

--- a/html/user/server_status.php
+++ b/html/user/server_status.php
@@ -30,8 +30,8 @@ require_once("../inc/cache.inc");
 require_once("../inc/util.inc");
 require_once("../inc/xml.inc");
 require_once("../inc/boinc_db.inc");
-if(file_exists('../../release.inc'))
-    include '../../release.inc';
+if(file_exists('../inc/release.inc'))
+    include '../inc/release.inc';
 
 if (!defined('STATUS_PAGE_TTL')) {
     define('STATUS_PAGE_TTL', 3600);
@@ -187,9 +187,8 @@ function show_status_html($x) {
     end_table();
     
     global $server_version;
-    global $git_commit;
-    if ( isset($server_version) && isset($git_commit) ) {
-        echo "Server version: $server_version (<a href=https://github.com/BOINC/boinc/commit/$git_commit>$git_commit</a>)<br>";
+    if ( isset($server_version) ) {
+        echo "Server version: $server_version <br>";
     }
 
     if ($j->db_revision) {

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -9,7 +9,6 @@ import boinc_path_config
 from Boinc import database, db_mid, configxml, tools
 from Boinc.boinc_db import *
 import os, sys, glob, time, shutil, re, random
-import subprocess
 
 class Options:
     pass
@@ -340,31 +339,6 @@ def install_boinc_files(dest_dir, install_web_files, install_server_files):
             shutil.copy(srcdir('html/user/sample_motd.php'), dir('html/user/motd.php'))
         os.system("rm -f "+dir('html/languages/translations/*'))
         install_glob(srcdir('html/languages/translations/*.po'), dir('html/languages/translations/'))
-        try:
-            os.remove(os.path.join(dest_dir, 'release.inc'))
-        except OSError:
-            pass
-        try:
-            s = subprocess.Popen(["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE, stderr=open(os.devnull, 'w'))
-            commit = s.stdout.read()[:7]
-            s = subprocess.Popen(["git", "describe", "--match", "server_release/*", "--tags", "--exact", "HEAD"],
-                                 stdout=subprocess.PIPE, stderr=open(os.devnull, 'w'))
-            version = s.stdout.read().split("/")[-1].strip()
-            content = '''<?php
-global $git_commit;
-global $server_version;
-$git_commit = "{commit}";
-$server_version = "{version}";
-
-?>
-'''.format(commit=commit, version=version)
-            f = open(os.path.join(dest_dir, 'release.inc'), 'w')
-            f.write(content)
-            f.close()
-            os.chmod(os.path.join(dest_dir, 'release.inc'), 0o644)
-        except Exception, e:    
-            print 'Not running from git source, no version or commit detected.'
-
 
     # copy Python stuff
     map(lambda (s): install(srcdir('sched',s), dir('bin',s)),


### PR DESCRIPTION
Fixes #2858 

**Description of the Change**

1. The version detection is now done in generate_svn_version.sh rather than setup_project.py. 
2. release.inc is created in html/inc and added to .gitignore
3. The link to the repository has been removed to avoid further discussion




