### PR TITLE
validator: Avoid infinite loop in --dry-run mode

### DIFF
--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -801,6 +801,7 @@ bool do_validate_scan() {
         if (!retval) found = true;
         if (++i == one_pass_N_WU) break;
         if (wu_id) break;
+        if (dry_run) break;  // otherwise it will enumerate forever
     }
     return found;
 }


### PR DESCRIPTION
**Description of the Change**
--dry-run option causes validator to hang in infinite loop.
do_validate_scan() enumerates workunits pending for validation in infinite loop. Since no DB updates are done in --dry-run mode, there is always something to validate and this loop will never terminate. Had to stop processing manually.

**Release Notes**
N/A