### PR TITLE
Allow the validator to flag compared results as `runtime_outlier`

### DIFF
--- a/sched/sample_bitwise_validator.cpp
+++ b/sched/sample_bitwise_validator.cpp
@@ -65,7 +65,7 @@ void validate_handler_usage() {
 }
 
 
-bool files_match(FILE_CKSUM_LIST& f1, FILE_CKSUM_LIST& f2) {
+bool files_match(RESULT &r1, FILE_CKSUM_LIST& f1, RESULT &r2, FILE_CKSUM_LIST& f2) {
     if (f1.files.size() != f2.files.size()) return false;
     for (unsigned int i=0; i<f1.files.size(); i++) {
         if (f1.files[i] != f2.files[i]) return false;
@@ -113,14 +113,14 @@ int init_result(RESULT& result, void*& data) {
 }
 
 int compare_results(
-    RESULT & /*r1*/, void* data1,
-    RESULT const& /*r2*/, void* data2,
+    RESULT & r1, void* data1,
+    RESULT & r2, void* data2,
     bool& match
 ) {
     FILE_CKSUM_LIST* f1 = (FILE_CKSUM_LIST*) data1;
     FILE_CKSUM_LIST* f2 = (FILE_CKSUM_LIST*) data2;
 
-    match = files_match(*f1, *f2);
+    match = files_match(r1, *f1, r2, *f2);
     return 0;
 }
 

--- a/sched/sample_substr_validator.cpp
+++ b/sched/sample_substr_validator.cpp
@@ -76,7 +76,7 @@ int init_result(RESULT& r, void*&) {
     return 0;
 }
 
-int compare_results(RESULT&, void*, RESULT const&, void*, bool& match) {
+int compare_results(RESULT&, void*, RESULT &, void*, bool& match) {
     match = true;
     return 0;
 }

--- a/sched/sample_trivial_validator.cpp
+++ b/sched/sample_trivial_validator.cpp
@@ -36,7 +36,7 @@ int init_result(RESULT&, void*&) {
     return 0;
 }
 
-int compare_results(RESULT&, void*, RESULT const&, void*, bool& match) {
+int compare_results(RESULT&, void*, RESULT &, void*, bool& match) {
     match = true;
     return 0;
 }

--- a/sched/script_validator.cpp
+++ b/sched/script_validator.cpp
@@ -140,7 +140,7 @@ int init_result(RESULT& result, void*&) {
     return 0;
 }
 
-int compare_results(RESULT& r1, void*, RESULT const& r2, void*, bool& match) {
+int compare_results(RESULT& r1, void*, RESULT & r2, void*, bool& match) {
     unsigned int i, j;
     char buf[256];
 

--- a/sched/validate_util2.h
+++ b/sched/validate_util2.h
@@ -30,7 +30,7 @@
     // host is unlikely to handle this app version; stop using
 
 extern int init_result(RESULT&, void*&);
-extern int compare_results(RESULT &, void*, RESULT const&, void*, bool&);
+extern int compare_results(RESULT &, void*, RESULT &, void*, bool&);
 extern int cleanup_result(RESULT const&, void*);
 
 // old/internal interface:


### PR DESCRIPTION
Fixes # https://github.com/BOINC/boinc/issues/3256

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
Give the possibility to the validator to set `result.runtime_outlier=true` all the compared results based on the content of the results after validation. This can be achieved via removing tagging the second result in `compare_results` as `const`.

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Setting `result.runtime_outlier=true` could be performed outside of `files_match`, but this would have implied either to store the value of the flag in a temporary variable and use it somewhere else, or parse again the validation file.

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
Give the possibility to the validator to set `result.runtime_outlier=true` all the compared results based on the content of the results after validation.