### PR TITLE
client: increase finish-file timeout

### DIFF
--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -135,9 +135,16 @@ bool ACTIVE_TASK_SET::poll() {
             ACTIVE_TASK* atp = active_tasks[i];
             if (atp->task_state() == PROCESS_UNINITIALIZED) continue;
             if (atp->finish_file_time) {
-                // process is still there 10 sec after it wrote finish file.
-                // abort the job
-                atp->abort_task(EXIT_ABORTED_BY_CLIENT, "finish file present too long");
+                if (gstate.now - atp->finish_file_time > FINISH_FILE_TIMEOUT) {
+                    // process is still there 5 min after it wrote finish file.
+                    // abort the job
+                    // Note: actually we should treat it as successful.
+                    // But this would be tricky.
+                    //
+                    atp->abort_task(EXIT_ABORTED_BY_CLIENT,
+                        "Process still present 5 min after writing finish file; aborting"
+                    );
+                }
             } else if (atp->finish_file_present()) {
                 atp->finish_file_time = gstate.now;
             }

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -538,7 +538,7 @@ extern THREAD throttle_thread;
 
 //////// TIME-RELATED CONSTANTS ////////////
 
-//////// CLIENT INTERNAL
+//////// POLLING PERIODS
 
 #define POLL_INTERVAL   1.0
     // the client will handle I/O (including GUI RPCs)
@@ -623,6 +623,11 @@ extern THREAD throttle_thread;
 
 #define MAX_STARTUP_TIME    10
     // if app startup takes longer than this, quit loop
+
+#define FINISH_FILE_TIMEOUT 300
+    // if app process exists this long after writing finish file, abort it.
+    // NOTE: this used to be 10 sec and it wasn't enough,
+    // e.g. during heavy paging.
 
 //////// NETWORK
 


### PR DESCRIPTION
When an app finishes, it writes a "finish file",
which ensures the client that the app really finished.

If the app process is still there N seconds after the finish file appears,
the client assumes that something went wrong, and it aborts the job.

Previously N was 10.
This was too small during periods of heavy paging.
I increased it to 300.

It has been pointed out that if the app creates the finish file,
and its output files are present,
it should be treated as successful regardless of whether it exits.
This is probably true, but right now we don't have a mechanism
for killing a job and marking it as success.
The longer timeout makes this moot.

Fixes #3017
