### PR TITLE
[Android] Fix issue when 'Add Project' list shows projects that have …

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
@@ -644,7 +644,8 @@ public class ClientInterfaceImplementation extends RpcClient {
 
             // project is not yet attached, check whether it supports CPU architecture
             for(String supportedPlatform : candidate.platforms) {
-                if(supportedPlatform.contains(boincPlatformName) || supportedPlatform.contains(boincAltPlatformName)) {
+                if(supportedPlatform.contains(boincPlatformName) ||
+                   (!boincAltPlatformName.isEmpty() && supportedPlatform.contains(boincAltPlatformName))) {
                     // project is not yet attached and does support platform
                     // add to list, if not already in it
                     if(!attachableProjects.contains(candidate)) {


### PR DESCRIPTION
…no Android support

In f6d550484a0aef9ae80f8ff1c55823de5c3ec006 was added getBoincAltPlatform() that provides the corresponding 32-bit architecture string for 64-bit devics but produces empty string for 32-bit devices.
Added verification for empty string in getAttachableProjects() method to filter projects that have no Android support.

Fixes #1581

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>