### PR TITLE
[Android] Fix 'equals()' between objects of inconvertible types

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -28,7 +28,7 @@ def buildVersionName() {
     def match = (tag =~ pattern)
 
     // Sanity checks for tag format
-    if(match.hasGroup() && 1L == match.size() && 5 == match[0].size() && head.commitDistance == 0) {
+    if(match.hasGroup() && 1L == match.size() && 5L == match[0].size() && head.commitDistance == 0) {
         def major = match.group('major')
         def minor = match.group('minor')
         def revision = match.group('revision')

--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -28,7 +28,7 @@ def buildVersionName() {
     def match = (tag =~ pattern)
 
     // Sanity checks for tag format
-    if(match.hasGroup() && 1 == match.size() && 5 == match[0].size() && head.commitDistance == 0) {
+    if(match.hasGroup() && 1L == match.size() && 5 == match[0].size() && head.commitDistance == 0) {
         def major = match.group('major')
         def minor = match.group('minor')
         def revision = match.group('revision')


### PR DESCRIPTION
**Description of the Change**
The `match.size()` return a `long`, and it was compared with an `int`.
The number 1 now used as long.

Fixes the following inspected error:  '==' between objects of inconvertible types 'Integer' and 'long'

**Release Notes**
N/A
