### PR TITLE
Do not allow page_head() to be called twice

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -243,6 +243,10 @@ function page_head(
     global $caching, $cache_control_extra, $did_page_head;
     global $is_login_page, $fixed_navbar;
 
+    if ($did_page_head) {
+        return;
+    }
+    
     $did_page_head = true;
     $url_base = url_base();
 


### PR DESCRIPTION
**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
error_page() calls page_head(), but there are instances of code that call error_page() having already called page_head() before, thus attempting to send headers twice and creating double page header.

Fixes #2960 

**Release Notes**
Prevent page_head() from being called multiple times. Notice to projects: If you have a page_head() function override in your project.inc you need to apply this change there too.