### PR TITLE
Strip HTML tags for the page title

### DIFF
--- a/html/user/team_members.php
+++ b/html/user/team_members.php
@@ -48,7 +48,7 @@ if (!$team) {
     set_cached_data(TEAM_PAGE_TTL, serialize($team), $cache_args);
 }
 
-page_head(tra("Members of %1", "<a href=team_display.php?teamid=$teamid>$team->name</a>"));
+page_head(tra("Members of %1", $team->name));
 display_team_members($team, $offset, $sort_by);
 page_tail();
 


### PR DESCRIPTION
**Description of the Change**
Strip HTML tags for the page title.

**Screenshots**
![image](https://user-images.githubusercontent.com/1256298/51661691-472cb080-1fba-11e9-884b-7767b04592e7.png)

**Release Notes**
- Fixed title for the pages that were subject to localization