### PR TITLE
[AppVeyor] Update config to ignore more directories

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ skip_tags: true
 
 skip_commits:
   files:
+    - .github/
     - 3rdParty/*.sh
     - android/
     - client/android/
@@ -39,6 +40,7 @@ skip_commits:
     - doc/
     - drupal/
     - html/
+    - integration_test
     - lib/mac/
     - locale/
     - m4/
@@ -47,7 +49,7 @@ skip_commits:
     - packages/
     - py/
     - stripchart/
-    - test/
+    - tests/
     - tools/
     - vda/
     - xcompile/


### PR DESCRIPTION
Don't trigger build when content of '.github' or 'integration_test' directories changed.
Fix 'tests' directory name

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>