### PR TITLE
Drupal: PHP7 fixes for views modules

### DIFF
--- a/drupal/sites/default/boinc/modules/contrib/views/includes/handlers.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/includes/handlers.inc
@@ -510,8 +510,12 @@ class views_handler extends views_object {
  *
  */
 class views_many_to_one_helper {
-  function views_many_to_one_helper(&$handler) {
+  function __construct(&$handler) {
     $this->handler = &$handler;
+  }
+
+  function views_many_to_one_helper(&$handler) {
+    self::__construct($handler);
   }
 
   public static function option_definition(&$options) {

--- a/drupal/sites/default/boinc/modules/contrib/views/includes/query.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/includes/query.inc
@@ -67,7 +67,7 @@ class views_query {
   /**
    * Constructor; Create the basic query object and fill with default values.
    */
-  function views_query($base_table = 'node', $base_field = 'nid') {
+  function __construct($base_table = 'node', $base_field = 'nid') {
     $this->base_table = $base_table;  // Predefine these above, for clarity.
     $this->base_field = $base_field;
     $this->relationships[$base_table] = array(
@@ -105,6 +105,10 @@ class views_query {
       'alias' => $base_field,
       'count' => TRUE,
     );
+  }
+
+  function views_query($base_table = 'node', $base_field = 'nid') {
+    self::__construct($base_table, $base_field);
   }
 
   // ----------------------------------------------------------------

--- a/drupal/sites/default/boinc/modules/contrib/views/includes/tabs.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/includes/tabs.inc
@@ -146,10 +146,14 @@ class views_tab {
   /**
    * Construct a new tab.
    */
-  function views_tab($name, $title, $body = NULL) {
+  function __construct($name, $title, $body = NULL) {
     $this->name = $name;
     $this->title = $title;
     $this->body = $body;
+  }
+
+  function views_tab($name, $title, $body = NULL) {
+    self::__construct($name, $title, $body);
   }
 
   /**

--- a/drupal/sites/default/boinc/modules/contrib/views/includes/view.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/includes/view.inc
@@ -66,7 +66,7 @@ class view extends views_db_object {
   /**
    * Constructor
    */
-  function view() {
+  function __construct() {
     parent::init();
     // Make sure all of our sub objects are arrays.
     foreach ($this->db_objects() as $object) {
@@ -74,6 +74,10 @@ class view extends views_db_object {
     }
 
     $this->query = new stdClass();
+  }
+
+  function view() {
+    self::__construct();
   }
 
   /**
@@ -2055,8 +2059,11 @@ class views_db_object {
  */
 class views_display extends views_db_object {
   var $db_table = 'views_display';
-  function views_display($init = TRUE) {
+  function __construct($init = TRUE) {
     parent::init($init);
+  }
+  function views_display($init = TRUE) {
+    self::construct($init);
   }
 
   function options($type, $id, $title) {

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/locale/views_handler_field_locale_language.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/locale/views_handler_field_locale_language.inc
@@ -22,7 +22,7 @@ class views_handler_field_locale_language extends views_handler_field {
   }
 
   function render($values) {
-    $languages = locale_language_list(empty($this->$options['native_language']) ? 'name' : 'native');
+    $languages = locale_language_list(empty($this->{$options['native_language']}) ? 'name' : 'native');
     return isset($languages[$values->{$this->field_alias}]) ? $languages[$values->{$this->field_alias}] : '';
   }
 }

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/profile/views_handler_field_profile_list.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/profile/views_handler_field_profile_list.inc
@@ -11,7 +11,7 @@ class views_handler_field_profile_list extends views_handler_field_prerender_lis
     foreach ($values as $value) {
       $field = $value->{$this->field_alias};
       $this->items[$field] = array();
-      foreach (split("[,\n\r]", $field) as $item) {
+      foreach (preg_split("/[,\n\r]/", $field) as $item) {
         if ($item != '' && $item !== NULL) {
           $this->items[$field][] = array('item' => $item);
         }

--- a/drupal/sites/default/boinc/modules/contrib/views/modules/profile/views_handler_filter_profile_selection.inc
+++ b/drupal/sites/default/boinc/modules/contrib/views/modules/profile/views_handler_filter_profile_selection.inc
@@ -13,7 +13,7 @@ class views_handler_filter_profile_selection extends views_handler_filter_in_ope
     $all_options = profile_views_get_fields();
     $field = $all_options[$this->definition['fid']];
 
-    $lines = split("[,\n\r]", $field->options);
+    $lines = preg_split("/[,\n\r]/", $field->options);
     foreach ($lines as $line) {
       if ($line = trim($line)) {
         $this->value_options[$line] = $line;

--- a/drupal/sites/default/boinc/modules/contrib/views/views.info
+++ b/drupal/sites/default/boinc/modules/contrib/views/views.info
@@ -4,7 +4,7 @@ package = Views
 core = 6.x
 
 ; Information added by Drupal.org packaging script on 2015-02-11
-version = "6.x-2.18-boinc-4-dev"
+version = "6.x-2.18-boinc-5-dev"
 core = "6.x"
 project = "views"
-datestamp = "1503062455"
+datestamp = "1548705400"


### PR DESCRIPTION
**Description of the Change**
Fixed PHP7 compatibility issues for the `contrib/views` module.

* Replaced `split()` function with `preg_split()`.
* Add curly braces when necessary.
* Modified constructor to a modern PHP standard.

**Release Notes**
N/A

Part of https://dev.gridrepublic.org/browse/DBOINCP-468