### PR TITLE
adds error message in case of dir open failure

### DIFF
--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -154,7 +154,12 @@ DIRREF dir_open(const char* p) {
     dirp->handle = INVALID_HANDLE_VALUE;
 #else
     dirp = opendir(p);
-    if (!dirp) return NULL;
+    if (!dirp) {
+        char b[MAXPATHLEN+1];
+        boinc_getcwd(b);
+        fprintf(stderr,"dir_open: Could not open directory '%s' from '%s'.\n",p,b);
+        return NULL;
+    }
 #endif
     return dirp;
 }
@@ -682,7 +687,7 @@ static int boinc_rename_aux(const char* old, const char* newf) {
     //
     int retval = rename(old, newf);
     if (retval) {
-        char buf[MAXPATHLEN+MAXPATHLEN];
+        char buf[MAXPATHLEN+MAXPATHLEN+1+7];
         sprintf(buf, "mv \"%s\" \"%s\"", old, newf);
 #ifdef __APPLE__
         // system() is deprecated in Mac OS 10.10.


### PR DESCRIPTION
Trivial thing. Should also help to get better reports by users when they experience something exceptional.

Anchor: https://github.com/BOINC/boinc/issues/3260