### PR TITLE
Drupal: Add JS to terms-of-use form

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.js
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.js
@@ -1,0 +1,17 @@
+// Javascript for disabling the submit button, enables it when
+// terms-of-use checkbox is checked.
+
+$(document).ready(function() {
+  // Disable submit on initial page load
+  $("#edit-submit").attr("disabled", "disabled");
+  // On checkbox change, enable submit button
+  $("#edit-termsofuse-agreeTOU").change(function () {
+    if ($("#edit-termsofuse-agreeTOU").is(":checked")) {
+      // enable submit
+      $("#edit-submit").removeAttr("disabled");
+    } else {
+      // disable submit
+       $("#edit-submit").attr("disabled", "disabled");
+    }
+  })
+});

--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1220,25 +1220,37 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
       '#type' => 'hidden',
       '#value' => rand() . '.' . time()
     );
-    
+
+    // Add JS for submit button disabling
+    drupal_add_js(drupal_get_path('module', 'boincuser') . '/boincuser.js');
+
     // Terms of use section
     $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
     if (!empty($termsofuse)) {
-      $form['title1'] = array(
+
+      $form['termsofuse'] = array(
+        '#type'   => 'fieldset',
+        '#prefix' => '<div id="termsofuse-wrapper">', // This is our wrapper div.
+        '#suffix' => '</div>',
+        '#tree'   => TRUE,
+        '#weight' => -15,
+      );
+
+      $form['termsofuse']['title1'] = array(
         '#weight' => -12,
         '#value' => '<h2>' . bts(variable_get('boinc_weboptions_registrationtitle', 'Please read and acknowledge our terms of use'), array(), NULL, 'project:user-register' ) . '</h2>',
         '#prefix' => '<div id="register-title1">',
         '#suffix' => '</div>',
       );
 
-      $form['termsofuse'] = array(
+      $form['termsofuse']['body'] = array(
         '#weight' => -10,
         '#value' => bts($termsofuse, array(), NULL, 'project:user-register'),
         '#prefix' => '<div id="register-termsofuse">',
         '#suffix' => '</div>',
       );
 
-      $form['agreeTOU'] = array(
+      $form['termsofuse']['agreeTOU'] = array(
         '#type' => 'checkbox',
         '#title' => bts(variable_get('boinc_weboptions_agreequestion', 'Do you agree with the above terms of use?'), array(), NULL, 'project:user-register'),
         '#weight' => -8,

--- a/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
+++ b/drupal/sites/default/boinc/modules/boincuser/includes/boincuser.forms.inc
@@ -697,40 +697,49 @@ function boincuser_termsofuse_form() {
   drupal_set_message( bts('WARNING: You have not agreed to our terms of use. Please agree to the terms of use before continuing.', array(), NULL, 'boinc:termsofuse-form'), 'warning' );
 
   $form = array();
-
-  // Terms of use section
+  drupal_add_js(drupal_get_path('module', 'boincuser') . '/boincuser.js');
   $termsofuse = variable_get('boinc_weboptions_termsofuse', '');
-  $form['title1'] = array(
+
+  // Fieldset to hold all of the form as a container
+  $form['termsofuse'] = array(
+    '#type'   => 'fieldset',
+    '#prefix' => '<div id="termsofuse-wrapper">', // This is our wrapper div.
+    '#suffix' => '</div>',
+    '#tree'   => TRUE,
+  );
+
+  $form['termsofuse']['title1'] = array(
     '#weight' => -12,
     '#value' => '<h2>' . bts( variable_get('boinc_weboptions_registrationtitle', 'Please read and acknowledge our terms of use'), array(), NULL, 'project:termsofuse-form' ) . '</h2>',
     '#prefix' => '<div id="register-title1">',
     '#suffix' => '</div>',
   );
 
-  $form['termsofuse'] = array(
+  // Terms of use section
+  $form['termsofuse']['body'] = array(
     '#weight' => -10,
     '#value' => bts($termsofuse, array(), NULL, 'project:termsofuse-form'),
     '#prefix' => '<div id="register-termsofuse">',
     '#suffix' => '</div>',
   );
 
-  $form['agreeTOU'] = array(
-    '#type' => 'checkbox',
-    '#title' => bts(variable_get('boinc_weboptions_agreequestion', 'Do you agree with the above terms of use?'), array(), NULL, 'project:termsofuse-form'),
+  $form['termsofuse']['agreeTOU'] = array(
+    '#type'   => 'checkbox',
+    '#title'  => bts(variable_get('boinc_weboptions_agreequestion', 'Do you agree with the above terms of use?'), array(), NULL, 'project:termsofuse-form'),
     '#weight' => -8,
     '#prefix' => '<div id="register-checkbox">',
     '#suffix' => '</div>',
   );
 
-  $form['spacer'] = array(
-    '#prefix' => '<div id="register-title2">',
+  $form['termsofuse']['spacer'] = array(
+    '#prefix' => '<div class="clearfix" id="register-title2">',
     '#value'  => '&nbsp;',
     '#suffix' => '</div>',
   );
 
   // Form Control
   $form['submit'] = array(
-    '#prefix' => '<p><p><p><li class="first tab">',
+    '#prefix' => '<p><p><p><li class="first tab" id="register-submit">',
     '#type' => 'submit',
     '#value' => bts('Yes', array(), NULL, 'boinc:form-submit'),
     '#suffix' => '</li>',
@@ -756,7 +765,7 @@ function boincuser_termsofuse_form() {
 
 function boincuser_termsofuse_form_validate($form, &$form_state) {
   // Check TOU agreement
-  if (!$form_state['values']['agreeTOU']) {
+  if (!$form_state['values']['termsofuse']['agreeTOU']) {
     form_set_error('termsofuse', bts('ERROR: You must acknowledge our terms of use by clicking the checkbox before registering for an account.', array(), NULL, 'boinc:termsofuse-form'));
   }
 }

--- a/drupal/sites/default/boinc/themes/boinc/css/forms.css
+++ b/drupal/sites/default/boinc/themes/boinc/css/forms.css
@@ -205,6 +205,12 @@ form ul.tab-list {
   margin-top: 1em;
 }
 
+/* Form submit 'disabled' with javascript.*/
+.form-submit[disabled] {
+  color: #888888;
+  text-decoration: line-through;
+}
+
 .container-inline div,
 .container-inline label /* Inline labels and form divs */ {
   display: inline;


### PR DESCRIPTION
**Description of the Change**
Adds Javascript to terms-of-use forms, both user registration form and terms-of-use form for existing users. Disables submit button until the checkbox has been checked. For non-JS browsers, if the checkbox is not checked the submit button will work, but user will receive error message.

Also, changed a few items in form layout in order to get JS to work cleanly, renamed a few IDs.

**Release Notes**
N/A

https://dev.gridrepublic.org/browse/DBOINCP-469