### PR TITLE
Add SupplementaryGroups=video to systemd

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -8,6 +8,7 @@ ProtectHome=true
 Type=simple
 Nice=10
 User=boinc
+SupplementaryGroups=video
 WorkingDirectory=/var/lib/boinc
 ExecStart=@exec_prefix@/bin/boinc
 ExecStop=@exec_prefix@/bin/boinccmd --quit


### PR DESCRIPTION
**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
By including the video group, the boinc client can access video (GPU) hardware making boinc-client "just work" without the user having to perform additional steps.

All major distros (including Fedora, Gentoo, and Debian) have a video group.
**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I don't think there are any alternative designs.
**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
N/A