### PR TITLE
Manager: add account manager functions to simple view

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1959,15 +1959,6 @@ void CAdvancedFrame::OnNotebookSelectionChanged(wxNotebookEvent& event) {
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnNotebookSelectionChanged - Function End"));
 }
 
-void CBOINCBaseFrame::ResetReminderTimers() {
-#ifdef __WXMSW__
-    wxASSERT(m_pDialupManager);
-    wxASSERT(wxDynamicCast(m_pDialupManager, CBOINCDialUpManager));
-
-    m_pDialupManager->ResetReminderTimers();
-#endif
-}
-
 void CAdvancedFrame::UpdateActivityModeControls( CC_STATUS& status ) {
     wxMenuBar* pMenuBar = GetMenuBar();
     wxASSERT(pMenuBar);

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -171,10 +171,10 @@ BEGIN_EVENT_TABLE (CAdvancedFrame, CBOINCBaseFrame)
     EVT_MENU_RANGE(ID_ADVNOTICESVIEW, ID_ADVRESOURCEUSAGEVIEW, CAdvancedFrame::OnChangeView)
     EVT_MENU(ID_CHANGEGUI, CAdvancedFrame::OnChangeGUI)
     // Tools
-    EVT_MENU(ID_WIZARDATTACHPROJECT, CAdvancedFrame::OnWizardAttachProject)
-    EVT_MENU(ID_WIZARDATTACHACCOUNTMANAGER, CAdvancedFrame::OnWizardUpdate)
-    EVT_MENU(ID_WIZARDUPDATE, CAdvancedFrame::OnWizardUpdate)
-    EVT_MENU(ID_WIZARDDETACH, CAdvancedFrame::OnWizardDetach)
+    EVT_MENU(ID_WIZARDATTACHPROJECT, CBOINCBaseFrame::OnWizardAttachProject)
+    EVT_MENU(ID_WIZARDATTACHACCOUNTMANAGER, CBOINCBaseFrame::OnWizardUpdate)
+    EVT_MENU(ID_WIZARDUPDATE, CBOINCBaseFrame::OnWizardUpdate)
+    EVT_MENU(ID_WIZARDDETACH, CBOINCBaseFrame::OnWizardDetach)
     // Activity
     EVT_MENU_RANGE(ID_ADVACTIVITYRUNALWAYS, ID_ADVACTIVITYSUSPEND, CAdvancedFrame::OnActivitySelection)
     EVT_MENU_RANGE(ID_ADVACTIVITYGPUALWAYS, ID_ADVACTIVITYGPUSUSPEND, CAdvancedFrame::OnGPUSelection)
@@ -238,7 +238,7 @@ CAdvancedFrame::CAdvancedFrame(wxString title, wxIconBundle* icons, wxPoint posi
     SetIcons(*icons);
 
     // Create UI elements
-    wxCHECK_RET(CreateMenu(), _T("Failed to create menu bar."));
+    wxCHECK_RET(CreateMenus(), _T("Failed to create menu bar."));
     wxCHECK_RET(CreateNotebook(), _T("Failed to create notebook."));
     wxCHECK_RET(CreateStatusbar(), _T("Failed to create status bar."));
 
@@ -291,15 +291,11 @@ CAdvancedFrame::~CAdvancedFrame() {
         wxCHECK_RET(DeleteNotebook(), _T("Failed to delete notebook."));
     }
 
-    if (m_pMenubar) {
-        wxCHECK_RET(DeleteMenu(), _T("Failed to delete menu bar."));
-    }
-
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::~CAdvancedFrame - Function End"));
 }
 
 
-bool CAdvancedFrame::CreateMenu() {
+bool CAdvancedFrame::CreateMenus() {
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::CreateMenu - Function Begin"));
 
     CMainDocument*     pDoc = wxGetApp().GetDocument();
@@ -866,14 +862,6 @@ bool CAdvancedFrame::CreateStatusbar() {
     return true;
 }
 
-
-bool CAdvancedFrame::DeleteMenu() {
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::DeleteMenu - Function Begin"));
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::DeleteMenu - Function End"));
-    return true;
-}
-
-
 bool CAdvancedFrame::DeleteNotebook() {
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::DeleteNotebook - Function Begin"));
 
@@ -1146,152 +1134,6 @@ void CAdvancedFrame::OnChangeGUI(wxCommandEvent& WXUNUSED(event)) {
     wxGetApp().SetActiveGUI(BOINC_SIMPLEGUI, true);
 
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnChangeGUI - Function End"));
-}
-
-
-void CAdvancedFrame::OnWizardAttachProject( wxCommandEvent& WXUNUSED(event) ) {
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnWizardAttachProject - Function Begin"));
-
-    CMainDocument* pDoc     = wxGetApp().GetDocument();
-
-    wxASSERT(pDoc);
-    wxASSERT(wxDynamicCast(pDoc, CMainDocument));
-
-    if (!pDoc->IsUserAuthorized()) {
-        return;
-    }
-
-    if (pDoc->IsConnected()) {
-
-        // Stop all timers so that the wizard is the only thing doing anything
-        StopTimers();
-
-        CWizardAttach* pWizard = new CWizardAttach(this);
-
-        pWizard->Run(
-            wxEmptyString,
-            wxEmptyString,
-            wxEmptyString,
-            wxEmptyString,
-            wxEmptyString,
-            wxEmptyString,
-            wxEmptyString,
-            false,
-            false
-        );
-
-        if (pWizard) {
-            pWizard->Destroy();
-        }
-
-        DeleteMenu();
-        CreateMenu();
-
-        // Restart timers to continue normal operations.
-        StartTimers();
-
-        pDoc->ForceCacheUpdate();
-        FireRefreshView();
-    } else {
-        ShowNotCurrentlyConnectedAlert();
-    }
-
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnWizardAttachProject - Function End"));
-}
-
-
-void CAdvancedFrame::OnWizardUpdate(wxCommandEvent& WXUNUSED(event)) {
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnWizardUpdate - Function Begin"));
-
-    CMainDocument*            pDoc = wxGetApp().GetDocument();
-
-    wxASSERT(pDoc);
-    wxASSERT(wxDynamicCast(pDoc, CMainDocument));
-
-    if (!pDoc->IsUserAuthorized())
-        return;
-
-    if (pDoc->IsConnected()) {
-        // Stop all timers so that the wizard is the only thing doing anything
-        StopTimers();
-
-        CWizardAttach* pWizard = new CWizardAttach(this);
-
-        pWizard->SyncToAccountManager();
-
-        if (pWizard)
-            pWizard->Destroy();
-
-        DeleteMenu();
-        CreateMenu();
-        pDoc->ForceCacheUpdate();
-        FireRefreshView();
-        ResetReminderTimers();
-
-        // Restart timers to continue normal operations.
-        StartTimers();
-    } else {
-        ShowNotCurrentlyConnectedAlert();
-    }
-
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnWizardUpdate - Function End"));
-}
-
-
-void CAdvancedFrame::OnWizardDetach(wxCommandEvent& WXUNUSED(event)) {
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnWizardDetach - Function Begin"));
-
-    CMainDocument* pDoc           = wxGetApp().GetDocument();
-    CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
-    wxInt32        iAnswer        = 0; 
-    wxString       strTitle       = wxEmptyString;
-    wxString       strMessage     = wxEmptyString;
-    ACCT_MGR_INFO  ami;
-
-    wxASSERT(pDoc);
-    wxASSERT(wxDynamicCast(pDoc, CMainDocument));
-    wxASSERT(pSkinAdvanced);
-    wxASSERT(wxDynamicCast(pSkinAdvanced, CSkinAdvanced));
-
-    if (!pDoc->IsUserAuthorized())
-        return;
-
-    if (pDoc->IsConnected()) {
-
-        pDoc->rpc.acct_mgr_info(ami);
-
-        strTitle.Printf(
-            _("%s - Stop using %s"),
-            pSkinAdvanced->GetApplicationName().c_str(),
-            wxString(ami.acct_mgr_name.c_str(), wxConvUTF8).c_str()
-        );
-        strMessage.Printf(
-            _("If you stop using %s,\nyou'll keep all your current projects,\nbut you'll have to manage projects manually.\n\nDo you want to stop using %s?"), 
-            wxString(ami.acct_mgr_name.c_str(), wxConvUTF8).c_str(),
-            wxString(ami.acct_mgr_name.c_str(), wxConvUTF8).c_str()
-        );
-
-        iAnswer = wxGetApp().SafeMessageBox(
-            strMessage,
-            strTitle,
-            wxYES_NO | wxICON_QUESTION,
-            this
-        );
-
-        if (wxYES == iAnswer) {
-            pDoc->rpc.acct_mgr_rpc("", "", "", false);
-        }
-
-        DeleteMenu();
-        CreateMenu();
-        pDoc->ForceCacheUpdate();
-        FireRefreshView();
-
-    } else {
-        ShowNotCurrentlyConnectedAlert();
-    }
-
-    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnWizardDetach - Function End"));
 }
 
 
@@ -1958,8 +1800,7 @@ void CAdvancedFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
 
     // Update the menus
     //
-    DeleteMenu();
-    CreateMenu();
+    CreateMenus();
 
     // Restart timers to continue normal operations.
     //
@@ -2118,8 +1959,7 @@ void CAdvancedFrame::OnNotebookSelectionChanged(wxNotebookEvent& event) {
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnNotebookSelectionChanged - Function End"));
 }
 
-
-void CAdvancedFrame::ResetReminderTimers() {
+void CBOINCBaseFrame::ResetReminderTimers() {
 #ifdef __WXMSW__
     wxASSERT(m_pDialupManager);
     wxASSERT(wxDynamicCast(m_pDialupManager, CBOINCDialUpManager));
@@ -2127,7 +1967,6 @@ void CAdvancedFrame::ResetReminderTimers() {
     m_pDialupManager->ResetReminderTimers();
 #endif
 }
-
 
 void CAdvancedFrame::UpdateActivityModeControls( CC_STATUS& status ) {
     wxMenuBar* pMenuBar = GetMenuBar();
@@ -2326,7 +2165,7 @@ void CAdvancedFrame::UpdateRefreshTimerInterval() {
 void CAdvancedFrame::StartTimers() {
     wxASSERT(m_pRefreshStateTimer);
     wxASSERT(m_pFrameRenderTimer);
-    CBOINCBaseFrame::StartTimers();
+    CBOINCBaseFrame::StartTimersBase();
     m_pRefreshStateTimer->Start();
     m_pFrameRenderTimer->Start();
 }
@@ -2335,7 +2174,7 @@ void CAdvancedFrame::StartTimers() {
 void CAdvancedFrame::StopTimers() {
     wxASSERT(m_pRefreshStateTimer);
     wxASSERT(m_pFrameRenderTimer);
-    CBOINCBaseFrame::StopTimers();
+    CBOINCBaseFrame::StopTimersBase();
     m_pRefreshStateTimer->Stop();
     m_pFrameRenderTimer->Stop();
 }

--- a/clientgui/AdvancedFrame.h
+++ b/clientgui/AdvancedFrame.h
@@ -62,10 +62,6 @@ public:
     void OnChangeView( wxCommandEvent& event );
     void OnChangeGUI( wxCommandEvent& event );
 
-    void OnWizardAttachProject( wxCommandEvent& event );
-    void OnWizardUpdate( wxCommandEvent& event );
-    void OnWizardDetach( wxCommandEvent& event );
-
     void OnActivitySelection( wxCommandEvent& event );
     void OnGPUSelection( wxCommandEvent& event );
     void OnNetworkSelection( wxCommandEvent& event );
@@ -100,8 +96,6 @@ public:
     void OnConnect( CFrameEvent& event );
     void OnNotification( CFrameEvent& event );
 
-    void ResetReminderTimers();
-
     bool RestoreState();
     bool SaveState();
     wxNotebook* GetNotebook();
@@ -127,8 +121,7 @@ private:
 
     wxString        m_strBaseTitle;
 
-    bool            CreateMenu();
-    bool            DeleteMenu();
+    bool            CreateMenus();
 
     bool            CreateNotebook();
     bool            RepopulateNotebook();

--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -1042,3 +1042,12 @@ void CBOINCBaseFrame::OnWizardDetach(wxCommandEvent& WXUNUSED(event)) {
 
     wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::OnWizardDetach - Function End"));
 }
+
+void CBOINCBaseFrame::ResetReminderTimers() {
+#ifdef __WXMSW__
+    wxASSERT(m_pDialupManager);
+    wxASSERT(wxDynamicCast(m_pDialupManager, CBOINCDialUpManager));
+
+    m_pDialupManager->ResetReminderTimers();
+#endif
+}

--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -36,7 +36,9 @@
 #include "Events.h"
 #include "DlgEventLog.h"
 #include "DlgSelectComputer.h"
-
+#include "wizardex.h"
+#include "BOINCBaseWizard.h"
+#include "WizardAttach.h"
 
 DEFINE_EVENT_TYPE(wxEVT_FRAME_ALERT)
 DEFINE_EVENT_TYPE(wxEVT_FRAME_CONNECT)
@@ -703,7 +705,7 @@ void CBOINCBaseFrame::ShowNotCurrentlyConnectedAlert() {
 }
 
 
-void CBOINCBaseFrame::StartTimers() {
+void CBOINCBaseFrame::StartTimersBase() {
     wxASSERT(m_pAlertPollTimer);
     wxASSERT(m_pPeriodicRPCTimer);
     wxASSERT(m_pDocumentPollTimer);
@@ -713,7 +715,7 @@ void CBOINCBaseFrame::StartTimers() {
 }
 
 
-void CBOINCBaseFrame::StopTimers() {
+void CBOINCBaseFrame::StopTimersBase() {
     wxASSERT(m_pAlertPollTimer);
     wxASSERT(m_pPeriodicRPCTimer);
     wxASSERT(m_pDocumentPollTimer);
@@ -902,3 +904,141 @@ void CFrameAlertEvent::ProcessResponse(const int response) const {
     }
 }
 
+// bring up the attach-project dialog
+//
+void CBOINCBaseFrame::OnWizardAttachProject( wxCommandEvent& WXUNUSED(event) ) {
+    wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::OnWizardAttachProject - Function Begin"));
+
+    CMainDocument* pDoc     = wxGetApp().GetDocument();
+
+    wxASSERT(pDoc);
+    wxASSERT(wxDynamicCast(pDoc, CMainDocument));
+
+    if (!pDoc->IsUserAuthorized()) {
+        return;
+    }
+
+    if (pDoc->IsConnected()) {
+
+        // Stop all timers so that the wizard is the only thing doing anything
+        StopTimers();
+
+        CWizardAttach* pWizard = new CWizardAttach(this);
+
+        pWizard->Run(
+            wxEmptyString,
+            wxEmptyString,
+            wxEmptyString,
+            wxEmptyString,
+            wxEmptyString,
+            wxEmptyString,
+            wxEmptyString,
+            false,
+            false
+        );
+
+        pWizard->Destroy();
+
+        // Restart timers to continue normal operations.
+        StartTimers();
+
+        pDoc->ForceCacheUpdate();
+        FireRefreshView();
+    } else {
+        ShowNotCurrentlyConnectedAlert();
+    }
+
+    wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::OnWizardAttachProject - Function End"));
+}
+
+
+void CBOINCBaseFrame::OnWizardUpdate(wxCommandEvent& WXUNUSED(event)) {
+    wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::OnWizardUpdate - Function Begin"));
+
+    CMainDocument*            pDoc = wxGetApp().GetDocument();
+
+    wxASSERT(pDoc);
+    wxASSERT(wxDynamicCast(pDoc, CMainDocument));
+
+    if (!pDoc->IsUserAuthorized())
+        return;
+
+    if (pDoc->IsConnected()) {
+        // Stop all timers so that the wizard is the only thing doing anything
+        StopTimers();
+
+        CWizardAttach* pWizard = new CWizardAttach(this);
+
+        pWizard->SyncToAccountManager();
+        pWizard->Destroy();
+
+        CreateMenus();
+        pDoc->ForceCacheUpdate();
+        FireRefreshView();
+        ResetReminderTimers();
+
+        // Restart timers to continue normal operations.
+        StartTimers();
+    } else {
+        ShowNotCurrentlyConnectedAlert();
+    }
+
+    wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::OnWizardUpdate - Function End"));
+}
+
+// detach from account manager
+//
+void CBOINCBaseFrame::OnWizardDetach(wxCommandEvent& WXUNUSED(event)) {
+    wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::OnWizardDetach - Function Begin"));
+
+    CMainDocument* pDoc           = wxGetApp().GetDocument();
+    CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
+    wxInt32        iAnswer        = 0; 
+    wxString       strTitle       = wxEmptyString;
+    wxString       strMessage     = wxEmptyString;
+    ACCT_MGR_INFO  ami;
+
+    wxASSERT(pDoc);
+    wxASSERT(wxDynamicCast(pDoc, CMainDocument));
+    wxASSERT(pSkinAdvanced);
+    wxASSERT(wxDynamicCast(pSkinAdvanced, CSkinAdvanced));
+
+    if (!pDoc->IsUserAuthorized()) {
+        return;
+    }
+
+    if (pDoc->IsConnected()) {
+        pDoc->rpc.acct_mgr_info(ami);
+
+        strTitle.Printf(
+            _("%s - Stop using %s"),
+            pSkinAdvanced->GetApplicationName().c_str(),
+            wxString(ami.acct_mgr_name.c_str(), wxConvUTF8).c_str()
+        );
+        strMessage.Printf(
+            _("If you stop using %s,\nyou'll keep all your current projects,\nbut you'll have to manage projects manually.\n\nDo you want to stop using %s?"), 
+            wxString(ami.acct_mgr_name.c_str(), wxConvUTF8).c_str(),
+            wxString(ami.acct_mgr_name.c_str(), wxConvUTF8).c_str()
+        );
+
+        iAnswer = wxGetApp().SafeMessageBox(
+            strMessage,
+            strTitle,
+            wxYES_NO | wxICON_QUESTION,
+            this
+        );
+
+        if (wxYES == iAnswer) {
+            pDoc->rpc.acct_mgr_rpc("", "", "", false);
+        }
+
+        CreateMenus();
+        pDoc->ForceCacheUpdate();
+        FireRefreshView();
+
+    } else {
+        ShowNotCurrentlyConnectedAlert();
+    }
+
+    wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::OnWizardDetach - Function End"));
+}

--- a/clientgui/BOINCBaseFrame.h
+++ b/clientgui/BOINCBaseFrame.h
@@ -15,13 +15,15 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// CBOINCBaseFrame: Base class for the 2 variants of the main window,
+// CBOINCAdvancedFrame and CBOINCSimpleFrame
+
 #ifndef BOINC_BOINCBASEFRAME_H
 #define BOINC_BOINCBASEFRAME_H
 
 #if defined(__GNUG__) && !defined(__APPLE__)
 #pragma interface "BOINCBaseFrame.cpp"
 #endif
-
 
 class CFrameEvent;
 class CFrameAlertEvent;
@@ -31,7 +33,6 @@ enum FrameAlertEventType {
     AlertNormal = 0,
     AlertProcessResponse
 };
-
 
 class CBOINCBaseFrame : public wxFrame {
 
@@ -64,6 +65,10 @@ public:
     virtual void        OnCloseWindow( wxCommandEvent& event );
     virtual void        OnExit( wxCommandEvent& event );
 
+    void                OnWizardAttachProject( wxCommandEvent& event );
+    void                OnWizardUpdate( wxCommandEvent& event );
+    void                OnWizardDetach( wxCommandEvent& event );
+
     int                 GetCurrentViewPage();
     wxString            GetDialupConnectionName() { return m_strNetworkDialupConnectionName; }
     void                SetDialupConnectionName(wxString val) { m_strNetworkDialupConnectionName = val; }
@@ -83,8 +88,10 @@ public:
     void                ShowDaemonStartFailedAlert();
     void                ShowNotCurrentlyConnectedAlert();
 
-    virtual void        StartTimers();
-    virtual void        StopTimers();
+    void                StartTimersBase();
+    void                StopTimersBase();
+    virtual void        StartTimers() {}
+    virtual void        StopTimers() {}
     virtual void        UpdateRefreshTimerInterval();
 
     void                ShowAlert( 
@@ -99,6 +106,8 @@ public:
     
     virtual bool        RestoreState();
     virtual bool        SaveState();
+    virtual bool        CreateMenus(){return true;}
+    void ResetReminderTimers();
 
 protected:
 

--- a/clientgui/sg_BoincSimpleFrame.h
+++ b/clientgui/sg_BoincSimpleFrame.h
@@ -91,7 +91,8 @@ private:
 };
 
 
-// Define a new frame
+// Simple view frame
+//
 class CSimpleFrame : public CBOINCBaseFrame
 {
     DECLARE_DYNAMIC_CLASS(CSimpleFrame)
@@ -117,8 +118,6 @@ public:
     void OnCheckVersion( wxCommandEvent& event );
     void OnReportBug( wxCommandEvent& event );
 
-    void OnProjectsAttachToProject(wxCommandEvent& event);
-
 	void OnConnect(CFrameEvent& event );
     void OnReloadSkin( CFrameEvent& event );
     void OnRefreshView( CFrameEvent& event );
@@ -132,6 +131,14 @@ public:
     bool SaveState();
     bool RestoreState();
     void OnMove(wxMoveEvent& event);
+
+    void StartTimers() {
+        StartTimersBase();
+    }
+    void StopTimers() {
+        StopTimersBase();
+    }
+    bool CreateMenus();
 
 protected:
     virtual int     _GetCurrentViewPage();


### PR DESCRIPTION
Add AM functions (join, leave, synch) to simple view Tools menu, same as Advanced view.

Also did some code cleanup/reorg.
The simple view (CBOINCSimplFrame) and advanced view (CBOINCAdvancedFrame)
each had their own functions for invoking the attach wizard.
Instead, have only one function, and make it a member of CBOINCBaseFrame,
from which each of these classes derives.

Other stuff is duplicated between simple and advanced also,
and we should consolidate it at some point.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
