### PR TITLE
Converted all memset() deletions to conventional clearing methods

### DIFF
--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -423,7 +423,6 @@ int main(int argc, char** argv) {
         }
     } else if (!strcmp(cmd, "--set_host_info")) {
         HOST_INFO h;
-        memset(&h, 0, sizeof(h));
         char* pn = next_arg(argc, argv, i);
         safe_strcpy(h.product_name, pn);
         retval = rpc.set_host_info(h);
@@ -659,4 +658,3 @@ int main(int argc, char** argv) {
 #endif
     exit(retval);
 }
-

--- a/client/gpu_detect.cpp
+++ b/client/gpu_detect.cpp
@@ -146,13 +146,13 @@ void COPROCS::detect_gpus(vector<string> &warnings) {
     }
     try {
         ati.get(warnings);
-    } 
+    }
     catch (...) {
         warnings.push_back("Caught SIGSEGV in ATI GPU detection");
     }
     try {
         intel_gpu.get(warnings);
-    } 
+    }
     catch (...) {
         warnings.push_back("Caught SIGSEGV in INTEL GPU detection");
     }
@@ -170,7 +170,7 @@ void COPROCS::detect_gpus(vector<string> &warnings) {
     } else {
         nvidia.get(warnings);
     }
-    
+
 
 #ifndef __APPLE__       // ATI does not yet support CAL on Macs
     if (setjmp(resume)) {
@@ -208,7 +208,7 @@ void COPROCS::correlate_gpus(
     intel_gpu.correlate(use_all, ignore_gpu_instance[PROC_TYPE_INTEL_GPU]);
     correlate_opencl(use_all, ignore_gpu_instance);
 
-    // NOTE: OpenCL can report a max of only 4GB.  
+    // NOTE: OpenCL can report a max of only 4GB.
     //
     for (i=0; i<cpu_opencls.size(); i++) {
         gstate.host_info.opencl_cpu_prop[gstate.host_info.num_opencl_cpu_platforms++] = cpu_opencls[i];
@@ -323,7 +323,7 @@ void COPROCS::correlate_gpus(
         other_opencls[i].description(buf, sizeof(buf), other_opencls[i].name);
         descs.push_back(string(buf));
     }
-    
+
     // Create descriptions for OpenCL CPUs
     //
     for (i=0; i<cpu_opencls.size(); i++) {
@@ -342,19 +342,19 @@ void COPROCS::correlate_gpus(
 
 // This is called from CLIENT_STATE::init()
 // after adding NVIDIA, ATI and Intel GPUs
-// If we don't care about the order of GPUs in COPROCS::coprocs[], 
+// If we don't care about the order of GPUs in COPROCS::coprocs[],
 // this code could be included at the end of COPROCS::correlate_gpus().
 //
 int COPROCS::add_other_coproc_types() {
     int retval = 0;
-    
+
     for (unsigned int i=0; i<other_opencls.size(); i++) {
         if (other_opencls[i].is_used != COPROC_USED) continue;
         if (n_rsc >= MAX_RSC) {
             retval = ERR_BUFFER_OVERFLOW;
             break;
         }
-        
+
         COPROC c;
         // For device types other than NVIDIA, ATI or Intel GPU.
         // we put each instance into a separate other_opencls element,
@@ -375,9 +375,9 @@ int COPROCS::add_other_coproc_types() {
 
         // Don't call COPROCS::add() because duplicate type is legal here
         coprocs[n_rsc++] = c;
-        
+
     }
-    
+
     other_opencls.clear();
     return retval;
 }
@@ -392,18 +392,18 @@ int COPROCS::write_coproc_info_file(vector<string> &warnings) {
     MIOFILE mf;
     unsigned int i, temp;
     FILE* f;
-    
+
     f = boinc_fopen(COPROC_INFO_FILENAME, "wb");
     if (!f) return ERR_FOPEN;
     mf.init_file(f);
-    
+
     mf.printf("    <coprocs>\n");
 
     if (nvidia.have_cuda) {
         mf.printf("    <have_cuda>1</have_cuda>\n");
         mf.printf("    <cuda_version>%d</cuda_version>\n", nvidia.cuda_version);
     }
-    
+
     for (i=0; i<ati_gpus.size(); ++i) {
        ati_gpus[i].write_xml(mf, false);
     }
@@ -473,7 +473,7 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         fclose(f);
         return ERR_XML_PARSE;
     }
-    
+
     while (!xp.get_tag()) {
         if (xp.match_tag("/coprocs")) {
             fclose(f);
@@ -502,7 +502,7 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
             } else {
                 my_nvidia_gpu.device_num = (int)nvidia_gpus.size();
                 my_nvidia_gpu.pci_info = my_nvidia_gpu.pci_infos[0];
-                memset(&my_nvidia_gpu.pci_infos[0], 0, sizeof(struct PCI_INFO));
+                my_nvidia_gpu.pci_infos[0] = PCI_INFO{};
                 nvidia_gpus.push_back(my_nvidia_gpu);
             }
             continue;
@@ -517,12 +517,12 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
             }
             continue;
         }
-        
+
         if (xp.match_tag("ati_opencl")) {
-            memset(&ati_opencl, 0, sizeof(ati_opencl));
+            ati_opencl = OPENCL_DEVICE_PROP{};
             retval = ati_opencl.parse(xp, "/ati_opencl");
             if (retval) {
-                memset(&ati_opencl, 0, sizeof(ati_opencl));
+                ati_opencl = OPENCL_DEVICE_PROP{};
             } else {
                 ati_opencl.is_used = COPROC_IGNORED;
                 ati_opencls.push_back(ati_opencl);
@@ -531,10 +531,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("nvidia_opencl")) {
-            memset(&nvidia_opencl, 0, sizeof(nvidia_opencl));
+            nvidia_opencl = OPENCL_DEVICE_PROP{};
             retval = nvidia_opencl.parse(xp, "/nvidia_opencl");
             if (retval) {
-                memset(&nvidia_opencl, 0, sizeof(nvidia_opencl));
+                nvidia_opencl = OPENCL_DEVICE_PROP{};
             } else {
                 nvidia_opencl.is_used = COPROC_IGNORED;
                 nvidia_opencls.push_back(nvidia_opencl);
@@ -543,10 +543,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("intel_gpu_opencl")) {
-            memset(&intel_gpu_opencl, 0, sizeof(intel_gpu_opencl));
+            intel_gpu_opencl = OPENCL_DEVICE_PROP{};
             retval = intel_gpu_opencl.parse(xp, "/intel_gpu_opencl");
             if (retval) {
-                memset(&intel_gpu_opencl, 0, sizeof(intel_gpu_opencl));
+                intel_gpu_opencl = OPENCL_DEVICE_PROP{};
             } else {
                 intel_gpu_opencl.is_used = COPROC_IGNORED;
                 intel_gpu_opencls.push_back(intel_gpu_opencl);
@@ -555,10 +555,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("other_opencl")) {
-            memset(&other_opencl, 0, sizeof(other_opencl));
+            other_opencl = OPENCL_DEVICE_PROP{};
             retval = other_opencl.parse(xp, "/other_opencl");
             if (retval) {
-                memset(&other_opencl, 0, sizeof(other_opencl));
+                other_opencl = OPENCL_DEVICE_PROP{};
             } else {
                 other_opencl.is_used = COPROC_USED;
                 other_opencls.push_back(other_opencl);
@@ -567,17 +567,17 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("opencl_cpu_prop")) {
-            memset(&cpu_opencl, 0, sizeof(cpu_opencl));
+            cpu_opencl = OPENCL_CPU_PROP{};
             retval = cpu_opencl.parse(xp);
             if (retval) {
-                memset(&cpu_opencl, 0, sizeof(cpu_opencl));
+                cpu_opencl = OPENCL_CPU_PROP{};
             } else {
                 cpu_opencl.opencl_prop.is_used = COPROC_IGNORED;
                 cpu_opencls.push_back(cpu_opencl);
             }
             continue;
         }
-        
+
         if (xp.parse_string("warning", s)) {
             warnings.push_back(s);
             continue;
@@ -587,7 +587,7 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         //  gstate.host_info.have_cpu_opencl
         //  gstate.host_info.cpu_opencl_prop
     }
-    
+
     fclose(f);
     return ERR_XML_PARSE;
 }
@@ -601,7 +601,7 @@ int COPROCS::launch_child_process_to_detect_gpus() {
     char quoted_data_dir[MAXPATHLEN+2];
     char data_dir[MAXPATHLEN];
     int retval = 0;
-    
+
     retval = boinc_delete_file(COPROC_INFO_FILENAME);
     if (retval) {
         msg_printf(0, MSG_INFO,
@@ -614,7 +614,7 @@ int COPROCS::launch_child_process_to_detect_gpus() {
             boinc_sleep(0.01);
         }
     }
-    
+
     // use full path to exe if possible, otherwise keep using argv[0]
     char execpath[MAXPATHLEN];
     if (!get_real_executable_path(execpath, sizeof(execpath))) {
@@ -647,15 +647,15 @@ int COPROCS::launch_child_process_to_detect_gpus() {
             quoted_data_dir
         );
     }
-            
+
     int argc = 4;
     char* const argv[5] = {
          const_cast<char *>(client_path),
-         const_cast<char *>("--detect_gpus"), 
-         const_cast<char *>("--dir"), 
+         const_cast<char *>("--detect_gpus"),
+         const_cast<char *>("--dir"),
          const_cast<char *>(quoted_data_dir),
          NULL
-    }; 
+    };
 
     retval = run_program(
         client_dir,

--- a/client/gpu_detect.cpp
+++ b/client/gpu_detect.cpp
@@ -502,7 +502,7 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
             } else {
                 my_nvidia_gpu.device_num = (int)nvidia_gpus.size();
                 my_nvidia_gpu.pci_info = my_nvidia_gpu.pci_infos[0];
-                my_nvidia_gpu.pci_infos[0] = PCI_INFO{};
+                my_nvidia_gpu.pci_infos[0] = PCI_INFO();
                 nvidia_gpus.push_back(my_nvidia_gpu);
             }
             continue;
@@ -519,10 +519,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("ati_opencl")) {
-            ati_opencl = OPENCL_DEVICE_PROP{};
+            ati_opencl = OPENCL_DEVICE_PROP();
             retval = ati_opencl.parse(xp, "/ati_opencl");
             if (retval) {
-                ati_opencl = OPENCL_DEVICE_PROP{};
+                ati_opencl = OPENCL_DEVICE_PROP();
             } else {
                 ati_opencl.is_used = COPROC_IGNORED;
                 ati_opencls.push_back(ati_opencl);
@@ -531,10 +531,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("nvidia_opencl")) {
-            nvidia_opencl = OPENCL_DEVICE_PROP{};
+            nvidia_opencl = OPENCL_DEVICE_PROP();
             retval = nvidia_opencl.parse(xp, "/nvidia_opencl");
             if (retval) {
-                nvidia_opencl = OPENCL_DEVICE_PROP{};
+                nvidia_opencl = OPENCL_DEVICE_PROP();
             } else {
                 nvidia_opencl.is_used = COPROC_IGNORED;
                 nvidia_opencls.push_back(nvidia_opencl);
@@ -543,10 +543,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("intel_gpu_opencl")) {
-            intel_gpu_opencl = OPENCL_DEVICE_PROP{};
+            intel_gpu_opencl = OPENCL_DEVICE_PROP();
             retval = intel_gpu_opencl.parse(xp, "/intel_gpu_opencl");
             if (retval) {
-                intel_gpu_opencl = OPENCL_DEVICE_PROP{};
+                intel_gpu_opencl = OPENCL_DEVICE_PROP();
             } else {
                 intel_gpu_opencl.is_used = COPROC_IGNORED;
                 intel_gpu_opencls.push_back(intel_gpu_opencl);
@@ -555,10 +555,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("other_opencl")) {
-            other_opencl = OPENCL_DEVICE_PROP{};
+            other_opencl = OPENCL_DEVICE_PROP();
             retval = other_opencl.parse(xp, "/other_opencl");
             if (retval) {
-                other_opencl = OPENCL_DEVICE_PROP{};
+                other_opencl = OPENCL_DEVICE_PROP();
             } else {
                 other_opencl.is_used = COPROC_USED;
                 other_opencls.push_back(other_opencl);
@@ -567,10 +567,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("opencl_cpu_prop")) {
-            cpu_opencl = OPENCL_CPU_PROP{};
+            cpu_opencl = OPENCL_CPU_PROP();
             retval = cpu_opencl.parse(xp);
             if (retval) {
-                cpu_opencl = OPENCL_CPU_PROP{};
+                cpu_opencl = OPENCL_CPU_PROP();
             } else {
                 cpu_opencl.opencl_prop.is_used = COPROC_IGNORED;
                 cpu_opencls.push_back(cpu_opencl);

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -110,7 +110,7 @@
     // high-priority message from scheduler
     // (used internally within the client;
     // changed to MSG_USER_ALERT before passing to manager)
-    
+
 // values for suspend_reason, network_suspend_reason
 // Notes:
 // - doesn't need to be a bitmap, but keep for compatibility
@@ -286,21 +286,24 @@ struct TIME_STATS {
     void write(MIOFILE&);
     int parse(XML_PARSER&);
     void print();
+    void clear() {
+      now = 0;
+      on_frac = 1;
+      connected_frac = 1;
+      cpu_and_network_available_frac = 1;
+      active_frac = 1;
+      gpu_active_frac = 1;
+      client_start_time = 0;
+      previous_uptime = 0;
+      session_active_duration = 0;
+      session_gpu_active_duration = 0;
+      total_start_time = 0;
+      total_duration = 0;
+      total_active_duration = 0;
+      total_gpu_active_duration = 0;
+    }
     TIME_STATS() {
-        now = 0;
-        on_frac = 1;
-        connected_frac = 1;
-        cpu_and_network_available_frac = 1;
-        active_frac = 1;
-        gpu_active_frac = 1;
-        client_start_time = 0;
-        previous_uptime = 0;
-        session_active_duration = 0;
-        session_gpu_active_duration = 0;
-        total_start_time = 0;
-        total_duration = 0;
-        total_active_duration = 0;
-        total_gpu_active_duration = 0;
+        clear();
     }
 };
 
@@ -309,8 +312,8 @@ struct VERSION_INFO {
     int minor;
     int release;
     bool prerelease;
-    int parse(MIOFILE&); 
-    void write(MIOFILE&); 
+    int parse(MIOFILE&);
+    void write(MIOFILE&);
     bool greater_than(VERSION_INFO&);
     VERSION_INFO() {
         major = 0;

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -226,8 +226,8 @@ struct COPROC {
             running_graphics_app[i] = true;
         }
         device_num = 0;
-        opencl_prop = OPENCL_DEVICE_PROP{};
-        pci_info = PCI_INFO{};
+        opencl_prop = OPENCL_DEVICE_PROP();
+        pci_info = PCI_INFO();
         last_print_time = 0;
     }
     inline void clear_usage() {

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -59,12 +59,12 @@
 //  it may not use some GPUs that actually could be used.
 //
 //  Modified (as of 23 July 14) to allow coprocessors (OpenCL GPUs and OpenCL
-//  accelerators) from vendors other than original 3: NVIDIA, AMD and Intel.  
+//  accelerators) from vendors other than original 3: NVIDIA, AMD and Intel.
 //  For these original 3 GPU vendors, we still use the above approach, and the
 //  COPROC::type field contains a standardized vendor name "NVIDIA", "ATI" or
 //  "intel_gpu".  But for other, "new" vendors, we treat each device as a
 //  separate resource, creating an entry for each instance in the
-//  COPROCS::coprocs[] array and copying the device name COPROC::opencl_prop.name 
+//  COPROCS::coprocs[] array and copying the device name COPROC::opencl_prop.name
 //  into the COPROC::type field (instead of the vendor name.)
 
 #ifndef BOINC_COPROC_H
@@ -226,8 +226,8 @@ struct COPROC {
             running_graphics_app[i] = true;
         }
         device_num = 0;
-        memset(&opencl_prop, 0, sizeof(opencl_prop));
-        memset(&pci_info, 0, sizeof(pci_info));
+        opencl_prop = OPENCL_DEVICE_PROP{};
+        pci_info = PCI_INFO{};
         last_print_time = 0;
     }
     inline void clear_usage() {
@@ -431,7 +431,7 @@ struct COPROCS {
     int write_coproc_info_file(std::vector<std::string> &warnings);
     int read_coproc_info_file(std::vector<std::string> &warnings);
     int add_other_coproc_types();
-    
+
 #ifdef __APPLE__
     void opencl_get_ati_mem_size_from_opengl(std::vector<std::string> &warnings);
 #endif

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -496,7 +496,7 @@ struct ACCT_MGR_INFO {
     bool have_credentials;
     bool cookie_required;
     std::string cookie_failure_url;
-    
+
     ACCT_MGR_INFO();
 
     int parse(XML_PARSER&);
@@ -661,6 +661,7 @@ struct OLD_RESULT {
     double create_time;
 
     int parse(XML_PARSER&);
+    void clear();
     void print();
 };
 

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1511,7 +1511,7 @@ int RPC_CLIENT::exchange_versions(string client_name, VERSION_INFO& server) {
 
     retval = rpc.do_rpc(buf);
     if (!retval) {
-        server = VERSION_INFO{};
+        server = VERSION_INFO();
         while (rpc.fin.fgets(buf, 256)) {
             if (match_tag(buf, "</server_version>")) break;
             else if (parse_int(buf, "<major>", server.major)) continue;

--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -105,7 +105,9 @@ struct WEEK_PREFS {
     TIME_SPAN days[7];
 
     void clear() {
-        memset(this, 0, sizeof(WEEK_PREFS));
+        for (int i = 0; i < 7; i++) {
+          days[i] = TIME_SPAN{};
+        }
     }
     WEEK_PREFS() {
         clear();
@@ -128,10 +130,10 @@ struct TIME_PREFS : public TIME_SPAN {
         start_hour = start;
         end_hour = end;
     }
-    
+
     void clear();
     bool suspended(double t);
-    
+
 };
 
 

--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -106,7 +106,7 @@ struct WEEK_PREFS {
 
     void clear() {
         for (int i = 0; i < 7; i++) {
-          days[i] = TIME_SPAN{};
+          days[i] = TIME_SPAN();
         }
     }
     WEEK_PREFS() {


### PR DESCRIPTION
Fixes #3245

**Description of the Change**
The `memset()` function is used to delete certain structs by overwriting them with zeroes, this can be unsafe and causes the compiler to complain with a warning.

This was solved by replacing memsets with empty struct initialisers where possible. There were some instances where `this` was being overwritten, and in this case, I had to create `clear()` methods in each of the structs that had these memsets.

Notes:
* I took the liberty to do some garbage collection in one of the `clear()` functions, namely `APP_VERSION::clear()` in `gui_rpc_client_ops.cpp`. Just a heads-up in-case this is bad, but I saw only good in doing this considering the previous implementation simply made the ptr = 0.
*  It looks like my editor may have messed with some of the spaces and tabs.
* This is my first PR so feedback is appreciated!

**Alternate Designs**
N/A

**Release Notes**
Removed all object deletions using memset() and created conventional clearing functions
