### PR TITLE
Drupal: PHP7 fixes for ctools module

### DIFF
--- a/drupal/sites/default/boinc/modules/contrib/ctools/ctools.info
+++ b/drupal/sites/default/boinc/modules/contrib/ctools/ctools.info
@@ -3,8 +3,8 @@ description = A library of helpful tools by Merlin of Chaos.
 core = 6.x
 package = Chaos tool suite
 ; Information added by Drupal.org packaging script on 2015-12-22
-version = "6.x-1.15-boinc-1-dev"
+version = "6.x-1.15-boinc-2-dev"
 core = "6.x"
 project = "ctools"
-datestamp = "1547652669"
+datestamp = "1548704188"
 

--- a/drupal/sites/default/boinc/modules/contrib/ctools/includes/context.inc
+++ b/drupal/sites/default/boinc/modules/contrib/ctools/includes/context.inc
@@ -42,10 +42,13 @@ class ctools_context {
   var $restrictions = array();
   var $empty = FALSE;
 
-  function ctools_context($type = 'none', $data = NULL) {
+  function __construct($type = 'none', $data = NULL) {
     $this->type  = $type;
     $this->data  = $data;
     $this->title = t('Unknown context');
+  }
+  function ctools_context($type = 'none', $data = NULL) {
+    self::__construct($type, $data);
   }
 
   function is_type($type) {
@@ -113,7 +116,7 @@ class ctools_context_required {
    * @param ...
    *   One or more keywords to use for matching which contexts are allowed.
    */
-  function ctools_context_required($title) {
+  function __construct($title) {
     $args = func_get_args();
     $this->title = array_shift($args);
 
@@ -126,6 +129,10 @@ class ctools_context_required {
       $args = array_shift($args);
     }
     $this->keywords = $args;
+  }
+
+  function ctools_context_required($title) {
+    self::__construct($title);
   }
 
   function filter($contexts) {
@@ -181,9 +188,13 @@ class ctools_context_required {
  */
 class ctools_context_optional extends ctools_context_required {
   var $required = FALSE;
-  function ctools_context_optional() {
+  function __construct() {
     $args = func_get_args();
     call_user_func_array(array($this, 'ctools_context_required'), $args);
+  }
+
+  function ctools_context_optional() {
+    self::__construct();
   }
 
   /**

--- a/drupal/sites/default/boinc/modules/contrib/ctools/includes/math-expr.inc
+++ b/drupal/sites/default/boinc/modules/contrib/ctools/includes/math-expr.inc
@@ -98,11 +98,15 @@ class ctools_math_expr {
         'sqrt','abs','ln','log',
         'time', 'ceil', 'floor', 'min', 'max', 'round');
 
-    function ctools_math_expr() {
+    function __construct() {
         // make the variables a little more accurate
         $this->v['pi'] = pi();
         $this->v['e'] = exp(1);
         drupal_alter('ctools_math_expression_functions', $this->fb);
+    }
+
+    function ctools_math_expr() {
+        self::__construct();
     }
 
     function e($expr) {

--- a/drupal/sites/default/boinc/modules/contrib/ctools/page_manager/page_manager.info
+++ b/drupal/sites/default/boinc/modules/contrib/ctools/page_manager/page_manager.info
@@ -5,8 +5,8 @@ dependencies[] = ctools
 package = Chaos tool suite
 
 ; Information added by Drupal.org packaging script on 2015-12-22
-version = "6.x-1.15-boinc-1-dev"
+version = "6.x-1.15-boinc-2-dev"
 core = "6.x"
 project = "ctools"
-datestamp = "1547652669"
+datestamp = "1548704188"
 

--- a/drupal/sites/default/boinc/modules/contrib/ctools/page_manager/plugins/tasks/page.inc
+++ b/drupal/sites/default/boinc/modules/contrib/ctools/page_manager/plugins/tasks/page.inc
@@ -261,6 +261,7 @@ function page_manager_page_theme(&$items, $task) {
  *   creating named arguments in the path.
  */
 function page_manager_page_execute($subtask_id) {
+  $func_args = func_get_args();
   $page = page_manager_page_load($subtask_id);
   $task = page_manager_get_task($page->task);
   $subtask = page_manager_get_task_subtask($task, $subtask_id);
@@ -268,7 +269,7 @@ function page_manager_page_execute($subtask_id) {
   // Turn the contexts into a properly keyed array.
   $contexts = array();
   $args = array();
-  foreach (func_get_args() as $count => $arg) {
+  foreach ($func_args as $count => $arg) {
     if (is_object($arg) && get_class($arg) == 'ctools_context') {
       $contexts[$arg->id] = $arg;
       $args[] = $arg->original_argument;

--- a/drupal/sites/default/boinc/modules/contrib/ctools/plugins/export_ui/ctools_export_ui.class.php
+++ b/drupal/sites/default/boinc/modules/contrib/ctools/plugins/export_ui/ctools_export_ui.class.php
@@ -605,6 +605,7 @@ class ctools_export_ui {
   // These methods are the API for adding/editing exportable items
 
   function add_page($js, $input, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('add'));
 
     // If a step not set, they are trying to create a new item. If a step
@@ -627,7 +628,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     $output = $this->edit_execute_form($form_state);
@@ -643,6 +644,7 @@ class ctools_export_ui {
    * Main entry point to edit an item.
    */
   function edit_page($js, $input, $item, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('edit', $item));
 
     // Check to see if there is a cached item to get if we're using the wizard.
@@ -664,7 +666,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     $output = $this->edit_execute_form($form_state);
@@ -680,6 +682,7 @@ class ctools_export_ui {
    * Main entry point to clone an item.
    */
   function clone_page($js, $input, $original, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('clone', $original));
 
     // If a step not set, they are trying to create a new clone. If a step
@@ -713,7 +716,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     $output = $this->edit_execute_form($form_state);
@@ -1188,6 +1191,7 @@ class ctools_export_ui {
    * Page callback to import information for an exportable item.
    */
   function import_page($js, $input, $step = NULL) {
+    $args = func_get_args();
     drupal_set_title($this->get_page_title('import'));
     // Import is basically a multi step wizard form, so let's go ahead and
     // use CTools' wizard.inc for it.
@@ -1212,7 +1216,7 @@ class ctools_export_ui {
       'no_redirect' => TRUE,
       'step' => $step,
       // Store these in case additional args are needed.
-      'function args' => func_get_args(),
+      'function args' => $args,
     );
 
     // import always uses the wizard.


### PR DESCRIPTION
**Description of the Change**
For PHP7 compatibility:

* Fixed `func_get_args()` calls
* Modernized PHP4 style constructors.

**Release Notes**
N/A

Part of https://dev.gridrepublic.org/browse/DBOINCP-468