### PR TITLE
Server: add "punitive validation" mechanism

### DIFF
--- a/sched/sched_result.cpp
+++ b/sched/sched_result.cpp
@@ -31,7 +31,8 @@
 
 #include "sched_result.h"
 
-// got a SUCCESS result.  Doesn't mean it's valid!
+// got a SUCCESS result; double max jobs per day.
+// TODO: shouldn't we do this only for valid results?
 //
 static inline void got_good_result(SCHED_RESULT_ITEM& sri) {
     DB_ID_TYPE gavid = generalized_app_version_id(sri.app_version_id, sri.appid);
@@ -39,7 +40,7 @@ static inline void got_good_result(SCHED_RESULT_ITEM& sri) {
     if (!havp) {
         if (config.debug_handle_results) {
             log_messages.printf(MSG_NORMAL,
-                "[handle] No app version for %ld\n", gavid
+                "[handle] No HOST_APP_VERSION for app version %ld\n", gavid
             );
         }
         return;
@@ -70,7 +71,7 @@ static inline void got_bad_result(SCHED_RESULT_ITEM& sri) {
     if (!havp) {
         if (config.debug_handle_results) {
             log_messages.printf(MSG_NORMAL,
-                "[handle] No app version for %ld\n", gavid
+                "[handle] No HOST_APP_VERSION version for app version %ld\n", gavid
             );
         }
         return;

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -100,6 +100,13 @@ inline DB_ID_TYPE host_usage_to_gavid(HOST_USAGE& hu, APP& app) {
 //
 inline int scaled_max_jobs_per_day(DB_HOST_APP_VERSION& hav, HOST_USAGE& hu) {
     int n = hav.max_jobs_per_day;
+
+    // if max jobs per day is 1, don't scale;
+    // this host probably can't use this app version at all.
+    // Allow 1 job/day in case something changes.
+    //
+    if (n == 1) return 1;
+
     if (hu.proc_type == PROC_TYPE_CPU) {
         if (g_reply->host.p_ncpus) {
             n *= g_reply->host.p_ncpus;

--- a/sched/validate_util2.h
+++ b/sched/validate_util2.h
@@ -18,14 +18,16 @@
 #ifndef BOINC_VALIDATE_UTIL2_H
 #define BOINC_VALIDATE_UTIL2_H
 
-// return value of init_result if an "adaptive replication"
-// result looks suspicious
-//
-#define VAL_RESULT_SUSPICIOUS 1
-
 #include <vector>
 
 #include "boinc_db_types.h"
+
+// special return values of init_result():
+//
+#define VAL_RESULT_SUSPICIOUS       1
+    // if an "adaptive replication" result looks suspicious
+#define VAL_RESULT_LONG_TERM_FAIL   2
+    // host is unlikely to handle this app version; stop using
 
 extern int init_result(RESULT&, void*&);
 extern int compare_results(RESULT &, void*, RESULT const&, void*, bool&);

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -182,7 +182,7 @@ static inline void is_invalid(DB_HOST_APP_VERSION& hav) {
     }
 }
 
-// check for results with long-term failure; punish those hosts
+// check for results with long-term failure; punish those hosts.
 //
 void scan_punitive(vector<VALIDATOR_ITEM>& items) {
     void* data=NULL;
@@ -192,7 +192,6 @@ void scan_punitive(vector<VALIDATOR_ITEM>& items) {
         RESULT& result = items[i].res;
         if (result.server_state != RESULT_SERVER_STATE_OVER) continue;
         if (result.outcome != RESULT_OUTCOME_CLIENT_ERROR) continue;
-        if (result.validate_state != VALIDATE_STATE_INIT) continue;
         if (init_result(result, data) == VAL_RESULT_LONG_TERM_FAIL) {
             DB_HOST_APP_VERSION hav;
             sprintf(buf, "host_id=%ld and app_version_id=%ld",
@@ -214,13 +213,6 @@ void scan_punitive(vector<VALIDATOR_ITEM>& items) {
             cleanup_result(result, data);
             data = NULL;
         }
-
-        // make result as invalid so we don't check it again
-        //
-        DB_RESULT db_result;
-        db_result = result;
-        db_result.validate_state = VALIDATE_STATE_INVALID;
-        db_result.update();
     }
 }
 

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -861,6 +861,7 @@ void usage(char* name) {
         "    [--credit_from_wu]         Credit is specified in WU XML\n"
         "    [--credit_from_runtime X]  Grant credit based on runtime (max X seconds)and estimated FLOPS\n"
         "    [--no_credit]              Don't grant credit\n"
+        "    [--check_punitive]         Check failed results and reduce the daily quota to one.\n"  
         "    [--sleep_interval n]       Set sleep-interval to n\n"
         "    [--wu_id n]                Process WU with given ID\n"
         "    [-d level|--debug_level n] Set log verbosity level\n"


### PR DESCRIPTION
Say that a job has a "long-term failure" if it fails in a way
(as evidenced by its exit code and/or stderr)
suggesting that other jobs for that (host, app version) will fail too.
In this case we want to avoid sending more jobs to that (host, app version).

This implements this feature.
To use it, have your validator's init_result() return
VAL_RESULT_LONG_TERM_FAIL if it finds a long-term failure,
and run your validator with the --check_punitive option.
("Punitive" because we're "punishing" the host for its failure).

The validator punishes the (host, app version) by
setting host_app_version.max_jobs_per_day to 1.
One job per day can still be sent.
That way if the underlying problem is fixed
(e.g. the user enables VM acceleration in the BIOS)
we'll eventually go back to normal.

Also: normally HAV.max_jobs_per_day is scaled by the numbers
of CPUs and GPUs.
Disable this scaling in the case where it's 1.
