### PR TITLE
Fix prototype warnings in the BOINC API headers

### DIFF
--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -76,7 +76,7 @@ typedef struct BOINC_STATUS {
 
 extern volatile BOINC_STATUS boinc_status;
 
-typedef void (*FUNC_PTR)();
+typedef void (*FUNC_PTR)(void);
 
 struct APP_INIT_DATA;
 
@@ -93,13 +93,13 @@ extern int boinc_resume_other_activities(void);
 extern int boinc_report_app_status(
     double cpu_time, double checkpoint_cpu_time, double _fraction_done
 );
-extern int boinc_time_to_checkpoint();
-extern void boinc_begin_critical_section();
-extern int boinc_try_critical_section();
-extern void boinc_end_critical_section();
-extern void boinc_need_network();
-extern int boinc_network_poll();
-extern void boinc_network_done();
+extern int boinc_time_to_checkpoint(void);
+extern void boinc_begin_critical_section(void);
+extern int boinc_try_critical_section(void);
+extern void boinc_end_critical_section(void);
+extern void boinc_need_network(void);
+extern int boinc_network_poll(void);
+extern void boinc_network_done(void);
 extern void boinc_network_usage(double sent, double received);
 extern int boinc_is_standalone(void);
 extern void boinc_ops_per_cpu_sec(double fp, double integer);
@@ -108,9 +108,9 @@ extern void boinc_set_credit_claim(double credit);
 extern int boinc_receive_trickle_down(char* buf, int len);
 extern int boinc_init_options(BOINC_OPTIONS*);
 extern int boinc_get_status(BOINC_STATUS*);
-extern double boinc_get_fraction_done();
+extern double boinc_get_fraction_done(void);
 extern void boinc_register_timer_callback(FUNC_PTR);
-extern double boinc_worker_thread_cpu_time();
+extern double boinc_worker_thread_cpu_time(void);
 extern int boinc_init_parallel();
 extern void boinc_web_graphics_url(char*);
 extern void boinc_remote_desktop_addr(char*);

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -111,7 +111,7 @@ extern int boinc_get_status(BOINC_STATUS*);
 extern double boinc_get_fraction_done(void);
 extern void boinc_register_timer_callback(FUNC_PTR);
 extern double boinc_worker_thread_cpu_time(void);
-extern int boinc_init_parallel();
+extern int boinc_init_parallel(void);
 extern void boinc_web_graphics_url(char*);
 extern void boinc_remote_desktop_addr(char*);
 
@@ -130,7 +130,7 @@ extern int setMacIcon(char *filename, char *iconData, long iconSize);
 
 extern int boinc_get_init_data(APP_INIT_DATA&);
 extern int boinc_wu_cpu_time(double&);
-extern double boinc_elapsed_time();
+extern double boinc_elapsed_time(void);
 extern int boinc_upload_file(std::string& name);
 extern int boinc_upload_status(std::string& name);
 extern char* boinc_msg_prefix(char*, int);
@@ -155,7 +155,7 @@ extern APP_CLIENT_SHM *app_client_shm;
 extern HANDLE worker_thread_handle;
 #endif
 extern int boinc_init_options_general(BOINC_OPTIONS& opt);
-extern int start_timer_thread();
+extern int start_timer_thread(void);
 extern bool boinc_disable_timer_thread;
 
 inline void boinc_options_defaults(BOINC_OPTIONS& b) {

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -95,7 +95,6 @@ extern int boinc_report_app_status(
 );
 extern int boinc_time_to_checkpoint(void);
 extern void boinc_begin_critical_section(void);
-extern int boinc_try_critical_section(void);
 extern void boinc_end_critical_section(void);
 extern void boinc_need_network(void);
 extern int boinc_network_poll(void);

--- a/api/graphics_api.h
+++ b/api/graphics_api.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-typedef void (*WORKER_FUNC_PTR)();
+typedef void (*WORKER_FUNC_PTR)(void);
 
 extern int boinc_init_graphics(WORKER_FUNC_PTR);
 
@@ -40,8 +40,8 @@ extern void boinc_app_mouse_button(int x, int y, int which, int is_down);
 extern void boinc_app_mouse_move(int x, int y, int left, int middle, int right);
 extern void boinc_app_key_press(int, int);
 extern void boinc_app_key_release(int, int);
-extern void boinc_suspend_graphics_thread();
-extern void boinc_resume_graphics_thread();
+extern void boinc_suspend_graphics_thread(void);
+extern void boinc_resume_graphics_thread(void);
 
 // C++ API follows here 
 #ifdef __cplusplus
@@ -50,7 +50,7 @@ extern void boinc_resume_graphics_thread();
 #include "boinc_api.h"
 
 extern int boinc_init_options_graphics(BOINC_OPTIONS&, WORKER_FUNC_PTR);
-extern bool boinc_graphics_possible();
+extern bool boinc_graphics_possible(void);
 
 // Implementation stuff
 //

--- a/lib/diagnostics.h
+++ b/lib/diagnostics.h
@@ -80,50 +80,50 @@ extern "C" {
 // These are functions common to all platforms
 extern int boinc_init_diagnostics( int flags );
 extern int boinc_init_graphics_diagnostics( int flags );
-extern int boinc_install_signal_handlers();
-extern int boinc_finish_diag();
+extern int boinc_install_signal_handlers(void);
+extern int boinc_finish_diag(void);
 
 extern int diagnostics_init(
     int flags, const char* stdout_prefix, const char* stderr_prefix
 );
 extern int diagnostics_thread_init();
-extern int diagnostics_finish();
-extern int diagnostics_is_initialized();
+extern int diagnostics_finish(void);
+extern int diagnostics_is_initialized(void);
 extern int diagnostics_is_flag_set(int flags);
 
 // Properties
-extern char* diagnostics_get_boinc_dir();
-extern char* diagnostics_get_boinc_install_dir();
-extern char* diagnostics_get_symstore();
+extern char* diagnostics_get_boinc_dir(void);
+extern char* diagnostics_get_boinc_install_dir(void);
+extern char* diagnostics_get_symstore(void);
 extern int diagnostics_set_symstore(char* symstore);
-extern int diagnostics_is_proxy_enabled();
-extern char* diagnostics_get_proxy();
+extern int diagnostics_is_proxy_enabled(void);
+extern char* diagnostics_get_proxy(void);
 
-extern int diagnostics_is_aborted_via_gui();
-extern int diagnostics_set_aborted_via_gui();
+extern int diagnostics_is_aborted_via_gui(void);
+extern int diagnostics_set_aborted_via_gui(void);
 
 // Log rotation
-extern int diagnostics_cycle_logs();
+extern int diagnostics_cycle_logs(void);
 extern void diagnostics_set_max_file_sizes(int stdout_size, int stderr_size);
 
 // Thread Tracking
-extern int diagnostics_init_thread_list();
-extern int diagnostics_finish_thread_list();
-extern int diagnostics_update_thread_list();
-extern int diagnostics_set_thread_exempt_suspend();
+extern int diagnostics_init_thread_list(void);
+extern int diagnostics_finish_thread_list(void);
+extern int diagnostics_update_thread_list(void);
+extern int diagnostics_set_thread_exempt_suspend(void);
 extern int diagnostics_is_thread_exempt_suspend(long thread_id);
 
 // Message Monitoring (debugger viewport)
-extern int diagnostics_init_message_monitor();
-extern int diagnostics_finish_message_monitor();
+extern int diagnostics_init_message_monitor(void);
+extern int diagnostics_finish_message_monitor(void);
 #ifdef _WIN32
 extern UINT WINAPI diagnostics_message_monitor(LPVOID lpParameter);
 #endif
 extern int diagnostics_trace_to_debugger(const char* msg);
 
 // Unhandled exception monitor
-extern int diagnostics_init_unhandled_exception_monitor();
-extern int diagnostics_finish_unhandled_exception_monitor();
+extern int diagnostics_init_unhandled_exception_monitor(void);
+extern int diagnostics_finish_unhandled_exception_monitor(void);
 #ifdef _WIN32
 extern UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID lpParameter);
 extern LONG CALLBACK boinc_catch_signal(EXCEPTION_POINTERS *ExceptionInfo);

--- a/lib/diagnostics.h
+++ b/lib/diagnostics.h
@@ -86,7 +86,7 @@ extern int boinc_finish_diag(void);
 extern int diagnostics_init(
     int flags, const char* stdout_prefix, const char* stderr_prefix
 );
-extern int diagnostics_thread_init();
+extern int diagnostics_thread_init(void);
 extern int diagnostics_finish(void);
 extern int diagnostics_is_initialized(void);
 extern int diagnostics_is_flag_set(int flags);


### PR DESCRIPTION
Apply patch reported almost 10 years ago.
It doesn't make so much affect now but make API headers more consistent.
Also removed header of the function that was removed many years ago.
This is cosmetical change and make doesn't touch existing functionality.
Fixes #861 