### PR TITLE
scheduler: if plan class name contains "amd", assume it's AMD GPU

### DIFF
--- a/sched/sched_util_basic.cpp
+++ b/sched/sched_util_basic.cpp
@@ -281,6 +281,9 @@ int plan_class_to_proc_type(const char* plan_class) {
     if (strstr(plan_class, "ati")) {
         return PROC_TYPE_AMD_GPU;
     }
+    if (strstr(plan_class, "amd")) {
+        return PROC_TYPE_AMD_GPU;
+    }
     if (strstr(plan_class, "intel_gpu")) {
         return PROC_TYPE_INTEL_GPU;
     }


### PR DESCRIPTION
The docs said this was the case, but it wasn't.

Fixes bug (reported by Eric Driver) where hosts w/ AMD GPUs weren't being sent GPU app versions.