### PR TITLE
[Android] The setBackgroundDrawable was deprecated in API level 16.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectControlsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectControlsListAdapter.java
@@ -89,14 +89,14 @@ public class ProjectControlsListAdapter extends ArrayAdapter<ProjectControl> {
         	text = activity.getResources().getString(R.string.projects_control_reset);
     		break;
     	case RpcClient.PROJECT_DETACH:
-        	tvText.setBackgroundDrawable(activity.getResources().getDrawable(R.drawable.shape_light_red_background));
+        	tvText.setBackground(activity.getResources().getDrawable(R.drawable.shape_light_red_background));
         	text = activity.getResources().getString(R.string.projects_control_remove);
     		break;
     	case RpcClient.MGR_SYNC:
         	text = activity.getResources().getString(R.string.projects_control_sync_acctmgr);
     		break;
     	case RpcClient.MGR_DETACH:
-        	tvText.setBackgroundDrawable(activity.getResources().getDrawable(R.drawable.shape_light_red_background));
+        	tvText.setBackground(activity.getResources().getDrawable(R.drawable.shape_light_red_background));
         	text = activity.getResources().getString(R.string.projects_control_remove_acctmgr);
     		break;
     	case RpcClient.TRANSFER_RETRY:

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
@@ -253,7 +253,7 @@ public class ProjectsListAdapter extends ArrayAdapter<ProjectsListData> {
 	    	// icon background
     		RelativeLayout iconBackground = vi.findViewById(R.id.icon_background);
 	    	if(data.project.attached_via_acct_mgr) {
-	    		iconBackground.setBackgroundDrawable(activity.getApplicationContext().getResources().getDrawable(R.drawable.shape_light_blue_background_wo_stroke));
+	    		iconBackground.setBackground(activity.getApplicationContext().getResources().getDrawable(R.drawable.shape_light_blue_background_wo_stroke));
 	    	} else {
 	    		iconBackground.setBackgroundColor(activity.getApplicationContext().getResources().getColor(android.R.color.transparent));
 	    	}


### PR DESCRIPTION
**Description of the Change**
The [setBackgroundDrawable ](https://developer.android.com/reference/android/view/View.html#setBackgroundDrawable(android.graphics.drawable.Drawable)) was deprecated in API level 16. Android.com says to use the setBackground instead which was added in API level 16.

We target minimum API 19.

**Release Notes**
N/A
