### PR TITLE
Drupal: Removed old INI settings.

### DIFF
--- a/drupal/sites/default/settings.php
+++ b/drupal/sites/default/settings.php
@@ -163,8 +163,6 @@ else {
  * duplicated there so as to avoid conflict issues.
  */
 ini_set('arg_separator.output',     '&amp;');
-ini_set('magic_quotes_runtime',     0);
-ini_set('magic_quotes_sybase',      0);
 ini_set('session.cache_expire',     200000);
 ini_set('session.cache_limiter',    'none');
 ini_set('session.cookie_lifetime',  2000000);


### PR DESCRIPTION
**Description of the Change**
Removed PHP INI settings from settings.php that have been removed from PHP 7.0

**Release Notes**
N/A
Part of https://dev.gridrepublic.org/browse/DBOINCP-468