### PR TITLE
Disabling external libraries

### DIFF
--- a/mac_build/buildcurl.sh
+++ b/mac_build/buildcurl.sh
@@ -142,7 +142,7 @@ if [ "x${lprefix}" != "x" ]; then
     export CPPFLAGS=""
     export CXXFLAGS="-isysroot ${SDKPATH} -arch x86_64 -stdlib=libc++"
     export CFLAGS="-isysroot ${SDKPATH} -arch x86_64"
-    PKG_CONFIG_PATH="${lprefix}/lib/pkgconfig" ./configure --prefix=${lprefix} --enable-ares --enable-shared=NO --without-libidn --without-libidn2 --host=x86_64
+    PKG_CONFIG_PATH="${lprefix}/lib/pkgconfig" ./configure --prefix=${lprefix} --enable-ares --enable-shared=NO --without-libidn --without-libidn2 --without-nghttp2 --host=x86_64
     if [ $? -ne 0 ]; then return 1; fi
 else
     # Get the names of the current versions of c-ares and openssl from
@@ -166,7 +166,7 @@ else
     export CPPFLAGS=""
     export CXXFLAGS="-isysroot ${SDKPATH} -arch x86_64 -stdlib=libc++ -I${CURL_DIR}/../${opensslDirName}/include"
     export CFLAGS="-isysroot ${SDKPATH} -arch x86_64 -I${CURL_DIR}/../${opensslDirName}/include"
-    ./configure --enable-shared=NO --enable-ares="${libcares}" --without-libidn --without-libidn2 --host=x86_64
+    ./configure --enable-shared=NO --enable-ares="${libcares}" --without-libidn --without-libidn2 --without-nghttp2 --host=x86_64
     if [ $? -ne 0 ]; then return 1; fi
     echo ""
 fi

--- a/mac_build/buildfreetype.sh
+++ b/mac_build/buildfreetype.sh
@@ -140,7 +140,7 @@ export CFLAGS="-isysroot ${SDKPATH} -arch x86_64 -DMAC_OS_X_VERSION_MAX_ALLOWED=
 export SDKROOT="${SDKPATH}"
 export MACOSX_DEPLOYMENT_TARGET=10.7
 
-./configure --enable-shared=NO --prefix=${lprefix} --host=x86_64
+./configure --enable-shared=NO --prefix=${lprefix} --without-png --host=x86_64
 if [ $? -ne 0 ]; then return 1; fi
 
 if [ "${doclean}" = "yes" ]; then


### PR DESCRIPTION
This patch causes two libraries to be built without including two external libraries that get found when already installed on the Mac by other software builds.

Fixes #

**Description of the Change**
Building on a Mac that has libraries installed that are identical or similar to BOINC required libraries, will be found by the BOINC build. These two changes disable two such libraries. nghttp2 and png respectively found by buildcurl.sh and buildfreetype.sh.
**Alternate Designs**
It became impossible to cleanly build these two components with the external version libraries included in the build.
**Release Notes**
On OSX 10.14.3
buildcurl.sh --without-nghttp2
buildfreetype.sh --without-png