### PR TITLE
client: on startup, check for active task finish files

### DIFF
--- a/client/app.h
+++ b/client/app.h
@@ -276,7 +276,7 @@ struct ACTIVE_TASK {
     void get_graphics_msg();
     double est_dur();
     int read_stderr_file();
-    bool finish_file_present();
+    bool finish_file_present(int&);
     bool temporary_exit_file_present(double&, char*, bool&);
     void init_app_init_data(APP_INIT_DATA&);
     int write_app_init_file(APP_INIT_DATA&);
@@ -328,6 +328,7 @@ public:
     void free_mem();
     bool slot_taken(int);
     void get_memory_usage();
+    void check_for_finished_jobs();
 
     void process_control_poll();
     void request_reread_prefs(PROJECT*);

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -479,7 +479,8 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
             // if another process killed the app, it looks like exit(0).
             // So check for the finish file
             //
-            if (finish_file_present()) {
+            int e;
+            if (finish_file_present(e)) {
                 set_task_state(PROCESS_EXITED, "handle_exited_app");
                 break;
             }

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -835,6 +835,11 @@ int CLIENT_STATE::init() {
         notices.init_rss();
     }
 
+    // check for jobs with finish files
+    // (i.e. they finished just as client was exiting)
+    //
+    active_tasks.check_for_finished_jobs();
+
     // warn user if some jobs need more memory than available
     //
     check_too_large_jobs();

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -372,6 +372,7 @@ struct CLIENT_STATE {
     int app_finished(ACTIVE_TASK&);
     bool start_apps();
     bool handle_finished_apps();
+    void check_for_finished_jobs();
 
     ACTIVE_TASK* get_task(RESULT*);
 

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -328,3 +328,20 @@ ACTIVE_TASK* ACTIVE_TASK_SET::lookup_result(RESULT* result) {
     }
     return NULL;
 }
+
+// on startup, see if any active tasks have a finished file
+// i.e. they finished as the client was shutting down
+//
+void ACTIVE_TASK_SET::check_for_finished_jobs() {
+    for (unsigned int i=0; i<active_tasks.size(); i++) {
+        ACTIVE_TASK* atp = active_tasks[i];
+        int exit_code;
+        if (atp->finish_file_present(exit_code)) {
+            msg_printf(atp->wup->project, MSG_INFO,
+                "Found finish file for %s; exit code %d",
+                atp->result->name, exit_code
+            );
+            atp->handle_exited_app(exit_code);
+        }
+    }
+}


### PR DESCRIPTION
Should fix problem where jobs finish while client is shutting down, as described in #3300