### PR TITLE
Purge retired batches from the batch table

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -132,6 +132,8 @@ DB_HOST_DELETED::DB_HOST_DELETED(DB_CONN* dc) :
     DB_BASE("host_deleted", dc?dc:&boinc_db){}
 DB_WORKUNIT::DB_WORKUNIT(DB_CONN* dc) :
     DB_BASE("workunit", dc?dc:&boinc_db){}
+DB_BATCH::DB_BATCH(DB_CONN* dc) :
+    DB_BASE("batch", dc?dc:&boinc_db){}
 DB_CREDITED_JOB::DB_CREDITED_JOB(DB_CONN* dc) :
     DB_BASE("credited_job", dc?dc:&boinc_db){}
 DB_RESULT::DB_RESULT(DB_CONN* dc) :
@@ -206,6 +208,7 @@ DB_ID_TYPE DB_TEAM::get_id() {return id;}
 DB_ID_TYPE DB_HOST::get_id() {return id;}
 DB_ID_TYPE DB_HOST_DELETED::get_id() {return hostid;}
 DB_ID_TYPE DB_WORKUNIT::get_id() {return id;}
+DB_ID_TYPE DB_BATCH::get_id() {return id;}
 DB_ID_TYPE DB_RESULT::get_id() {return id;}
 DB_ID_TYPE DB_MSG_FROM_HOST::get_id() {return id;}
 DB_ID_TYPE DB_MSG_TO_HOST::get_id() {return id;}

--- a/db/boinc_db.h
+++ b/db/boinc_db.h
@@ -225,6 +225,13 @@ public:
     void operator=(WORKUNIT& w) {WORKUNIT::operator=(w);}
 };
 
+class DB_BATCH : public DB_BASE, public BATCH {
+public:
+    DB_BATCH(DB_CONN* p=0);
+    DB_ID_TYPE get_id();
+};
+
+
 class DB_CREDITED_JOB : public DB_BASE, public CREDITED_JOB {
 public:
     DB_CREDITED_JOB(DB_CONN* p=0);

--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -74,6 +74,7 @@ void usage() {
         "    [--one_pass]                  Make one DB scan, then exit\n"
         "    [--dont_delete]               Don't actually delete anything from the DB (for testing only)\n"
         "    [--mod M R ]                  Handle only WUs with ID mod M == R\n"
+        "    [--batches]                   Delete retired batches from the batch table\n"
         "    [--h | --help]                Show this help text\n"
         "    [--v | --version]             Show version information\n"
     );
@@ -227,6 +228,7 @@ double min_age_days = 0;
 bool no_archive = false;
 bool dont_delete = false;
 bool daily_dir = false;
+bool delete_batches = false;
 int purged_workunits = 0;
     // used if limiting the total number of workunits to eliminate
 int max_number_workunits_to_purge = 0;
@@ -504,7 +506,7 @@ int archive_result_gz (DB_RESULT& result) {
         fail("ERROR: writing result archive failed\n");
     }
 
-    n = gzflush((gzFile)re_stream, Z_SYNC_FLUSH);
+    n = gzflush((gzFile)re_stream, Z_FULL_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing result archive failed (flush)\n");
     }
@@ -538,7 +540,7 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
         fail("ERROR: writing workunit archive failed\n");
     }
 
-    n = gzflush((gzFile)wu_stream,Z_SYNC_FLUSH);
+    n = gzflush((gzFile)re_stream,Z_FULL_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing workunit archive failed (flush)\n");
     }
@@ -551,7 +553,7 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
         fail("ERROR: writing workunit index failed\n");
     }
 
-    n = gzflush((gzFile)wu_index_stream,Z_SYNC_FLUSH);
+    n = gzflush((gzFile)re_stream,Z_SYNC_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing workunit index failed (flush)\n");
     }
@@ -618,6 +620,12 @@ bool do_pass() {
     bool did_something = false;
     DB_WORKUNIT wu;
     char buf[256], buf2[256];
+
+    if (delete_batches && !dont_delete) {
+        DB_BATCH batch;
+	sprintf(buf, "delete from batch where state=%d", BATCH_STATE_RETIRED);
+        batch.delete_from_db_multi(buf);
+    }
 
     sprintf(buf, "where file_delete_state=%d", FILE_DELETE_DONE);
     if (min_age_days) {
@@ -801,6 +809,8 @@ int main(int argc, char** argv) {
             max_wu_per_file = atoi(argv[i]);
         } else if (is_arg(argv[i], "no_archive")) {
             no_archive = true;
+        } else if (is_arg(argv[i], "batches")) {
+            delete_batches=true;
         } else if (is_arg(argv[i], "sleep")) {
             if(!argv[++i]) {
                 log_messages.printf(MSG_CRITICAL, "%s requires an argument\n\n", argv[--i]);

--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -621,10 +621,15 @@ bool do_pass() {
     DB_WORKUNIT wu;
     char buf[256], buf2[256];
 
-    if (delete_batches && !dont_delete) {
+    if (delete_batches) {
+      if (dont_delete) {
+	log_messages.printf(MSG_DEBUG,
+			  "Didn't delete retired batches from database (-dont_delete)\n");
+      } else {
         DB_BATCH batch;
-	sprintf(buf, "delete from batch where state=%d", BATCH_STATE_RETIRED);
+	sprintf(buf, "state=%d", BATCH_STATE_RETIRED);
         batch.delete_from_db_multi(buf);
+      }
     }
 
     sprintf(buf, "where file_delete_state=%d", FILE_DELETE_DONE);

--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -506,7 +506,7 @@ int archive_result_gz (DB_RESULT& result) {
         fail("ERROR: writing result archive failed\n");
     }
 
-    n = gzflush((gzFile)re_stream, Z_FULL_FLUSH);
+    n = gzflush((gzFile)re_stream, Z_SYNC_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing result archive failed (flush)\n");
     }
@@ -540,7 +540,7 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
         fail("ERROR: writing workunit archive failed\n");
     }
 
-    n = gzflush((gzFile)re_stream,Z_FULL_FLUSH);
+    n = gzflush((gzFile)wu_stream,Z_SYNC_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing workunit archive failed (flush)\n");
     }
@@ -553,7 +553,7 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
         fail("ERROR: writing workunit index failed\n");
     }
 
-    n = gzflush((gzFile)re_stream,Z_SYNC_FLUSH);
+    n = gzflush((gzFile)wu_index_stream,Z_SYNC_FLUSH);
     if (n != Z_OK) {
         fail("ERROR: writing workunit index failed (flush)\n");
     }


### PR DESCRIPTION
Fixes #3005 

The change adds the option --batches to delete all retired batches from the batch table. It is an alternative implementation to #3101 which does this in a separate php script. 