### PR TITLE
server: Workaround for "finish file present too long" client bug

### DIFF
--- a/sched/sched_result.cpp
+++ b/sched/sched_result.cpp
@@ -393,6 +393,12 @@ int handle_results() {
         parse_int(srip->stderr_out, "<exit_status>", srip->exit_status);
         parse_int(srip->stderr_out, "<app_version>", srip->app_version_num);
 
+        if (srip->exit_status == EXIT_ABORTED_BY_CLIENT && strstr(srip->stderr_out, "finish file present too long")) {
+            log_messages.printf(MSG_CRITICAL, "[handle] [RESULT#%lu] [WU#%lu] fixed finish file problem\n", srip->id, srip->workunitid);
+            srip->client_state = RESULT_FILES_UPLOADED;  // if not, it'll fail in validator
+            srip->exit_status = 0;
+        }
+
         if ((srip->client_state == RESULT_FILES_UPLOADED) && (srip->exit_status == 0)) {
             srip->outcome = RESULT_OUTCOME_SUCCESS;
             if (config.debug_handle_results) {


### PR DESCRIPTION
Fixes second scenario of #3017 and improves #3019

**Description of the Change**
This patch deals with "finish file problem" completely, bringing tasks affected by this bug "back to life" on the server side.
As was noted in https://github.com/BOINC/boinc/issues/3017#issuecomment-475907501 , this problem may also appear when client shutting down, and this is not fixed yet (I'll explain this scenario below). In #3019 was mentioned that "it should be treated as successful regardless of whether it exits, but right now we don't have a mechanism for killing a job and marking it as success."
This patch marks job as successful on the server side, so it'll fix all problems with all client versions.

**Cause of the problem**
There are two causes. First reason is a when an application really exits too slow due to high system load and swap trashing. It was fixed in #3019 by increasing exit timeout up to 5 minutes.
But in real life, on PrimeGrid and my own Private GFN Server, I've encountered only second type of problem. This is a race condition with following scenario:

1. A client is requested to shutdown, It could be user request or system reboot, it does not matter.
2. At same time, application successfully finishes and writes boinc_finish file.
3. Client quits, nor noticing nor processing termination of application.
4. When client is restarted by user or after system reboot, it **does not check for presence of boinc_finish file in slot directories**.
5. This mean that is **a task which is already finished is started again**
6. If an application keeps internal state/checkpoint and could determine that nothing should be done, you're in luck. But many applications will delete own checkpoints before completion, so such a restart causes that application will do it's job again from beginning. But boinc_finish file is already here...
7. Client notices presence of boinc_finish, but application is not going to quit... Finally, it kills an application with "finish file present to long" diagnostic. An stderr log clearly says that application was run twice (and killed on the second run).

**Alternate Designs**
Of course, it would be nice if this problem was also fixed in client itself (check for boinc_finish before starting programs in slot directories for a first time after reboot). But it will not help to users with old clients.
Also, a wrapper or native Boinc application may check for boinc_finish itself and do exit(0) immediately. But it's not possible to update existing wrappers and applications.
So this server patch seems to be lowest of evils. First it was implemented on my Private GFN Server and works great. Every day, few tasks are silently recovered.

**Release Notes**
N/A
