### PR TITLE
Drupal: Removed PHP ini setting 'arg_separator.output'.

### DIFF
--- a/drupal/sites/default/settings.php
+++ b/drupal/sites/default/settings.php
@@ -162,7 +162,6 @@ else {
  * settings are used there. Settings defined here should not be
  * duplicated there so as to avoid conflict issues.
  */
-ini_set('arg_separator.output',     '&amp;');
 ini_set('session.cache_expire',     200000);
 ini_set('session.cache_limiter',    'none');
 ini_set('session.cookie_lifetime',  2000000);


### PR DESCRIPTION
**Description of the Change**
With this setting present, reCAPTCHA does not work. Removing this setting, un-breaks reCAPTCHA.

Part of PHP 7.0 compatibility.

https://dev.gridrepublic.org/browse/DBOINCP-484

**Release Notes**
N/A