### PR TITLE
[Android] Fix Dangling Javadoc comment inspections

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import android.app.Dialog;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BoincNotExclusiveDialog.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BoincNotExclusiveDialog.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import android.app.Activity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivityTabListener.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivityTabListener.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2013 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import android.support.v4.app.Fragment;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogClientFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogClientFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.adapter.ClientLogListAdapter;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogGuiFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogGuiFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/NoticesFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/NoticesFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import android.app.Dialog;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.attach.SelectionListActivity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/StatusFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/StatusFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ClientLogListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ClientLogListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/GalleryAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/GalleryAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import java.util.ArrayList;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import edu.berkeley.boinc.BOINCActivity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NoticesListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NoticesListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListItemWrapper.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListItemWrapper.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import edu.berkeley.boinc.R;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListItemWrapperBool.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListItemWrapperBool.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import android.content.Context;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListItemWrapperValue.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListItemWrapperValue.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import android.content.Context;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsSelectionDialogListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsSelectionDialogListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import java.util.ArrayList;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectControlsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectControlsListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import java.util.ArrayList;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
@@ -1,21 +1,21 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
- * 
+ *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation,
  * either version 3 of the License, or (at your option) any later version.
- * 
+ *
  * BOINC is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListActivity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.attach;
 
 import java.util.ArrayList;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/CredentialInputActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/CredentialInputActivity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/HintFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/HintFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/IndividualCredentialInputFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/IndividualCredentialInputFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.attach;
 
 import java.util.ArrayList;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectInfoFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectInfoFragment.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.attach;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.attach;
 
 import java.util.ArrayList;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.client;
 
 import edu.berkeley.boinc.R;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
@@ -57,9 +57,6 @@ public class ClientNotification {
 	}
 
 	/**
-	 * Updates notification with client's current status
-	 */
-	/**
 	 * Updates notification with client's current status. Notifies if not present. Checking notification related preferences.
 	 * @param updatedStatus client status data
 	 * @param service reference to service, sets to foreground if active

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.client;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.client;
 
 import edu.berkeley.boinc.rpc.DeviceStatusData;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.client;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
   This file is part of BOINC.
   http://boinc.berkeley.edu
   Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
   
   You should have received a copy of the GNU Lesser General Public License
   along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
-*******************************************************************************/
+**/
 package edu.berkeley.boinc.client;
 
 import android.annotation.SuppressLint;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.client;
 
 import android.content.Context;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/mutex/BoincMutex.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/mutex/BoincMutex.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2014 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.mutex;
 
 import java.io.IOException;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/BootReceiver.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/BootReceiver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.receiver;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PackageReplacedReceiver.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PackageReplacedReceiver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.receiver;
 
 import edu.berkeley.boinc.utils.*;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PowerConnectedReceiver.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PowerConnectedReceiver.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.receiver;
 
 import edu.berkeley.boinc.client.Monitor;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountIn.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountIn.java
@@ -1,21 +1,21 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
- * 
+ *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation,
  * either version 3 of the License, or (at your option) any later version.
- * 
+ *
  * BOINC is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import android.os.Parcel;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountOut.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountOut.java
@@ -1,21 +1,21 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
- * 
+ *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
  * as published by the Free Software Foundation,
  * either version 3 of the License, or (at your option) any later version.
- * 
+ *
  * BOINC is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import android.os.Parcel;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountOutParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountOutParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import org.xml.sax.Attributes;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrInfo.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrInfo.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrInfoParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrInfoParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrRPCReply.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrRPCReply.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrRPCReplyParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrRPCReplyParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/App.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/App.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppVersion.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppVersion.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppVersionsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppVersionsParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AppsParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/BaseParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/BaseParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Boinc.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Boinc.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcState.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcState.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcStateParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcStateParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcStatus.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcStatusParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/CcStatusParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/DeviceStatusData.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/DeviceStatusData.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 public class DeviceStatusData {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferences.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferences.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import android.os.Parcel;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferencesParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferencesParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import org.xml.sax.Attributes;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GuiUrl.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GuiUrl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/HostInfo.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/HostInfo.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/HostInfoParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/HostInfoParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Md5.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Md5.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 
 package edu.berkeley.boinc.rpc;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Message.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Message.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 
 package edu.berkeley.boinc.rpc;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessageCountParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessageCountParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessagesParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/MessagesParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Notice.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Notice.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/NoticesParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/NoticesParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/PlatformInfo.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/PlatformInfo.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectAttachReply.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectAttachReply.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import java.util.ArrayList;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectAttachReplyParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectAttachReplyParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import org.xml.sax.Attributes;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfig.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfig.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfigReplyParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectConfigReplyParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectInfo.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectInfo.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectInfoParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectInfoParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectsParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Result.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Result.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ResultsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ResultsParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2016 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/SimpleReplyParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/SimpleReplyParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/TimePreferences.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/TimePreferences.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.rpc;
 
 import java.util.Locale;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Transfer.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Transfer.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/TransfersParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/TransfersParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/VersionInfo.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/VersionInfo.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/VersionInfoParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/VersionInfoParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Workunit.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Workunit.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/WorkunitsParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/WorkunitsParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 
 package edu.berkeley.boinc.rpc;
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCDefs.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCDefs.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.utils;
 
 /*

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCErrors.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCErrors.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.utils;
 
 /*

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/Logging.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/Logging.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
  * Copyright (C) 2012 University of California
@@ -15,7 +15,7 @@
  * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************/
+ */
 package edu.berkeley.boinc.utils;
 
 public class Logging {


### PR DESCRIPTION
**Description of the Change**
Because of the multiple `*` signs the comments was parsed as Javadocs which resulted 100 warnings.
This PR not effect the code at all, just standardize the comments.

**Release Notes**
N/A
