### PR TITLE
Enforcing idle CPU scheduling policy

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -14,6 +14,7 @@ ExecStop=@exec_prefix@/bin/boinccmd --quit
 ExecReload=@exec_prefix@/bin/boinccmd --read_cc_config
 ExecStopPost=/bin/rm -f lockfile
 IOSchedulingClass=idle
+CPUSchedulingPolicy=idle
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Description of the Change**
Pull request https://github.com/BOINC/boinc/pull/1878
changed CPU scheduling policy from SCHED_BATCH to SCHED_IDLE. This pull request enforces such configuration by adding a flag in BOINC systemd unit file

**Release Notes**
Enforcing idle CPU scheduling policy in BOINC systemd unit file