### PR TITLE
Drupal: Add ReCaptcha to user password reset form.

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -1304,6 +1304,14 @@ function boincuser_form_alter(&$form, $form_state, $form_id) {
       ),
     ));
     
+    if (module_exists('captcha')) {
+      // Add an optional captcha
+      $form['register_captcha'] = array(
+        '#type' => 'captcha',
+        '#weight' => 1000,
+      );
+    }
+
     // Wrap action buttons for styling consistency
     $form['buttons']['form control tabs prefix'] = array(
       '#value' => '<ul class="form-control tab-list">',


### PR DESCRIPTION
Fixes #
https://dev.gridrepublic.org/browse/DBOINCP-509

**Description of the Change**

Adds a CAPTCHA to the user password reset form.

**Alternate Designs**
N/A

**Release Notes**
N/A