### PR TITLE
Web: fix deprecated php stuff

### DIFF
--- a/html/inc/bolt_ex.inc
+++ b/html/inc/bolt_ex.inc
@@ -323,7 +323,7 @@ function fitb() {
             }
             break;
         case 1:
-            if (ereg($answer->ans, $response)) {
+            if (preg_match('/'.$answer->ans.'/', $response)) {
                 $bolt_ex->score = 1;
             }
             break;

--- a/html/inc/translation.inc
+++ b/html/inc/translation.inc
@@ -119,8 +119,9 @@ function parse_po_file($file) {
     $current_token ="";
     $parsing_token = false;
     $parsing_text = false;
+    $size = sizeof($translation_file);
     $output = array();
-    for ($i=0; $i<sizeof($translation_file); $i++){
+    for ($i=0; $i<$size; $i++){
         $entry = trim($translation_file[$i]);
         //echo "line $i: $entry\n";
         if (substr($entry, 0, 1)=="#") {
@@ -160,7 +161,7 @@ function parse_po_file($file) {
 function get_po_line($line, $file) {
     $start = strpos($line, '"')+1;
     $stop = strrpos($line, '"');
-    $x =  substr($line, $start, $stop-$start);
+    $x = substr($line, $start, $stop-$start);
     $n = preg_match("/[^\\\\]\"/", $x);
     if ($n) {
         echo "ERROR - MISMATCHED QUOTES IN $file: $line\n";
@@ -212,6 +213,7 @@ function tr_specific($text, $language) {
 
 function language_log($message, $loglevel=0) {
     global $lang_log_level;
+    $msg = "";
     if ($loglevel==0) $msg = "[ Debug    ]";
     if ($loglevel==1) $msg = "[ Warning  ]";
     if ($loglevel==2) $msg = "[ CRITICAL ]";
@@ -255,7 +257,8 @@ $languages_in_use = array();
 
 // Loop over languages that the client requests
 //
-for ($i=0; $i<sizeof($client_languages); $i++) {
+$size = sizeof($client_languages);
+for ($i=0; $i<$size; $i++) {
     if ((strlen($client_languages[$i])>2)
         && (substr($client_languages[$i], 2, 1) == "_" || substr($client_languages[$i], 2, 1) == "-")
     ){

--- a/html/inc/translation.inc
+++ b/html/inc/translation.inc
@@ -196,9 +196,8 @@ function tra($text /* ...arglist... */) {
     for ($i=1; $i<func_num_args(); $i++){
         $replacements["%".$i] = func_get_arg($i);
     }
-    $text = strtr($text, $replacements);
 
-    return $text;
+    return strtr($text, $replacements);
 }
 
 function tr_specific($text, $language) {

--- a/html/ops/mass_email_script.php
+++ b/html/ops/mass_email_script.php
@@ -267,7 +267,7 @@ function read_log() {
         exit();
     }
     $startid = 0;
-    while (fscanf($f, '%d', &$startid)) {
+    while (fscanf($f, '%d', $startid)) {
         // read to the last entry in the file
     }
     fclose($f);
@@ -287,13 +287,13 @@ function main() {
             $startid = $new_startid;
         }
     } else {
-        $fid = fopen($id_file, 'r'); 
+        $fid = fopen($id_file, 'r');
         if (!$fid) {
             echo  $id_file . ' not found - create ID list and run again\n';
             exit();
         }
         $thisid = 0;
-        while (fscanf($fid, '%d', &$thisid)) {
+        while (fscanf($fid, '%d', $thisid)) {
             if ($thisid > $startid) {
                 do_one($thisid, $f);
             }

--- a/html/user/bolt_sched.php
+++ b/html/user/bolt_sched.php
@@ -326,7 +326,7 @@ function show_next($iter, $view) {
             //
             show_refresh_finished();
             $refresh->update('count=count+1');
-            break;
+            return;
         }
     }
 


### PR DESCRIPTION
**Description of the Change**
- The `ereg` function is deprecated since 5.3 and was removed in 7.0.
- Using `break;` outside a loop was working unintentionally before 7.0 but now throws a compile error.
- Using s call-time pass-by-reference throws an error since 5.4. The `&` is only needed in the function declaration not when calling the function.

Fixes #2102 

**Release Notes**
N/A
