### PR TITLE
Drupal: PHP 7 fixes for various contrib modules

### DIFF
--- a/drupal/sites/default/boinc/modules/contrib/cck/content.info
+++ b/drupal/sites/default/boinc/modules/contrib/cck/content.info
@@ -4,8 +4,8 @@ description = Allows administrators to define new content types.
 package = CCK
 core = 6.x
 ; Information added by Drupal.org packaging script on 2015-06-17
-version = "6.x-2.10"
+version = "6.x-2.10-boinc-2-dev"
 core = "6.x"
 project = "cck"
-datestamp = "1434568159"
+datestamp = "1548705400"
 

--- a/drupal/sites/default/boinc/modules/contrib/cck/content.module
+++ b/drupal/sites/default/boinc/modules/contrib/cck/content.module
@@ -362,8 +362,8 @@ function content_view(&$node, $teaser = FALSE, $page = FALSE) {
  */
 function content_view_field($field, $node, $teaser = FALSE, $page = FALSE) {
   $output = '';
-  if (isset($node->$field['field_name'])) {
-    $items = $node->$field['field_name'];
+  if (isset($node->{$field['field_name']})) {
+    $items = $node->{$field['field_name']};
 
     // Use 'full'/'teaser' if not specified otherwise.
     $node->build_mode = isset($node->build_mode) ? $node->build_mode : NODE_BUILD_NORMAL;
@@ -374,7 +374,7 @@ function content_view_field($field, $node, $teaser = FALSE, $page = FALSE) {
     $function = $module .'_field';
     if (function_exists($function)) {
       $function('sanitize', $node, $field, $items, $teaser, $page);
-      $node->$field['field_name'] = $items;
+      $node->{$field['field_name']} = $items;
     }
 
     $view = content_field('view', $node, $field, $items, $teaser, $page);
@@ -710,7 +710,7 @@ function content_field($op, &$node, $field, &$items, $teaser, $page) {
         foreach (array_keys($field['columns']) as $column) {
           $items[0][$column] = NULL;
         }
-        $node->$field['field_name'] = $items;
+        $node->{$field['field_name']} = $items;
       }
 
       // If there was an AHAH add more button in this field, don't save it.
@@ -880,8 +880,8 @@ function content_field($op, &$node, $field, &$items, $teaser, $page) {
 
     case 'prepare translation':
       $addition = array();
-      if (isset($node->translation_source->$field['field_name'])) {
-        $addition[$field['field_name']] = $node->translation_source->$field['field_name'];
+      if (isset($node->translation_source->{$field['field_name']})) {
+        $addition[$field['field_name']] = $node->translation_source->{$field['field_name']};
       }
       return $addition;
   }
@@ -1059,13 +1059,13 @@ function content_storage($op, $node) {
 
       // Handle multiple fields.
       foreach ($type['fields'] as $field) {
-        if ($field['multiple'] && isset($node->$field['field_name'])) {
+        if ($field['multiple'] && isset($node->{$field['field_name']})) {
           $db_info = content_database_info($field);
           // Delete and insert, rather than update, in case a value was added.
           if ($op == 'update') {
             db_query('DELETE FROM {'. $db_info['table'] .'} WHERE vid = %d', $node->vid);
           }
-          foreach ($node->$field['field_name'] as $delta => $item) {
+          foreach ($node->{$field['field_name']} as $delta => $item) {
             $record = array();
             foreach ($db_info['columns'] as $column => $attributes) {
               $record[$attributes['column']] = $item[$column];
@@ -1242,7 +1242,7 @@ function _content_field_invoke($op, &$node, $teaser = NULL, $page = NULL) {
 
   $return = array();
   foreach ($type['fields'] as $field) {
-    $items = isset($node->$field['field_name']) ? $node->$field['field_name'] : array();
+    $items = isset($node->{$field['field_name']}) ? $node->{$field['field_name']} : array();
 
     // Make sure AHAH 'add more' button isn't sent to the fields for processing.
     unset($items[$field['field_name'] .'_add_more']);
@@ -1259,8 +1259,8 @@ function _content_field_invoke($op, &$node, $teaser = NULL, $page = NULL) {
       }
     }
     // test for values in $items in case modules added items on insert
-    if (isset($node->$field['field_name']) || count($items)) {
-      $node->$field['field_name'] = $items;
+    if (isset($node->{$field['field_name']}) || count($items)) {
+      $node->{$field['field_name']} = $items;
     }
   }
   return $return;
@@ -1282,7 +1282,7 @@ function _content_field_invoke_default($op, &$node, $teaser = NULL, $page = NULL
   }
   else {
     foreach ($type['fields'] as $field) {
-      $items = isset($node->$field['field_name']) ? $node->$field['field_name'] : array();
+      $items = isset($node->{$field['field_name']}) ? $node->{$field['field_name']} : array();
       $result = content_field($op, $node, $field, $items, $teaser, $page);
       if (is_array($result)) {
         $return = array_merge($return, $result);
@@ -1290,8 +1290,8 @@ function _content_field_invoke_default($op, &$node, $teaser = NULL, $page = NULL
       else if (isset($result)) {
         $return[] = $result;
       }
-      if (isset($node->$field['field_name'])) {
-        $node->$field['field_name'] = $items;
+      if (isset($node->{$field['field_name']})) {
+        $node->{$field['field_name']} = $items;
       }
     }
   }

--- a/drupal/sites/default/boinc/modules/contrib/cck/includes/content.diff.inc
+++ b/drupal/sites/default/boinc/modules/contrib/cck/includes/content.diff.inc
@@ -26,11 +26,11 @@ function content_diff($old_node, $new_node) {
       $function = function_exists($function) ? $function : 'content_content_diff_values';
       $old_values = array();
       $new_values = array();
-      if (isset($old_node->$field['field_name'])) {
-        $old_values = $function($old_node, $field, $old_node->$field['field_name']);
+      if (isset($old_node->{$field['field_name']})) {
+        $old_values = $function($old_node, $field, $old_node->{$field['field_name']});
       }
-      if (isset($new_node->$field['field_name'])) {
-        $new_values = $function($new_node, $field, $new_node->$field['field_name']);
+      if (isset($new_node->{$field['field_name']})) {
+        $new_values = $function($new_node, $field, $new_node->{$field['field_name']});
       }
       if ($old_values || $new_values) {
         $result[$field['field_name']] = array(

--- a/drupal/sites/default/boinc/modules/contrib/cck/includes/content.node_form.inc
+++ b/drupal/sites/default/boinc/modules/contrib/cck/includes/content.node_form.inc
@@ -59,8 +59,8 @@ function content_field_form(&$form, &$form_state, $field, $get_delta = NULL) {
       // If there was an AHAH add more button in this field, don't save it.
       unset($items[$field['field_name'] .'_add_more']);
     }
-    elseif (!empty($node->$field['field_name'])) {
-      $items = $node->$field['field_name'];
+    elseif (!empty($node->{$field['field_name']})) {
+      $items = $node->{$field['field_name']};
     }
     elseif (empty($node->nid)) {
       if (content_callback('widget', 'default value', $field) != CONTENT_CALLBACK_NONE) {

--- a/drupal/sites/default/boinc/modules/contrib/cck/includes/content.rules.inc
+++ b/drupal/sites/default/boinc/modules/contrib/cck/includes/content.rules.inc
@@ -35,7 +35,7 @@ function content_rules_action_populate_field($node, $settings, $element, &$state
   $value = _content_rules_get_field_value($settings, $state);
 
   if (!empty($field) && is_array($value)) {
-    $node->$settings['field_name'] = $value;
+    $node->{$settings['field_name']} = $value;
     return array('node' => $node);
   }
 }
@@ -138,7 +138,7 @@ function content_rules_action_populate_field_validate($form, &$form_state) {
     $function = $field_types[$field['type']]['module'] .'_field';
     if (function_exists($function)) {
       $form['#node'] = (object)array('type' => '', $settings['field_name'] => $form_state['values'][$settings['field_name']]);
-      $items = isset($form['#node']->$field['field_name']) ? $form['#node']->$field['field_name'] : array();
+      $items = isset($form['#node']->{$field['field_name']}) ? $form['#node']->{$field['field_name']} : array();
 
       //Make sure AHAH 'add more' button isn't sent to the fields
       // for processing.
@@ -239,7 +239,7 @@ function content_rules_field_has_value($node, $settings) {
     return FALSE;
   }
 
-  return _content_rules_field_has_value($node->$settings['field_name'], $value);
+  return _content_rules_field_has_value($node->{$settings['field_name']}, $value);
 }
 
 /**
@@ -266,7 +266,7 @@ function content_rules_field_changed($node1, $node2, $settings) {
   // Get information about the field.
   $field = content_fields($settings['field_name'], $node1->type);
 
-  return !empty($field) && !_content_rules_field_has_value($node1->$settings['field_name'], $node2->$settings['field_name']);
+  return !empty($field) && !_content_rules_field_has_value($node1->{$settings['field_name']}, $node2->{$settings['field_name']});
 }
 
 function content_rules_field_changed_form($settings, &$form, &$form_state) {

--- a/drupal/sites/default/boinc/modules/contrib/cck/modules/nodereference/nodereference.info
+++ b/drupal/sites/default/boinc/modules/contrib/cck/modules/nodereference/nodereference.info
@@ -7,8 +7,8 @@ dependencies[] = optionwidgets
 package = CCK
 core = 6.x
 ; Information added by Drupal.org packaging script on 2015-06-17
-version = "6.x-2.10"
+version = "6.x-2.10-boinc-2-dev"
 core = "6.x"
 project = "cck"
-datestamp = "1434568159"
+datestamp = "1548705400"
 

--- a/drupal/sites/default/boinc/modules/contrib/cck/modules/nodereference/nodereference.module
+++ b/drupal/sites/default/boinc/modules/contrib/cck/modules/nodereference/nodereference.module
@@ -189,8 +189,8 @@ function nodereference_field($op, &$node, $field, &$items, $teaser, $page) {
     case 'prepare translation':
       $addition = array();
       $addition[$field['field_name']] = array();
-      if (isset($node->translation_source->$field['field_name']) && is_array($node->translation_source->$field['field_name'])) {
-        foreach ($node->translation_source->$field['field_name'] as $key => $reference) {
+      if (isset($node->translation_source->{$field['field_name']}) && is_array($node->translation_source->{$field['field_name']})) {
+        foreach ($node->translation_source->{$field['field_name']} as $key => $reference) {
           $reference_node = node_load($reference['nid']);
           // Test if the referenced node type is translatable and, if so,
           // load translations if the reference is not for the current language.

--- a/drupal/sites/default/boinc/modules/contrib/content_profile/content_profile.info
+++ b/drupal/sites/default/boinc/modules/contrib/content_profile/content_profile.info
@@ -4,8 +4,8 @@ description = "Use content types for user profiles."
 package = "Content Profile"
 core = 6.x
 ; Information added by drupal.org packaging script on 2010-04-07
-version = "6.x-1.0"
+version = "6.x-1.0-boinc-2-dev"
 core = "6.x"
 project = "content_profile"
-datestamp = "1270662007"
+datestamp = "1548705400"
 

--- a/drupal/sites/default/boinc/modules/contrib/content_profile/content_profile.theme_vars.inc
+++ b/drupal/sites/default/boinc/modules/contrib/content_profile/content_profile.theme_vars.inc
@@ -14,8 +14,12 @@ class content_profile_theme_variables {
   var $uid;
   var $_cache = array();
 
-  function content_profile_theme_variables($uid) {
+  function __constructor($uid) {
     $this->uid = $uid;
+  }
+
+  function content_profile_theme_variables($uid) {
+    self::__constructor($uid);
   }
 
   /**

--- a/drupal/sites/default/boinc/modules/contrib/elysia_cron/elysia_cron.ctools.inc
+++ b/drupal/sites/default/boinc/modules/contrib/elysia_cron/elysia_cron.ctools.inc
@@ -193,7 +193,7 @@ function elysia_cron_ctools_to_hook_code($names, $name) {
     $output .= "  \${$export['identifier']}s = array();\n\n";
     foreach ($objects as $object) {
       $output .= ctools_export_crud_export($table, $object, '  ');
-      $output .= "  \${$export['identifier']}s['" . check_plain($object->$export['key']) . "'] = \${$export['identifier']};\n\n";
+      $output .= "  \${$export['identifier']}s['" . check_plain($object->{$export['key']}) . "'] = \${$export['identifier']};\n\n";
     }
     $output .= "  return \${$export['identifier']}s;\n";
     $output .= "}\n";

--- a/drupal/sites/default/boinc/modules/contrib/elysia_cron/elysia_cron.info
+++ b/drupal/sites/default/boinc/modules/contrib/elysia_cron/elysia_cron.info
@@ -2,8 +2,8 @@ name = "Elysia Cron"
 description = "Extended cron support with crontab-like scheduling and other features."
 core = 6.x
 ; Information added by drupal.org packaging script on 2012-03-13
-version = "6.x-2.1-boinc-1-dev"
+version = "6.x-2.1-boinc-2-dev"
 core = "6.x"
 project = "elysia_cron"
-datestamp = "1494510782"
+datestamp = "1548705400"
 

--- a/drupal/sites/default/boinc/modules/contrib/elysia_cron/elysia_cron_scheduler.inc
+++ b/drupal/sites/default/boinc/modules/contrib/elysia_cron/elysia_cron_scheduler.inc
@@ -32,16 +32,16 @@ function _elysia_cron_next_run($conf) {
 
   $rule = array($rules[1], $rules[2], array($rules[3], $rules[5]), $rules[4]);
   $ruledec = array();
-  $date = __cronDecodeDate($conf['last_run'], 1);
-  $expected_date = __cronDecodeDate(!empty($conf['last_run_expected']) ? $conf['last_run_expected'] : 0);
+  $date = _cronDecodeDate($conf['last_run'], 1);
+  $expected_date = _cronDecodeDate(!empty($conf['last_run_expected']) ? $conf['last_run_expected'] : 0);
   
   for ($i = 0; $i < 4; $i++) {
     if ($i != 2) {
       // Standard scheme for mins, hours, month
-      $ruledec[$i] = __cronDecodeRule($rule[$i], $ranges[$i][0], $ranges[$i][1]);
+      $ruledec[$i] = _cronDecodeRule($rule[$i], $ranges[$i][0], $ranges[$i][1]);
     } else {
       // For mday+week we follow another scheme
-      $ruledec[$i] = __cronDecodeRuleMday($rule[2], $date[3], $date[4]);
+      $ruledec[$i] = _cronDecodeRuleMday($rule[2], $date[3], $date[4]);
     }
     $r = $ruledec[$i];
     $new = $date[$i];
@@ -52,7 +52,7 @@ function _elysia_cron_next_run($conf) {
       $new = $expected_date[$i] + ceil(($date[$i] - $expected_date[$i]) / $r['d']) * $r['d'];
     }
     elseif ($r['n']) {
-      $new = __cronNextOrEqual($date[$i], $r['n'], $ranges[$i][0], $ranges[$i][1]);
+      $new = _cronNextOrEqual($date[$i], $r['n'], $ranges[$i][0], $ranges[$i][1]);
     }
     if ($new != $date[$i]) {
       $date[$i] = $new;
@@ -63,7 +63,7 @@ function _elysia_cron_next_run($conf) {
       for ($j = 0; $j < $i; $j++) {
         if ($j == 2) {
           // For mday+week decoded rule could be changed (by month+year)
-          $ruledec[$j] = __cronDecodeRuleMday($rule[2], $date[3], $date[4]);
+          $ruledec[$j] = _cronDecodeRuleMday($rule[2], $date[3], $date[4]);
         }
         $date[$j] = $ruledec[$j]['d'] ? ($ranges[$j][0] == 0 ? 0 : $ruledec[$j]['d']) : ($ruledec[$j]['n'] ? reset($ruledec[$j]['n']) : $ranges[$j][0]);
         $expected_date[$j] = 0;
@@ -71,10 +71,10 @@ function _elysia_cron_next_run($conf) {
     }
   }
 
-  return __cronEncodeDate($date);
+  return _cronEncodeDate($date);
 }
 
-function __cronDecodeDate($timestamp, $min_diff = 0) {
+function _cronDecodeDate($timestamp, $min_diff = 0) {
   $time = floor($timestamp / 60);
   $time += $min_diff;
   
@@ -88,11 +88,11 @@ function __cronDecodeDate($timestamp, $min_diff = 0) {
   );
   return $date;
 }
-function __cronEncodeDate($date) {
+function _cronEncodeDate($date) {
   return mktime($date[1], $date[0], 0, $date[3], $date[2], $date[4]);
 }
 
-function __cronNextOrEqual($el, $arr, $range_start, $range_end) {
+function _cronNextOrEqual($el, $arr, $range_start, $range_end) {
   if (empty($arr)) {
     return $el;
   }
@@ -104,7 +104,7 @@ function __cronNextOrEqual($el, $arr, $range_start, $range_end) {
   return $range_end + reset($arr) + 1 - $range_start;
 }
 
-function __cronDecodeRule($rule, $min, $max) {
+function _cronDecodeRule($rule, $min, $max) {
   if ($rule == '*') {
     return array('n' => array(), 'd' => 0);
   }
@@ -125,11 +125,11 @@ function __cronDecodeRule($rule, $min, $max) {
   return $result;
 }
 
-function __cronDecodeRuleMday($rule, $month, $year) {
+function _cronDecodeRuleMday($rule, $month, $year) {
   $range_from = 1;
   $range_to = $month != 2 ? (in_array($month, array(4,6,9,11)) ? 30 : 31) : ($year % 4 == 0 ? 29 : 28);
-  $r1 = __cronDecodeRule($rule[0], $range_from, $range_to);
-  $r2 = __cronDecodeRule($rule[1], $range_from, $range_to);
+  $r1 = _cronDecodeRule($rule[0], $range_from, $range_to);
+  $r2 = _cronDecodeRule($rule[1], $range_from, $range_to);
   if ($r2['d']) {
     for ($i = 0; $i < 7; $i++) {
       if ($i % $r2['d'] == 0) {
@@ -139,13 +139,13 @@ function __cronDecodeRuleMday($rule, $month, $year) {
   }
   if ($r2['n']) {
     $r2['n'] = array_unique($r2['n']);
-    $r1['n'] = array_merge($r1['n'], __cronMonDaysFromWeekDays($year, $month, $r2['n']), __cronMonDaysFromWeekDays($year, $month + 1, $r2['n'], $range_to));
+    $r1['n'] = array_merge($r1['n'], _cronMonDaysFromWeekDays($year, $month, $r2['n']), _cronMonDaysFromWeekDays($year, $month + 1, $r2['n'], $range_to));
   }
   return $r1;
 }
 
 // Used by elysia_cron_should_run
-function __cronMonDaysFromWeekDays($year, $mon, $weekdays, $offset = 0) {
+function _cronMonDaysFromWeekDays($year, $mon, $weekdays, $offset = 0) {
   if ($mon > 12) {
     $year ++;
     $mon = $mon - 12;

--- a/drupal/sites/default/boinc/modules/contrib/filefield/filefield.info
+++ b/drupal/sites/default/boinc/modules/contrib/filefield/filefield.info
@@ -5,8 +5,8 @@ package = CCK
 core = 6.x
 php = 5.0
 ; Information added by Drupal.org packaging script on 2016-02-24
-version = "6.x-3.14-boinc-2-dev"
+version = "6.x-3.14-boinc-3-dev"
 core = "6.x"
 project = "filefield"
-datestamp = "1524676807"
+datestamp = "1548705400"
 

--- a/drupal/sites/default/boinc/modules/contrib/filefield/filefield_field.inc
+++ b/drupal/sites/default/boinc/modules/contrib/filefield/filefield_field.inc
@@ -190,8 +190,8 @@ function filefield_field_update($node, $field, &$items, $teaser, $page) {
   // Delete items from original node.
   $orig = node_load($node->nid); 
   // If there are, figure out which ones must go.
-  if (!empty($orig->$field['field_name'])) {
-    foreach ($orig->$field['field_name'] as $oitem) {
+  if (!empty($orig->{$field['field_name']})) {
+    foreach ($orig->{$field['field_name']} as $oitem) {
       if (isset($oitem['fid']) && !in_array($oitem['fid'], $curfids)) {
         // For hook_file_references, remember that this is being deleted.
         $oitem['field_name'] = $field['field_name'];

--- a/drupal/sites/default/boinc/modules/contrib/flag/flag.info
+++ b/drupal/sites/default/boinc/modules/contrib/flag/flag.info
@@ -5,8 +5,8 @@ package = Flags
 php = 5
 
 ; Information added by Drupal.org packaging script on 2015-07-12
-version = "6.x-2.2-boinc-1-dev"
+version = "6.x-2.2-boinc-2-dev"
 core = "6.x"
 project = "flag"
-datestamp = "1494857819"
+datestamp = "1548705400"
 

--- a/drupal/sites/default/boinc/modules/contrib/flag/includes/flag_handler_argument_content_id.inc
+++ b/drupal/sites/default/boinc/modules/contrib/flag/includes/flag_handler_argument_content_id.inc
@@ -36,7 +36,7 @@ class flag_handler_argument_content_id extends views_handler_argument_numeric {
 
     $result = db_query("SELECT o.". $views_info['title field'] ." FROM {". $views_info['views table'] ."} o WHERE o.". $views_info['join field'] ." IN ($placeholders)", $this->value);
     while ($title = db_fetch_object($result)) {
-      $titles[] = check_plain($title->$views_info['title field']);
+      $titles[] = check_plain($title->{$views_info['title field']});
     }
     return $titles;
   }

--- a/drupal/sites/default/boinc/modules/contrib/jump/jump.info
+++ b/drupal/sites/default/boinc/modules/contrib/jump/jump.info
@@ -4,8 +4,8 @@ core = 6.x
 dependencies[] = ahah_helper
 
 ; Information added by drupal.org packaging script on 2013-09-30
-version = "6.x-2.x-dev"
+version = "6.x-2.x-boinc-2-dev"
 core = "6.x"
 project = "jump"
-datestamp = "1393530079"
+datestamp = "1548705400"
 

--- a/drupal/sites/default/boinc/modules/contrib/jump/jump_views_plugin_style.inc
+++ b/drupal/sites/default/boinc/modules/contrib/jump/jump_views_plugin_style.inc
@@ -123,8 +123,8 @@ class jump_views_plugin_style extends views_plugin_style {
     $map = array_flip($this->field_map);
     foreach ($this->view->display_handler->get_handlers('field') as $field => $handler) {
       $map = array_flip($this->field_map);
-      if (isset($row->$map[$field])) {
-        $tokens["[$field]"] = $row->$map[$field];
+      if (isset($row->{$map[$field]})) {
+        $tokens["[$field]"] = $row->{$map[$field]};
       }
       else {
         $tokens["[$field]"] = '';

--- a/drupal/sites/default/boinc/modules/contrib/mobile_menu_toggle/mobile_menu_toggle.tpl.php
+++ b/drupal/sites/default/boinc/modules/contrib/mobile_menu_toggle/mobile_menu_toggle.tpl.php
@@ -1,1 +1,2 @@
+<?php
 <a id="mobile-menu-toggle" href="javascript:;">Menu</a>


### PR DESCRIPTION
**Description of the Change**
Changes to `contrib` directory modules for PHP7 compatibility.

* Added curly braces to fix variable interpolation.
* Misc other PHP fixes.

**Release Notes**
N/A

Part of https://dev.gridrepublic.org/browse/DBOINCP-468