### PR TITLE
if output file missing, mark task as error

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -273,6 +273,9 @@ void ACTIVE_TASK::cleanup_task() {
     kill_subsidiary_processes();
 
     if (cc_config.exit_after_finish) {
+        msg_printf(wup->project, MSG_INFO,
+            "exit_after_finish: job %s, slot %d", wup->name, slot
+        );
         gstate.write_state_file();
         exit(0);
     }

--- a/client/check_state.cpp
+++ b/client/check_state.cpp
@@ -94,8 +94,9 @@ void CLIENT_STATE::check_app(APP& p) {
 }
 
 void CLIENT_STATE::check_file_info(FILE_INFO& p) {
-    if (p.pers_file_xfer) check_pers_file_xfer_pointer(p.pers_file_xfer);
-    if (p.result) check_result_pointer(p.result);
+    if (p.pers_file_xfer) {
+        check_pers_file_xfer_pointer(p.pers_file_xfer);
+    }
     check_project_pointer(p.project);
 }
 

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -394,6 +394,7 @@ struct CLIENT_STATE {
 
 // --------------- cs_files.cpp:
     void check_file_existence();
+    RESULT* file_info_to_result(FILE_INFO*);
     bool start_new_file_xfer(PERS_FILE_XFER&);
 
     int make_project_dirs();

--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -208,7 +208,6 @@ FILE_INFO::FILE_INFO() {
     is_auto_update_file = false;
     anonymous_platform_file = false;
     pers_file_xfer = NULL;
-    result = NULL;
     project = NULL;
     download_urls.clear();
     upload_urls.clear();

--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -1133,11 +1133,13 @@ int WORKUNIT::parse(XML_PARSER& xp) {
         if (xp.parse_double("rsc_disk_bound", rsc_disk_bound)) continue;
         if (xp.match_tag("file_ref")) {
             retval = file_ref.parse(xp);
-            if (retval) msg_printf(0, MSG_INFO,
-                "can't parse file_ref in workunit: %s",
-                boincerror(retval)
-            );
-            return retval;
+            if (retval) {
+                msg_printf(0, MSG_INFO,
+                    "can't parse file_ref in workunit: %s",
+                    boincerror(retval)
+                );
+                return retval;
+            }
 #ifndef SIM
             input_files.push_back(file_ref);
 #endif

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -124,8 +124,6 @@ struct FILE_INFO {
         // for output files: gzip file when done, and append .gz to its name
     class PERS_FILE_XFER* pers_file_xfer;
         // nonzero if in the process of being up/downloaded
-    RESULT* result;
-        // for upload files (to authenticate)
     PROJECT* project;
     int ref_cnt;
     URL_LIST download_urls;

--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -507,16 +507,16 @@ void CLIENT_STATE::check_file_existence() {
                     path, fip->nbytes, size
                 );
             }
-            // If an output file disappears before it's uploaded,
-            // flag the job as an error.
-            //
-            if (fip->status == FILE_NOT_PRESENT && fip->uploadable() && !fip->uploaded) {
-                RESULT* rp = file_info_to_result(fip);
-                if (rp) {
-                    gstate.report_result_error(
-                        *rp, "output file missing or invalid"
-                    );
-                }
+        }
+        // If an output file disappears before it's uploaded,
+        // flag the job as an error.
+        //
+        if (fip->status == FILE_NOT_PRESENT && fip->uploadable() && !fip->uploaded) {
+            RESULT* rp = file_info_to_result(fip);
+            if (rp) {
+                gstate.report_result_error(
+                    *rp, "output file missing or invalid"
+                );
             }
         }
     }

--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -49,6 +49,7 @@
 #include "client_msgs.h"
 #include "file_xfer.h"
 #include "project.h"
+#include "result.h"
 #include "sandbox.h"
 
 using std::vector;
@@ -506,16 +507,34 @@ void CLIENT_STATE::check_file_existence() {
                     path, fip->nbytes, size
                 );
             }
-
             // If an output file disappears before it's uploaded,
             // flag the job as an error.
             //
-            if (fip->result && fip->status == FILE_NOT_PRESENT && !fip->uploaded) {
-                gstate.report_result_error(
-                    *fip->result, "output file missing or invalid"
-                );
+            if (fip->status == FILE_NOT_PRESENT && fip->uploadable() && !fip->uploaded) {
+                RESULT* rp = file_info_to_result(fip);
+                if (rp) {
+                    gstate.report_result_error(
+                        *rp, "output file missing or invalid"
+                    );
+                }
             }
         }
     }
 }
 
+// return the result that *fip is an output file of, if any
+//
+RESULT* CLIENT_STATE::file_info_to_result(FILE_INFO* fip) {
+    unsigned int i, j;
+    for (i=0; i<results.size(); i++) {
+        RESULT* rp = results[i];
+        if (rp->project != fip->project) continue;
+        for (j=0; j<rp->output_files.size(); j++) {
+            FILE_REF& fr = rp->output_files[i];
+            if (fr.file_info == fip) {
+                return rp;
+            }
+        }
+    }
+    return NULL;
+}

--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -530,7 +530,7 @@ RESULT* CLIENT_STATE::file_info_to_result(FILE_INFO* fip) {
         RESULT* rp = results[i];
         if (rp->project != fip->project) continue;
         for (j=0; j<rp->output_files.size(); j++) {
-            FILE_REF& fr = rp->output_files[i];
+            FILE_REF& fr = rp->output_files[j];
             if (fr.file_info == fip) {
                 return rp;
             }

--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -506,6 +506,15 @@ void CLIENT_STATE::check_file_existence() {
                     path, fip->nbytes, size
                 );
             }
+
+            // If an output file disappears before it's uploaded,
+            // flag the job as an error.
+            //
+            if (fip->result && fip->status == FILE_NOT_PRESENT && !fip->uploaded) {
+                gstate.report_result_error(
+                    *fip->result, "output file missing or invalid"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #3287

On startup, the client checks whether files marked as present
actually are present and have the right side.
If not it marks them as not present.
This is fine for downloaded files - they'll downloaded again.

For output files, this could leave the job stuck in the "uploading" state,
since there's no file to upload.

Fix this by marking the job as having an upload error in this stuation.