### PR TITLE
client: separate checkpoint debug from task debug

### DIFF
--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -1550,11 +1550,6 @@ void ACTIVE_TASK_SET::get_msgs() {
                         "[checkpoint] result %s checkpointed",
                         atp->result->name
                     );
-                } else if (log_flags.task_debug) {
-                    msg_printf(atp->wup->project, MSG_INFO,
-                        "[task] result %s checkpointed",
-                        atp->result->name
-                    );
                 }
                 atp->write_task_state_file();
             }


### PR DESCRIPTION
**Description of the Change**
Including checkpoint debug with task debug creates too much spam in log
for those who are interested only in task state change related log
messages.

Those who want both checkpoint debug and task debug can easily enable
both debug log flags.

**Alternate Designs**
None

**Release Notes**
client: separate checkpoint debug from task debug