### PR TITLE
Drupal: Modified email messages to remove language code.

### DIFF
--- a/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
+++ b/drupal/sites/all/features/boinc_standard/boinc_standard.features.inc
@@ -201,10 +201,10 @@ function boinc_standard_node_info() {
 function boinc_standard_rules_defaults() {
   return array(
     'rules' => array(
-      'rules_forum_topic_marked_sticky_by_moderator_admin' => array(
+      'rules_comment_converted_to_new_forum_topic_by_moderator_or_admin' => array(
         '#type' => 'rule',
-        '#set' => 'event_node_update',
-        '#label' => 'Forum topic marked sticky by moderator/admin',
+        '#set' => 'event_boinccore_comment_convert',
+        '#label' => 'Comment is converted to new forum topic by moderator or admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -212,138 +212,7 @@ function boinc_standard_rules_defaults() {
           '1' => 'moderator notification',
         ),
         '#status' => 'default',
-        '#conditions' => array(
-          '0' => array(
-            '#type' => 'condition',
-            '#settings' => array(
-              'roles' => array(
-                '0' => 3519698132,
-                '1' => 1271379760,
-              ),
-              'operation' => 'OR',
-              '#argument map' => array(
-                'user' => 'user',
-              ),
-            ),
-            '#name' => 'rules_condition_user_hasrole',
-            '#info' => array(
-              'label' => 'User has role(s): administrator or moderator',
-              'label callback' => FALSE,
-              'arguments' => array(
-                'user' => array(
-                  'type' => 'user',
-                  'label' => 'User',
-                ),
-              ),
-              'module' => 'User',
-            ),
-            '#weight' => 0,
-          ),
-          '1' => array(
-            '#weight' => 0,
-            '0' => array(
-              '#weight' => 0,
-              '#type' => 'condition',
-              '#settings' => array(
-                'type' => array(
-                  'forum' => 'forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#name' => 'rules_condition_content_is_type',
-              '#info' => array(
-                'label' => 'Updated content is Forum topic',
-                'arguments' => array(
-                  'node' => array(
-                    'type' => 'node',
-                    'label' => 'Content',
-                  ),
-                ),
-                'module' => 'Node',
-              ),
-            ),
-            '#type' => 'OR',
-            '1' => array(
-              '#type' => 'condition',
-              '#settings' => array(
-                'type' => array(
-                  'team_forum' => 'team_forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#name' => 'rules_condition_content_is_type',
-              '#info' => array(
-                'label' => 'Updated content is Team forum topic',
-                'arguments' => array(
-                  'node' => array(
-                    'type' => 'node',
-                    'label' => 'Content',
-                  ),
-                ),
-                'module' => 'Node',
-              ),
-              '#weight' => 0,
-            ),
-          ),
-          '3' => array(
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'PHP code: node content unchanged',
-              'label callback' => FALSE,
-              'module' => 'PHP',
-              'eval input' => array(
-                '0' => 'code',
-              ),
-            ),
-            '#name' => 'rules_condition_custom_php',
-            '#settings' => array(
-              'code' => 'return $node->body == $node_unchanged->body;',
-              'vars' => array(
-                '0' => 'node',
-                '1' => 'node_unchanged',
-              ),
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'code' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-            '#type' => 'condition',
-          ),
-          '4' => array(
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'PHP code: node made sticky',
-              'label callback' => FALSE,
-              'module' => 'PHP',
-              'eval input' => array(
-                '0' => 'code',
-              ),
-            ),
-            '#name' => 'rules_condition_custom_php',
-            '#type' => 'condition',
-            '#settings' => array(
-              'code' => 'return $node_unchanged->sticky == 0 && $node->sticky == 1;',
-              'vars' => array(
-                '0' => 'node',
-                '1' => 'node_unchanged',
-              ),
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'code' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
+        '#conditions' => array(),
         '#actions' => array(
           '0' => array(
             '#info' => array(
@@ -358,189 +227,53 @@ function boinc_standard_rules_defaults() {
             '#name' => 'boinccore_rules_action_mail_to_moderators',
             '#settings' => array(
               'from' => '',
-              'subject' => 'Forum topic at [:global:site-name] marked sticky by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been marked sticky by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'subject' => 'Comment at [:global:site-name] converted to new forum topic',
+              'message' => "Comment has been converted to new forum topic by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
                     '0' => ':global',
                   ),
                   'message' => array(
-                    '0' => 'node',
-                    '1' => 'user',
-                    '2' => ':global',
+                    '0' => 'user',
+                    '1' => ':global',
                   ),
                   'from' => array(
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
             '#type' => 'action',
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_marked_unsticky_by_moderator_admin' => array(
+      'rules_comment_deleted_by_admin' => array(
         '#type' => 'rule',
-        '#set' => 'event_node_update',
-        '#label' => 'Forum topic marked unsticky by moderator/admin',
+        '#set' => 'event_comment_delete',
+        '#label' => 'Comment deleted by admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
-          '0' => 'boinc_standard',
-          '1' => 'moderator notification',
+          '0' => 'moderator notification',
+          '1' => 'boinc_standard',
         ),
         '#status' => 'default',
-        '#conditions' => array(
-          '0' => array(
-            '#type' => 'condition',
-            '#settings' => array(
-              'roles' => array(
-                '0' => 3519698132,
-                '1' => 1271379760,
-              ),
-              'operation' => 'OR',
-              '#argument map' => array(
-                'user' => 'user',
-              ),
-            ),
-            '#name' => 'rules_condition_user_hasrole',
-            '#info' => array(
-              'label' => 'User has role(s): administrator or moderator',
-              'label callback' => FALSE,
-              'arguments' => array(
-                'user' => array(
-                  'type' => 'user',
-                  'label' => 'User',
-                ),
-              ),
-              'module' => 'User',
-            ),
-            '#weight' => 0,
-          ),
-          '1' => array(
-            '#weight' => 0,
-            '0' => array(
-              '#weight' => 0,
-              '#type' => 'condition',
-              '#settings' => array(
-                'type' => array(
-                  'forum' => 'forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#name' => 'rules_condition_content_is_type',
-              '#info' => array(
-                'label' => 'Updated content is Forum topic',
-                'arguments' => array(
-                  'node' => array(
-                    'type' => 'node',
-                    'label' => 'Content',
-                  ),
-                ),
-                'module' => 'Node',
-              ),
-            ),
-            '#type' => 'OR',
-            '1' => array(
-              '#type' => 'condition',
-              '#settings' => array(
-                'type' => array(
-                  'team_forum' => 'team_forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#name' => 'rules_condition_content_is_type',
-              '#info' => array(
-                'label' => 'Updated content is Team forum topic',
-                'arguments' => array(
-                  'node' => array(
-                    'type' => 'node',
-                    'label' => 'Content',
-                  ),
-                ),
-                'module' => 'Node',
-              ),
-              '#weight' => 0,
-            ),
-          ),
-          '3' => array(
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'PHP code: node content unchanged',
-              'label callback' => FALSE,
-              'module' => 'PHP',
-              'eval input' => array(
-                '0' => 'code',
-              ),
-            ),
-            '#name' => 'rules_condition_custom_php',
-            '#settings' => array(
-              'code' => 'return $node->body == $node_unchanged->body;',
-              'vars' => array(
-                '0' => 'node',
-                '1' => 'node_unchanged',
-              ),
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'code' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-            '#type' => 'condition',
-          ),
-          '4' => array(
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'PHP code: node made sticky',
-              'label callback' => FALSE,
-              'module' => 'PHP',
-              'eval input' => array(
-                '0' => 'code',
-              ),
-            ),
-            '#name' => 'rules_condition_custom_php',
-            '#type' => 'condition',
-            '#settings' => array(
-              'code' => 'return $node_unchanged->sticky == 1 && $node->sticky == 0;',
-              'vars' => array(
-                '0' => 'node',
-                '1' => 'node_unchanged',
-              ),
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'code' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
+        '#conditions' => array(),
         '#actions' => array(
           '0' => array(
-            '#info' => array(
-              'label' => 'Notify moderators via email',
-              'module' => 'BOINC core',
-              'eval input' => array(
-                '0' => 'subject',
-                '1' => 'message',
-                '2' => 'from',
-              ),
-            ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#type' => 'action',
             '#settings' => array(
               'from' => '',
-              'subject' => 'Forum topic at [:global:site-name] marked unsticky by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been marked unsticky by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'subject' => 'Comment deleted at [:global:site-name] by admin',
+              'message' => "Comment to [node:type] topic '[node:title]' deleted by admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -555,18 +288,32 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
-            '#type' => 'action',
-            '#weight' => 0,
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_locked_by_moderator_admin' => array(
+      'rules_comment_edited_by_moderator_or_admin' => array(
         '#type' => 'rule',
-        '#set' => 'event_node_update',
-        '#label' => 'Forum topic locked by moderator/admin',
+        '#set' => 'event_comment_update',
+        '#label' => 'Comment is edited by moderator or admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -576,138 +323,60 @@ function boinc_standard_rules_defaults() {
         '#status' => 'default',
         '#conditions' => array(
           '0' => array(
-            '#type' => 'condition',
-            '#settings' => array(
-              'roles' => array(
-                '0' => 3519698132,
-                '1' => 1271379760,
-              ),
-              'operation' => 'OR',
-              '#argument map' => array(
-                'user' => 'user',
-              ),
-            ),
-            '#name' => 'rules_condition_user_hasrole',
+            '#negate' => 1,
+            '#weight' => 0.0,
             '#info' => array(
-              'label' => 'User has role(s): administrator or moderator',
+              'label' => 'Compare two users: acting user (who edited the comment) is NOT the comment author',
               'label callback' => FALSE,
               'arguments' => array(
-                'user' => array(
+                'user1' => array(
                   'type' => 'user',
-                  'label' => 'User',
+                  'label' => 'User account 1',
+                ),
+                'user2' => array(
+                  'type' => 'user',
+                  'label' => 'User account 2',
                 ),
               ),
               'module' => 'User',
             ),
-            '#weight' => 0,
-          ),
-          '1' => array(
-            '#weight' => 0,
-            '0' => array(
-              '#weight' => 0,
-              '#type' => 'condition',
-              '#settings' => array(
-                'type' => array(
-                  'forum' => 'forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#name' => 'rules_condition_content_is_type',
-              '#info' => array(
-                'label' => 'Updated content is Forum topic',
-                'arguments' => array(
-                  'node' => array(
-                    'type' => 'node',
-                    'label' => 'Content',
-                  ),
-                ),
-                'module' => 'Node',
-              ),
-            ),
-            '#type' => 'OR',
-            '1' => array(
-              '#type' => 'condition',
-              '#settings' => array(
-                'type' => array(
-                  'team_forum' => 'team_forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#name' => 'rules_condition_content_is_type',
-              '#info' => array(
-                'label' => 'Updated content is Team forum topic',
-                'arguments' => array(
-                  'node' => array(
-                    'type' => 'node',
-                    'label' => 'Content',
-                  ),
-                ),
-                'module' => 'Node',
-              ),
-              '#weight' => 0,
-            ),
-          ),
-          '3' => array(
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'PHP code: node content unchanged',
-              'label callback' => FALSE,
-              'module' => 'PHP',
-              'eval input' => array(
-                '0' => 'code',
-              ),
-            ),
-            '#name' => 'rules_condition_custom_php',
+            '#name' => 'rules_condition_user_comparison',
             '#settings' => array(
-              'code' => 'return $node->body == $node_unchanged->body;',
-              'vars' => array(
-                '0' => 'node',
-                '1' => 'node_unchanged',
-              ),
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'code' => array(
-                    '0' => ':global',
-                  ),
-                ),
+              '#argument map' => array(
+                'user1' => 'user',
+                'user2' => 'comment_author',
               ),
             ),
             '#type' => 'condition',
-          ),
-          '4' => array(
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'PHP code: node locked',
-              'label callback' => FALSE,
-              'module' => 'PHP',
-              'eval input' => array(
-                '0' => 'code',
-              ),
-            ),
-            '#name' => 'rules_condition_custom_php',
-            '#type' => 'condition',
-            '#settings' => array(
-              'code' => 'return $node_unchanged->comment == 2 && $node->comment == 1;',
-              'vars' => array(
-                '0' => 'node',
-                '1' => 'node_unchanged',
-              ),
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'code' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
           ),
         ),
         '#actions' => array(
           '0' => array(
+            '#type' => 'action',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Comment edited at [:global:site-name] by moderator or admin',
+              'message' => "Comment has been edited by moderator/admin [user:display-name]\r\n\r\nLink: <?php print url('<front>', array('absolute' => TRUE, 'language' => 'en')); ?>/goto/comment/[comment:comment-cid]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'comment',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(),
+                ),
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
             '#info' => array(
               'label' => 'Notify moderators via email',
               'module' => 'BOINC core',
@@ -717,37 +386,15 @@ function boinc_standard_rules_defaults() {
                 '2' => 'from',
               ),
             ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
-            '#settings' => array(
-              'from' => '',
-              'subject' => 'Forum topic at [:global:site-name] locked by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been locked by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'subject' => array(
-                    '0' => ':global',
-                  ),
-                  'message' => array(
-                    '0' => 'node',
-                    '1' => 'user',
-                    '2' => ':global',
-                  ),
-                  'from' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-            '#type' => 'action',
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_unlocked_by_moderator_admin' => array(
+      'rules_comment_is_published_unhidden_by_moderator_or_admin' => array(
         '#type' => 'rule',
-        '#set' => 'event_node_update',
-        '#label' => 'Forum topic unlocked by moderator/admin',
+        '#set' => 'event_boinccore_comment_unhidden',
+        '#label' => 'Comment is unhidden by moderator or admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -757,6 +404,169 @@ function boinc_standard_rules_defaults() {
         '#status' => 'default',
         '#conditions' => array(
           '0' => array(
+            '#type' => 'condition',
+            '#settings' => array(
+              '#argument map' => array(
+                'user1' => 'user',
+                'user2' => 'comment_author',
+              ),
+            ),
+            '#name' => 'rules_condition_user_comparison',
+            '#info' => array(
+              'label' => 'Compare two users: acting user (who unhid the comment) is NOT the comment author',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user1' => array(
+                  'type' => 'user',
+                  'label' => 'User account 1',
+                ),
+                'user2' => array(
+                  'type' => 'user',
+                  'label' => 'User account 2',
+                ),
+              ),
+              'module' => 'User',
+            ),
+            '#negate' => 1,
+            '#weight' => 0.0,
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Comment at [:global:site-name] unhidden by moderator or admin',
+              'message' => "Comment has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('<front>', array('absolute' => TRUE, 'language' => 'en')); ?>/goto/comment/[comment:comment-cid]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'comment',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(),
+                ),
+              ),
+            ),
+            '#type' => 'action',
+            '#weight' => 0.0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_comment_is_unpublished_hidden_by_moderator_or_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_comment_unpublish',
+        '#label' => 'Comment is hidden by moderator or admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#weight' => 0.0,
+            '#negate' => 1,
+            '#info' => array(
+              'label' => 'Compare two users: acting user (who hid the comment) is NOT the comment author',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user1' => array(
+                  'type' => 'user',
+                  'label' => 'User account 1',
+                ),
+                'user2' => array(
+                  'type' => 'user',
+                  'label' => 'User account 2',
+                ),
+              ),
+              'module' => 'User',
+            ),
+            '#name' => 'rules_condition_user_comparison',
+            '#type' => 'condition',
+            '#settings' => array(
+              '#argument map' => array(
+                'user1' => 'user',
+                'user2' => 'comment_author',
+              ),
+            ),
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#type' => 'action',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Comment at [:global:site-name] hidden by moderator or admin',
+              'message' => "Comment has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('<front>', array('absolute' => TRUE, 'language' => 'en')); ?>/goto/comment/[comment:comment-cid]",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'comment',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(),
+                ),
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#weight' => 0.0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_is_edited_by_moderator_or_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic is edited by moderator or admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#weight' => 0.0,
             '#type' => 'condition',
             '#settings' => array(
               'roles' => array(
@@ -780,22 +590,11 @@ function boinc_standard_rules_defaults() {
               ),
               'module' => 'User',
             ),
-            '#weight' => 0,
           ),
           '1' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '0' => array(
-              '#weight' => 0,
-              '#type' => 'condition',
-              '#settings' => array(
-                'type' => array(
-                  'forum' => 'forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#name' => 'rules_condition_content_is_type',
+              '#weight' => 0.0,
               '#info' => array(
                 'label' => 'Updated content is Forum topic',
                 'arguments' => array(
@@ -806,6 +605,16 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
+              '#name' => 'rules_condition_content_is_type',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#type' => 'condition',
             ),
             '#type' => 'OR',
             '1' => array(
@@ -829,13 +638,13 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
-              '#weight' => 0,
+              '#weight' => 0.0,
             ),
           ),
-          '3' => array(
-            '#weight' => 0,
+          '2' => array(
+            '#weight' => 0.0,
             '#info' => array(
-              'label' => 'PHP code: node content unchanged',
+              'label' => 'PHP code: content changed',
               'label callback' => FALSE,
               'module' => 'PHP',
               'eval input' => array(
@@ -844,7 +653,7 @@ function boinc_standard_rules_defaults() {
             ),
             '#name' => 'rules_condition_custom_php',
             '#settings' => array(
-              'code' => 'return $node->body == $node_unchanged->body;',
+              'code' => 'return ($node->body != $node_unchanged->body);',
               'vars' => array(
                 '0' => 'node',
                 '1' => 'node_unchanged',
@@ -858,51 +667,15 @@ function boinc_standard_rules_defaults() {
               ),
             ),
             '#type' => 'condition',
-          ),
-          '4' => array(
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'PHP code: node unlocked',
-              'label callback' => FALSE,
-              'module' => 'PHP',
-              'eval input' => array(
-                '0' => 'code',
-              ),
-            ),
-            '#name' => 'rules_condition_custom_php',
-            '#type' => 'condition',
-            '#settings' => array(
-              'code' => 'return $node_unchanged->comment == 1 && $node->comment == 2;',
-              'vars' => array(
-                '0' => 'node',
-                '1' => 'node_unchanged',
-              ),
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'code' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
           ),
         ),
         '#actions' => array(
           '0' => array(
-            '#info' => array(
-              'label' => 'Notify moderators via email',
-              'module' => 'BOINC core',
-              'eval input' => array(
-                '0' => 'subject',
-                '1' => 'message',
-                '2' => 'from',
-              ),
-            ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#type' => 'action',
             '#settings' => array(
               'from' => '',
-              'subject' => 'Forum topic at [:global:site-name] unlocked by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been unlocked by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'subject' => 'Forum topic at [:global:site-name] edited by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been edited by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -917,10 +690,24 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
-            '#type' => 'action',
-            '#weight' => 0,
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
@@ -961,12 +748,12 @@ function boinc_standard_rules_defaults() {
               ),
               'module' => 'User',
             ),
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
           '1' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '0' => array(
-              '#weight' => 0,
+              '#weight' => 0.0,
               '#type' => 'condition',
               '#settings' => array(
                 'type' => array(
@@ -1010,11 +797,11 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
-              '#weight' => 0,
+              '#weight' => 0.0,
             ),
           ),
           '3' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '#info' => array(
               'label' => 'PHP code: node content unchanged',
               'label callback' => FALSE,
@@ -1041,7 +828,7 @@ function boinc_standard_rules_defaults() {
             '#type' => 'condition',
           ),
           '4' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '#info' => array(
               'label' => 'PHP code: node status changed to hidden',
               'label callback' => FALSE,
@@ -1083,7 +870,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] hidden by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1098,10 +885,174 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
             '#type' => 'action',
-            '#weight' => 0,
+            '#weight' => 0.0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_is_moved_to_a_different_forum_by_moderator_or_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic is moved to a different forum by moderator or admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#weight' => 0.0,
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+          ),
+          '1' => array(
+            '#weight' => 0.0,
+            '0' => array(
+              '#weight' => 0.0,
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#type' => 'condition',
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0.0,
+            ),
+          ),
+          '2' => array(
+            '#weight' => 0.0,
+            '#info' => array(
+              'label' => 'PHP code: node moved to new forum parent',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return ($node->tid != $node_unchanged->tid);',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
+            '#type' => 'action',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] moved by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been moved by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
@@ -1142,7 +1093,7 @@ function boinc_standard_rules_defaults() {
               ),
               'module' => 'User',
             ),
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
           '1' => array(
             '#type' => 'OR',
@@ -1167,11 +1118,11 @@ function boinc_standard_rules_defaults() {
                 ),
               ),
               '#type' => 'condition',
-              '#weight' => 0,
+              '#weight' => 0.0,
             ),
-            '#weight' => 0,
+            '#weight' => 0.0,
             '1' => array(
-              '#weight' => 0,
+              '#weight' => 0.0,
               '#info' => array(
                 'label' => 'Updated content is Team forum topic',
                 'arguments' => array(
@@ -1219,7 +1170,7 @@ function boinc_standard_rules_defaults() {
                 '0' => 'code',
               ),
             ),
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
           '4' => array(
             '#type' => 'condition',
@@ -1246,12 +1197,11 @@ function boinc_standard_rules_defaults() {
                 '0' => 'code',
               ),
             ),
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
         ),
         '#actions' => array(
           '0' => array(
-            '#weight' => 0,
             '#info' => array(
               'label' => 'Notify moderators via email',
               'module' => 'BOINC core',
@@ -1265,7 +1215,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] unhidden by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1280,17 +1230,23 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
             '#type' => 'action',
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_is_edited_by_moderator_or_admin' => array(
+      'rules_forum_topic_locked_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is edited by moderator or admin',
+        '#label' => 'Forum topic locked by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -1300,7 +1256,6 @@ function boinc_standard_rules_defaults() {
         '#status' => 'default',
         '#conditions' => array(
           '0' => array(
-            '#weight' => 0,
             '#type' => 'condition',
             '#settings' => array(
               'roles' => array(
@@ -1324,11 +1279,22 @@ function boinc_standard_rules_defaults() {
               ),
               'module' => 'User',
             ),
+            '#weight' => 0.0,
           ),
           '1' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '0' => array(
-              '#weight' => 0,
+              '#weight' => 0.0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
               '#info' => array(
                 'label' => 'Updated content is Forum topic',
                 'arguments' => array(
@@ -1339,16 +1305,6 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
-              '#name' => 'rules_condition_content_is_type',
-              '#settings' => array(
-                'type' => array(
-                  'forum' => 'forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#type' => 'condition',
             ),
             '#type' => 'OR',
             '1' => array(
@@ -1372,13 +1328,13 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
-              '#weight' => 0,
+              '#weight' => 0.0,
             ),
           ),
-          '2' => array(
-            '#weight' => 0,
+          '3' => array(
+            '#weight' => 0.0,
             '#info' => array(
-              'label' => 'PHP code: content changed',
+              'label' => 'PHP code: node content unchanged',
               'label callback' => FALSE,
               'module' => 'PHP',
               'eval input' => array(
@@ -1387,7 +1343,7 @@ function boinc_standard_rules_defaults() {
             ),
             '#name' => 'rules_condition_custom_php',
             '#settings' => array(
-              'code' => 'return ($node->body != $node_unchanged->body);',
+              'code' => 'return $node->body == $node_unchanged->body;',
               'vars' => array(
                 '0' => 'node',
                 '1' => 'node_unchanged',
@@ -1402,15 +1358,50 @@ function boinc_standard_rules_defaults() {
             ),
             '#type' => 'condition',
           ),
+          '4' => array(
+            '#weight' => 0.0,
+            '#info' => array(
+              'label' => 'PHP code: node locked',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->comment == 2 && $node->comment == 1;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+          ),
         ),
         '#actions' => array(
           '0' => array(
-            '#weight' => 0,
-            '#type' => 'action',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
             '#settings' => array(
               'from' => '',
-              'subject' => 'Forum topic at [:global:site-name] edited by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been edited by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'subject' => 'Forum topic at [:global:site-name] locked by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been locked by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1425,26 +1416,23 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
-            '#info' => array(
-              'label' => 'Notify moderators via email',
-              'module' => 'BOINC core',
-              'eval input' => array(
-                '0' => 'subject',
-                '1' => 'message',
-                '2' => 'from',
-              ),
-            ),
+            '#type' => 'action',
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
       ),
-      'rules_forum_topic_is_moved_to_a_different_forum_by_moderator_or_admin' => array(
+      'rules_forum_topic_marked_sticky_by_moderator_admin' => array(
         '#type' => 'rule',
         '#set' => 'event_node_update',
-        '#label' => 'Forum topic is moved to a different forum by moderator or admin',
+        '#label' => 'Forum topic marked sticky by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -1454,7 +1442,6 @@ function boinc_standard_rules_defaults() {
         '#status' => 'default',
         '#conditions' => array(
           '0' => array(
-            '#weight' => 0,
             '#type' => 'condition',
             '#settings' => array(
               'roles' => array(
@@ -1478,11 +1465,22 @@ function boinc_standard_rules_defaults() {
               ),
               'module' => 'User',
             ),
+            '#weight' => 0.0,
           ),
           '1' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '0' => array(
-              '#weight' => 0,
+              '#weight' => 0.0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
               '#info' => array(
                 'label' => 'Updated content is Forum topic',
                 'arguments' => array(
@@ -1493,16 +1491,6 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
-              '#name' => 'rules_condition_content_is_type',
-              '#settings' => array(
-                'type' => array(
-                  'forum' => 'forum',
-                ),
-                '#argument map' => array(
-                  'node' => 'node',
-                ),
-              ),
-              '#type' => 'condition',
             ),
             '#type' => 'OR',
             '1' => array(
@@ -1526,13 +1514,13 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
-              '#weight' => 0,
+              '#weight' => 0.0,
             ),
           ),
-          '2' => array(
-            '#weight' => 0,
+          '3' => array(
+            '#weight' => 0.0,
             '#info' => array(
-              'label' => 'PHP code: node moved to new forum parent',
+              'label' => 'PHP code: node content unchanged',
               'label callback' => FALSE,
               'module' => 'PHP',
               'eval input' => array(
@@ -1541,7 +1529,7 @@ function boinc_standard_rules_defaults() {
             ),
             '#name' => 'rules_condition_custom_php',
             '#settings' => array(
-              'code' => 'return ($node->tid != $node_unchanged->tid);',
+              'code' => 'return $node->body == $node_unchanged->body;',
               'vars' => array(
                 '0' => 'node',
                 '1' => 'node_unchanged',
@@ -1556,15 +1544,50 @@ function boinc_standard_rules_defaults() {
             ),
             '#type' => 'condition',
           ),
+          '4' => array(
+            '#weight' => 0.0,
+            '#info' => array(
+              'label' => 'PHP code: node made sticky',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->sticky == 0 && $node->sticky == 1;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+          ),
         ),
         '#actions' => array(
           '0' => array(
-            '#weight' => 0,
-            '#type' => 'action',
+            '#info' => array(
+              'label' => 'Notify moderators via email',
+              'module' => 'BOINC core',
+              'eval input' => array(
+                '0' => 'subject',
+                '1' => 'message',
+                '2' => 'from',
+              ),
+            ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
             '#settings' => array(
               'from' => '',
-              'subject' => 'Forum topic at [:global:site-name] moved by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has been moved by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'subject' => 'Forum topic at [:global:site-name] marked sticky by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been marked sticky by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1579,9 +1602,164 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#type' => 'action',
+            '#weight' => 0.0,
+          ),
+        ),
+        '#version' => 6003,
+      ),
+      'rules_forum_topic_marked_unsticky_by_moderator_admin' => array(
+        '#type' => 'rule',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic marked unsticky by moderator/admin',
+        '#active' => 1,
+        '#weight' => '0',
+        '#categories' => array(
+          '0' => 'boinc_standard',
+          '1' => 'moderator notification',
+        ),
+        '#status' => 'default',
+        '#conditions' => array(
+          '0' => array(
+            '#type' => 'condition',
+            '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
+              '#argument map' => array(
+                'user' => 'user',
+              ),
+            ),
+            '#name' => 'rules_condition_user_hasrole',
+            '#info' => array(
+              'label' => 'User has role(s): administrator or moderator',
+              'label callback' => FALSE,
+              'arguments' => array(
+                'user' => array(
+                  'type' => 'user',
+                  'label' => 'User',
+                ),
+              ),
+              'module' => 'User',
+            ),
+            '#weight' => 0.0,
+          ),
+          '1' => array(
+            '#weight' => 0.0,
+            '0' => array(
+              '#weight' => 0.0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0.0,
+            ),
+          ),
+          '3' => array(
+            '#weight' => 0.0,
+            '#info' => array(
+              'label' => 'PHP code: node content unchanged',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return $node->body == $node_unchanged->body;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+          '4' => array(
+            '#weight' => 0.0,
+            '#info' => array(
+              'label' => 'PHP code: node made sticky',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->sticky == 1 && $node->sticky == 0;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+        '#actions' => array(
+          '0' => array(
             '#info' => array(
               'label' => 'Notify moderators via email',
               'module' => 'BOINC core',
@@ -1591,6 +1769,34 @@ function boinc_standard_rules_defaults() {
                 '2' => 'from',
               ),
             ),
+            '#name' => 'boinccore_rules_action_mail_to_moderators',
+            '#settings' => array(
+              'from' => '',
+              'subject' => 'Forum topic at [:global:site-name] marked unsticky by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been marked unsticky by moderator/admin [user:display-name].\r\n\\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'subject' => array(
+                    '0' => ':global',
+                  ),
+                  'message' => array(
+                    '0' => 'node',
+                    '1' => 'user',
+                    '2' => ':global',
+                  ),
+                  'from' => array(
+                    '0' => ':global',
+                  ),
+                ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'action',
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
@@ -1608,7 +1814,7 @@ function boinc_standard_rules_defaults() {
         '#status' => 'default',
         '#conditions' => array(
           '0' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '#type' => 'condition',
             '#settings' => array(
               'roles' => array(
@@ -1634,9 +1840,9 @@ function boinc_standard_rules_defaults() {
             ),
           ),
           '1' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '0' => array(
-              '#weight' => 0,
+              '#weight' => 0.0,
               '#info' => array(
                 'label' => 'Updated content is Forum topic',
                 'arguments' => array(
@@ -1680,11 +1886,11 @@ function boinc_standard_rules_defaults() {
                 ),
                 'module' => 'Node',
               ),
-              '#weight' => 0,
+              '#weight' => 0.0,
             ),
           ),
           '2' => array(
-            '#weight' => 0,
+            '#weight' => 0.0,
             '#info' => array(
               'label' => 'PHP code: title changed',
               'label callback' => FALSE,
@@ -1713,12 +1919,11 @@ function boinc_standard_rules_defaults() {
         ),
         '#actions' => array(
           '0' => array(
-            '#weight' => 0,
             '#type' => 'action',
             '#settings' => array(
               'from' => '',
               'subject' => 'Forum topic at [:global:site-name] renamed by moderator/admin',
-              'message' => "[node:type] topic '[node:title]' has its title renamed by moderator/admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'message' => "[node:type] topic '[node:title]' has its title renamed by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -1733,132 +1938,9 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
-              ),
-            ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
-            '#info' => array(
-              'label' => 'Notify moderators via email',
-              'module' => 'BOINC core',
-              'eval input' => array(
-                '0' => 'subject',
-                '1' => 'message',
-                '2' => 'from',
-              ),
-            ),
-          ),
-        ),
-        '#version' => 6003,
-      ),
-      'rules_comment_converted_to_new_forum_topic_by_moderator_or_admin' => array(
-        '#type' => 'rule',
-        '#set' => 'event_boinccore_comment_convert',
-        '#label' => 'Comment is converted to new forum topic by moderator or admin',
-        '#active' => 1,
-        '#weight' => '0',
-        '#categories' => array(
-          '0' => 'boinc_standard',
-          '1' => 'moderator notification',
-        ),
-        '#status' => 'default',
-        '#conditions' => array(),
-        '#actions' => array(
-          '0' => array(
-            '#info' => array(
-              'label' => 'Notify moderators via email',
-              'module' => 'BOINC core',
-              'eval input' => array(
-                '0' => 'subject',
-                '1' => 'message',
-                '2' => 'from',
-              ),
-            ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
-            '#settings' => array(
-              'from' => '',
-              'subject' => 'Comment at [:global:site-name] converted to new forum topic',
-              'message' => 'Comment has been converted to new forum topic by moderator/admin [user:display-name].
-',
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'subject' => array(
-                    '0' => ':global',
-                  ),
+                'rules_input_evaluator_php' => array(
                   'message' => array(
-                    '0' => 'user',
-                    '1' => ':global',
-                  ),
-                  'from' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-            '#type' => 'action',
-            '#weight' => 0,
-          ),
-        ),
-        '#version' => 6003,
-      ),
-      'rules_comment_edited_by_moderator_or_admin' => array(
-        '#type' => 'rule',
-        '#set' => 'event_comment_update',
-        '#label' => 'Comment is edited by moderator or admin',
-        '#active' => 1,
-        '#weight' => '0',
-        '#categories' => array(
-          '0' => 'boinc_standard',
-          '1' => 'moderator notification',
-        ),
-        '#status' => 'default',
-        '#conditions' => array(
-          '0' => array(
-            '#negate' => 1,
-            '#weight' => 0,
-            '#info' => array(
-              'label' => 'Compare two users: acting user (who edited the comment) is NOT the comment author',
-              'label callback' => FALSE,
-              'arguments' => array(
-                'user1' => array(
-                  'type' => 'user',
-                  'label' => 'User account 1',
-                ),
-                'user2' => array(
-                  'type' => 'user',
-                  'label' => 'User account 2',
-                ),
-              ),
-              'module' => 'User',
-            ),
-            '#name' => 'rules_condition_user_comparison',
-            '#settings' => array(
-              '#argument map' => array(
-                'user1' => 'user',
-                'user2' => 'comment_author',
-              ),
-            ),
-            '#type' => 'condition',
-          ),
-        ),
-        '#actions' => array(
-          '0' => array(
-            '#weight' => 0,
-            '#type' => 'action',
-            '#settings' => array(
-              'from' => '',
-              'subject' => 'Comment edited at [:global:site-name] by moderator or admin',
-              'message' => "Comment has been edited by moderator/admin [user:display-name].\r\n\r\nLink: [:global:site-url]/goto/comment/[comment:comment-cid]",
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'subject' => array(
-                    '0' => ':global',
-                  ),
-                  'message' => array(
-                    '0' => 'comment',
-                    '1' => 'user',
-                    '2' => ':global',
-                  ),
-                  'from' => array(
-                    '0' => ':global',
+                    '0' => 'node',
                   ),
                 ),
               ),
@@ -1873,92 +1955,15 @@ function boinc_standard_rules_defaults() {
                 '2' => 'from',
               ),
             ),
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
       ),
-      'rules_comment_is_unpublished_hidden_by_moderator_or_admin' => array(
+      'rules_forum_topic_unlocked_by_moderator_admin' => array(
         '#type' => 'rule',
-        '#set' => 'event_comment_unpublish',
-        '#label' => 'Comment is hidden by moderator or admin',
-        '#active' => 1,
-        '#weight' => '0',
-        '#categories' => array(
-          '0' => 'boinc_standard',
-          '1' => 'moderator notification',
-        ),
-        '#status' => 'default',
-        '#conditions' => array(
-          '0' => array(
-            '#weight' => 0,
-            '#negate' => 1,
-            '#info' => array(
-              'label' => 'Compare two users: acting user (who hid the comment) is NOT the comment author',
-              'label callback' => FALSE,
-              'arguments' => array(
-                'user1' => array(
-                  'type' => 'user',
-                  'label' => 'User account 1',
-                ),
-                'user2' => array(
-                  'type' => 'user',
-                  'label' => 'User account 2',
-                ),
-              ),
-              'module' => 'User',
-            ),
-            '#name' => 'rules_condition_user_comparison',
-            '#type' => 'condition',
-            '#settings' => array(
-              '#argument map' => array(
-                'user1' => 'user',
-                'user2' => 'comment_author',
-              ),
-            ),
-          ),
-        ),
-        '#actions' => array(
-          '0' => array(
-            '#weight' => 0,
-            '#type' => 'action',
-            '#settings' => array(
-              'from' => '',
-              'subject' => 'Comment at [:global:site-name] hidden by moderator or admin',
-              'message' => "Comment has been hidden by moderator/admin [user:display-name].\r\n\r\nLink: [:global:site-url]/goto/comment/[comment:comment-cid]",
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'subject' => array(
-                    '0' => ':global',
-                  ),
-                  'message' => array(
-                    '0' => 'comment',
-                    '1' => 'user',
-                    '2' => ':global',
-                  ),
-                  'from' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
-            '#info' => array(
-              'label' => 'Notify moderators via email',
-              'module' => 'BOINC core',
-              'eval input' => array(
-                '0' => 'subject',
-                '1' => 'message',
-                '2' => 'from',
-              ),
-            ),
-          ),
-        ),
-        '#version' => 6003,
-      ),
-      'rules_comment_is_published_unhidden_by_moderator_or_admin' => array(
-        '#type' => 'rule',
-        '#set' => 'event_boinccore_comment_unhidden',
-        '#label' => 'Comment is unhidden by moderator or admin',
+        '#set' => 'event_node_update',
+        '#label' => 'Forum topic unlocked by moderator/admin',
         '#active' => 1,
         '#weight' => '0',
         '#categories' => array(
@@ -1970,34 +1975,136 @@ function boinc_standard_rules_defaults() {
           '0' => array(
             '#type' => 'condition',
             '#settings' => array(
+              'roles' => array(
+                '0' => 3519698132,
+                '1' => 1271379760,
+              ),
+              'operation' => 'OR',
               '#argument map' => array(
-                'user1' => 'user',
-                'user2' => 'comment_author',
+                'user' => 'user',
               ),
             ),
-            '#name' => 'rules_condition_user_comparison',
+            '#name' => 'rules_condition_user_hasrole',
             '#info' => array(
-              'label' => 'Compare two users: acting user (who unhid the comment) is NOT the comment author',
+              'label' => 'User has role(s): administrator or moderator',
               'label callback' => FALSE,
               'arguments' => array(
-                'user1' => array(
+                'user' => array(
                   'type' => 'user',
-                  'label' => 'User account 1',
-                ),
-                'user2' => array(
-                  'type' => 'user',
-                  'label' => 'User account 2',
+                  'label' => 'User',
                 ),
               ),
               'module' => 'User',
             ),
-            '#negate' => 1,
-            '#weight' => 0,
+            '#weight' => 0.0,
+          ),
+          '1' => array(
+            '#weight' => 0.0,
+            '0' => array(
+              '#weight' => 0.0,
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'forum' => 'forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+            ),
+            '#type' => 'OR',
+            '1' => array(
+              '#type' => 'condition',
+              '#settings' => array(
+                'type' => array(
+                  'team_forum' => 'team_forum',
+                ),
+                '#argument map' => array(
+                  'node' => 'node',
+                ),
+              ),
+              '#name' => 'rules_condition_content_is_type',
+              '#info' => array(
+                'label' => 'Updated content is Team forum topic',
+                'arguments' => array(
+                  'node' => array(
+                    'type' => 'node',
+                    'label' => 'Content',
+                  ),
+                ),
+                'module' => 'Node',
+              ),
+              '#weight' => 0.0,
+            ),
+          ),
+          '3' => array(
+            '#weight' => 0.0,
+            '#info' => array(
+              'label' => 'PHP code: node content unchanged',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#settings' => array(
+              'code' => 'return $node->body == $node_unchanged->body;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
+            '#type' => 'condition',
+          ),
+          '4' => array(
+            '#weight' => 0.0,
+            '#info' => array(
+              'label' => 'PHP code: node unlocked',
+              'label callback' => FALSE,
+              'module' => 'PHP',
+              'eval input' => array(
+                '0' => 'code',
+              ),
+            ),
+            '#name' => 'rules_condition_custom_php',
+            '#type' => 'condition',
+            '#settings' => array(
+              'code' => 'return $node_unchanged->comment == 1 && $node->comment == 2;',
+              'vars' => array(
+                '0' => 'node',
+                '1' => 'node_unchanged',
+              ),
+              '#eval input' => array(
+                'token_rules_input_evaluator' => array(
+                  'code' => array(
+                    '0' => ':global',
+                  ),
+                ),
+              ),
+            ),
           ),
         ),
         '#actions' => array(
           '0' => array(
-            '#weight' => 0,
             '#info' => array(
               'label' => 'Notify moderators via email',
               'module' => 'BOINC core',
@@ -2010,49 +2117,8 @@ function boinc_standard_rules_defaults() {
             '#name' => 'boinccore_rules_action_mail_to_moderators',
             '#settings' => array(
               'from' => '',
-              'subject' => 'Comment at [:global:site-name] unhidden by moderator or admin',
-              'message' => "Comment has been unhidden by moderator/admin [user:display-name].\r\n\r\nLink: [:global:site-url]/goto/comment/[comment:comment-cid]",
-              '#eval input' => array(
-                'token_rules_input_evaluator' => array(
-                  'subject' => array(
-                    '0' => ':global',
-                  ),
-                  'message' => array(
-                    '0' => 'comment',
-                    '1' => 'user',
-                    '2' => ':global',
-                  ),
-                  'from' => array(
-                    '0' => ':global',
-                  ),
-                ),
-              ),
-            ),
-            '#type' => 'action',
-          ),
-        ),
-        '#version' => 6003,
-      ),
-      'rules_comment_deleted_by_admin' => array(
-        '#type' => 'rule',
-        '#set' => 'event_comment_delete',
-        '#label' => 'Comment deleted by admin',
-        '#active' => 1,
-        '#weight' => '0',
-        '#categories' => array(
-          '0' => 'moderator notification',
-          '1' => 'boinc_standard',
-        ),
-        '#status' => 'default',
-        '#conditions' => array(),
-        '#actions' => array(
-          '0' => array(
-            '#weight' => 0,
-            '#type' => 'action',
-            '#settings' => array(
-              'from' => '',
-              'subject' => 'Comment deleted at [:global:site-name] by admin',
-              'message' => "Comment to [node:type] topic '[node:title]' deleted by admin [user:display-name].\r\n\r\nLink: [node:node-url]",
+              'subject' => 'Forum topic at [:global:site-name] unlocked by moderator/admin',
+              'message' => "[node:type] topic '[node:title]' has been unlocked by moderator/admin [user:display-name].\r\n\r\nLink: <?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -2067,18 +2133,15 @@ function boinc_standard_rules_defaults() {
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
-            '#name' => 'boinccore_rules_action_mail_to_moderators',
-            '#info' => array(
-              'label' => 'Notify moderators via email',
-              'module' => 'BOINC core',
-              'eval input' => array(
-                '0' => 'subject',
-                '1' => 'message',
-                '2' => 'from',
-              ),
-            ),
+            '#type' => 'action',
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
@@ -2110,11 +2173,7 @@ function boinc_standard_rules_defaults() {
             '#settings' => array(
               'from' => '',
               'subject' => 'Report of offensive [node:type] comment at [:global:site-name]',
-              'message' => '[flagging_user:display-name] has reported the following comment on [node:type] content as being offensive or inappropriate for the [:global:site-name] site:
-
-[:global:site-url]/goto/comment/[comment:comment-cid]
-
-Total reports of this comment: [comment:flag-abuse-comment-count]',
+              'message' => "[flagging_user:display-name] has reported the following comment on [node:type] content as being offensive or inappropriate for the [:global:site-name] site:\r\n\r\n<?php print url('<front>', array('absolute' => TRUE, 'language' => 'en')); ?>/goto/comment/[comment:comment-cid]\r\n\r\nTotal reports of this comment: [comment:flag-abuse-comment-count]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -2131,10 +2190,13 @@ Total reports of this comment: [comment:flag-abuse-comment-count]',
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(),
+                ),
               ),
             ),
             '#type' => 'action',
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
@@ -2157,11 +2219,7 @@ Total reports of this comment: [comment:flag-abuse-comment-count]',
             '#settings' => array(
               'from' => '',
               'subject' => 'Report of offensive [node:type] content at [:global:site-name]',
-              'message' => '[flagging_user:display-name] has reported the following [node:type] content as being offensive or inappropriate for the [:global:site-name] site:
-
-[:global:site-url]/[node:node-path]
-
-Total reports of this content: [node:flag-abuse-node-count]',
+              'message' => "[flagging_user:display-name] has reported the following [node:type] content as being offensive or inappropriate for the [:global:site-name] site:\r\n\r\n<?php print url('node/' . \$node->nid, array('absolute' => TRUE, 'language' => 'en')); ?>\r\n\r\nTotal reports of this content: [node:flag-abuse-node-count]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -2177,6 +2235,11 @@ Total reports of this content: [node:flag-abuse-node-count]',
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(
+                    '0' => 'node',
+                  ),
+                ),
               ),
             ),
             '#name' => 'boinccore_rules_action_mail_to_moderators',
@@ -2189,7 +2252,7 @@ Total reports of this content: [node:flag-abuse-node-count]',
                 '2' => 'from',
               ),
             ),
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,
@@ -2212,11 +2275,7 @@ Total reports of this content: [node:flag-abuse-node-count]',
             '#settings' => array(
               'from' => '',
               'subject' => 'Report of offensive user at [:global:site-name]',
-              'message' => '[flagging_user:display-name] has reported [account:display-name] for inappropriate behavior:
-
-[:global:site-url]/account/[account:uid]
-
-Total current reports of this user: [account:flag-abuse-user-count]',
+              'message' => "[flagging_user:display-name] has reported [account:display-name] for inappropriate behavior:\r\n\r\n<?php print url(\'<front>\', array(\'absolute\' => TRUE, \'language\' => \'en\')); ?>/account/[account:uid]\r\n\r\nTotal current reports of this user: [account:flag-abuse-user-count]",
               '#eval input' => array(
                 'token_rules_input_evaluator' => array(
                   'subject' => array(
@@ -2231,6 +2290,9 @@ Total current reports of this user: [account:flag-abuse-user-count]',
                     '0' => ':global',
                   ),
                 ),
+                'rules_input_evaluator_php' => array(
+                  'message' => array(),
+                ),
               ),
             ),
             '#name' => 'boinccore_rules_action_mail_to_moderators',
@@ -2243,7 +2305,7 @@ Total current reports of this user: [account:flag-abuse-user-count]',
                 '2' => 'from',
               ),
             ),
-            '#weight' => 0,
+            '#weight' => 0.0,
           ),
         ),
         '#version' => 6003,


### PR DESCRIPTION
**Description of the Change**
Modified triggered rules email messages to moderators to use the URL without a language code. Use PHP evaluation to produce URI with language 'en', which corresponds to the default language, which has no language code.

https://dev.gridrepublic.org/browse/DBOINCP-463

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
N/A