### PR TITLE
[Android] Fix incorrect constants.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
@@ -53,7 +53,7 @@ public class ClientNotification {
 		Intent intent = new Intent(context, BOINCActivity.class);
 		intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP); 
 		intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-		contentIntent = PendingIntent.getActivity(context, 0, intent, Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+		contentIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
 	}
 
 	/**


### PR DESCRIPTION
**Description of the Change**
`PendingIntent` function needs `PendingIntent` constant not normal `Intent`.

**Alternate Designs**
`FLAG_CANCEL_CURRENT` could be used instead of the `FLAG_UPDATE_CURRENT`

**Release Notes**
N/A
