### PR TITLE
[Android] Update Charger Type attribute to use the API's constant

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
@@ -242,7 +242,7 @@ public class DeviceStatus {
 		case BatteryManager.BATTERY_PLUGGED_AC:
 			enabled = appPrefs.getPowerSourceAc();
 			break;
-		case 4: // constant BATTERY_PLUGGED_WIRELESS, only defined in API Level 17
+		case BatteryManager.BATTERY_PLUGGED_WIRELESS:
 			enabled = appPrefs.getPowerSourceWireless();
 			break;
 		case BatteryManager.BATTERY_PLUGGED_USB:


### PR DESCRIPTION
**Description of the Change**
The previous solution used the fix number 4, because it was necessary prior API 17. Now we target minimum API 19, so updated to use the standard method.

**Release Notes**
N/A
