### PR TITLE
scheduler: Fix incorrect clamping of host' fraction_available

### DIFF
--- a/sched/sched_send.cpp
+++ b/sched/sched_send.cpp
@@ -450,7 +450,7 @@ static inline void clamp_frac(double& frac, const char* name) {
                 "[send] %s=%f; setting to %f\n", name, frac, FRAC_MIN
             );
         }
-        frac = .01;
+        frac = FRAC_MIN;
     }
 }
 


### PR DESCRIPTION
**Description of the Change**
Code around this point suggests that clamping should be done to FRAC_MIN define, but it's finally set to another, hardcoded and unacceptable small, value. 
<!-- We must be able to understand the design of your change from this description. -->

**Release Notes**
N/A
