### PR TITLE
Lib: increased size of opencl extensions[] from 1024 to 2048

### DIFF
--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -45,7 +45,7 @@ struct OPENCL_DEVICE_PROP {
     cl_device_fp_config double_fp_config;   // Double precision
     cl_bool endian_little;              // TRUE if little-endian
     cl_device_exec_capabilities execution_capabilities;
-    char extensions[1024];              // List of device extensions
+    char extensions[2048];              // List of device extensions
     cl_ulong global_mem_size;           // in bytes (OpenCL can report 4GB Max)
     cl_ulong local_mem_size;
     cl_uint max_clock_frequency;        // in MHz


### PR DESCRIPTION
Fixes https://boinc.berkeley.edu/forum_thread.php?id=12988:
Request for Intel iGPU support to be a working feature again.

**Description of the Change**
Extensions list for OpenCL in Intel Windows DCH drivers found to require 1,117 bytes

**Release Notes**
N/A