### PR TITLE
[Android] Fix verbose or redundant code constructs inspections

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
@@ -174,6 +174,5 @@ public class SplashActivity extends Activity {
     	notExclusiveDialogIntent.setClassName("edu.berkeley.boinc", "edu.berkeley.boinc.BoincNotExclusiveDialog");
 	    startActivity(notExclusiveDialogIntent);
 		finish();
-		return;
 	}
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
@@ -99,7 +99,7 @@ public class TasksListAdapter extends ArrayAdapter<TaskData>{
 		ImageView expandButton = v.findViewById(R.id.expandCollapse);
 		
 		// --- set up view elements that are independent of "active" and "expanded" state
-		ImageView ivIcon = (ImageView)v.findViewById(R.id.projectIcon);
+		ImageView ivIcon = v.findViewById(R.id.projectIcon);
 		String finalIconId = (String)ivIcon.getTag();
 	    if(finalIconId == null || !finalIconId.equals(listItem.id)) {
 			Bitmap icon = getIcon(position);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -319,7 +319,7 @@ public class RpcClient {
 	 */
 	protected void sendRequest(String request) throws IOException {
 		if (Logging.RPC_PERFORMANCE) if(Logging.DEBUG) Log.d(Logging.TAG, "mRequest.capacity() = " + mRequest.capacity());
-		if (Logging.RPC_DATA) if(Logging.DEBUG) Log.d(Logging.TAG, "Sending request: \n" + request.toString());
+		if (Logging.RPC_DATA) if(Logging.DEBUG) Log.d(Logging.TAG, "Sending request: \n" + request);
 		if (mOutput == null)
 			return;
 		mOutput.write("<boinc_gui_rpc_request>\n");


### PR DESCRIPTION
**Description of the Change**
- Fix Redundant String operation inspection.
- Fix Redundant type cast inspection.
- Fix Unnecessary 'return' statement inspections. 

**Alternate Designs**
There are 3 other Unnecessary 'return' statement warnings in the `ClientStatus.java`, but IMO they add readability and undesirability to the code.

**Release Notes**
N/A
