### PR TITLE
[Android] Fix the isSpace deprecated function.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessagesParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessagesParser.java
@@ -58,7 +58,7 @@ public class MessagesParser {
 			while (pos < end) {
 				/* skip spaces */
 				while (pos < end) {
-					if (!Character.isSpace(xml.charAt(pos)))
+					if (!Character.isWhitespace(xml.charAt(pos)))
 						break;
 					pos++;
 				}


### PR DESCRIPTION
**Description of the Change**
The `boolean isSpace(char)` method in the `java.lang.Character` class were [deprecated](http://leo.ugr.es/elvira/devel/Tutorial/Java/post1.0/converting/deprecated.html) in favor of `boolean isWhitespace(char)`.

**Release Notes**
N/A
