### PR TITLE
Drupal: Modified work_and_host_stats Feature.

### DIFF
--- a/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.pages_default.inc
+++ b/drupal/sites/all/features/work_and_host_stats/work_and_host_stats.pages_default.inc
@@ -135,7 +135,7 @@ function work_and_host_stats_default_page_manager_pages() {
   $display->title_pane = '0';
   $handler->conf['display'] = $display;
   $page->default_handlers[$handler->name] = $handler;
-  $pages['page_stats'] = $page;
+  $pages[''] = $page;
 
  return $pages;
 


### PR DESCRIPTION
**Description of the Change**

As part of PHP7 upgrade, this Feature cannot be reverted. This attempts
to fix that by changing the Feature.

https://dev.gridrepublic.org/browse/DBOINCP-468
