### PR TITLE
remote job submission: fix race condition

### DIFF
--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -96,6 +96,11 @@ function delete_remote_submit_user($user) {
 // TODO: update est_completion_time
 //
 function get_batch_params($batch, $wus) {
+    if ($batch->state == BATCH_STATE_INIT) {
+        // a batch in INIT state has no jobs
+        //
+        return $batch;
+    }
     $fp_total = 0;
     $fp_done = 0;
     $completed = true;


### PR DESCRIPTION
Scenario:
- a submit_batch() creates a batch in INIT state
    and starts creating jobs
- while it's in progress, a query_batches() RPC enumerates batches
- while the query_batches() is in progress,
    the submit_batch() finishes and changes the state to IN_PROGRESS
- the query_batches() finishes and rewrites the batch in INIT state

Solution: query_batches() doesn't update batches in INIT state

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
