### PR TITLE
Fixes a bug reg. "ncpus" in cc_config.xml in comb. with "Read config files".

### DIFF
--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1627,7 +1627,10 @@ ACTIVE_TASK* CLIENT_STATE::get_task(RESULT* rp) {
 void CLIENT_STATE::set_ncpus() {
     int ncpus_old = ncpus;
 
-    if (cc_config.ncpus>0) {
+    if (cc_config.ncpus == -1) {
+        ncpus = host_info.p_ncpus_genuine;
+        host_info.p_ncpus = ncpus;
+    } else if (cc_config.ncpus>0) {
         ncpus = cc_config.ncpus;
         host_info.p_ncpus = ncpus;
     } else if (host_info.p_ncpus>0) {

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1229,6 +1229,9 @@ int HOST_INFO::get_cpu_count() {
 #error Need to specify a method to get number of processors
 #endif
 
+    /* Save value for later use in CLIENT_STATE::set_ncpus() */
+    p_ncpus_genuine = p_ncpus;
+
     return 0;
 }
 

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -1454,6 +1454,10 @@ int HOST_INFO::get_host_info(bool init) {
         m_cache,
         p_ncpus
     );
+
+    /* Save value for later use in CLIENT_STATE::set_ncpus() */
+    p_ncpus_genuine = p_ncpus;
+
     collapse_whitespace(p_model);
     collapse_whitespace(p_vendor);
     if (!strlen(host_cpid)) {

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -57,6 +57,7 @@ public:
     char host_cpid[64];
 
     int p_ncpus;
+    int p_ncpus_genuine;
     char p_vendor[256];
     char p_model[256];
     char p_features[1024];


### PR DESCRIPTION
**Description of the Change**
https://boinc.berkeley.edu/wiki/Client_configuration states that you can put "-1" into the ncpus tag to use all cores. But in this case, "Read config files" doesn't work, so you have to restart the client.

This patch fixes the behaviour by introducing an additional variable which stores the original value.

**Release Notes**
If you set ncpus in cc_config.xml to "-1", you no longer have to restart the client; "Read config files" now works in this case.