### PR TITLE
Mac: Fix computation of non_BOINC CPU usage

### DIFF
--- a/lib/procinfo_mac.cpp
+++ b/lib/procinfo_mac.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -140,7 +140,7 @@ int procinfo_setup(PROC_MAP& pm) {
         // incorrect results for the % CPU used.
         p.is_low_priority = false;
 
-        if (!strcasestr(p.command, brandName[iBrandID])) {
+        if (strcasestr(p.command, brandName[iBrandID])) {
             p.is_boinc_app = true;
         }
 


### PR DESCRIPTION
Fixes a long-standing bug which caused non-BOINC CPU usage to always be computed as zero on Macs.
