### PR TITLE
Fixed get_other_projects function

### DIFF
--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -69,7 +69,7 @@ function get_other_projects($user) {
                 $xml_object = @simplexml_load_string($rawxml);
             }
             curl_close($ch);
-            if (!xml_object) {
+            if (!$xml_object) {
                 return $user;
             }
         }


### PR DESCRIPTION
As a part of: https://github.com/BOINC/boinc/issues/2975

**Description of the Change**

- Fixed misspelling: `xml_object` -> `$xml_object`

**Release Notes**
- Fixed bug when getting user projects via Netsoft API 

/cc @davidpanderson