### PR TITLE
[Android] Fix deprecated NotificationCompat.Builder(Context context)

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
@@ -155,7 +155,7 @@ public class ClientNotification {
 		String statusTitle = status.getCurrentStatusTitle();
 		
 		// build notification
-		NotificationCompat.Builder nb = new NotificationCompat.Builder(context);
+		NotificationCompat.Builder nb = new NotificationCompat.Builder(context, "main-channel");
 		nb.setContentTitle(statusTitle)
         	.setSmallIcon(getIcon(computingStatus))
         	.setLargeIcon(BitmapFactory.decodeResource(context.getResources(), getIcon(computingStatus)))

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
@@ -26,7 +26,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.support.v7.app.NotificationCompat;
+import android.support.v4.app.NotificationCompat;
 import android.util.Log;
 import edu.berkeley.boinc.BOINCActivity;
 import edu.berkeley.boinc.R;
@@ -129,14 +129,14 @@ public class NoticeNotification {
         final int notices;
         final String projectName;
 
-        nb = (android.support.v7.app.NotificationCompat.Builder)(new NotificationCompat.Builder(this.context).
-            setContentTitle(this.context.getResources().getQuantityString(
-                R.plurals.notice_notification,
-                notices = this.currentlyNotifiedNotices.size(),
-                projectName = this.currentlyNotifiedNotices.get(0).project_name,
-                notices)).
-            setSmallIcon(R.drawable.mailw).
-            setContentIntent(this.contentIntent));
+		nb = new NotificationCompat.Builder(this.context, "main-channel");
+        nb.setContentTitle(this.context.getResources().getQuantityString(
+			R.plurals.notice_notification,
+			notices = this.currentlyNotifiedNotices.size(),
+			projectName = this.currentlyNotifiedNotices.get(0).project_name,
+			notices)).
+				setSmallIcon(R.drawable.mailw).
+				setContentIntent(this.contentIntent);
         if (notices == 1) {
             // single notice view
             nb.setContentText(this.currentlyNotifiedNotices.get(0).title).

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
@@ -129,14 +129,14 @@ public class NoticeNotification {
         final int notices;
         final String projectName;
 
-		nb = new NotificationCompat.Builder(this.context, "main-channel");
+        nb = new NotificationCompat.Builder(this.context, "main-channel");
         nb.setContentTitle(this.context.getResources().getQuantityString(
-			R.plurals.notice_notification,
-			notices = this.currentlyNotifiedNotices.size(),
-			projectName = this.currentlyNotifiedNotices.get(0).project_name,
-			notices)).
-				setSmallIcon(R.drawable.mailw).
-				setContentIntent(this.contentIntent);
+                R.plurals.notice_notification,
+                notices = this.currentlyNotifiedNotices.size(),
+                projectName = this.currentlyNotifiedNotices.get(0).project_name,
+                notices)).
+                        setSmallIcon(R.drawable.mailw).
+                        setContentIntent(this.contentIntent);
         if (notices == 1) {
             // single notice view
             nb.setContentText(this.currentlyNotifiedNotices.get(0).title).


### PR DESCRIPTION
**Description of the Change**
Fix deprecated `Builder(android.content.Context)` and `android.support.v7.app.NotificationCompat.Builder`

The NotificationCompat.Builder(Context context) constructor was [deprecated](https://developer.android.com/reference/android/support/v4/app/NotificationCompat.Builder) in API level 26.1.0.
Google suggests to use NotificationCompat.Builder(Context, String) instead.

**Release Notes**
N/A
