### PR TITLE
client: get rid of the use of memset() to initialize structs to zero.

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -1082,7 +1082,7 @@ int ACTIVE_TASK::handle_upload_files() {
                     "Can't find uploadable file %s", p
                 );
             }
-            snprintf(path, sizeof(path), "%s/%s", slot_dir, buf);
+            snprintf(path, sizeof(path), "%.*s/%.*s", DIR_LEN, slot_dir, FILE_LEN, buf);
             delete_project_owned_file(path, true);  // delete the link file
         }
     }

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -542,7 +542,7 @@ void ACTIVE_TASK::handle_exited_app(int stat) {
                     snprintf(err_msg, sizeof(err_msg),
                         "process exited with code %d (0x%x, %d)",
                         result->exit_status, result->exit_status,
-                        (-1<<8)|result->exit_status
+                        (~0xff)|result->exit_status
                     );
                     gstate.report_result_error(*result, err_msg);
                 } else {
@@ -1554,7 +1554,7 @@ void ACTIVE_TASK_SET::get_msgs() {
         }
         if (atp->get_app_status_msg()) {
             if (old_time != atp->checkpoint_cpu_time) {
-                char buf[256];
+                char buf[512];
                 sprintf(buf, "%s checkpointed", atp->result->name);
                 if (atp->overdue_checkpoint) {
                     gstate.request_schedule_cpus(buf);

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -351,7 +351,7 @@ static int create_dirs_for_logical_name(
 
 static void prepend_prefix(APP_VERSION* avp, char* in, char* out, int len) {
     if (strlen(avp->file_prefix)) {
-        snprintf(out, len, "%s/%s", avp->file_prefix, in);
+        snprintf(out, len, "%.16s/%.200s", avp->file_prefix, in);
     } else {
         strlcpy(out, in, len);
     }
@@ -467,7 +467,7 @@ int ACTIVE_TASK::link_user_files() {
 }
 
 int ACTIVE_TASK::copy_output_files() {
-    char slotfile[256], projfile[256], open_name[256];
+    char slotfile[MAXPATHLEN], projfile[256], open_name[256];
     unsigned int i;
     for (i=0; i<result->output_files.size(); i++) {
         FILE_REF& fref = result->output_files[i];
@@ -476,7 +476,7 @@ int ACTIVE_TASK::copy_output_files() {
         prepend_prefix(
             app_version, fref.open_name, open_name, sizeof(open_name)
         );
-        snprintf(slotfile, sizeof(slotfile), "%s/%s", slot_dir, open_name);
+        snprintf(slotfile, sizeof(slotfile), "%.*s/%.*s", DIR_LEN, slot_dir, FILE_LEN, open_name);
         get_pathname(fip, projfile, sizeof(projfile));
         int retval = boinc_rename(slotfile, projfile);
         // the rename fails if the output file isn't there.
@@ -1108,7 +1108,7 @@ int ACTIVE_TASK::start(bool test) {
         if (test) {
             strcpy(buf, exec_path);
         } else {
-            snprintf(buf, sizeof(buf), "../../%s", exec_path);
+            snprintf(buf, sizeof(buf), "../../%.1024s", exec_path);
         }
         if (g_use_sandbox) {
             char switcher_path[MAXPATHLEN];
@@ -1167,7 +1167,7 @@ error:
     //
     gstate.input_files_available(result, true);
     char err_msg[4096];
-    snprintf(err_msg, sizeof(err_msg), "couldn't start app: %s", buf);
+    snprintf(err_msg, sizeof(err_msg), "couldn't start app: %.256s", buf);
     gstate.report_result_error(*result, err_msg);
     if (log_flags.task_debug) {
         msg_printf(wup->project, MSG_INFO,

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -423,7 +423,7 @@ int main(int argc, char** argv) {
         }
     } else if (!strcmp(cmd, "--set_host_info")) {
         HOST_INFO h;
-        memset(&h, 0, sizeof(h));
+        h.clear();
         char* pn = next_arg(argc, argv, i);
         safe_strcpy(h.product_name, pn);
         retval = rpc.set_host_info(h);

--- a/client/client_msgs.cpp
+++ b/client/client_msgs.cpp
@@ -75,10 +75,10 @@ void show_message(
     //
     switch (priority) {
     case MSG_INTERNAL_ERROR:
-        snprintf(event_msg, sizeof(event_msg), "[error] %s", message);
+        snprintf(event_msg, sizeof(event_msg), "[error] %.512s", message);
         break;
     case MSG_SCHEDULER_ALERT:
-        snprintf(event_msg, sizeof(event_msg), "%s: %s",
+        snprintf(event_msg, sizeof(event_msg), "%.64s: %.512s",
             _("Message from server"), message
         );
         break;

--- a/client/client_msgs.cpp
+++ b/client/client_msgs.cpp
@@ -55,7 +55,7 @@ void show_message(
     PROJ_AM *p, char* msg, int priority, bool is_html, const char* link
 ) {
     const char* x;
-    char message[1024], event_msg[1024], evt_message[2048];
+    char message[1024], event_msg[2048], evt_message[2048];
     double t = dtime();
     char* time_string = time_to_string(t);
 
@@ -75,10 +75,10 @@ void show_message(
     //
     switch (priority) {
     case MSG_INTERNAL_ERROR:
-        snprintf(event_msg, sizeof(event_msg), "[error] %.512s", message);
+        snprintf(event_msg, sizeof(event_msg), "[error] %s", message);
         break;
     case MSG_SCHEDULER_ALERT:
-        snprintf(event_msg, sizeof(event_msg), "%.64s: %.512s",
+        snprintf(event_msg, sizeof(event_msg), "%.64s: %s",
             _("Message from server"), message
         );
         break;

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -226,8 +226,14 @@ struct DAILY_STATS {
     double host_expavg_credit;
     double day;
 
-    void clear();
-    DAILY_STATS() {clear();}
+    DAILY_STATS(int){}
+    void clear() {
+        static const DAILY_STATS x(0);
+        *this = x;
+    }
+    DAILY_STATS() {
+        clear();
+    }
     int parse(FILE*);
 };
 bool operator < (const DAILY_STATS&, const DAILY_STATS&);
@@ -273,7 +279,14 @@ struct APP {
     bool ignore;
 #endif
 
-    APP() {memset(this, 0, sizeof(APP));}
+    APP(int){}
+    void clear() {
+        static const APP x(0);
+        *this = x;
+    }
+    APP(){
+        clear();
+    }
     int parse(XML_PARSER&);
     int write(MIOFILE&);
 };

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1227,7 +1227,7 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
     // and prune those that can't be assigned
     //
     assign_coprocs(run_list);
-    bool scheduled_mt = false;
+    //bool scheduled_mt = false;
 
     // prune jobs that don't fit in RAM or that exceed CPU usage limits.
     // Mark the rest as SCHEDULED
@@ -1337,9 +1337,11 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
             continue;
         }
 
+#if 0
         if (rp->avp->avg_ncpus > 1) {
             scheduled_mt = true;
         }
+#endif
         ncpus_used += rp->avp->avg_ncpus;
         atp->next_scheduler_state = CPU_SCHED_SCHEDULED;
         ram_left -= wss;

--- a/client/cs_account.cpp
+++ b/client/cs_account.cpp
@@ -358,10 +358,6 @@ int CLIENT_STATE::parse_account_files() {
     return 0;
 }
 
-void DAILY_STATS::clear() {
-    memset(this, 0, sizeof(DAILY_STATS));
-}
-
 int DAILY_STATS::parse(FILE* in) {
     MIOFILE mf;
     XML_PARSER xp(&mf);

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -175,7 +175,6 @@ int cpu_benchmarks(BENCHMARK_DESC* bdp) {
     double vax_mips, int_loops=0, int_time=0, fp_time;
 
     bdp->error_str[0] = '\0';
-    host_info.clear_host_info();
 
 #if defined(ANDROID) && defined(__arm__)
     // check for FP accelerator: VFP, Neon, or none;

--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -192,8 +192,8 @@ int FILE_INFO::verify_file(
     // see if we need to unzip it
     //
     if (download_gzipped && !boinc_file_exists(pathname)) {
-        char gzpath[MAXPATHLEN];
-        snprintf(gzpath, sizeof(gzpath), "%.2048s.gz", pathname);
+        char gzpath[MAXPATHLEN+16];
+        snprintf(gzpath, sizeof(gzpath), "%s.gz", pathname);
         if (boinc_file_exists(gzpath) ) {
             if (allow_async && nbytes > ASYNC_FILE_THRESHOLD) {
                 ASYNC_VERIFY* avp = new ASYNC_VERIFY;
@@ -417,10 +417,10 @@ bool CLIENT_STATE::create_and_delete_pers_file_xfers() {
                 // If this was a compressed download, rename .gzt to .gz
                 //
                 if (fip->download_gzipped) {
-                    char path[MAXPATHLEN], from_path[MAXPATHLEN], to_path[MAXPATHLEN];
+                    char path[MAXPATHLEN], from_path[MAXPATHLEN+16], to_path[MAXPATHLEN+16];
                     get_pathname(fip, path, sizeof(path));
-                    snprintf(from_path, sizeof(from_path), "%.2048s.gzt", path);
-                    snprintf(to_path, sizeof(to_path), "%.2048s.gz", path);
+                    snprintf(from_path, sizeof(from_path), "%s.gzt", path);
+                    snprintf(to_path, sizeof(to_path), "%s.gz", path);
                     boinc_rename(from_path, to_path);
                 }
 

--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -193,7 +193,7 @@ int FILE_INFO::verify_file(
     //
     if (download_gzipped && !boinc_file_exists(pathname)) {
         char gzpath[MAXPATHLEN];
-        snprintf(gzpath, sizeof(gzpath), "%s.gz", pathname);
+        snprintf(gzpath, sizeof(gzpath), "%.2048s.gz", pathname);
         if (boinc_file_exists(gzpath) ) {
             if (allow_async && nbytes > ASYNC_FILE_THRESHOLD) {
                 ASYNC_VERIFY* avp = new ASYNC_VERIFY;
@@ -419,8 +419,8 @@ bool CLIENT_STATE::create_and_delete_pers_file_xfers() {
                 if (fip->download_gzipped) {
                     char path[MAXPATHLEN], from_path[MAXPATHLEN], to_path[MAXPATHLEN];
                     get_pathname(fip, path, sizeof(path));
-                    snprintf(from_path, sizeof(from_path), "%s.gzt", path);
-                    snprintf(to_path, sizeof(to_path), "%s.gz", path);
+                    snprintf(from_path, sizeof(from_path), "%.2048s.gzt", path);
+                    snprintf(to_path, sizeof(to_path), "%.2048s.gz", path);
                     boinc_rename(from_path, to_path);
                 }
 

--- a/client/cs_notice.cpp
+++ b/client/cs_notice.cpp
@@ -59,7 +59,7 @@ static bool cmp(NOTICE n1, NOTICE n2) {
 static void project_feed_list_file_name(PROJ_AM* p, char* buf, int len) {
     char url[256];
     escape_project_url(p->master_url, url);
-    snprintf(buf, len, "notices/feeds_%.128s.xml", url);
+    snprintf(buf, len, "notices/feeds_%s.xml", url);
 }
 
 // parse feed descs from scheduler reply or feed list file
@@ -98,7 +98,7 @@ static void write_rss_feed_descs(MIOFILE& fout, vector<RSS_FEED>& feeds) {
 }
 
 static void write_project_feed_list(PROJ_AM* p) {
-    char buf[256];
+    char buf[MAXPATHLEN];
     project_feed_list_file_name(p, buf, sizeof(buf));
     FILE* f = fopen(buf, "w");
     if (!f) return;

--- a/client/cs_notice.cpp
+++ b/client/cs_notice.cpp
@@ -59,7 +59,7 @@ static bool cmp(NOTICE n1, NOTICE n2) {
 static void project_feed_list_file_name(PROJ_AM* p, char* buf, int len) {
     char url[256];
     escape_project_url(p->master_url, url);
-    snprintf(buf, len, "notices/feeds_%s.xml", url);
+    snprintf(buf, len, "notices/feeds_%.128s.xml", url);
 }
 
 // parse feed descs from scheduler reply or feed list file
@@ -619,7 +619,7 @@ void NOTICES::write(int seqno, GUI_RPC_CONN& grc, bool public_only) {
 void RSS_FEED::feed_file_name(char* path, int len) {
     char buf[256];
     escape_project_url(url_base, buf);
-    snprintf(path, len, NOTICES_DIR"/%s.xml", buf);
+    snprintf(path, len, NOTICES_DIR"/%.128s.xml", buf);
 }
 
 void RSS_FEED::archive_file_name(char* path, int len) {

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -1187,8 +1187,8 @@ void CLIENT_STATE::check_project_timeout() {
         PROJECT* p = projects[i];
         if (p->possibly_backed_off && now > p->min_rpc_time) {
             p->possibly_backed_off = false;
-            char buf[256];
-            snprintf(buf, sizeof(buf), "Backoff ended for %.128s", p->get_project_name());
+            char buf[1024];
+            snprintf(buf, sizeof(buf), "Backoff ended for %s", p->get_project_name());
             request_work_fetch(buf);
         }
     }

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -1188,7 +1188,7 @@ void CLIENT_STATE::check_project_timeout() {
         if (p->possibly_backed_off && now > p->min_rpc_time) {
             p->possibly_backed_off = false;
             char buf[256];
-            snprintf(buf, sizeof(buf), "Backoff ended for %s", p->get_project_name());
+            snprintf(buf, sizeof(buf), "Backoff ended for %.128s", p->get_project_name());
             request_work_fetch(buf);
         }
     }

--- a/client/file_names.cpp
+++ b/client/file_names.cpp
@@ -243,7 +243,7 @@ void delete_old_slot_dirs() {
             // Clean these up here. (We must do this before deleting the
             // INIT_DATA_FILE, if any, from each slot directory.)
             //
-            snprintf(init_data_path, sizeof(init_data_path), "%s/%s", path, INIT_DATA_FILE);
+            snprintf(init_data_path, sizeof(init_data_path), "%.*s/%.*s", DIR_LEN, path, FILE_LEN, INIT_DATA_FILE);
             shmem_seg_name = ftok(init_data_path, 1);
             if (shmem_seg_name != -1) {
                 destroy_shmem(shmem_seg_name);

--- a/client/file_xfer.h
+++ b/client/file_xfer.h
@@ -34,7 +34,7 @@ class FILE_XFER : public HTTP_OP {
 public:
     FILE_INFO* fip;
     char pathname[256];
-    char header[4096];
+    char header[8192];
     bool file_size_query;
     bool is_upload;
     double starting_size;

--- a/client/gpu_detect.cpp
+++ b/client/gpu_detect.cpp
@@ -201,7 +201,7 @@ void COPROCS::correlate_gpus(
     IGNORE_GPU_INSTANCE &ignore_gpu_instance
 ) {
     unsigned int i;
-    char buf[256], buf2[256];
+    char buf[256], buf2[1024];
 
     nvidia.correlate(use_all, ignore_gpu_instance[PROC_TYPE_NVIDIA_GPU]);
     ati.correlate(use_all, ignore_gpu_instance[PROC_TYPE_AMD_GPU]);

--- a/client/gpu_detect.cpp
+++ b/client/gpu_detect.cpp
@@ -502,7 +502,7 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
             } else {
                 my_nvidia_gpu.device_num = (int)nvidia_gpus.size();
                 my_nvidia_gpu.pci_info = my_nvidia_gpu.pci_infos[0];
-                memset(&my_nvidia_gpu.pci_infos[0], 0, sizeof(struct PCI_INFO));
+                my_nvidia_gpu.pci_infos[0].clear();
                 nvidia_gpus.push_back(my_nvidia_gpu);
             }
             continue;
@@ -519,10 +519,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
         
         if (xp.match_tag("ati_opencl")) {
-            memset(&ati_opencl, 0, sizeof(ati_opencl));
+            ati_opencl.clear();
             retval = ati_opencl.parse(xp, "/ati_opencl");
             if (retval) {
-                memset(&ati_opencl, 0, sizeof(ati_opencl));
+                ati_opencl.clear();
             } else {
                 ati_opencl.is_used = COPROC_IGNORED;
                 ati_opencls.push_back(ati_opencl);
@@ -531,10 +531,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("nvidia_opencl")) {
-            memset(&nvidia_opencl, 0, sizeof(nvidia_opencl));
+            nvidia_opencl.clear();
             retval = nvidia_opencl.parse(xp, "/nvidia_opencl");
             if (retval) {
-                memset(&nvidia_opencl, 0, sizeof(nvidia_opencl));
+                nvidia_opencl.clear();
             } else {
                 nvidia_opencl.is_used = COPROC_IGNORED;
                 nvidia_opencls.push_back(nvidia_opencl);
@@ -543,10 +543,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("intel_gpu_opencl")) {
-            memset(&intel_gpu_opencl, 0, sizeof(intel_gpu_opencl));
+            intel_gpu_opencl.clear();
             retval = intel_gpu_opencl.parse(xp, "/intel_gpu_opencl");
             if (retval) {
-                memset(&intel_gpu_opencl, 0, sizeof(intel_gpu_opencl));
+                intel_gpu_opencl.clear();
             } else {
                 intel_gpu_opencl.is_used = COPROC_IGNORED;
                 intel_gpu_opencls.push_back(intel_gpu_opencl);
@@ -555,10 +555,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("other_opencl")) {
-            memset(&other_opencl, 0, sizeof(other_opencl));
+            other_opencl.clear();
             retval = other_opencl.parse(xp, "/other_opencl");
             if (retval) {
-                memset(&other_opencl, 0, sizeof(other_opencl));
+                other_opencl.clear();
             } else {
                 other_opencl.is_used = COPROC_USED;
                 other_opencls.push_back(other_opencl);
@@ -567,10 +567,10 @@ int COPROCS::read_coproc_info_file(vector<string> &warnings) {
         }
 
         if (xp.match_tag("opencl_cpu_prop")) {
-            memset(&cpu_opencl, 0, sizeof(cpu_opencl));
+            cpu_opencl.clear();
             retval = cpu_opencl.parse(xp);
             if (retval) {
-                memset(&cpu_opencl, 0, sizeof(cpu_opencl));
+                cpu_opencl.clear();
             } else {
                 cpu_opencl.opencl_prop.is_used = COPROC_IGNORED;
                 cpu_opencls.push_back(cpu_opencl);

--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -392,7 +392,7 @@ void* cudalib = NULL;
     warnings.push_back(buf);
 
     for (j=0; j<cuda_ndevs; j++) {
-        memset(&cc.prop, 0, sizeof(cc.prop));
+        cc.prop.clear();
         CUdevice device;
         retval = (*p_cuDeviceGet)(&device, j);
         if (retval) {

--- a/client/gpu_opencl.cpp
+++ b/client/gpu_opencl.cpp
@@ -320,7 +320,7 @@ void COPROCS::get_opencl(
         }
 
         for (device_index=0; device_index<num_devices; ++device_index) {
-            memset(&prop, 0, sizeof(prop));
+            prop.clear();
             prop.device_id = devices[device_index];
             strlcpy(
                 prop.opencl_platform_version, platform_version,
@@ -406,7 +406,7 @@ void COPROCS::get_opencl(
         }
 
         for (device_index=0; device_index<num_devices; ++device_index) {
-            memset(&prop, 0, sizeof(prop));
+            prop.clear();
             prop.device_id = devices[device_index];
             strlcpy(
                 prop.opencl_platform_version, platform_version,

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1349,7 +1349,7 @@ vector<AUTH_INFO> auth_infos;
 // check HTTP authentication info
 //
 bool valid_auth(int id, long seqno, char* hash, char* request) {
-    char buf[256], my_hash[256];
+    char buf[1024], my_hash[256];
     //printf("valid_auth: id %d seqno %ld hash %s\n", id, seqno, hash);
     for (unsigned int i=0; i<auth_infos.size(); i++) {
         AUTH_INFO& ai = auth_infos[i];

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1580,7 +1580,7 @@ static const struct dir_tty_dev {
 vector<string> get_tty_list() {
     // Create a list of all terminal devices on the system.
     char devname[1024];
-    char fullname[1024];
+    char fullname[MAXPATHLEN];
     int done,i=0;
     vector<string> tty_list;
 
@@ -1594,7 +1594,7 @@ vector<string> get_tty_list() {
                 if (!done && (strstr(devname,tty_patterns[i].dev) == devname)) {
                     // don't add anything starting with .
                     if (devname[0] != '.') {
-                        sprintf(fullname,"%s/%s",tty_patterns[i].dir,devname);
+                        sprintf(fullname,"%s/%s", tty_patterns[i].dir, devname);
                         tty_list.push_back(fullname);
                     }
                 }

--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -77,7 +77,7 @@ static void get_user_agent_string() {
     );
     if (strlen(gstate.client_brand)) {
         char buf[256];
-        snprintf(buf, sizeof(buf), " (%s)", gstate.client_brand);
+        snprintf(buf, sizeof(buf), " (%.80s)", gstate.client_brand);
         safe_strcat(g_user_agent_string, buf);
     }
 }

--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -76,8 +76,8 @@ static void get_user_agent_string() {
         BOINC_MAJOR_VERSION, BOINC_MINOR_VERSION, BOINC_RELEASE
     );
     if (strlen(gstate.client_brand)) {
-        char buf[256];
-        snprintf(buf, sizeof(buf), " (%.80s)", gstate.client_brand);
+        char buf[1024];
+        snprintf(buf, sizeof(buf), " (%s)", gstate.client_brand);
         safe_strcat(g_user_agent_string, buf);
     }
 }

--- a/client/http_curl.h
+++ b/client/http_curl.h
@@ -60,7 +60,7 @@ public:
     char m_url[1024];  
     char m_curl_ca_bundle_location[256];
         // string needed for ssl support
-    char m_curl_user_credentials[128];
+    char m_curl_user_credentials[1024];
         // string needed for proxy username/password
 
     int content_length;

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -158,7 +158,7 @@ void log_message_error(const char* msg, int error_code) {
 }
 
 #ifndef _WIN32
-static void signal_handler(int signum) {
+static void signal_handler(int signum, siginfo_t*, void*) {
     msg_printf(NULL, MSG_INFO, "Received signal %d", signum);
     switch(signum) {
     case SIGHUP:

--- a/client/net_stats.cpp
+++ b/client/net_stats.cpp
@@ -51,11 +51,6 @@
 DAILY_XFER_HISTORY daily_xfer_history;
 NET_STATUS net_status;
 
-NET_STATS::NET_STATS() {
-    memset(&up, 0, sizeof(up));
-    memset(&down, 0, sizeof(down));
-}
-
 // called after file xfer to update rates
 //
 void NET_INFO::update(double nbytes, double dt) {
@@ -102,7 +97,7 @@ int NET_STATS::write(MIOFILE& out) {
 }
 
 int NET_STATS::parse(XML_PARSER& xp) {
-    memset(this, 0, sizeof(NET_STATS));
+    clear();
     while (!xp.get_tag()) {
         if (xp.match_tag("/net_stats")) return 0;
         if (xp.parse_double("bwup", up.max_rate)) continue;

--- a/client/net_stats.h
+++ b/client/net_stats.h
@@ -48,7 +48,6 @@ struct NET_INFO {
         // when avg_rate was last updated
     void update(double nbytes, double dt);
         // updates the above vars
-
 };
 
 class NET_STATS {
@@ -56,7 +55,14 @@ public:
     NET_INFO up;
     NET_INFO down;
 
-    NET_STATS();
+    NET_STATS(int){}
+    void clear() {
+        static const NET_STATS x(0);
+        *this = x;
+    }
+    NET_STATS() {
+        clear();
+    }
 
     int write(MIOFILE&);
     int parse(XML_PARSER&);

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -430,7 +430,7 @@ int RESULT::write_gui(MIOFILE& out) {
             }
         } else if (avp->missing_coproc) {
             snprintf(resources, sizeof(resources),
-                "%.3g %s + %s GPU (missing)",
+                "%.3g %s + %.12s GPU (missing)",
                 avp->avg_ncpus,
                 cpu_string(avp->avg_ncpus),
                 avp->missing_coproc_name

--- a/client/sandbox.cpp
+++ b/client/sandbox.cpp
@@ -346,7 +346,7 @@ int client_clean_out_dir(
         if (except && !strcmp(except, filename)) {
             continue;
         }
-        snprintf(path, sizeof(path), "%s/%s", dirpath,  filename);
+        snprintf(path, sizeof(path), "%.*s/%.*s", DIR_LEN, dirpath,  FILE_LEN, filename);
         if (is_dir(path)) {
             retval = client_clean_out_dir(path, NULL);
             if (retval) final_retval = retval;

--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -761,10 +761,6 @@ void SIM_RESULTS::divide(int n) {
     monotony /= n;
 }
 
-void SIM_RESULTS::clear() {
-    memset(this, 0, sizeof(*this));
-}
-
 void PROJECT::print_results(FILE* f, SIM_RESULTS& sr) {
     double t = project_results.flops_used;
     double gt = sr.flops_used;

--- a/client/sim.h
+++ b/client/sim.h
@@ -34,12 +34,19 @@ struct SIM_RESULTS {
     double idle_frac;
     int nrpcs;
 
+    SIM_RESULTS(int){}
+    void clear() {
+        static const SIM_RESULTS x(0);
+        *this = x;
+    }
+    SIM_RESULTS() {
+        clear();
+    }
     void compute_figures_of_merit();
     void print(FILE* f, bool human_readable=false);
     void parse(FILE* f);
     void add(SIM_RESULTS& r);
     void divide(int);
-    void clear();
 };
 
 struct PROJECT_RESULTS {

--- a/client/work_fetch.h
+++ b/client/work_fetch.h
@@ -325,8 +325,13 @@ struct PROJECT_WORK_FETCH {
         // If we're uploading but a resource is idle, make a work request.
         // If this succeeds, clear the flag.
 
+    PROJECT_WORK_FETCH(int) {}
+    void clear() {
+        static const PROJECT_WORK_FETCH x(0);
+        *this = x;
+    }
     PROJECT_WORK_FETCH() {
-        memset(this, 0, sizeof(*this));
+        clear();
     }
     void reset(PROJECT*);
     void rr_init(PROJECT*);

--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -269,7 +269,7 @@ void APP_INIT_DATA::clear() {
     host_total_credit = 0;
     host_expavg_credit = 0;
     resource_share_fraction = 0;
-    host_info.clear_host_info();
+    host_info.clear();
     proxy_info.clear();
     global_prefs.defaults();
     starting_elapsed_time = 0;

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -718,7 +718,7 @@ int APP_CONFIG::parse_gpu_versions(
             continue;
         }
         if (log_flags.unparsed_xml) {
-            snprintf(buf, sizeof(buf), "Unparsed line in app_config.xml: %s", xp.parsed_tag);
+            snprintf(buf, sizeof(buf), "Unparsed line in app_config.xml: %.128s", xp.parsed_tag);
             mv.push_back(string(buf));
         }
     }
@@ -755,7 +755,7 @@ int APP_CONFIG::parse(XML_PARSER& xp, MSG_VEC& mv, LOG_FLAGS& log_flags) {
         // unparsed XML not considered an error; maybe it should be?
         //
         if (log_flags.unparsed_xml) {
-            snprintf(buf, sizeof(buf), "Unparsed line in app_config.xml: %s", xp.parsed_tag);
+            snprintf(buf, sizeof(buf), "Unparsed line in app_config.xml: %.128s", xp.parsed_tag);
             mv.push_back(string(buf));
         }
         xp.skip_unexpected(log_flags.unparsed_xml, "APP_CONFIG::parse");
@@ -773,7 +773,7 @@ int APP_VERSION_CONFIG::parse(
 
     while (!xp.get_tag()) {
         if (!xp.is_tag) {
-            snprintf(buf, sizeof(buf), "unexpected text '%s' in app_config.xml", xp.parsed_tag);
+            snprintf(buf, sizeof(buf), "unexpected text '%.128s' in app_config.xml", xp.parsed_tag);
             mv.push_back(string(buf));
             return ERR_XML_PARSE;
         }
@@ -784,7 +784,7 @@ int APP_VERSION_CONFIG::parse(
         if (xp.parse_double("avg_ncpus", avg_ncpus)) continue;
         if (xp.parse_double("ngpus", ngpus)) continue;
         if (log_flags.unparsed_xml) {
-            snprintf(buf, sizeof(buf), "Unparsed line in app_config.xml: %s", xp.parsed_tag);
+            snprintf(buf, sizeof(buf), "Unparsed line in app_config.xml: %.128s", xp.parsed_tag);
             mv.push_back(string(buf));
         }
         xp.skip_unexpected(log_flags.unparsed_xml, "APP_VERSION_CONFIG::parse");
@@ -799,7 +799,7 @@ int APP_CONFIGS::parse(XML_PARSER& xp, MSG_VEC& mv, LOG_FLAGS& log_flags) {
     clear();
     while (!xp.get_tag()) {
         if (!xp.is_tag) {
-            snprintf(buf, sizeof(buf), "unexpected text '%s' in app_config.xml", xp.parsed_tag);
+            snprintf(buf, sizeof(buf), "unexpected text '%.128s' in app_config.xml", xp.parsed_tag);
             mv.push_back(string(buf));
             return ERR_XML_PARSE;
         }
@@ -834,7 +834,7 @@ int APP_CONFIGS::parse(XML_PARSER& xp, MSG_VEC& mv, LOG_FLAGS& log_flags) {
         if (xp.parse_bool("report_results_immediately", report_results_immediately)) {
             continue;
         }
-        snprintf(buf, sizeof(buf), "Unknown tag in app_config.xml: %s", xp.parsed_tag);
+        snprintf(buf, sizeof(buf), "Unknown tag in app_config.xml: %.128s", xp.parsed_tag);
         mv.push_back(string(buf));
 
         xp.skip_unexpected(log_flags.unparsed_xml, "APP_CONFIGS::parse");

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -39,12 +39,10 @@
 
 using std::string;
 
-LOG_FLAGS::LOG_FLAGS() {
-    init();
-}
-
 void LOG_FLAGS::init() {
-    memset(this, 0, sizeof(LOG_FLAGS));
+    static const LOG_FLAGS x;
+    *this = x;
+
     // on by default (others are off by default)
     //
     task = true;
@@ -55,6 +53,7 @@ void LOG_FLAGS::init() {
 // Parse log flag preferences
 //
 int LOG_FLAGS::parse(XML_PARSER& xp) {
+    init();
     while (!xp.get_tag()) {
         if (!xp.is_tag) {
             continue;
@@ -729,7 +728,8 @@ int APP_CONFIG::parse_gpu_versions(
 
 int APP_CONFIG::parse(XML_PARSER& xp, MSG_VEC& mv, LOG_FLAGS& log_flags) {
     char buf[1024];
-    memset(this, 0, sizeof(APP_CONFIG));
+    static const APP_CONFIG init;
+    *this = init;
 
     while (!xp.get_tag()) {
         if (xp.match_tag("/app")) return 0;
@@ -768,7 +768,8 @@ int APP_VERSION_CONFIG::parse(
     XML_PARSER& xp, MSG_VEC& mv, LOG_FLAGS& log_flags
 ) {
     char buf[1024];
-    memset(this, 0, sizeof(APP_VERSION_CONFIG));
+    static const APP_VERSION_CONFIG init;
+    *this = init;
 
     while (!xp.get_tag()) {
         if (!xp.is_tag) {

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -121,7 +121,7 @@ struct LOG_FLAGS {
     bool work_fetch_debug;
         // work fetch policy 
 
-    LOG_FLAGS();
+    LOG_FLAGS(){}
     void init();
     int parse(XML_PARSER&);
     void show();
@@ -224,6 +224,7 @@ struct APP_CONFIG {
     bool fraction_done_exact;
     bool report_results_immediately;
 
+    APP_CONFIG(){}
     int parse(XML_PARSER&, MSG_VEC&, LOG_FLAGS&);
     int parse_gpu_versions(XML_PARSER&, MSG_VEC&, LOG_FLAGS&);
 };
@@ -235,6 +236,7 @@ struct APP_VERSION_CONFIG {
     double avg_ncpus;
     double ngpus;
 
+    APP_VERSION_CONFIG(){}
     int parse(XML_PARSER&, MSG_VEC&, LOG_FLAGS&);
 };
 

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -408,7 +408,8 @@ void COPROC_NVIDIA::write_xml(MIOFILE& f, bool scheduler_rpc) {
 #endif
 
 void COPROC_NVIDIA::clear() {
-    COPROC::clear();
+    static const COPROC_NVIDIA x;
+    *this = x;
     safe_strcpy(type, proc_type_name_xml(PROC_TYPE_NVIDIA_GPU));
     estimated_delay = -1;   // mark as absent
     cuda_version = 0;
@@ -608,39 +609,40 @@ void COPROC_NVIDIA::set_peak_flops() {
 void COPROC_NVIDIA::fake(
     int driver_version, double ram, double avail_ram, int n
 ) {
-   safe_strcpy(type, proc_type_name_xml(PROC_TYPE_NVIDIA_GPU));
-   count = n;
-   for (int i=0; i<count; i++) {
-       device_nums[i] = i;
-   }
-   available_ram = avail_ram;
-   display_driver_version = driver_version;
-   cuda_version = 5000;
-   have_cuda = true;
-   safe_strcpy(prop.name, "Fake NVIDIA GPU");
-   memset(&prop, 0, sizeof(prop));
-   prop.totalGlobalMem = ram;
-   prop.sharedMemPerBlock = 100;
-   prop.regsPerBlock = 8;
-   prop.warpSize = 10;
-   prop.memPitch = 10;
-   prop.maxThreadsPerBlock = 20;
-   prop.maxThreadsDim[0] = 2;
-   prop.maxThreadsDim[1] = 2;
-   prop.maxThreadsDim[2] = 2;
-   prop.maxGridSize[0] = 10;
-   prop.maxGridSize[1] = 10;
-   prop.maxGridSize[2] = 10;
-   prop.totalConstMem = 10;
-   prop.major = 1;
-   prop.minor = 2;
-   prop.clockRate = 1250000;
-   prop.textureAlignment = 1000;
-   prop.multiProcessorCount = 14;
-   have_opencl = true;
-   safe_strcpy(opencl_prop.opencl_device_version, "OpenCL 3.17");
-   opencl_prop.opencl_device_version_int = 317;
-   set_peak_flops();
+    static const COPROC_NVIDIA x;
+    *this = x;
+    safe_strcpy(type, proc_type_name_xml(PROC_TYPE_NVIDIA_GPU));
+    count = n;
+    for (int i=0; i<count; i++) {
+        device_nums[i] = i;
+    }
+    available_ram = avail_ram;
+    display_driver_version = driver_version;
+    cuda_version = 5000;
+    have_cuda = true;
+    safe_strcpy(prop.name, "Fake NVIDIA GPU");
+    prop.totalGlobalMem = ram;
+    prop.sharedMemPerBlock = 100;
+    prop.regsPerBlock = 8;
+    prop.warpSize = 10;
+    prop.memPitch = 10;
+    prop.maxThreadsPerBlock = 20;
+    prop.maxThreadsDim[0] = 2;
+    prop.maxThreadsDim[1] = 2;
+    prop.maxThreadsDim[2] = 2;
+    prop.maxGridSize[0] = 10;
+    prop.maxGridSize[1] = 10;
+    prop.maxGridSize[2] = 10;
+    prop.totalConstMem = 10;
+    prop.major = 1;
+    prop.minor = 2;
+    prop.clockRate = 1250000;
+    prop.textureAlignment = 1000;
+    prop.multiProcessorCount = 14;
+    have_opencl = true;
+    safe_strcpy(opencl_prop.opencl_device_version, "OpenCL 3.17");
+    opencl_prop.opencl_device_version_int = 317;
+    set_peak_flops();
 }
 
 ////////////////// ATI STARTS HERE /////////////////
@@ -715,15 +717,14 @@ void COPROC_ATI::write_xml(MIOFILE& f, bool scheduler_rpc) {
 #endif
 
 void COPROC_ATI::clear() {
-    COPROC::clear();
+    static const COPROC_ATI x;
+    *this = x;
     safe_strcpy(type, proc_type_name_xml(PROC_TYPE_AMD_GPU));
     estimated_delay = -1;
     safe_strcpy(name, "");
     safe_strcpy(version, "");
     atirt_detected = false;
     amdrt_detected = false;
-    memset(&attribs, 0, sizeof(attribs));
-    memset(&info, 0, sizeof(info));
     version_num = 0;
     is_used = COPROC_USED;
 }
@@ -872,14 +873,13 @@ void COPROC_ATI::set_peak_flops() {
 }
 
 void COPROC_ATI::fake(double ram, double avail_ram, int n) {
+    clear();
     safe_strcpy(type, proc_type_name_xml(PROC_TYPE_AMD_GPU));
     safe_strcpy(version, "1.4.3");
     safe_strcpy(name, "foobar");
     count = n;
     available_ram = avail_ram;
     have_cal = true;
-    memset(&attribs, 0, sizeof(attribs));
-    memset(&info, 0, sizeof(info));
     attribs.localRAM = (int)(ram/MEGA);
     attribs.numberOfSIMD = 32;
     attribs.wavefrontSize = 32;
@@ -924,7 +924,8 @@ void COPROC_INTEL::write_xml(MIOFILE& f, bool scheduler_rpc) {
 #endif
 
 void COPROC_INTEL::clear() {
-    COPROC::clear();
+    static const COPROC_INTEL x;
+    *this = x;
     safe_strcpy(type, proc_type_name_xml(PROC_TYPE_INTEL_GPU));
     estimated_delay = -1;
     safe_strcpy(name, "");

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -136,7 +136,15 @@ struct PCI_INFO {
     int device_id;
     int domain_id;
 
-    PCI_INFO(): present(false), bus_id(0), device_id(0),domain_id(0) {}
+    void clear() {
+        present = false;
+        bus_id = 0;
+        device_id = 0;
+        domain_id = 0;
+    }
+    PCI_INFO() {
+        clear();
+    }
     void write(MIOFILE&);
     int parse(XML_PARSER&);
 };
@@ -196,48 +204,26 @@ struct COPROC {
 
     OPENCL_DEVICE_PROP opencl_prop;
 
+    COPROC(int){}
+    inline void clear() {
+        static const COPROC x(0);
+        *this = x;
+    }
+    COPROC(){
+        clear();
+    }
+
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc=false);
     void write_request(MIOFILE&);
 #endif
     int parse(XML_PARSER&);
 
-    inline void clear() {
-        // can't just memcpy() - trashes vtable
-        type[0] = 0;
-        count = 0;
-        non_gpu = false;
-        peak_flops = 0;
-        used = 0;
-        have_cuda = false;
-        have_cal = false;
-        have_opencl = false;
-        specified_in_config = false;
-        req_secs = 0;
-        req_instances = 0;
-        opencl_device_count = 0;
-        estimated_delay = 0;
-        available_ram = 0;
-        for (int i=0; i<MAX_COPROC_INSTANCES; i++) {
-            device_nums[i] = 0;
-            instance_has_opencl[i] = false;
-            opencl_device_ids[i] = 0;
-            opencl_device_indexes[i] = 0;
-            running_graphics_app[i] = true;
-        }
-        device_num = 0;
-        memset(&opencl_prop, 0, sizeof(opencl_prop));
-        memset(&pci_info, 0, sizeof(pci_info));
-        last_print_time = 0;
-    }
     inline void clear_usage() {
         for (int i=0; i<count; i++) {
             usage[i] = 0;
             pending_usage[i] = 0;
         }
-    }
-    COPROC() {
-        clear();
     }
     int device_num_index(int n) {
         for (int i=0; i<count; i++) {
@@ -296,6 +282,15 @@ struct CUDA_DEVICE_PROP {
     double   textureAlignment;
     int   deviceOverlap;
     int   multiProcessorCount;
+
+    CUDA_DEVICE_PROP(int){}
+    void clear() {
+        static const CUDA_DEVICE_PROP x(0);
+        *this = x;
+    }
+    CUDA_DEVICE_PROP() {
+        clear();
+    }
 };
 
 typedef int CUdevice;
@@ -309,9 +304,7 @@ struct COPROC_NVIDIA : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
-    COPROC_NVIDIA(): COPROC() {
-        clear();
-    }
+    COPROC_NVIDIA(): COPROC() {}
     void get(std::vector<std::string>& warnings);
     void correlate(
         bool use_all,
@@ -346,9 +339,7 @@ struct COPROC_ATI : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
-    COPROC_ATI(): COPROC() {
-        clear();
-    }
+    COPROC_ATI(): COPROC() {}
     void get(std::vector<std::string>& warnings);
     void correlate(
         bool use_all,
@@ -370,9 +361,7 @@ struct COPROC_INTEL : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
-    COPROC_INTEL(): COPROC() {
-        clear();
-    }
+    COPROC_INTEL(): COPROC() {}
     void get(std::vector<std::string>& warnings);
     void correlate(
         bool use_all,

--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -740,7 +740,7 @@ char *check_validity(
     char file[MAXPATHLEN];
     while (!dir_scan(file, dir, sizeof(file))) {
         char fpath[MAXPATHLEN];
-        snprintf(fpath, sizeof(fpath), "%s/%s", certPath, file);
+        snprintf(fpath, sizeof(fpath), "%.*s/%.*s", DIR_LEN, certPath, FILE_LEN, file);
         // TODO : replace '128'  
         if (check_validity_of_cert(fpath, md5_md, signature, 128, caPath)) {
             dir_close(dir);

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -696,7 +696,7 @@ extern "C" void boinc_set_signal_handler(int sig, handler_t handler) {
     struct sigaction temp;
     sigaction(sig, NULL, &temp);
     if (temp.sa_handler != SIG_IGN) {
-        temp.sa_handler = (void (*)(int))handler;
+        temp.sa_sigaction = handler;
         sigaction(sig, &temp, NULL);
     }
 #else
@@ -755,7 +755,7 @@ static char *xtoa(size_t x) {
 #ifdef ANDROID_VOODOO
 void boinc_catch_signal(int signal, struct siginfo *siginfo, void *sigcontext) {
 #else
-void boinc_catch_signal(int signal, struct siginfo *, void *) {
+void boinc_catch_signal(int signal, siginfo_t*, void *) {
 #endif  // ANDROID
 #else
 void boinc_catch_signal(int signal) {

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -83,7 +83,6 @@ static _CrtMemState difference_snapshot;
 
 #endif
 
-
 static int         diagnostics_initialized = false;
 static int         flags;
 static char        stdout_log[MAXPATHLEN];
@@ -295,10 +294,10 @@ int diagnostics_init(
             boinc_mkdir(user_dir);
         }
 
-        snprintf(stdout_log, sizeof(stdout_log), "%s/%s.txt", user_dir, stdout_prefix);
-        snprintf(stdout_archive, sizeof(stdout_archive), "%s/%s.old", user_dir, stdout_prefix);
-        snprintf(stderr_log, sizeof(stderr_log), "%s/%s.txt", user_dir, stderr_prefix);
-        snprintf(stderr_archive, sizeof(stderr_archive), "%s/%s.old", user_dir, stderr_prefix);
+        snprintf(stdout_log, sizeof(stdout_log), "%.*s/%.*s.txt", DIR_LEN, user_dir, FILE_LEN, stdout_prefix);
+        snprintf(stdout_archive, sizeof(stdout_archive), "%.*s/%.*s.old", DIR_LEN, user_dir, FILE_LEN, stdout_prefix);
+        snprintf(stderr_log, sizeof(stderr_log), "%.*s/%.*s.txt", DIR_LEN, user_dir, FILE_LEN, stderr_prefix);
+        snprintf(stderr_archive, sizeof(stderr_archive), "%.*s/%.*s.old", DIR_LEN, user_dir, FILE_LEN, stderr_prefix);
 
     } else {
 

--- a/lib/diagnostics.h
+++ b/lib/diagnostics.h
@@ -129,8 +129,8 @@ extern UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID lpParameter);
 extern LONG CALLBACK boinc_catch_signal(EXCEPTION_POINTERS *ExceptionInfo);
 #else
 #ifdef HAVE_SIGACTION
-typedef void (*handler_t)(int, struct siginfo *, void *);
-extern void boinc_catch_signal(int signal, struct siginfo *siginfo, void *sigcontext);
+typedef void (*handler_t)(int, siginfo_t*, void *);
+extern void boinc_catch_signal(int signal, siginfo_t *siginfo, void *sigcontext);
 #else
 typedef void (*handler_t)(int);
 extern void boinc_catch_signal(int signal);

--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -403,7 +403,7 @@ int clean_out_dir(const char* dirpath) {
         retval = dir_scan(filename, dirp, sizeof(filename));
         if (retval) break;
 
-        snprintf(path, sizeof(path), "%s/%s", dirpath,  filename);
+        snprintf(path, sizeof(path), "%.*s/%.*s", DIR_LEN, dirpath, FILE_LEN, filename);
         path[sizeof(path)-1] = 0;
 
         clean_out_dir(path);
@@ -443,7 +443,7 @@ int dir_size(const char* dirpath, double& size, bool recurse) {
 
             dsize = 0.0;
 
-            snprintf(buf, sizeof(buf), "%s/%s", dirpath, findData.cFileName);
+            snprintf(buf, sizeof(buf), "%.*s/%.*s", DIR_LEN, dirpath, FILE_LEN, findData.cFileName);
             buf[sizeof(buf)-1] = 0;
 
             dir_size(buf, dsize, true);
@@ -467,7 +467,7 @@ int dir_size(const char* dirpath, double& size, bool recurse) {
         retval = dir_scan(filename, dirp, sizeof(filename));
         if (retval) break;
 
-        snprintf(subdir, sizeof(subdir), "%s/%s", dirpath, filename);
+        snprintf(subdir, sizeof(subdir), "%.*s/%.*s", DIR_LEN, dirpath, FILE_LEN, filename);
         subdir[sizeof(subdir)-1] = 0;
 
         if (is_dir(subdir)) {
@@ -773,7 +773,7 @@ int boinc_make_dirs(const char* dirpath, const char* filepath) {
         p = strchr(q, '/');
         if (!p) break;
         *p = 0;
-        snprintf(newpath, sizeof(newpath), "%s/%s", oldpath, q);
+        snprintf(newpath, sizeof(newpath), "%.*s/%.*s", DIR_LEN, oldpath, FILE_LEN, q);
         newpath[sizeof(newpath)-1] = 0;
         retval = boinc_mkdir(newpath);
         if (retval) return retval;

--- a/lib/filesys.h
+++ b/lib/filesys.h
@@ -36,6 +36,11 @@
 #define MAXPATHLEN 4096
 #endif
 
+// use the following in format codes in snprintf
+//
+#define DIR_LEN 2048
+#define FILE_LEN 256
+
 #define FILE_RETRY_INTERVAL 5
     // On Windows, retry for this period of time, since some other program
     // (virus scan, defrag, index) may have the file open.

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -269,7 +269,7 @@ int RPC_CLIENT::init_unix_domain() {
 int RPC_CLIENT::authorize(const char* passwd) {
     bool found=false, authorized;
     int retval, n;
-    char nonce[256], nonce_hash[256], buf[256];
+    char nonce[256], nonce_hash[256], buf[1024];
     RPC rpc(this);
     XML_PARSER xp(&rpc.fin);
 

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -660,6 +660,7 @@ struct OLD_RESULT {
     double completed_time;
     double create_time;
 
+    OLD_RESULT(){}
     int parse(XML_PARSER&);
     void print();
 };

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -83,7 +83,8 @@ using std::vector;
 using std::sort;
 
 int OLD_RESULT::parse(XML_PARSER& xp) {
-    memset(this, 0, sizeof(OLD_RESULT));
+    static const OLD_RESULT x;
+    *this = x;
     while (!xp.get_tag()) {
         if (xp.match_tag("/old_result")) return 0;
         if (xp.parse_str("project_url", project_url, sizeof(project_url))) continue;
@@ -99,7 +100,8 @@ int OLD_RESULT::parse(XML_PARSER& xp) {
 }
 
 int TIME_STATS::parse(XML_PARSER& xp) {
-    memset(this, 0, sizeof(TIME_STATS));
+    static const TIME_STATS x;
+    *this = x;
     while (!xp.get_tag()) {
         if (xp.match_tag("/time_stats")) return 0;
         if (xp.parse_double("now", now)) continue;
@@ -588,7 +590,8 @@ int APP_VERSION::parse(XML_PARSER& xp) {
 }
 
 void APP_VERSION::clear() {
-    memset(this, 0, sizeof(*this));
+    static const APP_VERSION x;
+    *this = x;
 }
 
 WORKUNIT::WORKUNIT() {
@@ -1049,7 +1052,7 @@ void CC_STATE::clear() {
     results.clear();
     platforms.clear();
     executing_as_daemon = false;
-    host_info.clear_host_info();
+    host_info.clear();
     have_nvidia = false;
     have_ati = false;
 }
@@ -1480,7 +1483,8 @@ int RPC_CLIENT::exchange_versions(string client_name, VERSION_INFO& server) {
 
     retval = rpc.do_rpc(buf);
     if (!retval) {
-        memset(&server, 0, sizeof(server));
+        static const VERSION_INFO x;
+        server = x;
         while (rpc.fin.fgets(buf, 256)) {
             if (match_tag(buf, "</server_version>")) break;
             else if (parse_int(buf, "<major>", server.major)) continue;

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -39,50 +39,8 @@
 
 #include "hostinfo.h"
 
-HOST_INFO::HOST_INFO() {
-    clear_host_info();
-}
-
-void HOST_INFO::clear_host_info() {
-    timezone = 0;
-    safe_strcpy(domain_name, "");
-    safe_strcpy(serialnum, "");
-    safe_strcpy(ip_addr, "");
-    safe_strcpy(host_cpid, "");
-
-    p_ncpus = 0;
-    safe_strcpy(p_vendor, "");
-    safe_strcpy(p_model, "");
-    safe_strcpy(p_features, "");
-    p_fpops = 0;
-    p_iops = 0;
-    p_membw = 0;
-    p_calculated = 0;
-    p_vm_extensions_disabled = false;
-
-    m_nbytes = 0;
-    m_cache = 0;
-    m_swap = 0;
-
-    d_total = 0;
-    d_free = 0;
-
-    safe_strcpy(os_name, "");
-    safe_strcpy(os_version, "");
-
-    wsl_available = false;
-#ifdef _WIN64
-    wsls.clear();
-#endif
-
-    safe_strcpy(product_name, "");
-    safe_strcpy(mac_address, "");
-
-    safe_strcpy(virtualbox_version, "");
-    num_opencl_cpu_platforms = 0;
-}
-
 int HOST_INFO::parse(XML_PARSER& xp, bool static_items_only) {
+    clear();
     while (!xp.get_tag()) {
         if (xp.match_tag("/host_info")) return 0;
         if (xp.parse_double("p_fpops", p_fpops)) {

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -95,7 +95,12 @@ public:
     int num_opencl_cpu_platforms;
     OPENCL_CPU_PROP opencl_cpu_prop[MAX_OPENCL_CPU_PLATFORMS];
 
-    HOST_INFO();
+    HOST_INFO(int){}
+    HOST_INFO(){}
+    void clear() {
+        static const HOST_INFO x(0);
+        *this = x;
+    }
     int parse(XML_PARSER&, bool static_items_only = false);
     int write(MIOFILE&, bool include_net_info, bool include_coprocs);
     int parse_cpu_benchmarks(FILE*);
@@ -117,7 +122,6 @@ public:
     int get_host_battery_state();
     int get_local_network_info();
     int get_virtualbox_version();
-    void clear_host_info();
     void make_random_string(const char* salt, char* out);
     void generate_host_cpid();
     static bool parse_linux_os_info(FILE* file, const LINUX_OS_INFO_PARSER parser,

--- a/lib/mfile.cpp
+++ b/lib/mfile.cpp
@@ -88,7 +88,7 @@ int MFILE::vprintf(const char* format, va_list ap) {
         );
         exit(1);
     }
-    strncpy(buf+len, buf2, n);
+    strncpy(buf+len, buf2, n+1);
     len += n;
     buf[len] = 0;
     return k;
@@ -142,7 +142,7 @@ int MFILE::puts(const char* p) {
         );
         exit(1);
     }
-    strncpy(buf+len, p, n);
+    strncpy(buf+len, p, n+1);
     len += n;
     buf[len] = 0;
     return n;

--- a/lib/opencl_boinc.cpp
+++ b/lib/opencl_boinc.cpp
@@ -265,14 +265,14 @@ int OPENCL_DEVICE_PROP::get_opencl_driver_revision() {
 }
 
 void OPENCL_DEVICE_PROP::description(char* buf, int buflen, const char* type) {
-    char s1[256], s2[256];
+    char s1[256], s2[1024];
     int n;
     // openCL_device_version may have a trailing space
     strlcpy(s1, opencl_device_version, sizeof(s1));
     n = (int)strlen(s1) - 1;
     if ((n > 0) && (s1[n] == ' ')) s1[n] = '\0';
     snprintf(s2, sizeof(s2),
-        "%s (driver version %s, device version %s, %.0fMB, %.0fMB available, %.0f GFLOPS peak)",
+        "%.64s (driver version %.64s, device version %.64s, %.0fMB, %.0fMB available, %.0f GFLOPS peak)",
         name, opencl_driver_version,
         s1, global_mem_size/MEGA,
         opencl_available_ram/MEGA, peak_flops/1.e9

--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -85,8 +85,10 @@ struct OPENCL_DEVICE_PROP {
 #endif
     int parse(XML_PARSER&, const char* end_tag);
     void description(char* buf, int buflen, const char* type);
+    OPENCL_DEVICE_PROP(){}
     void clear() {
-        memset(this, 0, sizeof(*this));
+        static const OPENCL_DEVICE_PROP x;
+        *this = x;
     }
 };
 

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -915,7 +915,7 @@ int XML_PARSER::copy_element(string& out) {
     out = "<";
     out += parsed_tag;
     out += ">";
-    snprintf(end_tag, sizeof(end_tag), "</%s>", parsed_tag);
+    snprintf(end_tag, sizeof(end_tag), "</%.256s>", parsed_tag);
     int retval = element_contents(end_tag, buf, sizeof(buf));
     if (retval) return retval;
     out += buf;

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -38,14 +38,6 @@
 
 #include "prefs.h"
 
-GLOBAL_PREFS_MASK::GLOBAL_PREFS_MASK() {
-    clear();
-}
-
-void GLOBAL_PREFS_MASK::clear() {
-    memset(this, 0, sizeof(GLOBAL_PREFS_MASK));
-}
-
 void GLOBAL_PREFS_MASK::set_all() {
     battery_charge_min_pct = true;
     battery_max_temperature = true;
@@ -267,7 +259,6 @@ void GLOBAL_PREFS::defaults() {
     // mod_time, host_specific here
     // since they are outside of <venue> elements,
     // and this is called when find the right venue.
-    // Also, don't memset to 0
 }
 
 // values for fields with an enabling checkbox in the GUI.

--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -71,8 +71,14 @@ struct GLOBAL_PREFS_MASK {
     bool work_buf_additional_days;
     bool work_buf_min_days;
 
-    GLOBAL_PREFS_MASK();
-    void clear();
+    GLOBAL_PREFS_MASK(int){}
+    void clear() {
+        static const GLOBAL_PREFS_MASK x(0);
+        *this = x;
+    }
+    GLOBAL_PREFS_MASK() {
+        clear();
+    }
     bool are_prefs_set();
     bool are_simple_prefs_set();
     void set_all();
@@ -104,11 +110,10 @@ struct TIME_SPAN {
 struct WEEK_PREFS {
     TIME_SPAN days[7];
 
+    WEEK_PREFS() {}
     void clear() {
-        memset(this, 0, sizeof(WEEK_PREFS));
-    }
-    WEEK_PREFS() {
-        clear();
+        static const WEEK_PREFS init;
+        *this = init;
     }
 
     void set(int day, double start, double end);

--- a/lib/proxy_info.cpp
+++ b/lib/proxy_info.cpp
@@ -22,7 +22,8 @@
 #include "proxy_info.h"
 
 int PROXY_INFO::parse(XML_PARSER& xp) {
-    memset(this, 0, sizeof(PROXY_INFO));
+    static const PROXY_INFO x;
+    *this = x;
     while (!xp.get_tag()) {
         if (xp.match_tag("/proxy_info")) {
             present = false;

--- a/lib/remote_submit.cpp
+++ b/lib/remote_submit.cpp
@@ -600,7 +600,8 @@ int query_batch_set(
 }
 
 int BATCH_STATUS::parse(XML_PARSER& xp) {
-    memset(this, 0, sizeof(BATCH_STATUS));
+    static const BATCH_STATUS x;
+    *this = x;
     while (!xp.get_tag()) {
         if (xp.match_tag("/batch")) {
             return 0;
@@ -710,7 +711,8 @@ int query_batches(
 }
 
 int JOB_STATE::parse(XML_PARSER& xp) {
-    memset(this, 0, sizeof(JOB_STATE));
+    static const JOB_STATE x;
+    *this = x;
     while (!xp.get_tag()) {
         if (xp.match_tag("/job")) {
             return 0;

--- a/lib/remote_submit.h
+++ b/lib/remote_submit.h
@@ -209,6 +209,7 @@ struct BATCH_STATUS {
     double credit_estimate;     // original estimate for credit
     double credit_canonical;    // if completed, granted credit
 
+    BATCH_STATUS(){}
     int parse(XML_PARSER&);
     void print();
 };
@@ -229,6 +230,7 @@ struct JOB_STATE {
                                     // the ID of the canonical instance
     int n_outfiles;                 // number of output files
 
+    JOB_STATE(){}
     int parse(XML_PARSER&);
     void print();
 };


### PR DESCRIPTION
Instead: declare a static const instance (whose data members are zero)
and copy that.
This avoid the error-prone need to assign each member,
and it works even if there are virtual function tables.
