### PR TITLE
Fixes window close action on Linux

### DIFF
--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -330,9 +330,8 @@ void CBOINCBaseFrame::OnClose(wxCloseEvent& event) {
         Destroy();
     } else {
 #ifdef __WXGTK__
-        // Apparently aborting a close event just causes the main window to be displayed
-        // again.  Just minimize the window instead.
-        Iconize();
+        wxGetApp().FrameClosed();
+        Destroy();
 #else
         Hide();
 #endif


### PR DESCRIPTION
Fixes #2604 #1348 

**Description of the Change**
On Linux when you close the BOINC Manager window, it will be minimized instead of closed.
The patch closes the BOINC Manager window correctly.

**Alternate Designs**
Read
https://github.com/BOINC/boinc/issues/2604#issuecomment-445826926
and
https://github.com/BOINC/boinc/issues/1348#issuecomment-444534306
(they are the same comment)

**Release Notes**
On Linux, when a user closes BOINC Manager window, it will be closed rather than minimized.