### PR TITLE
client: clear the vm_extensions_disabled flag on startup.

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -624,6 +624,13 @@ int CLIENT_STATE::init() {
     // domain_name for Android
     //
     host_info.get_host_info(true);
+
+    // clear the VM extensions disabled flag.
+    // It's possible that the user enabled them since the last VM failure,
+    // or that the last failure was specious.
+    //
+    host_info.p_vm_extensions_disabled = false;
+
     set_ncpus();
     show_host_info();
 


### PR DESCRIPTION
Fixes #1460
