### PR TITLE
[Android] Fix to return the user name with the team name.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
@@ -77,9 +77,12 @@ public class ProjectsListAdapter extends ArrayAdapter<ProjectsListData> {
 	public String getUser(int position) {
 		String user = entries.get(position).project.user_name;
 		String team = entries.get(position).project.team_name;
-		String userString = user;
-		if(!team.isEmpty()) user = user + " (" + team + ")";
-		return userString;
+
+		if(!team.isEmpty()) {
+			return (user + " (" + team + ")");
+		}
+
+		return user;
 	}
 	
 	public Boolean getIsAcctMgr(int position) {


### PR DESCRIPTION
Fixes #2905

**Description of the Change**
- The getUser never returned the team name, even it was available. This is fixed.
- Saved one `String` variable.

**Alternate Designs**
Nope.

**Release Notes**
[Android] Show the team name with the username in the project tab.