### PR TITLE
wu_check: Skip WUs without input files

### DIFF
--- a/sched/wu_check.cpp
+++ b/sched/wu_check.cpp
@@ -71,7 +71,9 @@ int handle_result(DB_RESULT& result) {
         );
         return 1;
     }
-    get_file_path(wu, path);
+    if (get_file_path(wu, path)) { // no input files
+        return 0;
+    }
     f = fopen(path, "r");
     if (f) {
         fclose(f);


### PR DESCRIPTION
**Description of the Change**
This tool cannot handle workunits without input files (e.g. if task parameters are set from command line). Accesses uninitialized memory, trying to open a file with a garbage name, prints a garbage on screen. In 'repair' mode, it will erroneously kill these completely normal workunits.

The patch silently skips such types of workunits.

**Release Notes**
N/A