### PR TITLE
cppcheck: independent iterators declared independently

### DIFF
--- a/client/rrsim_test.cpp
+++ b/client/rrsim_test.cpp
@@ -184,7 +184,6 @@ bool CLIENT_STATE::rr_simulation() {
     vector<RESULT*> active;
     unsigned int i;
     double x;
-    vector<RESULT*>::iterator it;
     bool rval = false;
 
     if (log_flags.rr_simulation) {
@@ -287,7 +286,9 @@ bool CLIENT_STATE::rr_simulation() {
         int last_active_size = active.size();
         int last_proj_active_size = pbest->active.size();
 
-        // remove *rpbest from active set,
+        {
+        vector<RESULT*>::iterator it;
+	// remove *rpbest from active set,
         // and adjust CPU time left for other results
         //
         it = active.begin();
@@ -301,7 +302,10 @@ bool CLIENT_STATE::rr_simulation() {
                 ++it;
             }
         }
+	}
 
+	{
+        vector<RESULT*>::iterator it;
         // remove *rpbest from its project's active set
         //
         it = pbest->active.begin();
@@ -313,6 +317,7 @@ bool CLIENT_STATE::rr_simulation() {
                 ++it;
             }
         }
+	}
 
         // If project has more results, add one to active set.
         //


### PR DESCRIPTION
Another very old patch with Debian, again one that originated from invoking cppcheck on the source tree.

The exact cppcheck warning I don't recall. I would have expected the iterator to know about how to properly terminate itself before going through the next iteration. The indentiation of the code is disturbed by the extra blocks to minimize the size of the patch. Alternatively, "it" could be renamed or the indentiation be updated.

Personally, I do not like this patch too much since the exact need to have to declarations of the iterator is not immediately apparent. A comment would be nice at least. But I very much like not to declare an iterator at the beginning of a function that is only needed in a branch of the code. So, I expect a bit of a discussion about this patch and confidently expect this code to improve over it.

Anchor: https://github.com/BOINC/boinc/issues/3260
