### PR TITLE
[Android] Change color to white in drop-down menus

### DIFF
--- a/android/BOINC/app/src/main/res/values/theme.xml
+++ b/android/BOINC/app/src/main/res/values/theme.xml
@@ -23,7 +23,7 @@
         <item name="android:actionBarStyle">@style/StyledActionBar</item>
         <item name="android:actionBarTabStyle">@style/StyledActionBarTabView</item>
         <item name="actionMenuTextColor">@android:color/white</item>
-        <item name="android:itemBackground">@color/dark_blue</item>
+        <item name="android:itemBackground">@color/white</item>
         <item name="android:windowBackground">@color/white</item>
         <item name="android:textColor">@color/black</item>
     </style>


### PR DESCRIPTION
By default there is dark-blue color as a background of drop-down menus.
This make black text drawn on blue looks not nice.
This changes default background color to white for better usability.

This fixes #2001

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
