### PR TITLE
[web][android][lib] Add conditional terms of use consent requirement to create_account RPC

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
@@ -265,6 +265,9 @@ public class AcctMgrFragment extends DialogFragment {
             case BOINCErrors.ERR_INVALID_URL:
                 stringResource = R.string.attachproject_error_invalid_url;
                 break;
+            case BOINCErrors.ERR_ACCT_REQUIRE_CONSENT:
+                stringResource = R.string.attachproject_error_consent_required;
+                break;
             default:
                 stringResource = R.string.attachproject_error_unknown;
                 break;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCErrors.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCErrors.java
@@ -47,4 +47,5 @@ public class BOINCErrors {
     public final static int ERR_BAD_PASSWD = -206;
     public final static int ERR_NONUNIQUE_EMAIL = -207;
     public final static int ERR_ACCT_CREATION_DISABLED = -208; // i.e. account creation currently disabled
+    public final static int ERR_ACCT_REQUIRE_CONSENT = -242; // project requires consent
 }

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="attachproject_error_bad_pwd">Password refused</string>
     <string name="attachproject_error_creation_disabled">Account creation is disabled on this project</string>
     <string name="attachproject_error_invalid_url">Invalid URL</string>
+    <string name="attachproject_error_consent_required">This project requires to consent to its terms of use</string>
     <!-- working activity -->
     <string name="attachproject_working_back_button">Back</string>
     <string name="attachproject_working_finish_button">Finish</string>

--- a/html/inc/common_defs.inc
+++ b/html/inc/common_defs.inc
@@ -95,4 +95,5 @@ define('ERR_BAD_PASSWD',              -206);
 define('ERR_ACCT_CREATION_DISABLED',  -208);
 define('ERR_ATTACH_FAIL_INIT',        -209);
 define('ERR_ATTACH_FAIL_DOWNLOAD',    -210);
+define('ERR_ACCT_REQUIRE_CONSENT',    -242);
 ?>

--- a/html/user/create_account.php
+++ b/html/user/create_account.php
@@ -114,12 +114,10 @@ if ($user) {
         // * not agree.
         //   -> no create account RPC at all
         //
-        // In the future, when the majority of BOINC clients and
-        // Account Managers have been updated to use the consent_flag
-        // parameter, then this code should be revised to only allow
-        // clients who do use this flag to continue. I.e., if
-        // is_null($consent_flag) returns TRUE, then return an
-        // xml_error(-1, ...).
+        // Projects can require explicit consent for account creation
+        // by setting "account_creation_rpc_require_consent" to 1 in
+        // config.xml
+        //
         if ( (!is_null($consent_flag)) and $source) {
             // Record the user giving consent in database - if consent_flag is 0,
             // this is an 'anonymous account' and consent_not_required is
@@ -132,6 +130,12 @@ if ($user) {
             if (!$rc) {
                 xml_error(-1, "database error, please contact site administrators");
             }
+        }
+        else if (parse_bool($config, "account_creation_rpc_require_consent")) {
+            xml_error(ERR_ACCT_REQUIRE_CONSENT, "This project requires to consent to its terms of use. " .
+                                                "Please update your BOINC software " .
+                                                "or register via the project's website " .
+                                                "or contact your account manager's provider.");
         }
     }
 

--- a/html/user/create_account.php
+++ b/html/user/create_account.php
@@ -92,7 +92,7 @@ if ($user) {
     // by setting "account_creation_rpc_require_consent" to 1 in
     // config.xml
     //
-    if (parse_bool($config, "account_creation_rpc_require_consent") {
+    if (parse_bool($config, "account_creation_rpc_require_consent")) {
         // Consistency checks
         if (!check_termsofuse()) {
             error_log("Project configuration error! " .

--- a/html/user/create_account.php
+++ b/html/user/create_account.php
@@ -93,12 +93,7 @@ if ($user) {
     // config.xml
     //
     if (parse_bool($config, "account_creation_rpc_require_consent") {
-        if (is_null($consent_flag) or !$source) {
-            xml_error(ERR_ACCT_REQUIRE_CONSENT, "This project requires to consent to its terms of use. " .
-                                                "Please update your BOINC software " .
-                                                "or register via the project's website " .
-                                                "or contact your account manager's provider.");
-        }
+        // Consistency checks
         if (!check_termsofuse()) {
             error_log("Project configuration error! " .
                       "Terms of use undefined while 'account_creation_rpc_require_consent' enabled!");
@@ -106,6 +101,14 @@ if ($user) {
         if (!$checkct) {
             error_log("Project configuration error! " .
                       "'CONSENT_TYPE_ENROLL' disabled while 'account_creation_rpc_require_consent' enabled!");
+        }
+
+        // Check consent requirement
+        if (is_null($consent_flag) or !$source) {
+            xml_error(ERR_ACCT_REQUIRE_CONSENT, "This project requires to consent to its terms of use. " .
+                                                "Please update your BOINC software " .
+                                                "or register via the project's website " .
+                                                "or contact your account manager's provider.");
         }
     }
 

--- a/lib/error_numbers.h
+++ b/lib/error_numbers.h
@@ -213,6 +213,7 @@
 #define ERR_CHMOD           -239
 #define ERR_STAT            -240
 #define ERR_FCLOSE          -241
+#define ERR_ACCT_REQUIRE_CONSENT -242
 
 // PLEASE: add a text description of your error to 
 // the text description function boincerror() in str_util.cpp.

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -625,7 +625,7 @@ const char* boincerror(int which_error) {
         case HTTP_STATUS_BAD_GATEWAY: return "HTTP bad gateway";
         case HTTP_STATUS_SERVICE_UNAVAILABLE: return "HTTP service unavailable";
         case HTTP_STATUS_GATEWAY_TIMEOUT: return "HTTP gateway timeout";
-        case ERR_ACCT_REQUIRE_CONSENT: return "This project requires to consent to its terms of use"
+        case ERR_ACCT_REQUIRE_CONSENT: return "This project requires to consent to its terms of use";
     }
     static char buf[128];
     sprintf(buf, "Error %d", which_error);

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -625,6 +625,7 @@ const char* boincerror(int which_error) {
         case HTTP_STATUS_BAD_GATEWAY: return "HTTP bad gateway";
         case HTTP_STATUS_SERVICE_UNAVAILABLE: return "HTTP service unavailable";
         case HTTP_STATUS_GATEWAY_TIMEOUT: return "HTTP gateway timeout";
+        case ERR_ACCT_REQUIRE_CONSENT: return "This project requires to consent to its terms of use"
     }
     static char buf[128];
     sprintf(buf, "Error %d", which_error);

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -489,6 +489,7 @@ class Project:
         config.daily_result_quota = 500
         config.disable_account_creation = 0
         config.disable_account_creation_rpc = 0
+        config.account_creation_rpc_require_consent = 0
         config.disable_web_account_creation = 0
         config.enable_login_mustagree_termsofuse = 0
         config.enable_privacy_by_default = 0


### PR DESCRIPTION
**Description of the Change**
* Added a new config.xml setting "account_creation_rpc_require_consent" (default: disabled)
* Added condition to create_account RPC to return an error if consent details aren't given but required
* Defined a dedicated error number and default message (for C and Android use)

**See also**
* #2413
* #2835

**Release Notes**
Allow projects to require explicit consent for RPC-based account creation to comply with GDPR.