### PR TITLE
[Android] Use apply() instead of commit on shared preferences. Wherea…

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
@@ -74,7 +74,7 @@ public class AppPreferences {
     public void setAutostart(Boolean as) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("autostart", as);
-        editor.commit();
+        editor.apply();
         this.autostart = as;
     }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
@@ -85,7 +85,7 @@ public class AppPreferences {
     public void setShowNotificationForNotices(Boolean as) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("showNotification", as);
-        editor.commit();
+        editor.apply();
         this.showNotificationForNotices = as;
     }
 
@@ -96,7 +96,7 @@ public class AppPreferences {
     public void setShowNotificationDuringSuspend(Boolean ns) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("showNotificationDuringSuspend", ns);
-        editor.commit();
+        editor.apply();
         this.showNotificationDuringSuspend = ns;
     }
 
@@ -107,7 +107,7 @@ public class AppPreferences {
     public void setShowAdvanced(Boolean as) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("showAdvanced", as);
-        editor.commit();
+        editor.apply();
         this.showAdvanced = as;
     }
 
@@ -118,7 +118,7 @@ public class AppPreferences {
     public void setLogLevel(Integer logLevel) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putInt("logLevel", logLevel);
-        editor.commit();
+        editor.apply();
         this.logLevel = logLevel;
         Logging.setLogLevel(logLevel);
     }
@@ -130,21 +130,21 @@ public class AppPreferences {
     public void setPowerSourceAc(Boolean ac) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("powerSourceAc", ac);
-        editor.commit();
+        editor.apply();
         this.powerSourceAc = ac;
     }
 
     public void setPowerSourceUsb(Boolean usb) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("powerSourceUsb", usb);
-        editor.commit();
+        editor.apply();
         this.powerSourceUsb = usb;
     }
 
     public void setPowerSourceWireless(Boolean wireless) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("powerSourceWireless", wireless);
-        editor.commit();
+        editor.apply();
         this.powerSourceWireless = wireless;
     }
 
@@ -163,7 +163,7 @@ public class AppPreferences {
     public void setStationaryDeviceMode(Boolean sdm) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("stationaryDeviceMode", sdm);
-        editor.commit();
+        editor.apply();
         this.stationaryDeviceMode = sdm;
     }
 
@@ -174,7 +174,7 @@ public class AppPreferences {
     public void setSuspendWhenScreenOn(Boolean swso) {
         SharedPreferences.Editor editor = prefs.edit();
         editor.putBoolean("suspendWhenScreenOn", swso);
-        editor.commit();
+        editor.apply();
         this.suspendWhenScreenOn = swso;
     }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.java
@@ -42,7 +42,7 @@ public class PersistentStorage {
     public void setLastNotifiedNoticeArrivalTime(double arrivalTime) {
         SharedPreferences.Editor editor = store.edit();
         editor.putLong("lastNotifiedNoticeArrivalTime", Double.doubleToRawLongBits(arrivalTime));
-        editor.commit();
+        editor.apply();
     }
 
     public String getLastEmailAddress() {
@@ -52,7 +52,7 @@ public class PersistentStorage {
     public void setLastEmailAddress(String email) {
         SharedPreferences.Editor editor = store.edit();
         editor.putString("lastEmailAddress", email);
-        editor.commit();
+        editor.apply();
     }
 
     public String getLastUserName() {
@@ -62,6 +62,6 @@ public class PersistentStorage {
     public void setLastUserName(String name) {
         SharedPreferences.Editor editor = store.edit();
         editor.putString("lastUserName", name);
-        editor.commit();
+        editor.apply();
     }
 }


### PR DESCRIPTION
…s commit blocks and writes its data to persistent storage immediately, apply will handle it in the background.

**Release Notes**
Increase responsiveness in the Preferences menu.
