### PR TITLE
Manager: task list scrolling

### DIFF
--- a/clientgui/BOINCBaseView.cpp
+++ b/clientgui/BOINCBaseView.cpp
@@ -278,7 +278,9 @@ void CBOINCBaseView::OnListRender(wxTimerEvent& event) {
                     // to draw the bottom items.  This could happen
                     // if the list was scrolled near the bottom and
                     // the user selected "Show active tasks."
-                    m_pListPane->EnsureVisible(iDocCount - 1);
+                    if (m_pListPane->GetItemCount() <= m_pListPane->GetCountPerPage()) {
+                        m_pListPane->EnsureVisible(iDocCount - 1);
+                    }
 #endif
                     m_bNeedSort = true;
                 }


### PR DESCRIPTION
Reduce the number of times the task list scrolls to the bottom under routine operations.

Fixes #2147

**Description of the Change**
6479868b7c4c2efa87ff69d9e0910d43d2c33df7 (Linux only) scrolls the task list viewport to display the bottom line every time the number of items in the list changes during reporting/requesting new work. This is unnecessary, and goes beyond the design statement for the commit.

**Release Notes**
Linux only: eliminate unnecessary 'jump to bottom' events in Manager task list, caused by over-enthusiastic wxWidgets bug fix in 6479868b7c4c2efa87ff69d9e0910d43d2c33df7
