### PR TITLE
Fix incorrect variable printed to sched debug

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -114,7 +114,7 @@ static bool wu_is_infeasible_for_plan_class(const PLAN_CLASS_SPEC* pc, const WOR
         if (config.debug_version_select) {
             log_messages.printf(MSG_NORMAL,
                 "[version] batch#%ld too new for plan class '%s' (%ld)\n",
-                wu->id, pc->name, pc->max_batch
+                wu->batch, pc->name, pc->max_batch
             );
         }
         return true;

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -105,7 +105,7 @@ static bool wu_is_infeasible_for_plan_class(const PLAN_CLASS_SPEC* pc, const WOR
         if (config.debug_version_select) {
             log_messages.printf(MSG_NORMAL,
                 "[version] batch#%ld too old for plan class '%s' (%ld)\n",
-                wu->id, pc->name, pc->min_batch
+                wu->batch, pc->name, pc->min_batch
             );
         }
         return true;


### PR DESCRIPTION
Fix message stating batch but printing workunit ID instead.