### PR TITLE
[Android] Fix menu button icon

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
@@ -133,6 +133,7 @@ public class BOINCActivity extends AppCompatActivity {
         // enabling action bar app icon and behaving it as toggle button
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setHomeButtonEnabled(true);
+        getSupportActionBar().setHomeAsUpIndicator(R.drawable.ic_drawer);
 
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout,
                                                   R.drawable.ic_drawer, //nav menu toggle icon


### PR DESCRIPTION
By default there was collapse icon on menu button.
After SDK update it looks like that is necessary to add extra function `setHomeAsUpIndicator()` to show correct icon instead of default 'Back' icon

This fixes #2940

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
