### PR TITLE
[Android] Update NDK to r18b.

### DIFF
--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -21,7 +21,7 @@ set -e
 
 export OPENSSL_VERSION=1.0.2q
 export CURL_VERSION=7.62.0
-export NDK_VERSION=17c
+export NDK_VERSION=18b
 
 export ANDROID_HOME=$HOME/Android/Sdk
 export NDK_ROOT=$HOME/Android/Ndk


### PR DESCRIPTION
**Description of the Change**
The #2680 made the project compatible with the NDK r18b, but the build script has never been updated from r17c.

**Question**
- `android/build_androidtc_arm.sh`,
- `android/build_androidtc_arm64.sh`
- `android/build_androidtc_x86.sh`
- `android/build_androidtc_x86_64.sh`

has a line: `export NDK_ROOT="${NDK_ROOT:-$HOME/NVPACK/android-ndk-r10e}"`
How is it releated to the build script, becase the NDK r10e is fairly old, so it's surprising that even works.

**Release Notes**
N/A
