### PR TITLE
web: keep server version # in a file (html/inc/server_version.inc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,7 +96,6 @@ py/Boinc/version.py
 py/setup.py
 stamp-h1
 test/version.inc
-html/inc/release.inc
 
 ## files created by make:
 *.o

--- a/generate_svn_version.sh
+++ b/generate_svn_version.sh
@@ -62,16 +62,3 @@ if cmp "$HEADER" "$TMPFILE" >/dev/null 2>&1; then
 else
 	mv "$TMPFILE" "$HEADER"
 fi
-
-if [ ! -z ${SERVER_VERSION} ]; then
-    SERVER_VERSION=`echo ${SERVER_VERSION} | sed 's#.*/##'`
-    cat << EOF > html/inc/release.inc
-<?php
-
-global \$server_version ;
-\$server_version = "${SERVER_VERSION}";
-
-?>
-EOF
-
-fi

--- a/html/inc/server_version.inc
+++ b/html/inc/server_version.inc
@@ -1,0 +1,16 @@
+<?php
+
+// the server code release number (major/minor/release).
+// Update this when you do a server release.
+
+// public releases have even minor #,
+// and are assumed to have a branch on github.
+// dev versions (e.g. master) have an odd minor #
+
+$server_version = array(1, 1, 0);
+
+$server_version_str = sprintf("%d.%d.%d",
+    $server_version[0], $server_version[1], $server_version[2]
+);
+
+?>

--- a/html/user/get_project_config.php
+++ b/html/user/get_project_config.php
@@ -19,8 +19,7 @@
 require_once("../inc/consent.inc");
 require_once("../inc/util.inc");
 require_once("../inc/xml.inc");
-if(file_exists('../inc/release.inc'))
-    include '../inc/release.inc';
+require_once("../inc/server_version.inc");
 
 BoincDb::get(true);
 xml_header();
@@ -66,9 +65,7 @@ echo "<project_config>
     <web_rpc_url_base>".secure_url_base()."</web_rpc_url_base>
 ";
 
-if ( isset($server_version) ) {
-    echo "<server_version>$server_version</server_version>\n";
-}
+echo "<server_version>$server_version_str</server_version>\n";
 
 if (parse_config($config, "<account_manager>")) {
     echo "    <account_manager/>\n";
@@ -114,16 +111,17 @@ show_platforms();
 // Conditional added to allow for backwards-compatability. If a
 // project has not defined the constant TERMSOFUSE_FILE, then look for
 // the terms_of_use.txt file in the project base directory.
+//
 if (defined('TERMSOFUSE_FILE')) {
   $tou_file = TERMSOFUSE_FILE;
-}
-else {
+} else {
   $tou_file =  "../../terms_of_use.txt";
 }
 if (file_exists($tou_file)) {
     $terms_of_use = trim(file_get_contents($tou_file));
 
     // Also check consent type ENROLL is enabled.
+    //
     list($checkct, $ctid) = check_consent_type(CONSENT_TYPE_ENROLL);
     if ($terms_of_use and $checkct) {
         echo "    <terms_of_use>\n$terms_of_use\n</terms_of_use>\n";

--- a/html/user/server_status.php
+++ b/html/user/server_status.php
@@ -16,7 +16,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// Show server status page.
+// Get server status.
+//
+// default: show as web page
+// ?xml=1:  show as XML
+// ?counts=1: show only overall job counts, w/o caching
+//      (for remote job submission systems)
 // Sources of data:
 // - daemons on this host: use "ps" to see if each is running
 //   (this could be made more efficient using a single "ps",
@@ -30,8 +35,7 @@ require_once("../inc/cache.inc");
 require_once("../inc/util.inc");
 require_once("../inc/xml.inc");
 require_once("../inc/boinc_db.inc");
-if(file_exists('../inc/release.inc'))
-    include '../inc/release.inc';
+require_once("../inc/server_version.inc");
 
 if (!defined('STATUS_PAGE_TTL')) {
     define('STATUS_PAGE_TTL', 3600);
@@ -102,6 +106,8 @@ function item_html($name, $val) {
 }
 
 function show_status_html($x) {
+    global $server_version, $server_version_str;
+
     page_head(tra("Project status"));
     $j = $x->jobs;
     $daemons = $x->daemons;
@@ -186,12 +192,20 @@ function show_status_html($x) {
     }
     end_table();
     
-    global $server_version;
-    if ( isset($server_version) ) {
-       $url = "https://github.com/BOINC/boinc/tree/server_release/";
-       $url .= explode(".", $server_version)[0] . "." . explode(".", $server_version)[1] . "/" . "$server_version";
-       echo "Upstream server release: <a href=\"" . $url . "\">$server_version</a> <br>";
+    // show server software version.
+    // If it's a release (minor# is even) link to github branch
+    //
+    echo "Server software version: $server_version_str";
+    if ($server_version[1]%2 == 0) {
+        $url = sprintf("%s/%d/%d.%d",
+            "https://github.com/BOINC/boinc/tree/server_release",
+            $server_version[0],
+            $server_version[0],
+            $server_version[1]
+        );
+        echo " <a href=\"$url\">View source on Github</a>.";
     }
+    echo "<br>\n";
 
     if ($j->db_revision) {
         echo tra("Database schema version: "), $j->db_revision;


### PR DESCRIPTION
... rather than generating it during configure.
This way things work for projects that don't do "configure",
e.g. because they use only the web code.
And it's simpler.

Maintain this as for client version #s.
The minor version # is even in release branches,
odd in development branches like master.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
