### PR TITLE
build: fix removing ln test directory

### DIFF
--- a/m4/sah_links.m4
+++ b/m4/sah_links.m4
@@ -14,7 +14,7 @@ AC_DEFUN([SAH_LINKS],[
       LN=cp
     fi
     /bin/rm erase.me$$ lntest/config.sub
-    /bin/rmdir ln_test
+    /bin/rmdir lntest
   else
     LN=cp
   fi


### PR DESCRIPTION
**Description of the Change**
Fixes a typo that resulted in `/bin/rmdir: failed to remove 'ln_test': No such file or directory`
error message from configure and a leftover directory in build directory.

**Alternate Designs**
None needed

**Release Notes**
N/A
