### PR TITLE
[Android] Update the Android Gradle plugin to version 3.4.0 and Gradl…

### DIFF
--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.4.0'
     }
 }
 

--- a/android/BOINC/gradle/wrapper/gradle-wrapper.properties
+++ b/android/BOINC/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 04 09:57:33 UTC 2019
+#Fri May 03 17:44:56 UTC 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
…e to version 5.1.1.

**Description of the Change**
To take advantage of the latest features, improvements, and security fixes, it is strongly recommended to update the Android Gradle plugin to version 3.4.0 and Gradle to version 5.1.1. [Release notes.](https://developer.android.com/studio/releases/gradle-plugin)

**Release Notes**
N/A