### PR TITLE
web: add ability to put extra stuff in <head> element of all pages

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -257,8 +257,8 @@ function page_head(
         <html lang="en">
         <head>
     ';
-    if (defined('HEAD_EXTRA')) {
-        echo HEAD_EXTRA;
+    if (defined('GLOBAL_HEAD_EXTRA')) {
+        echo GLOBAL_HEAD_EXTRA;
     }
     echo '
         <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -243,15 +243,24 @@ function page_head(
 
     if (!$caching) {
         header("Content-type: text/html; charset=utf-8");
-        header ("Expires: Mon, 26 Jul 1997 05:00:00 UTC");    // Date in the past
-        header ("Last-Modified: " . gmdate("D, d M Y H:i:s") . " UTC"); // always modified
-        header ("Cache-Control: $cache_control_extra no-cache, must-revalidate, post-check=0, pre-check=0");  // HTTP/1.1
-        header ("Pragma: no-cache");                          // HTTP/1.0
+        header("Expires: Mon, 26 Jul 1997 05:00:00 UTC");
+            // Date in the past
+        header("Last-Modified: " . gmdate("D, d M Y H:i:s") . " UTC");
+            // always modified
+        header("Cache-Control: $cache_control_extra no-cache, must-revalidate, post-check=0, pre-check=0");
+            // for HTTP/1.1
+        header("Pragma: no-cache");
+            // for HTTP/1.0
     }
 
     echo '<!DOCTYPE html>
         <html lang="en">
         <head>
+    ';
+    if (defined('HEAD_EXTRA')) {
+        echo HEAD_EXTRA;
+    }
+    echo '
         <meta name="viewport" content="width=device-width, initial-scale=1">
     ';
     if ($head_extra) {


### PR DESCRIPTION
project.inc can include a constant HEAD_EXTRA.
Its contents are inserted at the beginning of <head> tags.

This makes it possible to use Google Analytics,
which requires that a script be added at that point.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
