### PR TITLE
[Android] Fix day_prefs parse

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferencesParser.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferencesParser.java
@@ -57,9 +57,7 @@ public class GlobalPreferencesParser extends BaseParser {
             mPreferences = new GlobalPreferences();
         }
         else if(localName.equalsIgnoreCase("day_prefs")) {
-            if(mInsideDayPrefs) {
-                mInsideDayPrefs = true;
-            }
+            mInsideDayPrefs = true;
         }
         else {
             // Another element, hopefully primitive and not constructor


### PR DESCRIPTION
While fixing a warning found by static analyzer:
`V6026 This value is already assigned to the 'mInsideDayPrefs' variable. GlobalPreferencesParser.java(61)`
I found that because of this mistake these settings were not parsed at all.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
