### PR TITLE
[Android] Fix WifiManager Leak issue.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -113,8 +113,10 @@ public class ClientStatus {
 		wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, Logging.TAG);
 		wakeLock.setReferenceCounted(false); // "one call to release() is sufficient to undo the effect of all previous calls to acquire()"
 		
-		// set up Wifi wake lock
-		WifiManager wm = (WifiManager) ctx.getSystemService(Context.WIFI_SERVICE);
+		// Set up Wifi wake lock
+		// On versions prior to Android N (24), initializing the WifiManager via Context#getSystemService can cause a memory leak if the context is not the application context.
+		// You should consider using context.getApplicationContext().getSystemService() rather then context.getSystemService()
+		WifiManager wm = (WifiManager) ctx.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
 		wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL , "MyWifiLock");
 		wifiLock.setReferenceCounted(false);
 	}


### PR DESCRIPTION
**Description of the Change**
On versions prior to Android N (API 24), initializing the `WifiManager` via `Context#getSystemService` can cause a memory leak if the context is not the application context.  In many cases, it's not obvious from the code where the Context is coming from (e.g. it might be a parameter to a method, or a field initialized from various method calls). It's possible that the context being passed in is the application context, but to be on the safe side, you should consider changing `context.getSystemService()` to `context.getApplicationContext().getSystemService()`.

**Alternate Designs**
Update the minimum API to 24.

**Release Notes**
[Android] Fix WifiManager Leak issue on devices prior to Android 7.
