### PR TITLE
Added grcpool.com to account manager list

### DIFF
--- a/android/BOINC/app/src/main/res/values/configuration.xml
+++ b/android/BOINC/app/src/main/res/values/configuration.xml
@@ -86,5 +86,6 @@
         <item>http://bam.boincstats.com/</item>
         <item>http://gridrepublic.org/</item>
         <item>http://www.extremadurathome.org/extremadurathome/</item>
+        <item>https://www.grcpool.com</item>
     </string-array>
 </resources>


### PR DESCRIPTION
grcpool.com has more than 10'000 active users and should therefore also be an option in the account manager dropdown menu.


**Release Notes**
- Users can now select grcpool.com as their account manager