### PR TITLE
Drupal: Add form to send email to all team-members.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincteam/boincteam.module
+++ b/drupal/sites/default/boinc/modules/boincteam/boincteam.module
@@ -101,6 +101,15 @@ function boincteam_menu() {
     'access arguments' => array(2),
     'type' => MENU_CALLBACK,
   );
+  $items['community/teams/%/message-all-members'] = array(
+    'title' => bts('Send Message to Team', array(), NULL, 'boinc:team-manage'),
+    'description' => bts('Send Message to Team', array(), NULL, 'boinc:team-manage'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('boincteam_sendmessagetoteam', 2),
+    'access callback' => 'boincteam_is_admin',
+    'access arguments' => array(2),
+    'type' => MENU_CALLBACK,
+  );
   $items['admin/boinc/utility-team-delete'] = array(
     'title' => 'Utility: Delete SPAM Teams',
     'description' => 'Utililities to help delete BOINC teams created by SPAMMERs.',
@@ -201,6 +210,16 @@ function boincteam_cron_queue_info() {
     'worker callback' => 'boincteam_delete',
     'time' => 60,
   );
+}
+
+/**
+ * Implementation of hook_mail_alter()
+ */
+function boincteam_mail_alter(&$message) {
+  if (isset($message['params']['boincteam_headers'])) {
+    $message['headers']['Bcc'] = $message['params']['boincteam_headers']['Bcc'];
+    $message['to'] = '';
+  }
 }
 
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
@@ -976,20 +995,13 @@ function boincteam_management_panel($team_id) {
   
   // PM all members
   if (module_exists('privatemsg')) {
-    // Obtain all Drupal uids of team members and construct URL to send
-    // a private message to all.
-    $boinc_id = boincteam_lookup_id($team_id);
-    $member_drupaluids = _boincteam_userids($boinc_id, FALSE);
-    $members = array_map("user_load", $member_drupaluids);
-    $team_pm_link = privatemsg_get_link($members);
-
     $output .= '<div class="form-item">';
     $output .= '  <ul class="tab-list action-list">';
     $output .= '    <li class="first tab primary">' .
-      l('Send message to team', $team_pm_link) . '</li>';
+      l('Send message to team', "community/teams/{$team_id}/message-all-members") . '</li>';
     $output .= '  </ul>';
     $output .= '  <div class="description">';
-    $output .=   bts('Private message all team members.', array(), NULL, 'boinc:team-manage');
+    $output .=   bts('Contact all team members using e-mail.', array(), NULL, 'boinc:team-manage');
     $output .= '  </div>';
     $output .= '</div>';
   }

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
@@ -830,7 +830,7 @@ function boincteam_sendmessagetoteam_submit($form, &$form_state) {
     'from'    => '',
     'to'      => "webmaster@{$base_url}",
     'boincteam_headers' => array(
-      'Bcc'     => implode($member_emails, ','),
+      'Bcc'     => implode(',', $member_emails),
     ),
     'subject' => $form_state['validated_built_message']['subject'],
     'message' => $mybody,

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.forms.inc
@@ -629,3 +629,221 @@ function boincteam_add_admin_form_submit($form, &$form_state) {
   // The storage variable quietly kills redirection for some reason... unset it
   unset($form_state['storage']);
 }
+
+/*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
+ * Team email functions
+ *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  */
+
+
+/**
+ * Send all team members an email message function
+ */
+function boincteam_sendmessagetoteam(&$form_state, $team_id) {
+  global $user;
+  $form = array();
+
+  if (isset($form_state['values'])) {
+    $subject   = $form_state['values']['subject'];
+    $body      = $form_state['values']['body'];
+  }
+  else {
+    $subject   = '';
+    $body      = '';
+  }
+
+  // Title
+  $mytitle = bts('Send E-mail All Team Members', array(), NULL, 'boinc:team-message-form');
+  drupal_set_title($mytitle);
+
+  $form['emailteam']['header'] = array(
+    '#value'              => '<h1>' . $mytitle . '</h1>',
+    '#weight'             => '-10',
+    '#prefix'             => "<div id='sendmessageteammembers-header'>",
+    '#suffix'             => "</div>",
+  );
+
+  $form['emailteam']['instructions'] = array(
+    '#value'              => bts('This will send an email to all team members. If a team member has opt-ed out of notification e-mails, they will not receive your message. At the bottom of your message, a link will be provied to Direct Message you the sender. This link is added automatically, you do not need to add it below in the Message box.', array(), NULL, 'boinc:team-message-form'),
+    '#weight'             => '-8',
+    '#prefix'             => "<div id='sendmessageteammembers-instructions'>",
+    '#suffix'             => "</div>",
+  );
+
+  // Subject
+  $form['emailteam']['subject'] = array(
+    '#type'               => 'textfield',
+    '#title'              => bts('Subject', array(), NULL, 'boinc:team-message-form'),
+    '#size'               => 50,
+    '#maxlength'          => 255,
+    '#default_value'      => $subject,
+    '#weight'             => -5,
+  );
+
+  // Body
+  $form['emailteam']['body'] = array(
+    '#type'               => 'textarea',
+    '#title'              => bts('Message', array(), NULL, 'boinc:team-message-form'),
+    '#rows'               => 8,
+    '#weight'             => 0,
+    '#default_value'      => $body,
+    '#resizable'          => TRUE,
+  );
+
+  // checkbox for 'sent to self'
+  $form['emailteam']['selfsend'] = array(
+    '#type'    => 'checkbox',
+    '#title'   => bts('Check this box if you wish to be sent a copy of the above to your email address.', array(), NULL, 'boinc:team-message-form'),
+    '#weight'  => 10,
+    '#prefix'  => '<div class="clearfix" id="confirm-checkbox">',
+    '#suffix'  => '</div>',
+  );
+
+  // Add a captcha to form
+  if (module_exists('captcha')) {
+    $form['register_captcha'] = array(
+        '#type' => 'captcha',
+        '#weight' => 1000,
+    );
+  }
+
+  // form buttons
+  $form['emailteam']['form control tabs prefix'] = array(
+    '#value'  => '<ul class="form-control tab-list">',
+    '#weight' => 1000,
+  );
+
+  $form['emailteam']['submit'] = array(
+    '#type'               => 'submit',
+    '#value'              => bts('Send message', array(), NULL, 'boinc:form-submit'),
+    '#submit'             => array('boincteam_sendmessagetoteam_submit'),
+    '#validate'           => array('boincteam_sendmessagetoteam_validate'),
+    '#weight'             => 1001,
+    '#prefix'             => '<li class="first tab">',
+    '#suffix'             => '</li>'
+  );
+
+  $title = bts('Cancel', array(), NULL, 'boinc:form-cancel');
+  $url = "community/teams/{$team_id}";
+  $form['emailteam']['cancel'] = array(
+    '#value'              => l($title, $url, array('attributes' => array('id' => 'edit-cancel'))),
+    '#weight'             => 1005,
+    '#prefix'             => '<li class="tab">',
+    '#suffix'             => '</li>'
+  );
+
+  $form['emailteam']['form control tabs suffix'] = array(
+    '#value'  => '</ul>',
+    '#weight' => 1010,
+  );
+
+  // Add team id information to form_state
+  $form['_team_id'] = array(
+    '#type'  => 'value',
+    '#value' => $team_id,
+  );
+
+  // Add sender user object to form_state
+  $form['_senderuid'] = array(
+    '#type'  => 'value',
+    '#value' => $user->uid,
+  );
+
+  // redirect after sending message
+  $form['#redirect'] = "community/teams/{$team_id}";
+
+  return $form;
+}
+
+/**
+ * Send all team members validation handler
+ */
+function boincteam_sendmessagetoteam_validate($form, &$form_state) {
+  $message = $form_state['values'];
+  $message['timestamp'] = time();
+  // Avoid subjects which only consist of a space as these can not be clicked.
+  $message['subject'] = trim($message['subject']);
+
+  $trimed_body = trim(truncate_utf8(strip_tags($message['body']), 50, TRUE, TRUE));
+  if (empty($message['subject']) && !empty($trimed_body)) {
+    $message['subject'] = $trimed_body;
+    $form_state['values']['subject'] = $message['subject'];
+  }
+
+  // Check subject line
+  $message['subject'] = trim($message['subject']);
+  if (empty($message['subject'])) {
+    form_set_error('subject',
+      bts('Not allowed to send a message without subject', array(), NULL, 'boinc:team-message-form')
+    );
+  }
+
+  // Check body
+  if ( ($message['body'] === NULL || $message['body'] === '') ) {
+    form_set_error('body',
+      bts('Not allowed to send an empty message.', array(), NULL, 'boinc:team-message-form')
+    );
+  }
+
+  // Check team id
+  if (empty($message['_team_id'])) {
+    form_set_error('team_id',
+      bts('Error, no team_id supplied.', array(), NULL, 'boinc:team-message-form')
+    );
+  }
+
+  $form_state['validated_built_message'] = $message;
+}
+
+/**
+ * Send all team members submit handler
+ */
+function boincteam_sendmessagetoteam_submit($form, &$form_state) {
+  module_load_include('inc', 'rules', 'modules/system.rules');
+  global $base_url;
+  global $base_path;
+
+  $suid = $form_state['values']['_senderuid'];
+  $account = user_load(array('uid' => $suid ));
+  $site_url = $base_url . $base_path . "/messages/new/" . $suid;
+
+  // Form is validated, now send to all team members. Lookup boinc
+  // id of all team members, and then use user_load() to load user
+  // object. Send message using email.
+  //
+  $boinc_id = boincteam_lookup_id($form_state['values']['_team_id']);
+  // Email addresses, with those who have opt-ed out of notification
+  // emails removed.
+  $member_emails = _boincteam_emails($boinc_id);
+  // Remove sender's email address, unless selfsend is true.
+  if ( !$form_state['values']['selfsend'] ) {
+    $pos = array_search($account->mail, $member_emails);
+    unset($member_emails[$pos]);
+  }
+
+  // Add link at bottom of body
+  $mybody = $form_state['validated_built_message']['body'];
+  $mybody .= "\n\n"
+      . "To reply to the sender using a Direct Message (DM), please use this link:\n"
+      . "${site_url}";
+
+  $emailsettings = array(
+    'from'    => '',
+    'to'      => "webmaster@{$base_url}",
+    'boincteam_headers' => array(
+      'Bcc'     => implode($member_emails, ','),
+    ),
+    'subject' => $form_state['validated_built_message']['subject'],
+    'message' => $mybody,
+  );
+  rules_action_mail($emailsettings);
+
+  $om = bts(
+    'Sent your email message to !number team members.',
+    array( '!number' => count($member_emails) ),
+    'NULL',
+    'boinc:team-message-sent'
+  );
+  drupal_set_message($om, 'info');
+
+  $form_state['redirect'] = "community/teams/{$form_state['values']['_team_id']}";
+}

--- a/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
+++ b/drupal/sites/default/boinc/modules/boincteam/includes/boincteam.helpers.inc
@@ -120,12 +120,21 @@ function boincteam_import($boincteam, $nid = NULL) {
  * @param bool $boincid
  *   A boolean, if TRUE the function will return the BOINC ids. If
  *   FALSE, the function will return the Drupal uids.
+ * @param bool $respectprivacy
+ *   A boolean, if TRUE the function will only return users who have
+ *   flag send_email=1, meaning their notification privacy will be
+ *   respected. This is useful the list of users are to be contacted.
  */
-function _boincteam_userids($boincteamid, $boincid=TRUE) {
+function _boincteam_userids($boincteamid, $boincid=TRUE, $respectprivacy=TRUE) {
   $sql = 'SELECT user.id as id FROM {user} user WHERE user.teamid=%s';
+  if ($respectprivacy) {
+    $sql .= ' AND user.send_email=1';
+  }
+
   db_set_active('boinc_ro');
   $dbres = db_query($sql, $boincteamid);
   db_set_active('default');
+
   $ids = array();
   while (($result = db_fetch_object($dbres)) != FALSE) {
     $ids[] = $result->id;
@@ -136,4 +145,31 @@ function _boincteam_userids($boincteamid, $boincid=TRUE) {
   else {
     return array_map('boincuser_lookup_uid', $ids);
   }
+}
+
+/**
+ * Obtains an array of email addresses for a given team
+ *
+ * @param int $boincteamid
+ *    The BOINC team id (not drupal team/node id).
+ * @param bool $respectprivacy
+ *   A boolean, if TRUE the function will only return users who have
+ *   flag send_email=1, meaning their notification privacy will be
+ *   respected. This is useful the list of users are to be contacted.
+ */
+function _boincteam_emails($boincteamid, $respectprivacy=TRUE) {
+  $sql = 'SELECT user.email_addr as email_addr FROM {user} user WHERE user.teamid=%s';
+  if ($respectprivacy) {
+    $sql .= ' AND user.send_email=1';
+  }
+
+  db_set_active('boinc_ro');
+  $dbres = db_query($sql, $boincteamid);
+  db_set_active('default');
+
+  $emails = array();
+  while (($result = db_fetch_object($dbres)) != FALSE) {
+    $emails[] = $result->email_addr;
+  }
+  return $emails;
 }

--- a/drupal/sites/default/boinc/themes/boinc/css/forms.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/forms.css
@@ -643,3 +643,15 @@ select.task-app-filter {
   width: 120px;
   white-space: nowrap;
 }
+
+/* Team email members forms */
+#sendmessageteammembers-header {
+  ;
+}
+
+#sendmessageteammembers-instructions {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 24px;
+  margin-right: 40px;
+}


### PR DESCRIPTION
**Description of the Change**
Boincteam- Send email to all team members. This sends an email to team members but respects the privacy option : do/do not send notification emails. The sender's e-mail address is hidden from the recipients and the recipients email-addresses are hidden as well.

**Release Notes**
N/A

https://dev.gridrepublic.org/browse/DBOINCP-479