### PR TITLE
job submission: add ability to view mem/disk usage stats for a batch.

### DIFF
--- a/html/inc/consent.inc
+++ b/html/inc/consent.inc
@@ -18,10 +18,15 @@
 
 // functions dealing with the consent and consent_type tables.
 
-include_once("../inc/boinc_db.inc");
-include_once("../inc/util.inc");
+require_once("../inc/boinc_db.inc");
+require_once("../inc/util.inc");
 
 define('CONSENT_TYPE_ENROLL','ENROLL');
+
+// Utility function to check the terms of use.
+function check_termsofuse() {
+    return defined('TERMSOFUSE_FILE') and file_exists(TERMSOFUSE_FILE);
+}
 
 function consent_to_a_policy($user, $consent_type_id, $consent_flag, $consent_not_required, $source, $ctime = 0) {
     $mys = BoincDb::escape_string($source);

--- a/html/inc/result.inc
+++ b/html/inc/result.inc
@@ -707,16 +707,15 @@ function show_result($result, $show_outfile_links=false) {
     row2(tra("Device peak FLOPS"), number_format($result->flops_estimate/1e9, 2)." GFLOPS");
     row2(tra("Application version"), app_version_string($result));
     if ($result->peak_working_set_size) {
-        $x = number_format($result->peak_working_set_size/MEGA, 2);
-        row2("Peak working set size", "$x MB");
+        row2("Peak working set size",
+            size_string($result->peak_working_set_size)
+        );
     }
     if ($result->peak_swap_size) {
-        $x = number_format($result->peak_swap_size/MEGA, 2);
-        row2("Peak swap size", "$x MB");
+        row2("Peak swap size", size_string($result->peak_swap_size));
     }
     if ($result->peak_disk_usage) {
-        $x = number_format($result->peak_disk_usage/MEGA, 2);
-        row2("Peak disk usage", "$x MB");
+        row2("Peak disk usage", size_string($result->peak_disk_usage));
     }
     if ($show_outfile_links && $result->outcome == 1) {
         $fanout = parse_config(get_config(), "<uldl_dir_fanout>");

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -1148,9 +1148,13 @@ function text_end() {
     echo "</div>\n";
 }
 
-// Utility function to check the terms of use.
-function check_termsofuse() {
-    return defined('TERMSOFUSE_FILE') and file_exists(TERMSOFUSE_FILE);
+// express a size in terms of GB or MB
+//
+function size_string($x) {
+    if ($x > GIGA) {
+        return number_format($x/GIGA, 2)." GB";
+    }
+    return number_format($x/MEGA, 2)." MB";
 }
 
 function cert_filename() {


### PR DESCRIPTION
It's useful to see the stats (mean, max) of memory and disk usage,
e.g. so that you can set the appropriate bounds for future jobs.
In the case of universal VM apps (e.g. nanoHUB@home)
the natural place to put this is at the batch level;
jobs in a a batch use the same tool.

Also: add a general function for printing sizes in MB and GB,
and move a function from util.inc to the appropriate file.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
