### PR TITLE
size_t matters

### DIFF
--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -149,13 +149,13 @@ int copy_socket_to_file(FILE* in, char* name, char* path, double offset, double 
     bytes_left = nbytes - offset;
 
     while (bytes_left > 0) {
-        int n, m, to_write;
+        size_t m;
 
-        m = bytes_left<(double)BLOCK_SIZE ? (int)bytes_left : BLOCK_SIZE;
+        m = bytes_left<(double)BLOCK_SIZE ? (size_t)bytes_left : BLOCK_SIZE;
 
         // try to get m bytes from socket (n>=0 is number actually returned)
         //
-        n = fread(buf, 1, m, in);
+        size_t n = fread(buf, 1, m, in);
 
         // delay opening the file until we've done the first socket read
         // to avoid filesystem lockups (WCG, possible paranoia)
@@ -219,8 +219,8 @@ int copy_socket_to_file(FILE* in, char* name, char* path, double offset, double 
             if (sbuf.st_size < offset) {
                 close(fd);
                 return return_error(ERR_TRANSIENT,
-                    "length of file %s %d bytes < offset %.0f bytes",
-                    name, (int)sbuf.st_size, offset
+                    "length of file %s %zu bytes < offset %.0f bytes",
+                    name, sbuf.st_size, offset
                 );
             }
             if (offset) {
@@ -238,15 +238,15 @@ int copy_socket_to_file(FILE* in, char* name, char* path, double offset, double 
             }
             if (sbuf.st_size > offset) {
                 log_messages.printf(MSG_NORMAL,
-                    "file %s length on disk %d bytes; host upload starting at %.0f bytes.\n",
-                     this_filename, (int)sbuf.st_size, offset
+                    "file %s length on disk %zu bytes; host upload starting at %.0f bytes.\n",
+                     this_filename, sbuf.st_size, offset
                 );
             }
         }
 
         // try to write n bytes to file
         //
-        to_write=n;
+        size_t to_write=n;
         while (to_write > 0) {
             ssize_t ret = write(fd, buf+n-to_write, to_write);
             if (ret < 0) {


### PR DESCRIPTION
When sizeof(int) != sizeof(size_t) the current code is a bit dangerous, imho. The signed vs unsigned may also be tricky together with the large files as for virtualbox. I admittedly only stumbled across it while chasing one of compiler warnings of the Debian package.
The "ul" instead of "d"+cast for printf, well, maybe I miss some hidden functionality then please add a comment.

Part of this patch lives as a Debian-only patch for years. I was revisiting the code to chase other warnings as promised in https://github.com/BOINC/boinc/issues/3245. There are more size_t issue in other files. If I get some positive vibes back about them then I will add them to this branch.

Cheers,
Steffen