### PR TITLE
Drupal: Add boinccore_mail_alter to change encoding.

### DIFF
--- a/drupal/sites/default/boinc/modules/boinccore/boinccore.module
+++ b/drupal/sites/default/boinc/modules/boinccore/boinccore.module
@@ -787,6 +787,21 @@ function boinccore_link($type, $object, $teaser = FALSE) {
   return $links;
 }
 
+/**
+ * Implementation of hook_mail_alter()
+ */
+function boinccore_mail_alter(&$message) {
+  /* This code alters the headers for all emails sent by the Drupal Web site to use
+     'Quote-Printable' as the encoding, both altering the header and modifies the body to the
+     new encoding.
+  */
+  $message['headers']['Content-Transfer-Encoding'] = 'Quoted-Printable';
+  if (is_array($message['body'])) {
+    $message['body'] = array_map( "quoted_printable_encode", $message['body'] );
+  } else {
+    $message['body'] = quoted_printable_encode($message['body']);
+  }
+}
 
 /*  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *
  * Page callbacks from hook_menu()


### PR DESCRIPTION
**Description of the Change**
Changes header and body encoding to use 'quoted-printable'.

**Release Notes**
N/A

Part of https://dev.gridrepublic.org/browse/DBOINCP-479