### PR TITLE
Remove duplicate success XML

### DIFF
--- a/html/user/am_set_info.php
+++ b/html/user/am_set_info.php
@@ -236,7 +236,6 @@ if (strlen($query)) {
         if ($send_changed_email_to_user) {
             send_changed_email($user);
         }
-        success("");
     } else {
         xml_error(-1, "database error: ".BoincDb::error());
     }


### PR DESCRIPTION
success() call was duplicated, resulting in duplicate XML.

Fixes #3297

**Description of the Change**
success() is already called later in the code, so remove the early code, considering that a failure can still happen further on.

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
Remove duplicate XML in am_set_info.php reply
