### PR TITLE
db_purge: fix bugs in zlib support

### DIFF
--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -504,7 +504,7 @@ int archive_result_gz (DB_RESULT& result) {
         fail("ERROR: writing result archive failed\n");
     }
 
-    n = gzflush((gzFile)re_stream, Z_FULL_FLUSH);
+    n = gzflush((gzFile)re_stream, Z_SYNC_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing result archive failed (flush)\n");
     }
@@ -538,7 +538,7 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
         fail("ERROR: writing workunit archive failed\n");
     }
 
-    n = gzflush((gzFile)re_stream,Z_FULL_FLUSH);
+    n = gzflush((gzFile)wu_stream,Z_SYNC_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing workunit archive failed (flush)\n");
     }
@@ -551,7 +551,7 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
         fail("ERROR: writing workunit index failed\n");
     }
 
-    n = gzflush((gzFile)re_stream,Z_SYNC_FLUSH);
+    n = gzflush((gzFile)wu_index_stream,Z_SYNC_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing workunit index failed (flush)\n");
     }


### PR DESCRIPTION
There are two bugs in db_purge zlib support code:
1. Wrong archive streams flushed (copy-paste programming...)
2. `Z_FULL_FLUSH` must not be used as it clears compression dictionary, this ruins compression. Use `Z_SYNC_FLUSH` instead.

This fixes #3145

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
