### PR TITLE
Fix invalid error message on accept terms of use page

### DIFF
--- a/html/inc/consent.inc
+++ b/html/inc/consent.inc
@@ -27,8 +27,7 @@ function consent_to_a_policy($user, $consent_type_id, $consent_flag, $consent_no
     $mys = BoincDb::escape_string($source);
     if ($ctime==0) {
         $mytime = $user->create_time;
-    }
-    else {
+    } else {
         $mytime = $ctime;
     }
     return BoincConsent::insert(
@@ -78,8 +77,7 @@ function intercept_login($user, $perm, $in_next_url = "") {
         send_cookie('tempperm', $perm, false);
         $save_url = $in_next_url;
         return "user_agreetermsofuse.php?next_url=$save_url";
-    }
-    else {
+    } else {
         send_cookie('auth', $user->authenticator, $perm);
         return $in_next_url;
     }

--- a/html/user/user_agreetermsofuse_action.php
+++ b/html/user/user_agreetermsofuse_action.php
@@ -58,7 +58,7 @@ if (isset($_COOKIE['tempuserid'])) {
 if (isset($_COOKIE['tempperm'])) {
     $perm = $_COOKIE['tempperm'];
 } else {
-    error_page(tra("Website error when attempting to agree to terms of use. Please contact the site administrators."));
+    $perm = false;
 }
 
 // Verify login token to authenticate the account.

--- a/html/user/user_agreetermsofuse_action.php
+++ b/html/user/user_agreetermsofuse_action.php
@@ -48,16 +48,16 @@ if (isset($_COOKIE['logintoken'])) {
 } else {
     error_page(tra("Website error when attempting to agree to terms of use."));
 }
+
 if (isset($_COOKIE['tempuserid'])) {
     $userid = $_COOKIE['tempuserid'];
-}
-else {
+} else {
     error_page(tra("Website error when attempting to agree to terms of use. Please contact the site administrators."));
 }
+
 if (isset($_COOKIE['tempperm'])) {
     $perm = $_COOKIE['tempperm'];
-}
-else {
+} else {
     error_page(tra("Website error when attempting to agree to terms of use. Please contact the site administrators."));
 }
 


### PR DESCRIPTION
Fixes #3188

**Description of the Change**
Instead of generating an error page when the use hasn't selected to use the "Stay Logged In" feature, the website should handle the absence the checkbox and simply create a session cookie.  This is done by setting $perm = false instead of generating the error page if the tempperm cookie is not present.

**Release Notes**
Fix bug causing an error when user did not select "Stay Logged In" and they needed to accept the websites terms of use.
