### PR TITLE
FreeBSD: Add missing #include <sys/wait.h> for WEXITSTATUS macro.

### DIFF
--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
From PR #3179