### PR TITLE
web: Fix auto-attach process for VBox projects

### DIFF
--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -89,7 +89,7 @@ function navbar_right($user) {
             );
         } else {
             echo sprintf('
-                <li><a href="%screate_account_form.php">Sign Up</a></li>
+                <li><a href="%ssignup.php">Join</a></li>
                 <li><a href="%slogin_form.php">Login</a></li>
                 ', url_base(), url_base()
             );

--- a/html/user/join.php
+++ b/html/user/join.php
@@ -28,6 +28,8 @@
 // This page routes people to the right place depending on whether
 // they already have BOINC installed on this device.
 
+// DEPRECATED.  Use signup.php instead
+
 require_once("../inc/util.inc");
 
 // "old" (misnomer) means BOINC is already installed on this device

--- a/html/user/register.php
+++ b/html/user/register.php
@@ -22,6 +22,8 @@
 //
 // Link to this from a "Join" button on home page
 
+// DEPRECATED; use signup.php instead
+
 require_once("../inc/util.inc");
 require_once("../inc/account.inc");
 require_once("../inc/recaptchalib.php");
@@ -34,7 +36,7 @@ function reg_form() {
     page_head("Register",  null, null, null, boinc_recaptcha_get_head_extra());
     echo "<h3>Create an account</h3>";
     form_start("create_account_action.php", "post");
-    create_account_form(0, "download.php");
+    create_account_form(0, "download_software.php");
     if ($recaptcha_public_key) {
         form_general("", boinc_recaptcha_get_html($recaptcha_public_key));
     }
@@ -42,7 +44,7 @@ function reg_form() {
     form_end();
 
     echo "<h3>If you already have an account, log in</h3>";
-    login_form("download.php");
+    login_form("download_software.php");
     echo "</td></tr>";
     page_tail();
 }

--- a/html/user/sample_index.php
+++ b/html/user/sample_index.php
@@ -98,7 +98,7 @@ function left(){
                     ',
                     tra("Want to help more?"),
                     tra("If BOINC is not installed on this computer, %1download it%2.",
-                        "<a href=download.php>", "</a>"
+                        "<a href=download_software.php>", "</a>"
                     ),
                     tra("Install BOINC on your other computers, tablets, and phones."),
                     tra("Tell your friends about BOINC, and show them how to join %1.", PROJECT)

--- a/html/user/signup.php
+++ b/html/user/signup.php
@@ -111,7 +111,7 @@ function join_action() {
         $prefs = compute_prefs_xml($preset);
         $user->update("global_prefs='$prefs'");
     }
-    Header("Location: download.php");
+    Header("Location: download_software.php");
     send_cookie('auth', $user->authenticator, false);
 }
 


### PR DESCRIPTION
Problem: the new signup/download process (auto-attach) wasn't telling
Mac and Linux users to install VirtualBox for projects that require it.
(These platforms don't have a combined BOINC/VBox installer;
the user has to install VBox separately).

Solution: add links to the VirtualBox download page in appropriate places.

Also: we currently have a <need_vbox/> config option
for projects that require VBox (i.e. all their apps are VM)
Add a <recommend_vbox/> option for projects with some but not all VM apps.

Also: rename download.php to download_software.php.
There was a name conflict with a file from the boinc-site repo.
This caused problems on the BOINC web site, which uses both code bases.
Projects with a link to download.php on their home page
should change this to download_software.php.
