### PR TITLE
Check return value of write function - avoiding leak of file descriptors

### DIFF
--- a/lib/shmem.cpp
+++ b/lib/shmem.cpp
@@ -339,7 +339,10 @@ int create_shmem_mmap(const char *path, size_t size, void** pp) {
         // area to all zeros because they write beyond the old EOF. 
         // See the lseek man page for details.
         lseek(fd, size-1, SEEK_SET);
-        write(fd, "\0", 1);
+        if (1 != write(fd, "\0", 1)) {
+	    close(fd);
+	    return ERR_SHMGET;
+	}
     }
 
     *pp = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);


### PR DESCRIPTION
This is yet another patch that is living for a lllooonnnggg time with Debian, so there should not be too many side issues. In the contrary, it could be contributing to a fix of the rarely observed leak of file descriptors, compare https://github.com/BOINC/boinc/issues/1175.

The motivation for this patch originated from clang who complained that we don't check if the write has failed.

Anchor: https://github.com/BOINC/boinc/issues/3260