### PR TITLE
[Linux] change nice level to 19

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -6,7 +6,7 @@ After=network-online.target
 [Service]
 ProtectHome=true
 Type=simple
-Nice=10
+Nice=19
 User=boinc
 WorkingDirectory=/var/lib/boinc
 ExecStart=@exec_prefix@/bin/boinc


### PR DESCRIPTION
**Description of the Change**
In past, In BOINC systemd unit file, nice level has been setted to 10, because in [this comment](https://github.com/BOINC/boinc/pull/2260#issuecomment-360619802) 

> Normally the client run GPU apps, wrappers and non-compute intensive apps at nice level 10. If you run the client at nice level 19 that won't be possible.

I runned some tests on Fedora 29 with systemd unit file flag nice=19 and:
- all processes related to BOINC (working units, wrappers, VirtualBox virtual machines,etc.) run at same nice=19 level;
- GPU calculus works fine;
- working units that use VirtualBox (like Theory Simulation 263.90 (vbox64_mt_mcore)) works fine.
I will also continue the testing in next days.

**Release Notes**
[Linux] changed nice level to 19
