### PR TITLE
client: fix bug that caused jobs to run after client exit.

### DIFF
--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -201,14 +201,6 @@ static void print_descendants(int pid, vector<int>desc, const char* where) {
 // Send a quit message, start timer, get descendants
 //
 int ACTIVE_TASK::request_exit() {
-    // unsuspend the process.
-    // If it's suspended, the timer thread is suspended and
-    // won't process the quit message
-    //
-    if (task_state() == PROCESS_SUSPENDED) {
-        unsuspend();
-    }
-
     if (app_client_shm.shm) {
         process_control_queue.msg_queue_send(
             "<quit/>",


### PR DESCRIPTION
Take out #2871.
That change was based on the incorrect assumption
that a suspended process doesn't handle quit messages.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
