### PR TITLE
cppcheck: React to failing memory reallocation

### DIFF
--- a/lib/unix_util.cpp
+++ b/lib/unix_util.cpp
@@ -80,7 +80,13 @@ int setenv(const char *name, const char *value, int overwrite) {
             }
             if (i!=envstrings.end()) {
                 // we allocated this string.  Reallocate it.
+		char *b=buf;
                 buf=(char *)realloc(buf,strlen(name)+strlen(value)+2);
+		if (!buf) {
+		    free(b);
+		    errno=ENOMEM;
+		    return -1;
+		}
                 *i=buf;
             } else {
                 // someone else allocated the string.  Allocate new memory.


### PR DESCRIPTION
This is another one of the concerns that cppcheck raised. If the the memory that "we" own is not extendable, then this is likely an out of memory situation to which BOINC should possibly react nicely as nicely as it can. That patch meant to prevent a memory leak in low-memory situations. It does not look nice, admittedly. Maybe someone else has a constructive idea about it.

Anchor: https://github.com/BOINC/boinc/issues/3260