### PR TITLE
Disabled Manager system tray icon for Linux builds

### DIFF
--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -944,11 +944,13 @@ void CMainDocument::HandleCompletedRPC() {
 
     if (m_bNeedTaskBarRefresh && !m_bWaitingForRPC) {
         m_bNeedTaskBarRefresh = false;
+#ifndef __WXGTK__
         CTaskBarIcon* pTaskbar = wxGetApp().GetTaskBarIcon();
         if (pTaskbar) {
             CTaskbarEvent event(wxEVT_TASKBAR_REFRESH, pTaskbar);
             pTaskbar->ProcessEvent(event);
         }
+#endif
     }
 
     if (current_rpc_request.rpcType == RPC_TYPE_ASYNC_WITH_REFRESH_EVENT_LOG_AFTER) {

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -84,7 +84,9 @@ bool CBOINCGUIApp::OnInit() {
     m_pSkinManager = NULL;
     m_pFrame = NULL;
     m_pDocument = NULL;
+#ifndef __WXGTK__
     m_pTaskBarIcon = NULL;
+#endif
     m_pEventLog = NULL;
     m_bEventLogWasActive = false;
     m_bProcessingActivateAppEvent = false;
@@ -426,7 +428,7 @@ bool CBOINCGUIApp::OnInit() {
         }
     }
 
-
+#ifndef __WXGTK__
     // Initialize the task bar icon
 	m_pTaskBarIcon = new CTaskBarIcon(
         m_pSkinManager->GetAdvanced()->GetApplicationName(), 
@@ -438,6 +440,7 @@ bool CBOINCGUIApp::OnInit() {
 #endif
     );
     wxASSERT(m_pTaskBarIcon);
+#endif // __WXGTK__
 #ifdef __WXMAC__
     m_pMacDockIcon = new CTaskBarIcon(
         m_pSkinManager->GetAdvanced()->GetApplicationName(), 
@@ -510,11 +513,12 @@ int CBOINCGUIApp::OnExit() {
     }
     m_pMacDockIcon = NULL;
 #endif
+#ifndef __WXGTK__
     if (m_pTaskBarIcon) {
         delete m_pTaskBarIcon;
     }
     m_pTaskBarIcon = NULL;
-
+#endif
     if (m_pDocument) {
         m_pDocument->OnExit();
         delete m_pDocument;
@@ -1036,9 +1040,11 @@ void CBOINCGUIApp::FireReloadSkin() {
     if (m_pFrame) {
 	    m_pFrame->FireReloadSkin();
     }
+#ifndef __WXGTK__
     if (m_pTaskBarIcon) {
 	    m_pTaskBarIcon->FireReloadSkin();
     }
+#endif
 }
 
 

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -38,7 +38,9 @@
 class wxLogBOINC;
 class CBOINCBaseFrame;
 class CMainDocument;
+#ifndef __WXGTK__
 class CTaskBarIcon;
+#endif
 class CSkinManager;
 class CDlgEventLog;
 class CRPCFinishedEvent;
@@ -78,7 +80,9 @@ protected:
     CSkinManager*       m_pSkinManager;
     CBOINCBaseFrame*    m_pFrame;
     CMainDocument*      m_pDocument;
+#ifndef __WXGTK__
     CTaskBarIcon*       m_pTaskBarIcon;
+#endif
     CDlgEventLog*       m_pEventLog;
     bool                m_bEventLogWasActive;
     bool                m_bProcessingActivateAppEvent;
@@ -133,7 +137,9 @@ public:
     wxString            GetArguments()              { return m_strBOINCArguments; }
     int                 GetClientRPCPortArg()       { return m_iRPCPortArg; }
     CDlgEventLog*       GetEventLog()               { return m_pEventLog; }
+#ifndef __WXGTK__
     CTaskBarIcon*       GetTaskBarIcon()            { return m_pTaskBarIcon; }
+#endif
 
     bool                IsAnotherInstanceRunning()  { return m_pInstanceChecker->IsAnotherRunning(); }
     bool                IsMgrMultipleInstance()     { return m_bMultipleInstancesOK; }

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -922,11 +922,13 @@ void CMainDocument::RunPeriodicRPCs(int frameRefreshRate) {
     if (!IsConnected()) {
         CFrameEvent event(wxEVT_FRAME_REFRESHVIEW, pFrame);
         pFrame->GetEventHandler()->AddPendingEvent(event);
+#ifndef __WXGTK__
         CTaskBarIcon* pTaskbar = wxGetApp().GetTaskBarIcon();
         if (pTaskbar) {
             CTaskbarEvent event(wxEVT_TASKBAR_REFRESH, pTaskbar);
             pTaskbar->AddPendingEvent(event);
         }
+#endif
         CDlgEventLog* eventLog = wxGetApp().GetEventLog();
         if (eventLog) {
             eventLog->OnRefresh();


### PR DESCRIPTION
**Description of the Change**
Disables BOINC Manager system tray icon on Linux platforms.
On Linux BOINC client runs regardless the Manager is running or not, so having a Manager system tray icon may suggest the user that calculus are running only when the Manager is running, leading to misunderstandings.
Moreover removing Manager system tray icon, prevents also the user from accessing to tray icon right-clic menu that can let the user interfere with client service, as stated in pull request ["Removed "Exit from BOINC Manager", "Shut down connected client" menu entries on Linux"](https://github.com/BOINC/boinc/pull/3028)

**Release Notes**
Disablec BOINC Manager system tray icon on Linux platforms.