### PR TITLE
[Android] Fix Java language level migration aids

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
@@ -212,7 +212,7 @@ public class EventLogActivity extends AppCompatActivity {
 	// clientLog = true: client log
 	// clientlog = false: gui log
 	private String getLogDataAsString() {
-		StringBuffer text = new StringBuffer();
+		StringBuilder text = new StringBuilder();
 		int type = getActiveLog();
 		if(type == CLIENT_LOG_TAB_ACTIVE) {
 			text.append(getString(R.string.eventlog_client_header) + "\n\n");

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
@@ -50,14 +50,14 @@ public class EventLogActivity extends AppCompatActivity {
 	public EventLogClientFragment clientFrag;
 	public ListView clientLogList;
 	public ClientLogListAdapter clientLogListAdapter;
-	public ArrayList<Message> clientLogData = new ArrayList<Message>();
+	public ArrayList<Message> clientLogData = new ArrayList<>();
 
 	public EventLogGuiFragment guiFrag;
 	public ListView guiLogList;
 	public ArrayAdapter<String> guiLogListAdapter;
-	public ArrayList<String> guiLogData = new ArrayList<String>();
+	public ArrayList<String> guiLogData = new ArrayList<>();
 	
-	private ArrayList<EventLogActivityTabListener<?>> listener = new ArrayList<EventLogActivityTabListener<?>>();
+	private ArrayList<EventLogActivityTabListener<?>> listener = new ArrayList<>();
 	
 	final static int GUI_LOG_TAB_ACTIVE =1;
 	final static int CLIENT_LOG_TAB_ACTIVE =2;
@@ -73,14 +73,14 @@ public class EventLogActivity extends AppCompatActivity {
 
         actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_TABS);
         
-        EventLogActivityTabListener<EventLogClientFragment> clientListener = new EventLogActivityTabListener<EventLogClientFragment>(this, getString(R.string.eventlog_client_header), EventLogClientFragment.class);
+        EventLogActivityTabListener<EventLogClientFragment> clientListener = new EventLogActivityTabListener<>(this, getString(R.string.eventlog_client_header), EventLogClientFragment.class);
         listener.add(clientListener);
         Tab tab = actionBar.newTab()
                 .setText(R.string.eventlog_client_header)
                 .setTabListener(clientListener);
         actionBar.addTab(tab);
         
-        EventLogActivityTabListener<EventLogGuiFragment> guiListener = new EventLogActivityTabListener<EventLogGuiFragment>(this, getString(R.string.eventlog_gui_header), EventLogGuiFragment.class);
+        EventLogActivityTabListener<EventLogGuiFragment> guiListener = new EventLogActivityTabListener<>(this, getString(R.string.eventlog_gui_header), EventLogGuiFragment.class);
         listener.add(guiListener);
         tab = actionBar.newTab()
                 .setText(R.string.eventlog_gui_header)

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogClientFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogClientFragment.java
@@ -134,7 +134,7 @@ public class EventLogClientFragment extends Fragment {
 			} catch (RemoteException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
-				return new ArrayList<edu.berkeley.boinc.rpc.Message>();
+				return new ArrayList<>();
 			} 
 		}
 
@@ -170,7 +170,7 @@ public class EventLogClientFragment extends Fragment {
 			} catch (RemoteException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
-				return new ArrayList<edu.berkeley.boinc.rpc.Message>();
+				return new ArrayList<>();
 			} 
 		}
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogGuiFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogGuiFragment.java
@@ -42,7 +42,7 @@ public class EventLogGuiFragment extends Fragment {
     	View layout = inflater.inflate(R.layout.eventlog_gui_layout, container, false);
 
 		a.guiLogList = layout.findViewById(R.id.guiLogList);
-		a.guiLogListAdapter = new ArrayAdapter<String>(getActivity(), R.layout.eventlog_gui_listitem_layout, a.guiLogData);
+		a.guiLogListAdapter = new ArrayAdapter<>(getActivity(), R.layout.eventlog_gui_listitem_layout, a.guiLogData);
 		a.guiLogList.setAdapter(a.guiLogListAdapter);
 		
 		// read messages

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/NoticesFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/NoticesFragment.java
@@ -40,7 +40,7 @@ public class NoticesFragment extends Fragment {
 
 	private ListView noticesList;
 	private NoticesListAdapter noticesListAdapter;
-	private ArrayList<Notice> data = new ArrayList<Notice>();
+	private ArrayList<Notice> data = new ArrayList<>();
 
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
@@ -56,7 +56,7 @@ public class PrefsFragment extends Fragment {
 	private ListView lv;
 	private PrefsListAdapter listAdapter;
 	
-	private ArrayList<PrefsListItemWrapper> data = new ArrayList<PrefsListItemWrapper>(); //Adapter for list data
+	private ArrayList<PrefsListItemWrapper> data = new ArrayList<>(); //Adapter for list data
 	private GlobalPreferences clientPrefs = null; //preferences of the client, read on every onResume via RPC
 	//private AppPreferences appPrefs = null; //Android specific preferences, singleton of monitor
 	private HostInfo hostinfo = null;
@@ -313,7 +313,7 @@ public class PrefsFragment extends Fragment {
 		dialog.setContentView(R.layout.prefs_layout_dialog_selection);
 		
 		if(item.ID == R.string.prefs_client_log_flags_header) {
-			final ArrayList<SelectionDialogOption> options = new ArrayList<SelectionDialogOption>();
+			final ArrayList<SelectionDialogOption> options = new ArrayList<>();
 			String[] array = getResources().getStringArray(R.array.prefs_client_log_flags);
 			for(String option: array) options.add(new SelectionDialogOption(option));
 			ListView lv = dialog.findViewById(R.id.selection);
@@ -324,7 +324,7 @@ public class PrefsFragment extends Fragment {
 			confirm.setOnClickListener(new OnClickListener() {
 				@Override
 				public void onClick(View v) {
-					ArrayList<String> selectedOptions = new ArrayList<String>();
+					ArrayList<String> selectedOptions = new ArrayList<>();
 					for(SelectionDialogOption option: options) if(option.selected) selectedOptions.add(option.name);
 					if(Logging.DEBUG) Log.d(Logging.TAG, selectedOptions.size() + " log flags selected");
 					new SetCcConfigAsync().execute(formatOptionsToCcConfig(selectedOptions)); 
@@ -332,7 +332,7 @@ public class PrefsFragment extends Fragment {
 				}
 			});
 		}else if(item.ID == R.string.prefs_power_source_header) {
-			final ArrayList<SelectionDialogOption> options = new ArrayList<SelectionDialogOption>();
+			final ArrayList<SelectionDialogOption> options = new ArrayList<>();
 			options.add(new SelectionDialogOption(R.string.prefs_power_source_ac, BOINCActivity.monitor.getPowerSourceAc()));
 			options.add(new SelectionDialogOption(R.string.prefs_power_source_usb, BOINCActivity.monitor.getPowerSourceUsb()));
 			options.add(new SelectionDialogOption(R.string.prefs_power_source_wireless, BOINCActivity.monitor.getPowerSourceWireless()));

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
@@ -728,12 +728,12 @@ public class PrefsFragment extends Fragment {
 		
 		public SelectionDialogOption(int ID, Boolean selected) {
 			this(getResources().getString(ID), selected);
-			this.ID = Integer.valueOf(ID);
+			this.ID = ID;
 		}
 		
 		public SelectionDialogOption(int ID, Boolean selected, Boolean highlighted) {
 			this(getResources().getString(ID), selected, highlighted);
-			this.ID = Integer.valueOf(ID);
+			this.ID = ID;
 		}
 	}
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
@@ -61,7 +61,7 @@ public class ProjectDetailsFragment extends Fragment {
 	private String url;
 	private ProjectInfo projectInfo; // might be null for projects added via manual URL attach
 	private Project project;
-    private ArrayList<ImageWrapper> slideshowImages = new ArrayList<ImageWrapper>();
+    private ArrayList<ImageWrapper> slideshowImages = new ArrayList<>();
     
     private LayoutInflater li;
     private View root;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
@@ -56,7 +56,7 @@ public class ProjectsFragment extends Fragment {
 
 	private ListView lv;
 	private ProjectsListAdapter listAdapter;
-	private ArrayList<ProjectsListData> data = new ArrayList<ProjectsListData>();
+	private ArrayList<ProjectsListData> data = new ArrayList<>();
 
 	// controls popup dialog
 	Dialog dialogControls;
@@ -236,7 +236,7 @@ public class ProjectsFragment extends Fragment {
 	
 	// takes list of all ongoing transfers and a project id (url) and returns transfer that belong to given project
 	private ArrayList<Transfer> mapTransfersToProject(String id, ArrayList<Transfer> allTransfers) {
-		ArrayList<Transfer> projectTransfers = new ArrayList<Transfer>();
+		ArrayList<Transfer> projectTransfers = new ArrayList<>();
 		for(Transfer trans: allTransfers) {
 			if(trans.project_url.equals(id)) {
 				// project id matches url in transfer, add to list
@@ -303,7 +303,7 @@ public class ProjectsFragment extends Fragment {
 				// - client status, e.g. either suspend or resume
 				// - show advanced preference
 				// - project attached via account manager (e.g. hide Remove)
-				ArrayList<ProjectControl> controls = new ArrayList<ProjectControl>();
+				ArrayList<ProjectControl> controls = new ArrayList<>();
 				if(isMgr) {
 					((TextView)dialogControls.findViewById(R.id.title)).setText(R.string.projects_control_dialog_title_acctmgr);
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
@@ -50,7 +50,7 @@ public class TasksFragment extends Fragment {
 
 	private ListView lv;
 	private TasksListAdapter listAdapter;
-	private ArrayList<TaskData> data = new ArrayList<TaskData>();
+	private ArrayList<TaskData> data = new ArrayList<>();
 
 	private BroadcastReceiver mClientStatusChangeRec = new BroadcastReceiver() {
 		@Override

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/GalleryAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/GalleryAdapter.java
@@ -35,7 +35,7 @@ public class GalleryAdapter extends BaseAdapter{
 	int mGalleryItemBackground;
     private Context ctx;
 
-    private ArrayList<ImageWrapper> images = new ArrayList<ImageWrapper>();
+    private ArrayList<ImageWrapper> images = new ArrayList<>();
 
     public GalleryAdapter(Context ctx, ArrayList<ImageWrapper> images) {
         this.ctx = ctx;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -41,7 +41,7 @@ public class NavDrawerListAdapter extends BaseAdapter{
 
 	//private final String TAG = "NavDrawerListAdapter";
 	private Context context;
-	private ArrayList<NavDrawerItem> navDrawerItems = new ArrayList<NavDrawerItem>();
+	private ArrayList<NavDrawerItem> navDrawerItems = new ArrayList<>();
 	
 	public int selectedMenuId = 0;
 	

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListAdapter.java
@@ -103,10 +103,10 @@ public class PrefsListAdapter extends ArrayAdapter<PrefsListItemWrapper>{
 	    					value = NumberFormat.getInstance().format(item.status) + this.activity.getString(R.string.prefs_unit_celsius);
 	    					break;
 	    				case MEGABYTES:
-	    					value = Formatter.formatShortFileSize(this.activity, (long)(item.status.doubleValue() * 0x100000));
+	    					value = Formatter.formatShortFileSize(this.activity, (long)(item.status * 0x100000));
 	    					break;
 	    				case GIGABYTES:
-	    					value = Formatter.formatShortFileSize(this.activity, (long)(item.status.doubleValue() * 0x40000000));
+	    					value = Formatter.formatShortFileSize(this.activity, (long)(item.status * 0x40000000));
 	    					break;
 	    				case DECIMAL:
 	    					value = DecimalFormat.getNumberInstance().format(item.status);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListActivity.java
@@ -45,7 +45,7 @@ public class BatchConflictListActivity extends FragmentActivity implements Indiv
 
 	private ListView lv;
 	private BatchConflictListAdapter listAdapter;
-	private ArrayList<ProjectAttachWrapper> results = new ArrayList<ProjectAttachWrapper>();
+	private ArrayList<ProjectAttachWrapper> results = new ArrayList<>();
 	
 	private ProjectAttachService attachService = null;
 	private boolean asIsBound = false;
@@ -164,7 +164,7 @@ public class BatchConflictListActivity extends FragmentActivity implements Indiv
 
 	@Override
 	public ArrayList<String> getDefaultInput() {
-		ArrayList<String> values = new ArrayList<String>();
+		ArrayList<String> values = new ArrayList<>();
 		if(asIsBound) {
 			values = attachService.getUserDefaultValues();
 		}

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.java
@@ -53,7 +53,7 @@ public class BatchProcessingActivity extends FragmentActivity{
     private static final int NUM_HINTS = 3; // number of available hint screens
     private ViewPager mPager; // pager widget, handles animation and horizontal swiping gestures
     private PagerAdapter mPagerAdapter; // provides content to pager
-	private ArrayList<HintFragment> hints = new ArrayList<HintFragment>(); // hint fragments
+	private ArrayList<HintFragment> hints = new ArrayList<>(); // hint fragments
 	
 	//header
 	private TextView hintTv;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
@@ -106,7 +106,7 @@ public class ProjectAttachService extends Service {
 
 	private PersistentStorage store;
 	
-    private ArrayList<ProjectAttachWrapper> selectedProjects = new ArrayList<ProjectAttachWrapper>();
+    private ArrayList<ProjectAttachWrapper> selectedProjects = new ArrayList<>();
     
     public boolean projectConfigRetrievalFinished = true; // shows whether project retrieval is ongoing
     
@@ -137,7 +137,7 @@ public class ProjectAttachService extends Service {
      * @return array of values, index 0: email address, index 1: user name
      */
     public ArrayList<String> getUserDefaultValues() {
-    	ArrayList<String> values = new ArrayList<String>();
+    	ArrayList<String> values = new ArrayList<>();
     	values.add(store.getLastEmailAddress());
     	values.add(store.getLastUserName());
     	return values;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
@@ -47,8 +47,8 @@ import java.util.Collections;
 public class SelectionListActivity extends FragmentActivity{
 
 	private ListView lv;
-	ArrayList<ProjectListEntry> entries = new ArrayList<ProjectListEntry>();
-	ArrayList<ProjectInfo> selected = new ArrayList<ProjectInfo>();
+	ArrayList<ProjectListEntry> entries = new ArrayList<>();
+	ArrayList<ProjectInfo> selected = new ArrayList<>();
 	
 	// services
 	private IMonitor monitor = null;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
@@ -423,7 +423,7 @@ public class ClientInterfaceImplementation extends RpcClient{
 		// less than desired number of messsages available, adapt lower bound
 		if(lowerBound < 0) lowerBound = 0;
 		ArrayList<Message> msgs= getMessages(lowerBound); // returns ever messages with seqNo > lowerBound
-		if(msgs == null) msgs = new ArrayList<Message>(); // getMessages might return null in case of parsing or IO error
+		if(msgs == null) msgs = new ArrayList<>(); // getMessages might return null in case of parsing or IO error
 		
 		if(seqNo > 0) {
 			// remove messages that are >= seqNo
@@ -454,7 +454,7 @@ public class ClientInterfaceImplementation extends RpcClient{
 		ArrayList<ProjectInfo> allProjectsList = getAllProjectsList(); // all_proejcts_list.xml
 		ArrayList<Project> attachedProjects = getState().projects; // currently attached projects
 		
-		ArrayList<ProjectInfo> attachableProjects = new ArrayList<ProjectInfo>(); // array to be filled and returned
+		ArrayList<ProjectInfo> attachableProjects = new ArrayList<>(); // array to be filled and returned
 		
 		if(allProjectsList == null || attachedProjects == null) return null;
 		

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
@@ -95,7 +95,7 @@ public class ClientInterfaceImplementation extends RpcClient{
 	 * @return GUI RPC authentication code
 	 */
 	public String readAuthToken(String authFilePath) {
-    	StringBuffer fileData = new StringBuffer(100);
+    	StringBuilder fileData = new StringBuilder(100);
     	char[] buf = new char[1024];
     	int read = 0;
     	try{

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
@@ -107,13 +107,13 @@ public class ClientNotification {
 		if(Logging.VERBOSE) Log.d(Logging.TAG, "ClientNotification: notification needs update? "+ (clientNotification.mOldComputingStatus == -1) 
 				+ activeTasksChanged
 				+ !notificationShown
-				+ (updatedStatus.computingStatus.intValue() != clientNotification.mOldComputingStatus)
+				+ (updatedStatus.computingStatus != clientNotification.mOldComputingStatus)
 				+ (updatedStatus.computingStatus == ClientStatus.COMPUTING_STATUS_SUSPENDED
 					&& updatedStatus.computingSuspendReason != clientNotification.mOldSuspendReason));
 		if (clientNotification.mOldComputingStatus == -1 
 				|| activeTasksChanged
 				|| !notificationShown
-				|| updatedStatus.computingStatus.intValue() != clientNotification.mOldComputingStatus
+				|| updatedStatus.computingStatus != clientNotification.mOldComputingStatus
 				|| (updatedStatus.computingStatus == ClientStatus.COMPUTING_STATUS_SUSPENDED
 					&& updatedStatus.computingSuspendReason != clientNotification.mOldSuspendReason)) {
 			

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
@@ -28,7 +28,7 @@ public class ClientNotification {
 	
 	private int mOldComputingStatus = -1;
 	private int mOldSuspendReason = -1;
-	private ArrayList<Result> mOldActiveTasks = new ArrayList<Result>();
+	private ArrayList<Result> mOldActiveTasks = new ArrayList<>();
 	private boolean notificationShown = false;
 	// debug foreground state by running
 	// adb shell: dumpsys activity services edu.berkeley.boinc

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -100,8 +100,8 @@ public class ClientStatus {
 	private Boolean networkParseError = false; //indicates that status could not be parsed and is therefore invalid
 	
 	// notices
-	private ArrayList<Notice> rssNotices = new ArrayList<Notice>();
-	private ArrayList<Notice> serverNotices = new ArrayList<Notice>();
+	private ArrayList<Notice> rssNotices = new ArrayList<>();
+	private ArrayList<Notice> serverNotices = new ArrayList<>();
 	private int mostRecentNoticeSeqNo = 0; 
 	
 	public ClientStatus(Context ctx) {
@@ -324,7 +324,7 @@ public class ClientStatus {
 	// images: 126 * 290 pixel from /projects/PNAME/slideshow_appname_n
 	// not aware of application!
 	public synchronized ArrayList<ImageWrapper> getSlideshowForProject(String masterUrl) {
-		ArrayList<ImageWrapper> images = new ArrayList<ImageWrapper>();
+		ArrayList<ImageWrapper> images = new ArrayList<>();
 		for(Project project: projects) {
 			if(!project.master_url.equals(masterUrl)) continue;
 			// get file paths of soft link files
@@ -336,7 +336,7 @@ public class ClientStatus {
 			});
 			if(foundFiles == null) continue; // prevent NPE
 			
-			ArrayList<String> allImagePaths = new ArrayList<String>();
+			ArrayList<String> allImagePaths = new ArrayList<>();
 			for (File file: foundFiles) {
 				String slideshowImagePath = parseSoftLinkToAbsPath(file.getAbsolutePath(), project.project_dir);
 				//check whether path is not empty, and avoid duplicates (slideshow images can 
@@ -409,7 +409,7 @@ public class ClientStatus {
 	}
 	
 	public ArrayList<Result> getExecutingTasks() {
-		ArrayList<Result> activeTasks = new ArrayList<Result>();
+		ArrayList<Result> activeTasks = new ArrayList<>();
 		for(Result tmp: results) {
 			if(tmp.active_task && tmp.active_task_state == BOINCDefs.PROCESS_EXECUTING)
 				activeTasks.add(tmp);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -664,15 +664,13 @@ public class ClientStatus {
 		// reading text of symbolic link
 		String softLinkContent = "";
 		try {
-			FileInputStream stream = new FileInputStream(softLink);
-			try {
+			try (FileInputStream stream = new FileInputStream(softLink)) {
 				FileChannel fc = stream.getChannel();
-			    MappedByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
-			    /* Instead of using default, pass in a decoder. */
-			    softLinkContent =  Charset.defaultCharset().decode(bb).toString();
-			} catch (IOException e) {if(Logging.WARNING) Log.w(Logging.TAG,"IOException in parseIconFileName()",e);}
-			finally {
-				stream.close();
+				MappedByteBuffer bb = fc.map(FileChannel.MapMode.READ_ONLY, 0, fc.size());
+				/* Instead of using default, pass in a decoder. */
+				softLinkContent = Charset.defaultCharset().decode(bb).toString();
+			} catch (IOException e) {
+				if (Logging.WARNING) Log.w(Logging.TAG, "IOException in parseIconFileName()", e);
 			}
 		} catch (Exception e) {
 			// probably FileNotFoundException

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -795,7 +795,7 @@ public class Monitor extends Service {
     private Integer getPidForProcessName(String processName) {
     	int count;
     	char[] buf = new char[1024];
-    	StringBuffer sb = new StringBuffer();
+    	StringBuilder sb = new StringBuilder();
     	
     	//run ps and read output
     	try {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -773,8 +773,8 @@ public class Monitor extends Service {
 
 			byte[] md5hash = md5.digest();
 			StringBuilder sb = new StringBuilder();
-			for (int i = 0; i < md5hash.length; ++i) {
-				sb.append(String.format("%02x", md5hash[i]));
+			for (byte singleMd5hash : md5hash) {
+				sb.append(String.format("%02x", singleMd5hash));
 			}
     		
     		return sb.toString();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
@@ -44,7 +44,7 @@ public class NoticeNotification {
 	private Integer notificationId;
 	private PendingIntent contentIntent;
 	
-	private ArrayList<Notice> currentlyNotifiedNotices = new ArrayList<Notice>();
+	private ArrayList<Notice> currentlyNotifiedNotices = new ArrayList<>();
 	private Boolean isNotificationShown = false;
 
 	//private Boolean debug = true;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrRPCReply.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrRPCReply.java
@@ -23,5 +23,5 @@ import java.util.ArrayList;
 
 public class AcctMgrRPCReply {
 	public int error_num = 0;
-	public ArrayList<String> messages = new ArrayList<String>();
+	public ArrayList<String> messages = new ArrayList<>();
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppVersionsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppVersionsParser.java
@@ -29,7 +29,7 @@ import android.util.Xml;
 
 public class AppVersionsParser extends DefaultHandler {
 
-	private ArrayList<AppVersion> mAppVersions = new ArrayList<AppVersion>();
+	private ArrayList<AppVersion> mAppVersions = new ArrayList<>();
 	private AppVersion mAppVersion = null;
 	private StringBuilder mCurrentElement = new StringBuilder();
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppsParser.java
@@ -28,7 +28,7 @@ import android.util.Xml;
 
 public class AppsParser extends BaseParser {
 
-	private ArrayList<App> mApps = new ArrayList<App>();
+	private ArrayList<App> mApps = new ArrayList<>();
 	private App mApp = null;
 
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcState.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcState.java
@@ -24,11 +24,11 @@ import java.util.ArrayList;
 public class CcState{
 	public VersionInfo version_info;
 	public HostInfo host_info;
-	public ArrayList<Project> projects = new ArrayList<Project>();
-	public ArrayList<App> apps = new ArrayList<App>();
-	public ArrayList<AppVersion> app_versions = new ArrayList<AppVersion>();
-	public ArrayList<Workunit> workunits = new ArrayList<Workunit>();
-	public ArrayList<Result> results = new ArrayList<Result>();
+	public ArrayList<Project> projects = new ArrayList<>();
+	public ArrayList<App> apps = new ArrayList<>();
+	public ArrayList<AppVersion> app_versions = new ArrayList<>();
+	public ArrayList<Workunit> workunits = new ArrayList<>();
+	public ArrayList<Result> results = new ArrayList<>();
 	public boolean have_ati;
 	public boolean have_cuda;
 	

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Md5.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Md5.java
@@ -46,8 +46,8 @@ public class Md5 {
 			md5.update(text.getBytes("iso-8859-1"), 0, text.length());
 			byte[] md5hash = md5.digest();
 			StringBuilder sb = new StringBuilder();
-			for (int i = 0; i < md5hash.length; ++i) {
-				sb.append(String.format("%02x", md5hash[i]));
+			for (byte singleMd5hash : md5hash) {
+				sb.append(String.format("%02x", singleMd5hash));
 			}
 			return sb.toString();
 		}

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessagesParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessagesParser.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 
 public class MessagesParser {
 
-	private ArrayList<Message> mMessages = new ArrayList<Message>();
+	private ArrayList<Message> mMessages = new ArrayList<>();
 	//private Message mMessage = null;
 
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/NoticesParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/NoticesParser.java
@@ -30,7 +30,7 @@ import android.util.Xml;
 public class NoticesParser extends BaseParser {
 	
 	private Notice mNotice = null;
-	private ArrayList<Notice> mNotices = new ArrayList<Notice>();
+	private ArrayList<Notice> mNotices = new ArrayList<>();
 
 	public final ArrayList<Notice> getNotices() {
 		return mNotices;
@@ -44,7 +44,7 @@ public class NoticesParser extends BaseParser {
 		}
 		catch (SAXException e) {
 			Log.d("NoticesParser","SAXException " + e.getMessage() + e.getException());
-			return new ArrayList<Notice>();
+			return new ArrayList<>();
 		}
 	}
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.java
@@ -35,7 +35,7 @@ public class Project implements Parcelable{
 	public String  team_name = "";
 	public String  venue = "";
 	public int     hostid = 0;
-	public ArrayList<GuiUrl> gui_urls = new ArrayList<GuiUrl>();
+	public ArrayList<GuiUrl> gui_urls = new ArrayList<>();
 	public double  user_total_credit = 0.0;
 	public double  user_expavg_credit = 0.0;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectAttachReply.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectAttachReply.java
@@ -22,5 +22,5 @@ import java.util.ArrayList;
 
 public class ProjectAttachReply {
 	public int error_num = 0;
-	public ArrayList<String> messages = new ArrayList<String>();
+	public ArrayList<String> messages = new ArrayList<>();
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfig.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfig.java
@@ -41,7 +41,7 @@ public class ProjectConfig implements Parcelable{
 	public Boolean accountManager = false;
 	public Integer minClientVersion = 0;
 	public String rpcPrefix = "";
-	public ArrayList<PlatformInfo> platforms = new ArrayList<PlatformInfo>();
+	public ArrayList<PlatformInfo> platforms = new ArrayList<>();
 	public String termsOfUse;
 	
 	/**

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfigReplyParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfigReplyParser.java
@@ -67,7 +67,7 @@ public class ProjectConfigReplyParser extends BaseParser {
 			mProjectConfig = new ProjectConfig();
 		} else if (localName.equalsIgnoreCase("platforms")) {
 			withinPlatforms = true;
-			mPlatforms = new ArrayList<PlatformInfo>(); //initialize new list (flushing old elements)
+			mPlatforms = new ArrayList<>(); //initialize new list (flushing old elements)
 		}
 		else {
 			// Another element, hopefully primitive and not constructor

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectInfoParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectInfoParser.java
@@ -27,7 +27,7 @@ import android.util.Xml;
 
 public class ProjectInfoParser extends BaseParser {
 
-	private ArrayList<ProjectInfo> mProjectInfos = new ArrayList<ProjectInfo>();
+	private ArrayList<ProjectInfo> mProjectInfos = new ArrayList<>();
 	private ProjectInfo mProjectInfo = null;
 	private ArrayList<String> mPlatforms;
 	Boolean withinPlatforms = false;
@@ -55,7 +55,7 @@ public class ProjectInfoParser extends BaseParser {
 		if (localName.equalsIgnoreCase("project")) {
 			mProjectInfo = new ProjectInfo();
 		} else if (localName.equalsIgnoreCase("platforms")) {
-			mPlatforms = new ArrayList<String>(); //initialize new list (flushing old elements)
+			mPlatforms = new ArrayList<>(); //initialize new list (flushing old elements)
 			withinPlatforms = true;
 		}
 		else {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectsParser.java
@@ -28,7 +28,7 @@ import android.util.Xml;
 
 public class ProjectsParser extends BaseParser {
 
-	private ArrayList<Project> mProjects = new ArrayList<Project>();
+	private ArrayList<Project> mProjects = new ArrayList<>();
 	private Project mProject = null;
 	private GuiUrl mGuiUrl = null;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ResultsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ResultsParser.java
@@ -27,7 +27,7 @@ import android.util.Xml;
 
 public class ResultsParser extends BaseParser {
 
-	private ArrayList<Result> mResults = new ArrayList<Result>();
+	private ArrayList<Result> mResults = new ArrayList<>();
 	private Result mResult = null;
 	private boolean mInActiveTask = false;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -530,12 +530,12 @@ public class RpcClient {
 			}
 			sendRequest(request);
 			ArrayList<Notice> notices = NoticesParser.parse(receiveReply());
-			if(notices == null) notices = new ArrayList<Notice>(); // do not return null
+			if(notices == null) notices = new ArrayList<>(); // do not return null
 			return notices;
 		}
 		catch (IOException e) {
 			if(Logging.WARNING) Log.w(Logging.TAG, "error in getMessages()", e);
-			return new ArrayList<Notice>();
+			return new ArrayList<>();
 		}
 	}
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -181,7 +181,7 @@ public class RpcClient {
 			return false;
 		}
 		catch (IOException e) {
-			if(Logging.WARNING) Log.w(Logging.TAG, "connect failure", e);
+			if(Logging.WARNING) Log.w(Logging.TAG, "connect failure: IO", e);
 			mSocket = null;
 			return false;
 		}

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/TransfersParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/TransfersParser.java
@@ -28,7 +28,7 @@ import android.util.Xml;
 
 public class TransfersParser extends BaseParser {
 
-	private ArrayList<Transfer> mTransfers = new ArrayList<Transfer>();
+	private ArrayList<Transfer> mTransfers = new ArrayList<>();
 	private Transfer mTransfer = null;
 
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/WorkunitsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/WorkunitsParser.java
@@ -27,7 +27,7 @@ import android.util.Xml;
 
 public class WorkunitsParser extends BaseParser {
 
-	private ArrayList<Workunit> mWorkunits = new ArrayList<Workunit>();
+	private ArrayList<Workunit> mWorkunits = new ArrayList<>();
 	private Workunit mWorkunit = null;
 
 


### PR DESCRIPTION
**Description of the Change**
Fixed the following code inspections in the `Java language level migration aids` category:

_'for' loop replaceable with 'foreach'_
Reports for loops which iterate over collections or arrays, and can be replaced with the foreach iteration syntax, available in Java 5 and newer.

_'StringBuffer' may be 'StringBuilder'_
Reports any variables declared as java.lang.StringBuffer which may be more efficiently declared as java.lang.StringBuilder.

_Unnecessary boxing_
Reports explicit boxing, i.e. wrapping of primitive values in objects. Explicit manual boxing is unnecessary under Java 5 and newer, and can be safely removed.

_Unnecessary unboxing_
Reports "unboxing", e.g. explicit unwrapping of wrapped primitive values. Unboxing is unnecessary under Java 5 and newer, and can be safely removed.

_Explicit type can be replaced with <>_
This inspection reports all new expressions with type arguments which can be replaced with diamond type <>

_'try' can use automatic resource management_
Reports try finally statements which can use Java 7 Automatic Resource Management. A quickfix is available to convert the try finally statement into a try with resources statement.

_Identical 'catch' branches in 'try' statement_
Reports identical catch sections in try blocks under JDK 7. A quickfix is available to collapse the sections into a multi-catch section.

**Release Notes**
N/A
