### PR TITLE
Closing files after opening them.

### DIFF
--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -168,8 +168,8 @@ int main(int argc, char** argv) {
         if (!fpub) die("fopen");
         print_key_hex(fpriv, (KEY*)&private_key, sizeof(private_key));
         print_key_hex(fpub, (KEY*)&public_key, sizeof(public_key));
-	fclose(fpriv);
-	fclose(fpub);
+        fclose(fpriv);
+        fclose(fpub);
 
     } else if (!strcmp(argv[1], "-sign")) {
         if (argc < 4) {
@@ -196,7 +196,7 @@ int main(int argc, char** argv) {
         if (retval) die("scan_key_hex\n");
         generate_signature(argv[2], cbuf, private_key);
         puts(cbuf);
-	fclose(fpriv);
+        fclose(fpriv);
     } else if (!strcmp(argv[1], "-verify")) {
         if (argc < 5) {
             usage();
@@ -211,8 +211,8 @@ int main(int argc, char** argv) {
         signature.data = signature_buf;
         signature.len = 256;
         retval = scan_hex_data(f, signature);
-	fclose(f);
-	fclose(fpub);
+        fclose(f);
+        fclose(fpub);
         if (retval) die("scan_hex_data");
 
         char md5_buf[64];
@@ -242,8 +242,8 @@ int main(int argc, char** argv) {
         if (!fpub) die("fopen");
         retval = scan_key_hex(fpub, (KEY*)&public_key, sizeof(public_key));
         if (retval) die("read_public_key");
-	fclose(fpriv);
-	fclose(fpub);
+        fclose(fpriv);
+        fclose(fpub);
         strcpy((char*)buf2, "encryption test successful");
         in.data = buf2;
         in.len = strlen((char*)in.data);
@@ -435,7 +435,7 @@ int main(int argc, char** argv) {
                     die("fopen");
                 }
                 print_key_hex(fpub, (KEY*)&public_key, sizeof(public_key));
-		fclose(fpub);
+                fclose(fpub);
             }
         }
     } else {

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -168,6 +168,8 @@ int main(int argc, char** argv) {
         if (!fpub) die("fopen");
         print_key_hex(fpriv, (KEY*)&private_key, sizeof(private_key));
         print_key_hex(fpub, (KEY*)&public_key, sizeof(public_key));
+	fclose(fpriv);
+	fclose(fpub);
 
     } else if (!strcmp(argv[1], "-sign")) {
         if (argc < 4) {
@@ -182,6 +184,7 @@ int main(int argc, char** argv) {
         signature.len = 256;
         retval = sign_file(argv[2], private_key, signature);
         print_hex_data(stdout, signature);
+	fclose(fpriv);
     } else if (!strcmp(argv[1], "-sign_string")) {
         if (argc < 4) {
             usage();
@@ -193,6 +196,7 @@ int main(int argc, char** argv) {
         if (retval) die("scan_key_hex\n");
         generate_signature(argv[2], cbuf, private_key);
         puts(cbuf);
+	fclose(fpriv);
     } else if (!strcmp(argv[1], "-verify")) {
         if (argc < 5) {
             usage();
@@ -207,6 +211,8 @@ int main(int argc, char** argv) {
         signature.data = signature_buf;
         signature.len = 256;
         retval = scan_hex_data(f, signature);
+	fclose(f);
+	fclose(fpub);
         if (retval) die("scan_hex_data");
 
         char md5_buf[64];
@@ -236,6 +242,8 @@ int main(int argc, char** argv) {
         if (!fpub) die("fopen");
         retval = scan_key_hex(fpub, (KEY*)&public_key, sizeof(public_key));
         if (retval) die("read_public_key");
+	fclose(fpriv);
+	fclose(fpub);
         strcpy((char*)buf2, "encryption test successful");
         in.data = buf2;
         in.len = strlen((char*)in.data);
@@ -254,6 +262,7 @@ int main(int argc, char** argv) {
         signature.data = signature_buf;
         signature.len = 256;
         retval = scan_hex_data(f, signature);
+	fclose(f);
         if (retval) die("cannot scan_hex_data");
         certpath = check_validity(argv[4], argv[2], signature.data, argv[5]);
         if (certpath == NULL) {
@@ -426,6 +435,7 @@ int main(int argc, char** argv) {
                     die("fopen");
                 }
                 print_key_hex(fpub, (KEY*)&public_key, sizeof(public_key));
+		fclose(fpub);
             }
         }
     } else {

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -184,7 +184,7 @@ int main(int argc, char** argv) {
         signature.len = 256;
         retval = sign_file(argv[2], private_key, signature);
         print_hex_data(stdout, signature);
-	fclose(fpriv);
+        fclose(fpriv);
     } else if (!strcmp(argv[1], "-sign_string")) {
         if (argc < 4) {
             usage();
@@ -262,7 +262,7 @@ int main(int argc, char** argv) {
         signature.data = signature_buf;
         signature.len = 256;
         retval = scan_hex_data(f, signature);
-	fclose(f);
+        fclose(f);
         if (retval) die("cannot scan_hex_data");
         certpath = check_validity(argv[4], argv[2], signature.data, argv[5]);
         if (certpath == NULL) {

--- a/lib/mfile.cpp
+++ b/lib/mfile.cpp
@@ -42,7 +42,7 @@ MFILE::MFILE() {
 }
 
 MFILE::~MFILE() {
-    if (buf) free(buf);
+    close();
 }
 
 int MFILE::open(const char* path, const char* mode) {

--- a/lib/parse_test.cpp
+++ b/lib/parse_test.cpp
@@ -57,6 +57,7 @@ int main() {
         exit(1);
     }
     parse(f);
+    fclose(f);
 }
 
 /* try it with something like:


### PR DESCRIPTION
This patch is with Debian for a really long time, likely to have its origins also in the cppcheck and/or clang runs. Just like PR https://github.com/BOINC/boinc/pull/3284, this also addresses the reported leaking of file descriptors (https://github.com/BOINC/boinc/issues/1175).

Anchor: https://github.com/BOINC/boinc/issues/3260