### PR TITLE
Fix wrapper not ending critical section

### DIFF
--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -1070,7 +1070,10 @@ void check_trickle_period() {
 void write_checkpoint(int ntasks_completed, double cpu, double rt) {
     boinc_begin_critical_section();
     FILE* f = fopen(CHECKPOINT_FILENAME, "w");
-    if (!f) return;
+    if (!f) {
+        boinc_end_critical_section();
+        return;
+    }
     fprintf(f, "%d %f %f\n", ntasks_completed, cpu, rt);
     fclose(f);
     boinc_checkpoint_completed();


### PR DESCRIPTION
In case checkpoint file fopen fails, BOINC stays in critical section.

**Description of the Change**
End critical section in case of fopen failures in the wrapper

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
N/A
