### PR TITLE
Server: fix db_dump segfault

### DIFF
--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -589,7 +589,6 @@ void write_user(USER& user, ZFILE* f, bool /*detail*/) {
         " <cpid>%s</cpid>\n",
         user.id,
         name,
-        user.country,
         user.create_time,
         user.total_credit,
         user.expavg_credit,


### PR DESCRIPTION
**Description of the Change**
One too many argument for write function. Introduced in ff91f05.

Fixes #2958

**Release Notes**
Fix db_dump crash