### PR TITLE
[Android] Fix number comparison

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
@@ -336,7 +336,7 @@ public class BOINCActivity extends AppCompatActivity {
 		try {
 			if(mIsBound) { 
 				Integer newComputingStatus = monitor.getComputingStatus();
-				if(newComputingStatus != clientComputingStatus) {
+				if(!newComputingStatus.equals(clientComputingStatus)) {
 					// computing status has changed, update and invalidate to force adaption of action items
 					clientComputingStatus = newComputingStatus;
 					supportInvalidateOptionsMenu();


### PR DESCRIPTION
**Description of the Change**
Fix number comparison using '==', instead of 'equals()'.
Reports any use of == or != to test for Number equality, rather than the equals() method. With auto-boxing it is easy to make the mistake of comparing two Integer (or other subclasses of java.lang.Number) objects instead of two ints.

**Release Notes**
N/A
