### PR TITLE
[Android] Update Graddle to v3.3.0

### DIFF
--- a/android/BOINC/.idea/misc.xml
+++ b/android/BOINC/.idea/misc.xml
@@ -35,5 +35,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
     }
 }
 

--- a/android/BOINC/gradle/wrapper/gradle-wrapper.properties
+++ b/android/BOINC/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 23 11:36:09 CET 2018
+#Mon Feb 04 09:57:33 UTC 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
**Description of the Change**
To take advantage of the latest features, improvements, and security fixes, it is strongly recommended to update the Android Gradle plugin to version 3.3.0 and Gradle to version 4.10.1. [Release notes.](https://developer.android.com/studio/releases/gradle-plugin)

**Release Notes**
N/A
