### PR TITLE
Wrapper: Monitor status of child task process even if parent exits

### DIFF
--- a/lib/proc_control.cpp
+++ b/lib/proc_control.cpp
@@ -277,6 +277,33 @@ void suspend_or_resume_process(int pid, bool resume) {
 #endif
 }
 
+#ifdef _WIN32
+
+// Handling of job objects
+//
+
+void get_job_object_processes(HANDLE job_handle, vector<int>& pids) {
+    JOBOBJECT_BASIC_PROCESS_ID_LIST process_list;
+    QueryInformationJobObject(job_handle, JobObjectBasicProcessIdList, &process_list, sizeof(JOBOBJECT_BASIC_PROCESS_ID_LIST), NULL);
+    for (int i = 0; i < process_list.NumberOfProcessIdsInList; i++) {
+        pids.push_back(process_list.ProcessIdList[i]);
+    }
+}
+
+void suspend_or_resume_job_object(HANDLE job_handle, bool resume) {
+    vector<int> pids;
+    get_job_object_processes(job_handle, pids);
+    suspend_or_resume_threads(pids, 0, resume, false);
+}
+
+void kill_job_object(HANDLE job_handle) {
+    vector<int> pids;
+    get_job_object_processes(job_handle, pids);
+    kill_all(pids);
+}
+
+#endif
+
 // return OS-specific value associated with priority code
 //
 int process_priority_value(int priority) {

--- a/lib/proc_control.h
+++ b/lib/proc_control.h
@@ -36,6 +36,11 @@ extern void kill_descendants(int child_pid=0);
 #endif
 extern void suspend_or_resume_descendants(bool resume);
 extern void suspend_or_resume_process(int pid, bool resume);
+#ifdef _WIN32
+extern void get_job_object_processes(HANDLE job_handle, std::vector<int>& pids);
+extern void suspend_or_resume_job_object(HANDLE job_handle, bool resume);
+extern void kill_job_object(HANDLE job_handle);
+#endif
 
 extern int process_priority_value(int);
 

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -1032,14 +1032,22 @@ bool TASK::poll(int& status) {
 //
 void TASK::kill() {
 #ifdef _WIN32
-    kill_descendants();
+    if (wait_for_children) {
+        kill_job_object(job_handle);
+    }
+    else {
+        kill_descendants();
+    }
 #else
     kill_descendants(pid);
 #endif
 }
 
 void TASK::stop() {
-    if (multi_process) {
+    if (wait_for_children) {
+        suspend_or_resume_job_object(job_handle, false);
+    }
+    else if (multi_process) {
         suspend_or_resume_descendants(false);
     } else {
         suspend_or_resume_process(pid, false);
@@ -1048,7 +1056,10 @@ void TASK::stop() {
 }
 
 void TASK::resume() {
-    if (multi_process) {
+    if (wait_for_children) {
+        suspend_or_resume_job_object(job_handle, true);
+    }
+    else if (multi_process) {
         suspend_or_resume_descendants(true);
     } else {
         suspend_or_resume_process(pid, true);

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -978,7 +978,7 @@ bool TASK::poll(int& status) {
             if ((HANDLE)completion_key == job_handle && completion_code == JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO) {
                 status = exit_code;
                 final_cpu_time = current_cpu_time;
-                fprintf(stderr, "%s %s exited; CPU time %f\n",
+                fprintf(stderr, "%s %s all processes exited; CPU time %f\n",
                     boinc_msg_prefix(buf, sizeof(buf)),
                     application.c_str(), final_cpu_time
                 );

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -750,14 +750,14 @@ int TASK::run(int argct, char** argvt) {
         // Some processes will launch child processes and then exit; set up a
         // job object to prevent this from ending the task
         //
-        job_handle = CreateJobObject(nullptr, nullptr);
+        job_handle = CreateJobObject(NULL, NULL);
         if (!job_handle) {
             fprintf(stderr, "CreateJobObject failed: %d\n", GetLastError());
             return ERR_FORK;
         }
 
         ioport_handle = CreateIoCompletionPort(INVALID_HANDLE_VALUE,
-            nullptr, 0, 1);
+            NULL, 0, 1);
         if (!ioport_handle) {
             fprintf(stderr, "CreateIoCompletionPort failed: %d\n", GetLastError());
             return ERR_FORK;

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -1043,9 +1043,14 @@ void TASK::kill() {
 }
 
 void TASK::stop() {
+#ifdef _WIN32
     if (wait_for_children) {
         suspend_or_resume_job_object(job_handle, false);
-    } else if (multi_process) {
+        suspended = true;
+        return;
+    }
+#endif
+    if (multi_process) {
         suspend_or_resume_descendants(false);
     } else {
         suspend_or_resume_process(pid, false);
@@ -1054,9 +1059,14 @@ void TASK::stop() {
 }
 
 void TASK::resume() {
+#ifdef _WIN32
     if (wait_for_children) {
         suspend_or_resume_job_object(job_handle, true);
-    } else if (multi_process) {
+        suspended = false;
+        return;
+    }
+#endif
+    if (multi_process) {
         suspend_or_resume_descendants(true);
     } else {
         suspend_or_resume_process(pid, true);

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -1034,8 +1034,7 @@ void TASK::kill() {
 #ifdef _WIN32
     if (wait_for_children) {
         kill_job_object(job_handle);
-    }
-    else {
+    } else {
         kill_descendants();
     }
 #else
@@ -1046,8 +1045,7 @@ void TASK::kill() {
 void TASK::stop() {
     if (wait_for_children) {
         suspend_or_resume_job_object(job_handle, false);
-    }
-    else if (multi_process) {
+    } else if (multi_process) {
         suspend_or_resume_descendants(false);
     } else {
         suspend_or_resume_process(pid, false);
@@ -1058,8 +1056,7 @@ void TASK::stop() {
 void TASK::resume() {
     if (wait_for_children) {
         suspend_or_resume_job_object(job_handle, true);
-    }
-    else if (multi_process) {
+    } else if (multi_process) {
         suspend_or_resume_descendants(true);
     } else {
         suspend_or_resume_process(pid, true);


### PR DESCRIPTION
**Description of the Change**
On Windows, CreateProcess() is used to launch tasks, but this on its own does not handle child processes; if the parent task process exits, the workunit will be terminated. If <wait_for_children> is set in the job file, attach the task process to a job object instead, which can then be monitored to determine when all child processes are finished.

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
Add <wait_for_children> option for tasks in job.xml