### PR TITLE
[Android] Fix build_all.sh script to run CI script

### DIFF
--- a/android/Vagrantfile
+++ b/android/Vagrantfile
@@ -116,7 +116,7 @@ Vagrant.configure("2") do |config|
       apt-get --assume-yes update
       apt-get --assume-yes dist-upgrade -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef --allow-downgrades --allow-remove-essential --allow-change-held-packages
       apt-get --assume-yes install lubuntu-core virtualbox-guest-x11
-      apt-get --assume-yes install ubuntu-make git automake libtool pkg-config
+      apt-get --assume-yes install ubuntu-make git automake libtool pkg-config unzip
       update-locale LC_ALL=en_US.UTF-8
   SHELL
 
@@ -127,8 +127,6 @@ Vagrant.configure("2") do |config|
           umake --verbose android android-studio --accept-license $HOME/Android/Android-Studio
           printf "\n# umake fix-up\nexport ANDROID_HOME=\$HOME/Android/Sdk\n" >> $HOME/.profile
           umake --verbose android android-sdk --accept-license $HOME/Android/Sdk
-          printf "\n# umake fix-up\nexport NDK_ROOT=\$HOME/Android/Ndk\n" >> $HOME/.profile
-          umake --verbose android android-ndk --accept-license $HOME/Android/Ndk
           yes | $HOME/Android/Sdk/tools/bin/sdkmanager --update
           yes | $HOME/Android/Sdk/tools/bin/sdkmanager "extras;android;m2repository" "extras;google;m2repository"
           mkdir $HOME/Desktop
@@ -141,21 +139,12 @@ Vagrant.configure("2") do |config|
       s.name = "Cloning BOINC repository and configuring toolchain..."
       s.privileged  = false
       s.inline  = <<-SHELL
-          export OPENSSL_VERSION=1.0.2q
-          export CURL_VERSION=7.62.0
           git clone https://github.com/BOINC/boinc.git $HOME/BOINC
           export BUILD_TOOLS=`sed -n "s/.*buildToolsVersion\\s*\\"\\(.*\\)\\"/\\1/p" $HOME/BOINC/android/BOINC/app/build.gradle`
           export COMPILE_SDK=`sed -n "s/.*compileSdkVersion\\s*\\(\\d*\\)/\\1/p" $HOME/BOINC/android/BOINC/app/build.gradle`
           yes | $HOME/Android/Sdk/tools/bin/sdkmanager "build-tools;${BUILD_TOOLS}"
           yes | $HOME/Android/Sdk/tools/bin/sdkmanager "platforms;android-${COMPILE_SDK}"
           printf "\n# Build toolchains\nexport ANDROID_TC=\$HOME/Android/Toolchains\n" >> $HOME/.profile
-          mkdir $HOME/3rdParty
-          wget -O /tmp/openssl.tgz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-          tar xzf /tmp/openssl.tgz --directory=$HOME/3rdParty
-          printf "\n# OpenSSL sources\nexport OPENSSL_SRC=\$HOME/3rdParty/openssl-${OPENSSL_VERSION}\n" >> $HOME/.profile
-          wget -O /tmp/curl.tgz https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
-          tar xzf /tmp/curl.tgz --directory=$HOME/3rdParty
-          printf "\n# cURL sources\nexport CURL_SRC=\$HOME/3rdParty/curl-${CURL_VERSION}\n" >> $HOME/.profile
       SHELL
   end
 

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -91,7 +91,7 @@ fi
 
 if [ "x$build_dir" != "x" ]; then
     if isPathCanonical "$build_dir" && [ "$build_dir" != "/" ]; then
-         PREFIX="$build_dir"
+         BUILD_DIR="$build_dir"
      else
          echo "build_dir must be an absolute path without ./ or ../ in it"
          exit 1

--- a/android/build_all.sh
+++ b/android/build_all.sh
@@ -7,19 +7,7 @@ set -e
 
 # Script to compile everything BOINC needs for Android
 
-./build_androidtc_arm.sh
-./build_androidtc_arm64.sh
-./build_androidtc_x86.sh
-./build_androidtc_x86_64.sh
-./build_openssl_arm.sh
-./build_openssl_arm64.sh
-./build_openssl_x86.sh
-./build_openssl_x86_64.sh
-./build_curl_arm.sh
-./build_curl_arm64.sh
-./build_curl_x86.sh
-./build_curl_x86_64.sh
-./build_boinc_arm.sh
-./build_boinc_arm64.sh
-./build_boinc_x86.sh
-./build_boinc_x86_64.sh
+./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch arm
+./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch arm64
+./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch x86
+./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch x86_64


### PR DESCRIPTION
Move functionality to install NDK and download curl and openssl sources to CI script that are already presented there.
Fix usage of BUILD_DIR variable that was missed during input parameters parsing.
This fixes #3119