### PR TITLE
[Android] Show message sent from server when connecting to AM

### DIFF
--- a/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
+++ b/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2012 University of California
+ * Copyright (C) 2019 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -33,6 +33,7 @@ import edu.berkeley.boinc.rpc.ProjectInfo;
 import edu.berkeley.boinc.rpc.Project;
 import edu.berkeley.boinc.rpc.Result;
 import edu.berkeley.boinc.rpc.ImageWrapper;
+import edu.berkeley.boinc.utils.ErrorCodeDescription;
 
 interface IMonitor {
 /////// client interface //////////////////////////////////////////
@@ -46,7 +47,7 @@ boolean resultOp(in int op, in String url, in String name);      // implement: c
 AccountOut createAccountPolling(in AccountIn information);  // implement: call clientInterface.createAccountPolling(information);
 String readAuthToken(in String path);               // implement: call clientInterface.readAuthToken(String);
 ProjectConfig getProjectConfigPolling(in String url);    // implement: call clientInterface.getProjectConfigPolling(url);
-int addAcctMgrErrorNum(in String url, in String userName, in String pwd);  // implement: return clientInterface.addAcctMgr(url, userName, pwd).error_num; check return null!=clientInterface.addAcctMgr(url, userName, pwd)
+ErrorCodeDescription addAcctMgrErrorNum(in String url, in String userName, in String pwd);  // implement: return clientInterface.addAcctMgr(url, userName, pwd).error_num; check return null!=clientInterface.addAcctMgr(url, userName, pwd)
 AcctMgrInfo getAcctMgrInfo();               // implement: call clientInterface.getAcctMgrInfo();
 boolean synchronizeAcctMgr(in String url);         // implement: call clientInterface.synchronizeAcctMgr(String);
 boolean setRunMode(in int mode);                // implement: call clientInterface.setRunMode(Integer);
@@ -65,7 +66,7 @@ ProjectInfo getProjectInfo(String url);  // clientInterface.getProjectInfo(Strin
 boolean setDomainName(in String deviceName);            // clientInterface.setDomainName(String deviceName);
 
 /////// general //////////////////////////////////////////
-boolean boincMutexAcquired();				// implment: call Monitor.boincMutexAcquired();
+boolean boincMutexAcquired();				// implement: call Monitor.boincMutexAcquired();
 void forceRefresh();                        // implement: call Monitor.forceRefresh();
 boolean isStationaryDeviceSuspected();               // implement: call Monitor.getDeviceStatus().isStationaryDevice();
 int getBatteryChargeStatus();           // implement: return getDeviceStatus().getStatus().battery_charge_pct;

--- a/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/utils/ErrorCodeDescription.aidl
+++ b/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/utils/ErrorCodeDescription.aidl
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2019 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package edu.berkeley.boinc.utils;
+
+parcelable ErrorCodeDescription;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2012 University of California
+ * Copyright (C) 2019 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -531,7 +531,7 @@ public class ProjectsFragment extends Fragment {
                     case RpcClient.MGR_SYNC:
                         return BOINCActivity.monitor.synchronizeAcctMgr(data.acctMgrInfo.acct_mgr_url);
                     case RpcClient.MGR_DETACH:
-                        return BOINCActivity.monitor.addAcctMgrErrorNum("", "", "") == BOINCErrors.ERR_OK;
+                        return BOINCActivity.monitor.addAcctMgrErrorNum("", "", "").code == BOINCErrors.ERR_OK;
 
                     // transfer operations
                     case RpcClient.TRANSFER_RETRY:

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2012 University of California
+ * Copyright (C) 2019 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -314,7 +314,7 @@ public class AcctMgrFragment extends DialogFragment {
         return getString(stringResource);
     }
 
-    private class AttachProjectAsyncTask extends AsyncTask<String, Void, Integer> {
+    private class AttachProjectAsyncTask extends AsyncTask<String, Void, ErrorCodeDescription> {
 
         @Override
         protected void onPreExecute() {
@@ -322,7 +322,7 @@ public class AcctMgrFragment extends DialogFragment {
         }
 
         @Override
-        protected Integer doInBackground(String... arg0) {
+        protected ErrorCodeDescription doInBackground(String... arg0) {
 
             String url = arg0[0];
             String name = arg0[1];
@@ -332,11 +332,11 @@ public class AcctMgrFragment extends DialogFragment {
         }
 
         @Override
-        protected void onPostExecute(Integer result) {
+        protected void onPostExecute(ErrorCodeDescription result) {
             super.onPostExecute(result);
             if (Logging.DEBUG)
                 Log.d(Logging.TAG, "AcctMgrFragment.AttachProjectAsyncTask onPostExecute, returned: " + result);
-            if (result == BOINCErrors.ERR_OK) {
+            if (result.code == BOINCErrors.ERR_OK && (result.description == null || result.description.isEmpty())) {
                 dismiss();
                 if (returnToMainActivity) {
                     if (Logging.DEBUG)
@@ -352,7 +352,11 @@ public class AcctMgrFragment extends DialogFragment {
                 ongoingWrapper.setVisibility(View.GONE);
                 continueB.setVisibility(View.VISIBLE);
                 warning.setVisibility(View.VISIBLE);
-                warning.setText(mapErrorNumToString(result));
+                if (result.description != null && !result.description.isEmpty()) {
+                    warning.setText(result.description);
+                } else {
+                    warning.setText(mapErrorNumToString(result.code));
+                }
             }
         }
     }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2012 University of California
+ * Copyright (C) 2019 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -30,6 +30,7 @@ import edu.berkeley.boinc.rpc.AcctMgrInfo;
 import edu.berkeley.boinc.rpc.ProjectConfig;
 import edu.berkeley.boinc.rpc.ProjectInfo;
 import edu.berkeley.boinc.utils.BOINCErrors;
+import edu.berkeley.boinc.utils.ErrorCodeDescription;
 import edu.berkeley.boinc.utils.Logging;
 
 import android.app.Service;
@@ -316,9 +317,9 @@ public class ProjectAttachService extends Service {
      * @param pwd  password
      * @return result code, see BOINCErrors
      */
-    public int attachAcctMgr(String url, String name, String pwd) {
+    public ErrorCodeDescription attachAcctMgr(String url, String name, String pwd) {
 
-        int reply = -1;
+        ErrorCodeDescription reply = new ErrorCodeDescription();
         Integer maxAttempts = getResources().getInteger(R.integer.attach_acctmgr_retries);
         Integer attemptCounter = 0;
         Boolean retry = true;
@@ -340,7 +341,7 @@ public class ProjectAttachService extends Service {
             if(Logging.DEBUG) {
                 Log.d(Logging.TAG, "ProjectAttachService.attachAcctMgr returned: " + reply);
             }
-            switch(reply) {
+            switch(reply.code) {
                 case BOINCErrors.ERR_GETHOSTBYNAME: // no internet
                     attemptCounter++; // limit number of retries
                     break;
@@ -365,7 +366,7 @@ public class ProjectAttachService extends Service {
             }
         }
 
-        if(reply != BOINCErrors.ERR_OK) {
+        if(reply.code != BOINCErrors.ERR_OK || (reply.description != null && !reply.description.isEmpty())) {
             return reply;
         }
 
@@ -379,7 +380,7 @@ public class ProjectAttachService extends Service {
             }
         }
         if(info == null) {
-            return -1;
+            return new ErrorCodeDescription(-1);
         }
 
         if(Logging.DEBUG) {
@@ -387,7 +388,7 @@ public class ProjectAttachService extends Service {
                   "ProjectAttachService.attachAcctMgr successful: " + info.acct_mgr_url + info.acct_mgr_name +
                   info.have_credentials);
         }
-        return BOINCErrors.ERR_OK;
+        return new ErrorCodeDescription(BOINCErrors.ERR_OK);
     }
 
     public class ProjectAttachWrapper {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2012 University of California
+ * Copyright (C) 2019 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -1176,13 +1176,13 @@ public class Monitor extends Service {
         }
 
         @Override
-        public int addAcctMgrErrorNum(String url, String userName, String pwd)
+        public ErrorCodeDescription addAcctMgrErrorNum(String url, String userName, String pwd)
                 throws RemoteException {
             AcctMgrRPCReply acctMgr = clientInterface.addAcctMgr(url, userName, pwd);
             if (acctMgr != null) {
-                return acctMgr.error_num;
+                return new ErrorCodeDescription(acctMgr.error_num, acctMgr.messages.isEmpty() ? "" : acctMgr.messages.toString());
             }
-            return -1;
+            return new ErrorCodeDescription(-1);
         }
 
         @Override

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/ErrorCodeDescription.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/ErrorCodeDescription.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2019 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ ******************************************************************************/
+package edu.berkeley.boinc.utils;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+public class ErrorCodeDescription implements Parcelable {
+    public int code;
+    public String description;
+
+    public static final Parcelable.Creator<ErrorCodeDescription> CREATOR = new Parcelable.Creator<ErrorCodeDescription>() {
+        public ErrorCodeDescription createFromParcel(Parcel in) {
+            return new ErrorCodeDescription(in);
+        }
+
+        public ErrorCodeDescription[] newArray(int size) {
+            return null;
+        }
+    };
+
+    public ErrorCodeDescription() {
+        code = 0;
+        description = "";
+    }
+
+    public ErrorCodeDescription(Parcel parcel)
+    {
+        readFromParcel(parcel);
+    }
+
+    public ErrorCodeDescription (int _code, String _description) {
+        code = _code;
+        description = _description;
+    }
+    public ErrorCodeDescription (int _code) {
+        code = _code;
+        description = "";
+    }
+
+    public int describeContents() {
+        return 0;
+    }
+
+    public void writeToParcel(Parcel parcel, int i) {
+        parcel.writeInt(code);
+        parcel.writeString(description);
+    }
+
+    public void readFromParcel(Parcel in) {
+        code = in.readInt();
+        description= in.readString();
+    }
+}


### PR DESCRIPTION
BAM! and GRCPool doesn't return any error code on wrong credentials.
Actual error message is written in 'messages' field in response.
This commit fixes this behaviour by showing an error message that is sent via response and treats it like an error while login.

This fixes #3236

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
