### PR TITLE
[Android] Add 'Bug report' menu item

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
@@ -274,7 +274,7 @@ public class BOINCActivity extends AppCompatActivity {
 	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://boinc.berkeley.edu/wiki/BOINC_Help")));
 	    		break;
 	    	case R.string.menu_bug_report:
-	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/BOINC/boinc/issues")));
+	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://boinc.berkeley.edu/forum_forum.php?id=24")));
 	    		break;
 	    	case R.string.menu_about:
 				final Dialog dialog = new Dialog(this);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
@@ -271,8 +271,10 @@ public class BOINCActivity extends AppCompatActivity {
 				fragmentChanges = true;
 				break;
 	    	case R.string.menu_help:
-	    		Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse("http://boinc.berkeley.edu/wiki/BOINC_Help"));
-	    		startActivity(i);
+	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://boinc.berkeley.edu/wiki/BOINC_Help")));
+	    		break;
+	    	case R.string.menu_bug_report:
+	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/BOINC/boinc/issues")));
 	    		break;
 	    	case R.string.menu_about:
 				final Dialog dialog = new Dialog(this);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
@@ -273,8 +273,8 @@ public class BOINCActivity extends AppCompatActivity {
 	    	case R.string.menu_help:
 	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://boinc.berkeley.edu/wiki/BOINC_Help")));
 	    		break;
-	    	case R.string.menu_bug_report:
-	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://boinc.berkeley.edu/forum_forum.php?id=24")));
+	    	case R.string.menu_report_issue:
+	    		startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://boinc.berkeley.edu/trac/wiki/ReportBugs")));
 	    		break;
 	    	case R.string.menu_about:
 				final Dialog dialog = new Dialog(this);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -55,7 +55,7 @@ public class NavDrawerListAdapter extends BaseAdapter{
 		navDrawerItems.add(new NavDrawerItem(R.string.projects_add, R.drawable.sqplusb, false, true));
 		navDrawerItems.add(new NavDrawerItem(R.string.tab_preferences, R.drawable.cogsb));
 		navDrawerItems.add(new NavDrawerItem(R.string.menu_help, R.drawable.helpb));
-		navDrawerItems.add(new NavDrawerItem(R.string.menu_bug_report, R.drawable.bugb));
+		navDrawerItems.add(new NavDrawerItem(R.string.menu_report_issue, R.drawable.bugb));
 		navDrawerItems.add(new NavDrawerItem(R.string.menu_about, R.drawable.infob));
 		navDrawerItems.add(new NavDrawerItem(R.string.menu_eventlog, R.drawable.attentionb));
 	}

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -55,8 +55,9 @@ public class NavDrawerListAdapter extends BaseAdapter{
 		navDrawerItems.add(new NavDrawerItem(R.string.projects_add, R.drawable.sqplusb, false, true));
 		navDrawerItems.add(new NavDrawerItem(R.string.tab_preferences, R.drawable.cogsb));
 		navDrawerItems.add(new NavDrawerItem(R.string.menu_help, R.drawable.helpb));
+		navDrawerItems.add(new NavDrawerItem(R.string.menu_bug_report, R.drawable.bugb));
 		navDrawerItems.add(new NavDrawerItem(R.string.menu_about, R.drawable.infob));
-		navDrawerItems.add(new NavDrawerItem(R.string.menu_eventlog, R.drawable.bugb));
+		navDrawerItems.add(new NavDrawerItem(R.string.menu_eventlog, R.drawable.attentionb));
 	}
 
 	@Override

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -366,6 +366,7 @@
     <string name="menu_run_mode_enable">Resume</string>
     <string name="menu_about">About</string>
     <string name="menu_help">Help</string>
+    <string name="menu_bug_report">Bug report</string>
 
     <!-- about dialog -->
     <string name="about_button">Return</string>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -366,7 +366,7 @@
     <string name="menu_run_mode_enable">Resume</string>
     <string name="menu_about">About</string>
     <string name="menu_help">Help</string>
-    <string name="menu_bug_report">Bug report</string>
+    <string name="menu_report_issue">Report Issue</string>
 
     <!-- about dialog -->
     <string name="about_button">Return</string>


### PR DESCRIPTION
#2937 
This PR does not close the issue, because this feature can be implemented in the desktop version too.

**Description of the Change**
- Add 'Bug report' menu item, which redirects to [GitHub/issues](https://github.com/BOINC/boinc/issues). 
- 'Help menu' link changed to https.
- Switch Bug report and Event Log menu icons.

**Release Notes**
[Android] Add Bug report menu item.

**Screenshot**
![screenshot_20181227-170424_boinc](https://user-images.githubusercontent.com/16503773/50486561-dc0fae80-09fa-11e9-8d20-b571ddf9de39.png)

