### PR TITLE
[Android] Clean up the MIPS architecture.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -286,7 +286,7 @@ public class Monitor extends Service {
     }
 	
 	/**
-	 * Determines BOINC platform name corresponding to device's cpu architecture (ARM, x86 or MIPS).
+	 * Determines BOINC platform name corresponding to device's cpu architecture (ARM, x86).
 	 * Defaults to ARM
 	 * @return ID of BOINC platform name string in resources
 	 */
@@ -296,10 +296,8 @@ public class Monitor extends Service {
 		String normalizedArch = arch.toUpperCase(Locale.US);
 		if (normalizedArch.contains("AARCH64")) platformId = R.string.boinc_platform_name_arm64;
 		else if (normalizedArch.contains("ARM64")) platformId = R.string.boinc_platform_name_arm64;
-		else if (normalizedArch.contains("MIPS64")) platformId = R.string.boinc_platform_name_mips64;
-	    else if (normalizedArch.contains("X86_64")) platformId= R.string.boinc_platform_name_x86_64;
+		else if (normalizedArch.contains("X86_64")) platformId= R.string.boinc_platform_name_x86_64;
 		else if (normalizedArch.contains("ARM")) platformId = R.string.boinc_platform_name_arm;
-		else if (normalizedArch.contains("MIPS")) platformId = R.string.boinc_platform_name_mips;
 	    else if (normalizedArch.contains("86")) platformId= R.string.boinc_platform_name_x86;
 	    else {
 	    	if(Logging.ERROR) Log.w(Logging.TAG,"could not map os.arch (" + arch + ") to platform, default to arm.");
@@ -311,7 +309,7 @@ public class Monitor extends Service {
 	}
 	
 	/**
-	 * Determines BOINC alt platform name corresponding to device's cpu architecture (ARM, x86 or MIPS).
+	 * Determines BOINC alt platform name corresponding to device's cpu architecture (ARM, x86).
 	 * @return  BOINC platform name string in resources
 	 */
 	public String getBoincAltPlatform() {
@@ -320,7 +318,6 @@ public class Monitor extends Service {
 		String normalizedArch = arch.toUpperCase(Locale.US);
 		if (normalizedArch.contains("AARCH64")) platformName = getString(R.string.boinc_platform_name_arm);
 		else if (normalizedArch.contains("ARM64")) platformName = getString(R.string.boinc_platform_name_arm);
-		else if (normalizedArch.contains("MIPS64")) platformName = getString(R.string.boinc_platform_name_mips);
 	    else if (normalizedArch.contains("X86_64")) platformName = getString(R.string.boinc_platform_name_x86);
 	    
 	    if(Logging.ERROR) Log.d(Logging.TAG,"BOINC Alt platform: " + platformName + " for os.arch: " + arch);
@@ -732,7 +729,7 @@ public class Monitor extends Service {
     }
 	
 	/**
-	 * Determines assets directory (contains BOINC client binaries) corresponding to device's cpu architecture (ARM, x86 or MIPS)
+	 * Determines assets directory (contains BOINC client binaries) corresponding to device's cpu architecture (ARM, x86)
 	 * @return name of assets directory for given platform, not an absolute path.
 	 */
 	private String getAssestsDirForCpuArchitecture() {
@@ -749,12 +746,6 @@ public class Monitor extends Service {
 			break;
 		case R.string.boinc_platform_name_x86_64:
 			archAssetsDirectory = getString(R.string.assets_dir_x86_64);
-			break;
-		case R.string.boinc_platform_name_mips:
-			archAssetsDirectory = getString(R.string.assets_dir_mips);
-			break;
-		case R.string.boinc_platform_name_mips64:
-			archAssetsDirectory = getString(R.string.assets_dir_mips64);
 			break;
 		}
 	    return archAssetsDirectory;

--- a/android/BOINC/app/src/main/res/values/configuration.xml
+++ b/android/BOINC/app/src/main/res/values/configuration.xml
@@ -29,13 +29,11 @@
         <string name="global_prefs_override" translatable="false">global_prefs_override.xml</string>
         <string name="assets_dir_arm64" translatable="false">arm64-v8a/</string><string name="assets_dir_arm" translatable="false">armeabi-v7a/</string>
         <string name="assets_dir_x86_64" translatable="false">x86_64/</string><string name="assets_dir_x86" translatable="false">x86/</string>
-        <string name="assets_dir_mips64" translatable="false">mips64/</string><string name="assets_dir_mips" translatable="false">mips/</string>
     <!-- client socket address, CAUTION: change this if you are building branded BOINC app to avoid interference btwn apps! -->
         <string name="client_socket_address" translatable="false">edu_berkeley_boinc_client_socket</string>
     <!-- BOINC platform -->
     	<string name="boinc_platform_name_arm64" translatable="false">aarch64-android-linux-gnu</string><string name="boinc_platform_name_arm" translatable="false">arm-android-linux-gnu</string>
     	<string name="boinc_platform_name_x86_64" translatable="false">x86_64-android-linux-gnu</string><string name="boinc_platform_name_x86" translatable="false">x86-android-linux-gnu</string>
-    	<string name="boinc_platform_name_mips64" translatable="false">mips64el-android-linux-gnu</string><string name="boinc_platform_name_mips" translatable="false">mipsel-android-linux-gnu</string>
     <!-- Default preferences of Android app-->
     	<bool name="prefs_default_autostart">true</bool>
         <bool name="prefs_default_notification_notices">true</bool>


### PR DESCRIPTION
**Description of the Change**
The MIPS architecture has been dropped in #2680. This PR cleans up the rest of the code.

**Release Notes**
N/A
