### PR TITLE
[Android] Update target SDK to 28 (Android 9)

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -47,13 +47,13 @@ def buildVersionName() {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "edu.berkeley.boinc"
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode buildVersionCode()
         versionName buildVersionName()
     }
@@ -71,5 +71,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:28.0.0'
 }

--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -71,5 +71,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:26.0.2'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
 }


### PR DESCRIPTION
Closes #2891

**Description of the Change**
Fix 'Target SDK attribute is not targeting latest version' inspection.

When your application runs on a version of Android that is more recent than your targetSdkVersion specifies that it has been tested with, various compatibility modes kick in. This ensures that your application continues to work, but it may look out of place. For example, if the targetSdkVersion is less than 14, your app may get an option button in the UI.  To fix this issue, set the targetSdkVersion to the highest available value. Then test your app to make sure everything works correctly. You may want to consult the compatibility notes to see what changes apply to each version you are adding support for: http://developer.android.com/reference/android/os/Build.VERSION_CODES.html as well as follow this guide: https://developer.android.com/distribute/best-practices/develop/target-sdk.html

**Release Notes**
Add Android 9 (Pie) compatibility.