### PR TITLE
Remove boincsynergy.com from the stats site list

### DIFF
--- a/html/inc/stats_sites.inc
+++ b/html/inc/stats_sites.inc
@@ -31,9 +31,6 @@ $cpid_stats_sites = array(
     array("BOINCstats",
         "http://boincstats.com/en/stats/-1/user/detail/%s"
     ),
-    array("BOINC Statistics for the WORLD!",
-        "http://www.boincsynergy.com/stats/boinc-individual.php?cpid=%s"
-    ),
     array("BOINC Combined Statistics",
         "http://boinc.netsoft-online.com/e107_plugins/boinc/get_user.php?cpid=%s&amp;html=1"
     ),
@@ -66,10 +63,6 @@ $stats_sites = array(
         ""
     ),
 */
-    array("http://www.boincsynergy.com/stats/index.php",
-        "BOINC Statistics for the WORLD!",
-        "developed by Zain Upton"
-    ),
     array("http://boinc.netsoft-online.com/",
         "BOINC Combined Statistics",
         "developed by James Drews"


### PR DESCRIPTION
According to archive.org, the site is down at least since February 2019, so removing it from the list.

Fixes #3244