### PR TITLE
client: unsuspend jobs before telling them to quit

### DIFF
--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -194,6 +194,14 @@ static void print_descendants(int pid, vector<int>desc, const char* where) {
 // Send a quit message, start timer, get descendants
 //
 int ACTIVE_TASK::request_exit() {
+    // unsuspend the process.
+    // If it's suspended, the timer thread is suspended and
+    // won't process the quit message
+    //
+    if (task_state() == PROCESS_SUSPENDED) {
+        unsuspend();
+    }
+
     if (app_client_shm.shm) {
         process_control_queue.msg_queue_send(
             "<quit/>",


### PR DESCRIPTION
If a job is suspended (e.g. because of CPU throttling)
its timer thread is suspended and won't process any messages,
including quit messages.
This could cause a delay in client exit,
and possibly job processes that don't go away.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
