### PR TITLE
[Windows] [AppVeyor] Use secure windows git dependencies path

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ environment:
   matrix:
     - TOOLCHAIN_VERSION: 12.0
       solution_name: win_build\boinc_vs2013.sln
-      depends_git_path: http://boinc.berkeley.edu/git/boinc_depends_win_vs2013.git
+      depends_git_path: https://boinc.berkeley.edu/git/boinc_depends_win_vs2013.git
       depends_path: C:\projects\boinc_depends_win_vs2013
   BINTRAY_API_KEY:
     secure: kZI9k0Kh2bFSCbXfkz+J16fGNAee1ToRMl10D8QPQsKpC2PqhF/uVMpd6gRC+OSI


### PR DESCRIPTION
Change from http://boinc.berkeley.edu/git/boinc_depends_win_vs2013.git to https://boinc.berkeley.edu/git/boinc_depends_win_vs2013.git for CI windows builds when loading windows build dependencies from Berkeley git repo

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
