### PR TITLE
[Android] Add Cancel button to 'Add Project' screen

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
@@ -146,8 +146,7 @@ public class SelectionListActivity extends FragmentActivity {
         startActivity(new Intent(this, CredentialInputActivity.class));
     }
 
-    // triggered by cancel button
-    public void cancelClicked(View v) {
+    private void onCancel() {
         // go to projects screen and clear history
         Intent intent = new Intent(this, BOINCActivity.class);
         // add flags to return to main activity and clearing all others and clear the back stack
@@ -155,6 +154,16 @@ public class SelectionListActivity extends FragmentActivity {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         intent.putExtra("targetFragment", R.string.tab_projects); // make activity display projects fragment
         startActivity(intent);
+    }
+
+    @Override
+    public void onBackPressed() {
+        onCancel();
+    }
+
+    // triggered by cancel button
+    public void cancelClicked(View v) {
+        onCancel();
     }
 
     private ServiceConnection mMonitorConnection = new ServiceConnection() {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2016 University of California
+ * Copyright (C) 2019 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -36,6 +36,7 @@ import android.view.View;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import edu.berkeley.boinc.BOINCActivity;
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.client.IMonitor;
 import edu.berkeley.boinc.client.Monitor;
@@ -143,6 +144,17 @@ public class SelectionListActivity extends FragmentActivity {
 
         // start credential input activity
         startActivity(new Intent(this, CredentialInputActivity.class));
+    }
+
+    // triggered by cancel button
+    public void cancelClicked(View v) {
+        // go to projects screen and clear history
+        Intent intent = new Intent(this, BOINCActivity.class);
+        // add flags to return to main activity and clearing all others and clear the back stack
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.putExtra("targetFragment", R.string.tab_projects); // make activity display projects fragment
+        startActivity(intent);
     }
 
     private ServiceConnection mMonitorConnection = new ServiceConnection() {

--- a/android/BOINC/app/src/main/res/layout/attach_project_list_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_list_layout.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   This file is part of BOINC.
   http://boinc.berkeley.edu
-  Copyright (C) 2012 University of California
+  Copyright (C) 2019 University of California
   
   BOINC is free software; you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License
@@ -59,7 +59,7 @@
             android:id="@+id/continue_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentBottom="true"
             android:text="@string/generic_button_continue"
             android:textColor="@android:color/white"
@@ -69,5 +69,20 @@
             android:padding="5dp"
             android:layout_margin="10dp"
             android:onClick="continueClicked"/>
+
+    <Button
+            android:id="@+id/cancel_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentBottom="true"
+            android:text="@string/confirm_cancel"
+            android:textColor="@android:color/white"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:background="@drawable/shape_button_blue"
+            android:minWidth="150dp"
+            android:padding="5dp"
+            android:layout_margin="10dp"
+            android:onClick="cancelClicked"/>
 
 </RelativeLayout>


### PR DESCRIPTION
Currently there is no way to cancel 'Add Project' procedure once it is started.
This pull request add cancel button to this screen.
Also it fixes the warning with `layout_alignParentRight` setting that could work in not a proper way for right-to-left UI.
I'm not sure whether it is an issue now but definitely will be better to have.

This fixes #3136

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
