### PR TITLE
[GUI][AM] Show error from response when conencting to AM

### DIFF
--- a/clientgui/AccountManagerProcessingPage.cpp
+++ b/clientgui/AccountManagerProcessingPage.cpp
@@ -300,7 +300,7 @@ void CAccountManagerProcessingPage::OnStateChange( CAccountManagerProcessingPage
                 wxEventLoopBase::GetActive()->YieldFor(wxEVT_CATEGORY_USER_INPUT);
             }
     
-            if (!iReturnValue && !reply.error_num) {
+            if (!iReturnValue && (!reply.error_num && reply.messages.size() == 0)) {
                 SetProjectAttachSucceeded(true);
                 pWA->SetAttachedToProjectSuccessfully(true);
             } else {


### PR DESCRIPTION
BAM! and GRCPool doesn't return any error code on wrong credentials.
The actual error is written in 'messages' field of the response.
Currently on worng credentials attach wizard shows that everything is fine while in the notices actual error is shown.
It is confusing.
This approach shows message from the response even if error code is equal zero (like when there is no error at all) and process it like an error.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
