### PR TITLE
[Client] Ignore 'skip_cpu_benckmark' flag if requested via RPC

### DIFF
--- a/client/client_state.h
+++ b/client/client_state.h
@@ -380,7 +380,7 @@ struct CLIENT_STATE {
 
     void check_if_need_benchmarks();
     bool can_run_cpu_benchmarks();
-    void start_cpu_benchmarks();
+    void start_cpu_benchmarks(bool force = false);
     bool cpu_benchmarks_poll();
     void abort_cpu_benchmarks();
     bool cpu_benchmarks_done();

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -236,7 +236,7 @@ DWORD WINAPI win_cpu_benchmarks(LPVOID p) {
 }
 #endif
 
-void CLIENT_STATE::start_cpu_benchmarks() {
+void CLIENT_STATE::start_cpu_benchmarks(bool force) {
     int i;
 
     if (benchmarks_running) {
@@ -246,7 +246,7 @@ void CLIENT_STATE::start_cpu_benchmarks() {
         return;
     }
 
-    if (cc_config.skip_cpu_benchmarks) {
+    if (cc_config.skip_cpu_benchmarks && !force) {
         if (log_flags.benchmark_debug) {
             msg_printf(0, MSG_INFO,
                 "[benchmark] start_cpu_benchmarks(): Skipping CPU benchmarks"

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -459,7 +459,7 @@ static void handle_set_network_mode(GUI_RPC_CONN& grc) {
 }
 
 static void handle_run_benchmarks(GUI_RPC_CONN& grc) {
-    gstate.start_cpu_benchmarks();
+    gstate.start_cpu_benchmarks(true);
     grc.mfout.printf("<success/>\n");
 }
 


### PR DESCRIPTION
If CPU benchmark is requested via RPC by user, it should always run even if 'skip_cpu_bechmark' is set.

This fixes #2358

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
