### PR TITLE
Revisited Debian patch 'more_maxpathlen.patch'

### DIFF
--- a/api/graphics2_util.cpp
+++ b/api/graphics2_util.cpp
@@ -38,9 +38,9 @@
 
 #ifdef __EMX__
 static key_t get_shmem_name(const char* prog_name) {
-    char cwd[MAXPATHLEN], path[MAXPATHLEN];
+    char cwd[MAXPATHLEN+1], path[MAXPATHLEN+1];
     boinc_getcwd(cwd);
-    sprintf(path, "%s/init_data.xml", cwd);
+    snprintf(path, sizeof(path), "%s/init_data.xml", cwd);
     return ftok(path, 2);
 }
 #else
@@ -50,14 +50,14 @@ static void get_shmem_name(const char* prog_name, char* shmem_name) {
     APP_INIT_DATA aid;
     int retval = boinc_get_init_data(aid);
     if (retval) aid.slot = 0;
-    sprintf(shmem_name, "boinc_%s_%d", prog_name, aid.slot);
+    snprintf(shmem_name, MAXPATHLEN+1, "boinc_%s_%d", prog_name, aid.slot);
 }
 #endif
 
 void* boinc_graphics_make_shmem(const char* prog_name, int size) {
 #ifdef _WIN32
     HANDLE shmem_handle;
-    char shmem_name[MAXPATHLEN];
+    char shmem_name[MAXPATHLEN+1];
     void* p;
     get_shmem_name(prog_name, shmem_name);
     shmem_handle = create_shmem(shmem_name, size, &p);
@@ -70,7 +70,7 @@ void* boinc_graphics_make_shmem(const char* prog_name, int size) {
     int retval = create_shmem(key, size, 0, &p);
 #else
     // V6 Unix/Linux/Mac applications always use mmap() shared memory for graphics communication
-    char shmem_name[MAXPATHLEN];
+    char shmem_name[MAXPATHLEN+1];
     get_shmem_name(prog_name, shmem_name);
     int retval = create_shmem_mmap(shmem_name, size, &p);
     // make sure user/group RW permissions are set, but not other.
@@ -85,7 +85,7 @@ void* boinc_graphics_make_shmem(const char* prog_name, int size) {
 #ifdef _WIN32
 void* boinc_graphics_get_shmem(const char* prog_name) {
     HANDLE shmem_handle;
-    char shmem_name[MAXPATHLEN];
+    char shmem_name[MAXPATHLEN+1];
     void* p;
     get_shmem_name(prog_name, shmem_name);
     shmem_handle = attach_shmem(shmem_name, &p);
@@ -103,7 +103,7 @@ void* boinc_graphics_get_shmem(const char* prog_name) {
     retval = attach_shmem(key, &p);
 #else
     // V6 Unix/Linux/Mac applications always use mmap() shared memory for graphics communication
-    char shmem_name[MAXPATHLEN];
+    char shmem_name[MAXPATHLEN+1];
     get_shmem_name(prog_name, shmem_name);
     retval = attach_shmem_mmap(shmem_name, &p);
 #endif

--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -598,9 +598,8 @@ int boinc_copy(const char* orig, const char* newf) {
     }
     return 0;
 #elif defined(__EMX__)
-    char cmd[2*MAXPATHLEN];
+    char cmd[2*MAXPATHLEN+4+2+4+1]; // 2 blanks, 4 '"'s, 1 terminating 0
     snprintf(cmd, sizeof(cmd), "copy \"%s\" \"%s\"", orig, newf);
-    cmd[sizeof(cmd)-1] = 0;
     return system(cmd);
 #else
     // POSIX requires that shells run from an application will use the 


### PR DESCRIPTION
This patch is about 7 years old in Debian. I don't recally the exact original. Typically the compiler warns about something or say, the (admittedly, mostly irrelelvant) Hurd platform does not have a limit in the maxpathlen and so one has a look into that.

The patch is about using MAXPATHLEN both to limit the number of bytes copied into a char[] and to prepare the size of the char[]s for it. When there are MAXPATHLEN characters allowed, a buffer needs MAXPATHLEN+1 characters max because of the terminating 0. snprintf adds the terminating 0 itself and the "n" in snprintf helps to avoid buffer overruns.

When looking at this code, I wish the boinc_getcwd would be allowed to fail. It happens all the time to me that I have removed a directory that I was still in with another shell. And the same could well happen with some magic performed on the /var partition or whatever magic all these clouds and containers may now be preparing to come up with. This has not been addressed in this patch but should possibly be addressed as a separate issue.

Anchor: https://github.com/BOINC/boinc/issues/3260