### PR TITLE
Android version plan class fix

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -75,6 +75,10 @@ static int android_version_num(HOST h) {
     if (n == 2) {
         return maj*10000 + min*100;
     }
+    n = sscanf(p, "%d", &maj);
+    if (n == 1) {
+    return maj*10000;
+}
     return 0;
 }
 


### PR DESCRIPTION
Fixes #

**Description of the Change**
Detect Android major version as described in issue:  #3172  

Kudos to @JamesMolson 

**Release Notes**
Correct detection of of Android client version from the scheduler in cases where only the Android major version is read (e.g. 9.)