### PR TITLE
Removed extra .gz from badge_user and badge_team

### DIFF
--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -644,7 +644,7 @@ void write_badge_user(char* output_dir) {
     DB_BADGE_USER bu;
     char path[MAXPATHLEN];
     ZFILE zf("badge_users", COMPRESSION_GZIP);
-    sprintf(path, "%s/badge_user.gz", output_dir);
+    sprintf(path, "%s/badge_user", output_dir);
     zf.open(path);
     while (!bu.enumerate("")) {
         zf.write(
@@ -665,7 +665,7 @@ void write_badge_team(char* output_dir) {
     DB_BADGE_TEAM bt;
     char path[MAXPATHLEN];
     ZFILE zf("badge_teams", COMPRESSION_GZIP);
-    sprintf(path, "%s/badge_team.gz", output_dir);
+    sprintf(path, "%s/badge_team", output_dir);
     zf.open(path);
     while (!bt.enumerate("")) {
         zf.write(


### PR DESCRIPTION
Removed extra .gz from badge_user and badge_team when running du_dump as described in issue #3074. The [open function](https://github.com/BOINC/boinc/blob/master/sched/db_dump.cpp#L309) of the GZIP_FILE class appends '.gz'.