### PR TITLE
cppcheck: avoid chance to read from uninitialised data

### DIFF
--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -349,6 +349,7 @@ int check_file_signature(
     char clear_buf[MD5_LEN];
     int n, retval;
     DATA_BLOCK clear_signature;
+    clear_buf[0]=0;
 
     n = (int)strlen(md5_buf);
     clear_signature.data = (unsigned char*)clear_buf;


### PR DESCRIPTION
This was once found by cppcheck and lives for a long time in
the Debian distribution. The decrypt_public function should set the data
attribute, so this is of no functional danger. But as much
as this irritated cppcheck, a human reader is confused at first
sight. Also, at some point the function called may be happy to
know that it is not overwriting a string or the well-defined
string helps some debug output.

Most notably, with this patch, the final copy will always copy
reasonable data, even if the decrypt_public function changes its return
codes.

Anchor: https://github.com/BOINC/boinc/pull/3276