### PR TITLE
Allow compilation of BOINC when there is no MAX_PATH(length)

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -49,6 +49,9 @@
 #include "procinfo.h"
 #include "sg_BoincSimpleFrame.h"
 
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 bool s_bSkipExitConfirmation = false;
 


### PR DESCRIPTION
Linux has a maximal length of paths. Other platforms, notably HURD,
are unlimited in the length of their paths and filenames.
This patch (and there have been others before) allow to compile
and use BOINC on such technically advanced(?) OSs by simply imposing
the same maximal path length as for Linux.

Anchor: https://github.com/BOINC/boinc/issues/3260