### PR TITLE
[Android] Change the Desktop Environment from Mate to Lubuntu in Vagrant

### DIFF
--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -115,7 +115,7 @@ Vagrant.configure("2") do |config|
       add-apt-repository ppa:lyzardking/ubuntu-make
       apt-get --assume-yes update
       apt-get --assume-yes dist-upgrade -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --allow-downgrades --allow-remove-essential --allow-change-held-packages
-      apt-get --assume-yes install ubuntu-mate-core virtualbox-guest-x11
+      apt-get --assume-yes install lubuntu-core virtualbox-guest-x11
       apt-get --assume-yes install ubuntu-make git automake libtool pkg-config
       update-locale LC_ALL=en_US.UTF-8
   SHELL


### PR DESCRIPTION
**Description of the Change**
Lubuntu Desktop Environment is lighter than the Mate DE, which is very beneficial in a virtual environments situation.
Lubuntu uses 194 MB RAM and 12,47 GB disk space, while Mate uses 435 MB RAM and 13,95 GB disk space. Plus with the new DE the installation process is also faster.

**Release Notes**
N/A