### PR TITLE
client: don't allow ".." or "%" in logical names

### DIFF
--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -107,7 +107,12 @@ int parse_project_files(XML_PARSER& xp, vector<FILE_REF>& project_files) {
         if (xp.match_tag("file_ref")) {
             FILE_REF file_ref;
             retval = file_ref.parse(xp);
-            if (!retval) {
+            if (retval) {
+                msg_printf(0, MSG_INFO,
+                    "can't parse file_ref in project file: %s",
+                    boincerror(retval)
+                );
+            } else {
                 project_files.push_back(file_ref);
             }
         } else {
@@ -843,12 +848,16 @@ int APP_VERSION::parse(XML_PARSER& xp) {
         if (xp.parse_str("app_name", app_name, sizeof(app_name))) continue;
         if (xp.match_tag("file_ref")) {
             int retval = file_ref.parse(xp);
-            if (!retval) {
-                if (strstr(file_ref.file_name, "vboxwrapper")) {
-                    is_vm_app = true;
-                }
-                app_files.push_back(file_ref);
+            if (retval) {
+                msg_printf(0, MSG_INFO,
+                    "couldn't parse file_ref: %s", boincerror(retval)
+                );
+                return retval;
             }
+            if (strstr(file_ref.file_name, "vboxwrapper")) {
+                is_vm_app = true;
+            }
+            app_files.push_back(file_ref);
             continue;
         }
         if (xp.parse_int("version_num", version_num)) continue;
@@ -1044,7 +1053,11 @@ int FILE_REF::parse(XML_PARSER& xp) {
     copy_file = false;
     optional = false;
     while (!xp.get_tag()) {
-        if (xp.match_tag("/file_ref")) return 0;
+        if (xp.match_tag("/file_ref")) {
+            if (strstr(open_name, "..")) return ERR_BAD_FILENAME;
+            if (strstr(open_name, "%")) return ERR_BAD_FILENAME;
+            return 0;
+        }
         if (xp.parse_str("file_name", file_name, sizeof(file_name))) continue;
         if (xp.parse_str("open_name", open_name, sizeof(open_name))) continue;
         if (xp.parse_bool("main_program", main_program)) continue;
@@ -1089,6 +1102,7 @@ int WORKUNIT::parse(XML_PARSER& xp) {
     FILE_REF file_ref;
     double dtemp;
     char buf[1024];
+    int retval;
 
     safe_strcpy(name, "");
     safe_strcpy(app_name, "");
@@ -1118,7 +1132,12 @@ int WORKUNIT::parse(XML_PARSER& xp) {
         if (xp.parse_double("rsc_memory_bound", rsc_memory_bound)) continue;
         if (xp.parse_double("rsc_disk_bound", rsc_disk_bound)) continue;
         if (xp.match_tag("file_ref")) {
-            file_ref.parse(xp);
+            retval = file_ref.parse(xp);
+            if (retval) msg_printf(0, MSG_INFO,
+                "can't parse file_ref in workunit: %s",
+                boincerror(retval)
+            );
+            return retval;
 #ifndef SIM
             input_files.push_back(file_ref);
 #endif

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -108,6 +108,7 @@ void RESULT::clear() {
 //
 int RESULT::parse_server(XML_PARSER& xp) {
     FILE_REF file_ref;
+    int retval;
 
     clear();
     while (!xp.get_tag()) {
@@ -119,7 +120,14 @@ int RESULT::parse_server(XML_PARSER& xp) {
         if (xp.parse_str("plan_class", plan_class, sizeof(plan_class))) continue;
         if (xp.parse_int("version_num", version_num)) continue;
         if (xp.match_tag("file_ref")) {
-            file_ref.parse(xp);
+            retval = file_ref.parse(xp);
+            if (retval) {
+                msg_printf(0, MSG_INFO,
+                    "can't parse file_ref in result: %s",
+                    boincerror(retval)
+                );
+                return retval;
+            }
             output_files.push_back(file_ref);
             continue;
         }
@@ -139,6 +147,7 @@ int RESULT::parse_server(XML_PARSER& xp) {
 //
 int RESULT::parse_state(XML_PARSER& xp) {
     FILE_REF file_ref;
+    int retval;
 
     clear();
     while (!xp.get_tag()) {
@@ -164,7 +173,14 @@ int RESULT::parse_state(XML_PARSER& xp) {
             continue;
         }
         if (xp.match_tag("file_ref")) {
-            file_ref.parse(xp);
+            retval = file_ref.parse(xp);
+            if (retval) {
+                msg_printf(0, MSG_INFO,
+                    "can't parse file_ref in result: %s",
+                    boincerror(retval)
+                );
+                return retval;
+            }
 #ifndef SIM
             output_files.push_back(file_ref);
 #endif


### PR DESCRIPTION
This fixes a vulnerability where hacked projects could
write files outside the BOINC data directory.

Also: error-check parsing of file refs.

This doesn't handle Rytis's requirement; we can do that separately.