### PR TITLE
Drupal: panels module - Fixed old style PHP4 constructors.

### DIFF
--- a/drupal/sites/default/boinc/modules/contrib/panels/includes/common.inc
+++ b/drupal/sites/default/boinc/modules/contrib/panels/includes/common.inc
@@ -89,11 +89,15 @@ class panels_allowed_layouts {
    *  as allowed or not allowed on the initial call to panels_allowed_layouts::set_allowed()
    *
    */
-  function panels_allowed_layouts($start_allowed = TRUE) {
+  function __construct($start_allowed = TRUE) {
     // TODO would be nice if there was a way to just fetch the names easily
     foreach ($this->list_layouts() as $layout_name) {
       $this->allowed_layout_settings[$layout_name] = $start_allowed ? 1 : 0;
     }
+  }
+
+  function panels_allowed_layouts($start_allowed = TRUE) {
+    self::__construct($start_allowed);
   }
 
   /**

--- a/drupal/sites/default/boinc/modules/contrib/panels/includes/plugins.inc
+++ b/drupal/sites/default/boinc/modules/contrib/panels/includes/plugins.inc
@@ -123,7 +123,7 @@ class panels_cache_object {
   /**
    * When constructed, take a snapshot of our existing out of band data.
    */
-  function panels_cache_object() {
+  function __construct() {
     $this->head = drupal_set_html_head();
     $this->css = drupal_add_css();
     $this->tokens = ctools_set_page_token();
@@ -133,6 +133,9 @@ class panels_cache_object {
     }
   }
 
+  function panels_cache_object() {
+    self::__construct();
+  }
   /**
    * Add content to the cache. This assumes a pure stream;
    * use set_content() if it's something else.

--- a/drupal/sites/default/boinc/modules/contrib/panels/panels.module
+++ b/drupal/sites/default/boinc/modules/contrib/panels/panels.module
@@ -594,10 +594,14 @@ class panels_display {
   var $did = 'new';
   var $renderer;
 
-  function panels_display() {
+  function __construct() {
     // Set the default renderer to either the legacy or the standard renderer,
     // depending on the legacy rendering state
     $this->renderer = variable_get('panels_legacy_rendering_mode', TRUE) ? 'legacy' : 'standard';
+  }
+
+  function panels_display() {
+    self::__construct();
   }
 
   function add_pane(&$pane, $location = NULL) {


### PR DESCRIPTION
**Description of the Change**
Fixed old style PHP4 constructors, adding new modern PHP constructors.

Part of PHP 7.0 compatibility.

**Release Notes**
N/A

Part of https://dev.gridrepublic.org/browse/DBOINCP-468