### PR TITLE
[AppVeyor] Fix VS2013 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,6 +71,7 @@ cache:
 before_build:
   - call win_build\load_dependencies.bat %depends_git_path% %depends_path% %platform% %configuration%
   - if %TOOLCHAIN_VERSION%==12.0 call "%VS120COMNTOOLS%\vsvars32.bat"
+  - rmdir /S /Q %localappdata%\Microsoft\VisualStudio\%TOOLCHAIN_VERSION%\ComponentModelCache
 
 build_script:
   - devenv %solution_name% /Build "%configuration%|%platform%"


### PR DESCRIPTION
Sometimes in case of non-clean VS cache folder nex issue could happen:
https://stackoverflow.com/questions/17574089/how-can-i-fix-the-microsoft-visual-studio-error-package-did-not-load-correctly

The only way to fix this is to clean this folder manually.
Doing this is this script is safer for potential further image upgrade when mentioned folder could be not cleaned up.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
