### PR TITLE
mac: Fixes for screensaver under OS 10.15 Catalina

### DIFF
--- a/api/graphics2_unix.cpp
+++ b/api/graphics2_unix.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -46,8 +46,10 @@ static int win=0;
 static int checkparentcounter=0;
 
 #ifdef __APPLE__
-
 static bool need_show = false;
+
+// Set to true to draw both directly to window and also to offscreen buffer
+bool debugSharedOffscreenBuffer = false;
 #endif
 
 bool fullscreen;
@@ -119,7 +121,7 @@ static void maybe_render() {
 
     if (throttled_app_render(new_width, new_height, dtime())) {
 #ifdef __APPLE__
-        if (UseSharedOffscreenBuffer()) {
+        if (UseSharedOffscreenBuffer() && !debugSharedOffscreenBuffer) {
             return; // Don't waste cycles drawing to hidden window on screen
         }
 #endif

--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -1,6 +1,6 @@
 // Berkeley Open Infrastructure for Network Computing
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2019 University of California
 //
 // This is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -285,7 +285,6 @@ kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, uin
 	{
 		if(clientPortNames[i])
 		{
-            // print_to_log_file("BOINCSCR: about to call _MGCDisplayFrame  with iosurface_port %d, IOSurfaceGetID %d and frameIndex %d", (int)iosurface_port, IOSurfaceGetID(ioSurfaceBuffers[index]), (int)index);
 			_MGCDisplayFrame(clientPortNames[i], index, iosurface_port);
 		}
 	}
@@ -293,24 +292,31 @@ kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, uin
 @end
 
 
+// OpenGL apps built under Xcode 11 under Catalina apparently use window 
+// dimensions based on the number of backing store pixels. That is, they 
+// double the window dimensiona for Retina displays (which have two pixels 
+// per point.) But OpenGL apps built under earlier versions of Xcode don't.
+// Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
+// older builds at half width and height, unless we compensate in our code.
+// This code is part of my attempt to ensure that BOINC graphics apps built on 
+// all versions of Xcode work proprly on different versions of OS X. See also 
+// [BOINC_Saver_ModuleView initWithFrame:] in clientscr/Mac_Saver_ModuleCiew.m
+//
 void MacPassOffscreenBufferToScreenSaver() {
     NSOpenGLContext * myContext = [ NSOpenGLContext currentContext ];
-    NSView *myView = [ myContext view ];
-    GLsizei w = myView.bounds.size.width;
-    GLsizei h = myView.bounds.size.height;
-
+    int viewportRect[4];
+    GLsizei w, h;
     GLuint name, namef;
+
+    glGetIntegerv(GL_VIEWPORT, (GLint*)viewportRect);
+    w = viewportRect[2];
+    h = viewportRect[3];
 
     if (!myserverController) {
         myserverController = [[[ServerController alloc] init] retain];
     }
 
     if (!ioSurfaceBuffers[0]) {
-        NSOpenGLContext * myContext = [ NSOpenGLContext currentContext ];
-        NSView *myView = [ myContext view ];
-        GLsizei w = myView.bounds.size.width;
-        GLsizei h = myView.bounds.size.height;
-
         // Set up all of our iosurface buffers
         for(int i = 0; i < NUM_IOSURFACE_BUFFERS; i++) {
             ioSurfaceBuffers[i] = IOSurfaceCreate((CFDictionaryRef)@{

--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -292,14 +292,14 @@ kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, uin
 @end
 
 
-// OpenGL apps built under Xcode 11 under Catalina apparently use window 
-// dimensions based on the number of backing store pixels. That is, they 
-// double the window dimensiona for Retina displays (which have two pixels 
-// per point.) But OpenGL apps built under earlier versions of Xcode don't.
-// Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
-// older builds at half width and height, unless we compensate in our code.
-// This code is part of my attempt to ensure that BOINC graphics apps built on 
-// all versions of Xcode work proprly on different versions of OS X. See also 
+// Under OS 10.15 Catalina, OpenGL apps apparently use window dimensions 
+// based on the number of backing store pixels. That is, they double the 
+// window dimensions for Retina displays (which have two pixels per point.) 
+// But OpenGL apps running under earlier versions of OS X don't. As a 
+// result, Catalina displays BOINC graphics at half width and height 
+// unless we compensate in our code.
+// This code is part of my attempt to ensure that BOINC graphics apps are 
+// displayed properly on different versions of OS X. See also 
 // [BOINC_Saver_ModuleView initWithFrame:] in clientscr/Mac_Saver_ModuleCiew.m
 //
 void MacPassOffscreenBufferToScreenSaver() {

--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -292,14 +292,14 @@ kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, uin
 @end
 
 
-// Under OS 10.15 Catalina, OpenGL apps apparently use window dimensions 
-// based on the number of backing store pixels. That is, they double the 
-// window dimensions for Retina displays (which have two pixels per point.) 
-// But OpenGL apps running under earlier versions of OS X don't. As a 
-// result, Catalina displays BOINC graphics at half width and height 
-// unless we compensate in our code.
-// This code is part of my attempt to ensure that BOINC graphics apps are 
-// displayed properly on different versions of OS X. See also 
+// OpenGL apps built under Xcode 11 apparently use window dimensions based 
+// on the number of backing store pixels. That is, they double the window 
+// dimensiona for Retina displays (which have two pixels per point.) But 
+// OpenGL apps built under earlier versions of Xcode don't.
+// Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
+// older builds at half width and height, unless we compensate in our code.
+// This code is part of my attempt to ensure that BOINC graphics apps built on 
+// all versions of Xcode work proprly on different versions of OS X. See also 
 // [BOINC_Saver_ModuleView initWithFrame:] in clientscr/Mac_Saver_ModuleCiew.m
 //
 void MacPassOffscreenBufferToScreenSaver() {

--- a/api/x_opengl.h
+++ b/api/x_opengl.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -30,6 +30,7 @@ extern void MacPassOffscreenBufferToScreenSaver(void);
 extern void BringAppToFront(void);
 extern void HideThisApp(void);
 extern bool UseSharedOffscreenBuffer(void);
+extern bool debugSharedOffscreenBuffer;
 
 extern void print_to_log_file(const char *format, ...);
 

--- a/client/app.h
+++ b/client/app.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -173,6 +173,8 @@ struct ACTIVE_TASK {
     double finish_file_time;
         // time when we saw finish file in slot dir.
         // Used to kill apps that hang after writing finished file
+    int graphics_pid;
+        // PID of running graphics app (Mac)
 
     void set_task_state(int, const char*);
     inline int task_state() {
@@ -302,6 +304,7 @@ public:
     active_tasks_v active_tasks;
     ACTIVE_TASK* lookup_pid(int);
     ACTIVE_TASK* lookup_result(RESULT*);
+    ACTIVE_TASK* lookup_slot(int);
     void init();
     bool poll();
     void suspend_all(int reason);

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -93,7 +93,10 @@ Commands:\n\
  --read_cc_config\n\
  --read_global_prefs_override\n\
  --run_benchmarks\n\
- --set_gpu_mode mode duration       set GPU run mode for given duration\n\
+ --run_graphics_app id op         run, test or stop graphics app\n\
+   op = run | runfullscreen | stop | test\n\
+   id = slot # for run or runfullscreen, process ID for stop or test\n\
+   --set_gpu_mode mode duration       set GPU run mode for given duration\n\
    mode = always | auto | never\n\
  --set_host_info product_name\n\
  --set_network_mode mode duration   set network mode for given duration\n\
@@ -542,6 +545,18 @@ int main(int argc, char** argv) {
         retval = rpc.acct_mgr_rpc("", "", "");
     } else if (!strcmp(cmd, "--run_benchmarks")) {
         retval = rpc.run_benchmarks();
+    } else if (!strcmp(cmd, "--run_graphics_app")) {
+        int slot = 0;
+        if (!strcmp(argv[3], "test") || (!strcmp(argv[3], "stop"))) {
+            i = atoi(argv[2]);
+        } else {
+            slot = atoi(argv[2]);
+            i = 0;
+        }
+        retval = rpc.run_graphics_app(slot, i, argv[3]);
+        if (strcmp(argv[3], "stop") & !retval) {
+            printf("pid: %d\n", i);
+        }
     } else if (!strcmp(cmd, "--get_project_config")) {
         char* gpc_url = next_arg(argc, argv,i);
         retval = rpc.get_project_config(string(gpc_url));

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -332,3 +332,22 @@ ACTIVE_TASK* ACTIVE_TASK_SET::lookup_slot(int slot) {
     }
     return NULL;
 }
+
+#ifndef SIM
+// on startup, see if any active tasks have a finished file
+// i.e. they finished as the client was shutting down
+//
+void ACTIVE_TASK_SET::check_for_finished_jobs() {
+    for (unsigned int i=0; i<active_tasks.size(); i++) {
+        ACTIVE_TASK* atp = active_tasks[i];
+        int exit_code;
+        if (atp->finish_file_present(exit_code)) {
+            msg_printf(atp->wup->project, MSG_INFO,
+                "Found finish file for %s; exit code %d",
+                atp->result->name, exit_code
+            );
+            atp->handle_exited_app(exit_code);
+        }
+    }
+}
+#endif

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -304,11 +304,8 @@ int CLIENT_STATE::latest_version(APP* app, char* platform) {
 // Find the ACTIVE_TASK in the current set with the matching PID
 //
 ACTIVE_TASK* ACTIVE_TASK_SET::lookup_pid(int pid) {
-    unsigned int i;
-    ACTIVE_TASK* atp;
-
-    for (i=0; i<active_tasks.size(); i++) {
-        atp = active_tasks[i];
+    for (unsigned int i=0; i<active_tasks.size(); i++) {
+        ACTIVE_TASK *atp = active_tasks[i];
         if (atp->pid == pid) return atp;
     }
     return NULL;
@@ -317,11 +314,8 @@ ACTIVE_TASK* ACTIVE_TASK_SET::lookup_pid(int pid) {
 // Find the ACTIVE_TASK in the current set with the matching result
 //
 ACTIVE_TASK* ACTIVE_TASK_SET::lookup_result(RESULT* result) {
-    unsigned int i;
-    ACTIVE_TASK* atp;
-
-    for (i=0; i<active_tasks.size(); i++) {
-        atp = active_tasks[i];
+    for (unsigned int i=0; i<active_tasks.size(); i++) {
+        ACTIVE_TASK *atp = active_tasks[i];
         if (atp->result == result) {
             return atp;
         }
@@ -329,21 +323,12 @@ ACTIVE_TASK* ACTIVE_TASK_SET::lookup_result(RESULT* result) {
     return NULL;
 }
 
-#ifndef SIM
-// on startup, see if any active tasks have a finished file
-// i.e. they finished as the client was shutting down
-//
-void ACTIVE_TASK_SET::check_for_finished_jobs() {
+ACTIVE_TASK* ACTIVE_TASK_SET::lookup_slot(int slot) {
     for (unsigned int i=0; i<active_tasks.size(); i++) {
-        ACTIVE_TASK* atp = active_tasks[i];
-        int exit_code;
-        if (atp->finish_file_present(exit_code)) {
-            msg_printf(atp->wup->project, MSG_INFO,
-                "Found finish file for %s; exit code %d",
-                atp->result->name, exit_code
-            );
-            atp->handle_exited_app(exit_code);
+        ACTIVE_TASK *atp = active_tasks[i];
+        if (atp->slot == slot) {
+            return atp;
         }
     }
+    return NULL;
 }
-#endif

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -22,6 +22,7 @@
 #ifdef __APPLE__
 #include <Carbon/Carbon.h>
 #include <libproc.h>
+#include "sandbox.h"
 #endif
 
 #ifdef _WIN32
@@ -1332,6 +1333,201 @@ static void handle_get_daily_xfer_history(GUI_RPC_CONN& grc) {
     daily_xfer_history.write_xml(grc.mfout);
 }
 
+// start, stop or get status of a graphics app on behalf of the screensaver.
+// (needed for Mac OS X 10.5+)
+//
+// <slot>n</slot> { <run/> | <runfullscreen/> }
+// <graphics_pid>p</graphics_pid> { <stop/> | <test/> }
+//
+// n is the slot number:
+//   if slot = -1, start the default screensaver
+// p is the process id to stop or test
+//   test returns 0 for the pid if it has exited, else returns the child's pid
+//
+// As of 3 November 2019, only the "stop" verb is being used, because the client 
+// can't launch or test gfx apps outside the user session within which the client
+// is running. So if another user is logged in and runs the screensaver, that
+// sure would not see the graphics. But I'm leaving code for all the verbs for 
+// now as a possible starting point for future development.
+//
+// The stop verb still works because it calls kill_via_switcher(), which calls 
+// kill(pid, SIGKILL) after setting user and group to pbionc_project. That does 
+// work across different login sessions.
+//
+static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
+#ifndef __APPLE__
+    grc.mfout.printf("<error>run_graphics_app RPC is currently available only on Mac OS</error>\n");
+#else
+    static int boincscr_pid = 0;
+    bool run = false;
+    bool runfullscreen = false;
+    bool stop = false;
+    bool test = false;
+    int slot = -2, retval;
+    int status;
+    pid_t p;
+    char* argv[5];
+    int argc;
+    int thePID = 0;
+
+    while (!grc.xp.get_tag()) {
+        if (grc.xp.match_tag("/run_graphics_app")) break;
+        if (grc.xp.parse_int("slot", slot)) continue;
+        if (grc.xp.parse_bool("run", run)) continue;
+        if (grc.xp.parse_bool("runfullscreen", runfullscreen)) continue;
+        if (grc.xp.parse_bool("stop", stop)) continue;
+        if (grc.xp.parse_bool("test", test)) continue;
+        if (grc.xp.parse_int("graphics_pid", thePID)) continue;
+    }
+    
+    if (stop || test) {
+        if (thePID < 1) {
+            grc.mfout.printf("<error>missing or invalid process id</error>\n");
+            return;
+        }
+    } else if (run || runfullscreen) {
+        if (slot < -1) {
+            grc.mfout.printf("<error>missing or invalid slot</error>\n");
+            return;
+        }
+    } else {
+        grc.mfout.printf("<error>missing or invalid operation</error>\n");
+        return;
+    }
+
+    if (test) {
+        // returns 0 for the pid if it has exited, else returns the child's pid
+        p = waitpid(thePID, &status, WNOHANG);
+        if (p != 0) thePID = 0;
+        grc.mfout.printf(
+            "<graphics_pid>%d</graphics_pid>\n",
+            thePID
+        );
+        return;
+    }
+
+    if (stop) {
+        if (g_use_sandbox && (thePID != boincscr_pid )) {
+            retval = kill_via_switcher(thePID);
+        } else {
+            retval = kill_program(thePID);
+        }
+        if (retval) {
+            grc.mfout.printf("<error>attempt to kill graphics app failed</error>\n");
+            return;
+        }
+        if (thePID == boincscr_pid) boincscr_pid = 0;
+        grc.mfout.printf("<success/>\n");
+        return;
+    }
+
+    // start boincscr
+    //
+    if (slot == -1) {
+        char path[MAXPATHLEN];
+
+#ifdef __APPLE__
+        safe_strcpy(path, "./boincscr");
+#else
+        if (get_real_executable_path(path, sizeof(path))) {
+            grc.mfout.printf("<error>can't get client path</error>\n");
+            return;
+        }
+        char *p = strrchr(path, '/');
+        if (!p) {
+            grc.mfout.printf("<error>no / in client path</error>\n");
+            return;
+        }
+        safe_strcpy(p, "/boincscr");
+#endif
+        argv[0] = (char*)"boincscr";
+        if (runfullscreen) {
+            argv[1] = (char*)"--fullscreen";
+            argc = 2;
+        } else {
+            argv[1] = 0;
+            argc = 1;
+        }
+        argv[2] = 0;
+        retval = run_program(NULL, path, argc, argv, 0, boincscr_pid);
+    
+        if (retval) {
+            grc.mfout.printf("<error>couldn't run boincscr</error>\n");
+            return;
+        }
+        grc.mfout.printf(
+            "<graphics_pid>%d</graphics_pid>\n",
+            boincscr_pid
+        );
+        return;
+    }   // end if (slot == -1)
+
+    // start a graphics app
+    //
+    ACTIVE_TASK* atp = gstate.active_tasks.lookup_slot(slot);
+    if (!atp) {
+        grc.mfout.printf("<error>no job in slot</error>\n");
+        return;
+    }
+    if (atp->scheduler_state != CPU_SCHED_SCHEDULED) {
+        grc.mfout.printf("<error>job not running</error>\n");
+        return;
+    }
+    if (!strlen(atp->app_version->graphics_exec_path)) {
+        grc.mfout.printf("<error>job has no graphics app</error>\n");
+        return;
+    }
+
+    if (g_use_sandbox) {
+        char current_dir[MAXPATHLEN], switcher_path[MAXPATHLEN];
+        getcwd( current_dir, sizeof(current_dir));
+        snprintf(switcher_path, sizeof(switcher_path), 
+            "%s/%s/%s",
+            current_dir, SWITCHER_DIR, SWITCHER_FILE_NAME
+        );
+        argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
+        argv[1] = atp->app_version->graphics_exec_path;
+        argv[2] = atp->app_version->graphics_exec_file;
+        if (runfullscreen) {
+            argv[3] = (char*)"--fullscreen";
+            argc = 3;
+        } else {
+            argv[3] = 0;
+            argc = 2;
+        }
+        argv[4] = 0;
+        retval = run_program(
+            atp->slot_path, switcher_path,
+            argc, argv, 0, atp->graphics_pid
+        );
+    } else {    // not g_use_sandbox
+        argv[0] = atp->app_version->graphics_exec_file;
+        if (runfullscreen) {
+            argv[1] = (char*)"--fullscreen";
+            argc = 2;
+        } else {
+            argv[2] = 0;
+            argc = 1;
+        }
+        argv[2] = 0;
+        retval = run_program(
+            atp->slot_path, atp->app_version->graphics_exec_path,
+            argc, argv, 0, atp->graphics_pid
+        );
+    }
+    
+    if (retval) {
+        grc.mfout.printf("<error>couldn't run graphics app</error>\n");
+        return;
+    }
+    
+    grc.mfout.printf(
+        "<graphics_pid>%d</graphics_pid>\n",
+        atp->graphics_pid
+    );
+#endif  // __APPLE__
+}
+
 // We use a different authentication scheme for HTTP because
 // each request has its own connection.
 // Send clients an "authentication ID".
@@ -1599,6 +1795,7 @@ GUI_RPC gui_rpcs[] = {
     GUI_RPC("project_reset", handle_project_reset,                  true,   true,   false),
     GUI_RPC("project_update", handle_project_update,                true,   true,   false),
     GUI_RPC("retry_file_transfer", handle_retry_file_transfer,      true,   true,   false),
+    GUI_RPC("run_graphics_app", handle_run_graphics_app,            true,   true,   false),
 };
 
 // return nonzero only if we need to close the connection

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -56,8 +56,10 @@ int main(int /*argc*/, char** argv) {
     getcwd( current_dir, sizeof(current_dir));
     fprintf(stderr, "current directory = %s\n", current_dir);
 
-    for (int i=0; i<argc; i++) {
+    int i = 0;
+    while(argv[i]) {
         fprintf(stderr, "switcher arg %d: %s\n", i, argv[i]);
+        ++i;
     }
     fflush(stderr);
 #endif

--- a/clientscr/Mac_Saver_Module.h
+++ b/clientscr/Mac_Saver_Module.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -56,6 +56,10 @@ void            launchedGfxApp(char * appPath, pid_t thePID, int slot);
 void            print_to_log_file(const char *format, ...);
 void            strip_cr(char *buf);
 void            PrintBacktrace(void);
+extern bool     gIsMojave;
+extern bool     gIsCatalina;
+extern bool     gIsHighSierra;
+extern bool     gUseLaunchAgent;
 
 #ifdef __cplusplus
 }	// extern "C"
@@ -84,18 +88,18 @@ public:
     int             Create();
     int             Run();
 
-
     //
     // Infrastructure layer 
     //
 protected:
     OSStatus        initBOINCApp(void);
     int             GetBrandID(void);
-    char*           PersistentFGets(char *buf, size_t buflen, FILE *f);
-    pid_t           FindProcessPID(char* name, pid_t thePID);
+    pid_t           getClientPID(void);
     void            updateSSMessageText(char *msg);
     void            strip_cr(char *buf);
     char            m_gfx_Switcher_Path[PATH_MAX];
+    char            m_gfx_Cleanup_Path[PATH_MAX];
+    FILE*           m_gfx_Cleanup_IPC;
     void            SetDiscreteGPU(bool setDiscrete);
     void            CheckDualGPUPowerSource();
     bool            Host_is_running_on_batteries();
@@ -165,7 +169,7 @@ public:
     bool            SetError( bool bErrorMode, unsigned int hrError );
     void            setSSMessageText(const char *msg);
 
-    int             terminate_v6_screensaver(int& graphics_application);
+    int             terminate_v6_screensaver(int& graphics_application, RESULT* rp);
     bool            HasProcessExited(pid_t pid, int &exitCode);
 
     CC_STATE        state;

--- a/clientscr/Mac_Saver_ModuleView.h
+++ b/clientscr/Mac_Saver_ModuleView.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -94,6 +94,11 @@ void            launchedGfxApp(char * appPath, pid_t thePID, int slot);
 void            print_to_log_file(const char *format, ...);
 void            strip_cr(char *buf);
 void            PrintBacktrace(void);
+
+extern bool     gIsCatalina;
+extern bool     gIsHighSierra;
+extern bool     gIsMojave;
+extern bool     gUseLaunchAgent;
 
 #ifdef __cplusplus
 }    // extern "C"

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -218,14 +218,14 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
         myIsPreview = isPreview;
     }
     
-    // Under OS 10.15 Catalina, OpenGL apps apparently use window dimensions 
-    // based on the number of backing store pixels. That is, they double the 
-    // window dimensions for Retina displays (which have two pixels per point.) 
-    // But OpenGL apps running under earlier versions of OS X don't. As a 
-    // result, Catalina displays BOINC graphics at half width and height, 
-    // unless we compensate in our code.
-    // This code is part of my attempt to ensure that BOINC graphics apps are 
-    // displayed properly on different versions of OS X. See also 
+    // OpenGL apps built under Xcode 11 apparently use window dimensions based 
+    // on the number of backing store pixels. That is, they double the window 
+    // dimensiona for Retina displays (which have two pixels per point.) But 
+    // OpenGL apps built under earlier versions of Xcode don't.
+    // Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
+    // older builds at half width and height, unless we compensate in our code.
+    // This code is part of my attempt to ensure that BOINC graphics apps built on 
+    // all versions of Xcode work proprly on different versions of OS X. See also 
     // MacPassOffscreenBufferToScreenSaver() in lib/magglutfix.m for more info.
     //
     if (gIsCatalina) {

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -218,14 +218,14 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
         myIsPreview = isPreview;
     }
     
-    // OpenGL apps built under Xcode 11 under Catalina apparently use window 
-    // dimensions based on the number of backing store pixels. That is, they 
-    // double the window dimensiona for Retina displays (which have two pixels 
-    // per point.) But OpenGL apps built under earlier versions of Xcode don't.
-    // Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
-    // older builds at half width and height, unless we compensate in our code.
-    // This code is part of my attempt to ensure that BOINC graphics apps built on 
-    // all versions of Xcode work proprly on different versions of OS X. See also 
+    // Under OS 10.15 Catalina, OpenGL apps apparently use window dimensions 
+    // based on the number of backing store pixels. That is, they double the 
+    // window dimensions for Retina displays (which have two pixels per point.) 
+    // But OpenGL apps running under earlier versions of OS X don't. As a 
+    // result, Catalina displays BOINC graphics at half width and height, 
+    // unless we compensate in our code.
+    // This code is part of my attempt to ensure that BOINC graphics apps are 
+    // displayed properly on different versions of OS X. See also 
     // MacPassOffscreenBufferToScreenSaver() in lib/magglutfix.m for more info.
     //
     if (gIsCatalina) {

--- a/clientscr/gfx_cleanup.mm
+++ b/clientscr/gfx_cleanup.mm
@@ -1,0 +1,280 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2019 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+//
+//  gfx_cleanup.mm
+//
+// Used by screensaver to work around a bug in OS 10.15 Catalina
+// - Detects when ScreensaverEngine exits without calling [ScreenSaverView stopAnimation]
+// - If that happens, it sends RPC to BOINC client to kill current graphics app.
+// Note: this can rarely happen in earlier versions, but is of main concern under 
+// OS 10.13 and later, where it can cause an ugly white full-screen display
+//
+// Called by CScreensaver via popen(path, "w")
+//
+
+#import <Cocoa/Cocoa.h>
+
+#include <stdio.h>
+#include <pthread.h>
+
+#include "gui_rpc_client.h"
+#include "util.h"
+#include "mac_util.h"
+
+#define CREATE_LOG 0
+#define USE_TIMER 0
+
+#if CREATE_LOG
+void print_to_log_file(const char *format, ...);
+#endif
+
+pid_t parentPid;
+int GFX_PidFromScreensaver = 0;
+pthread_t MonitorParentThread = 0;
+bool quit_MonitorParentThread = false;
+
+#if USE_TIMER
+time_t startTime = 0;
+time_t endTime = 0;
+time_t elapsedTime = 0;
+#endif
+
+void killGfxApp(pid_t thePID) {
+    char passwd_buf[256];
+    RPC_CLIENT *rpc;
+    int retval;
+    
+    chdir("/Library/Application Support/BOINC Data");
+    safe_strcpy(passwd_buf, "");
+    read_gui_rpc_password(passwd_buf);
+    
+    rpc = new RPC_CLIENT;
+    if (rpc->init(NULL)) {     // Initialize communications with Core Client
+        fprintf(stderr, "in gfx_cleanup: killGfxApp(): rpc->init(NULL) failed");
+        return;
+    }
+    if (strlen(passwd_buf)) {
+        retval = rpc->authorize(passwd_buf);
+        if (retval) {
+            fprintf(stderr, "in gfx_cleanup: killGfxApp(): authorization failure: %d\n", retval);
+            rpc->close();
+            return;
+        }
+    }
+
+    retval = rpc->run_graphics_app(0, thePID, "stop");
+    // fprintf(stderr, "in gfx_cleanup: killGfxApp(): rpc->run_graphics_app() returned retval=%d", retval);   
+ 
+    rpc->close();
+}
+
+void * MonitorParent(void* param) {
+    // fprintf(stderr, "in gfx_cleanup: Starting MonitorParent");
+    while (true) {
+        boinc_sleep(0.25);  // Test every 1/4 second
+        if (getppid() != parentPid) {
+#if USE_TIMER
+            endTime = time(NULL);
+#endif
+            if (GFX_PidFromScreensaver) {
+                killGfxApp(GFX_PidFromScreensaver);
+            }
+            if (quit_MonitorParentThread) {
+                return 0;
+            }
+            // fprintf(stderr, "in gfx_cleanup: parent died, exiting (child) after handling %d, elapsed time=%d",GFX_PidFromScreensaver, (int) elapsedTime);
+            exit(0);
+        }
+    }
+
+}
+
+NSWindow* myWindow;
+
+@interface AppDelegate : NSObject <NSApplicationDelegate, NSUserNotificationCenterDelegate>
+{
+}
+@end
+
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification
+{
+    int retval = 0;
+    char buf[256];
+
+    retval = pthread_create(&MonitorParentThread, NULL, MonitorParent, 0);
+
+    while (true) {
+        fgets(buf, sizeof(buf), stdin);
+        // fprintf(stderr, "in gfx_cleanup: parent sent %d to child buf=%s", GFX_PidFromScreensaver, buf);
+        if (feof(stdin)) {
+            // fprintf(stderr, "in gfx_cleanup: got eof");
+            break;
+        }
+        if (ferror(stdin) && (errno != EINTR)) {
+            fprintf(stderr, "in gfx_cleanup: fgets got error %d %s", errno, strerror(errno));
+            break;
+        }
+
+        if (!strcmp(buf, "Quit\n")) {
+            break;
+        }
+        GFX_PidFromScreensaver = atoi(buf);
+        // fprintf(stderr, "in gfx_cleanup: parent sent %d to child buf=%s", GFX_PidFromScreensaver, buf);
+    }
+
+    if (GFX_PidFromScreensaver) {
+        killGfxApp(GFX_PidFromScreensaver);
+    }
+    
+    quit_MonitorParentThread = true;
+    
+//    [NSApp stop:self];
+    exit(0);
+    
+}
+@end
+
+int main(int argc, char* argv[]) {
+    // fprintf(stderr, "Entered gfx_cleanup");
+#if USE_TIMER
+    startTime = time(NULL);
+#endif
+    parentPid = getppid();
+
+    bool cover_gfx_window = (compareOSVersionTo(10, 13) >= 0);
+
+    // Create shared app instance
+    [NSApplication sharedApplication];
+
+     // Because prpject graphics applications under OS 10.13+ draw to an IOSurface, 
+    // the application's own window is white, but is normally covered by the 
+    // ScreensaverEngine's window. If the ScreensaverEngine exits without first
+    // calling [ScreenSaverView stopAnimation], the white fullscreen window will 
+    // briefly be visible until we kill the graphics app, causing an ugly and 
+    // annoying white flash. So we hide that with our own black fullscreen window
+    // to prevent the white flash.
+   if (cover_gfx_window) {
+        NSArray *allScreens = [NSScreen screens];
+        NSRect windowRect = [ allScreens[0] frame ];
+        NSUInteger windowStyle = NSWindowStyleMaskBorderless;
+        NSWindow *myWindow = [[NSWindow alloc] initWithContentRect:windowRect
+                                                       styleMask:windowStyle
+                                                         backing:NSBackingStoreBuffered
+                                                           defer:NO];
+        [myWindow setBackgroundColor:[NSColor blackColor]];
+        [ myWindow setLevel:kCGOverlayWindowLevel ];    // slightly above the graphics app's window
+        [myWindow orderFrontRegardless];
+    }
+
+    AppDelegate *myDelegate = [[AppDelegate alloc] init]; 
+    [ NSApp setDelegate:myDelegate];
+    
+    [NSApp run];
+
+#if USE_TIMER
+    endTime = time(NULL);
+    elapsedTime = endTime - startTime;
+#endif
+    // fprintf(stderr, "exiting gfx_cleanup after handling %d, elapsed time=%d",GFX_PidFromScreensaver, (int)elapsedTime);
+
+    return 0;
+}
+
+// print_to_log_file.c
+
+#if CREATE_LOG
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#include <time.h>
+#include <string.h>
+
+#ifdef unix
+//#include <unistd.h>
+#endif
+
+void strip_cr(char *buf);
+
+#endif    // CREATE_LOG
+
+#if CREATE_LOG
+// print_to_log_file - use for debugging.
+// prints time stamp plus a formatted string to log file.
+// calling syntax: same as printf.
+void print_to_log_file(const char *format, ...) {
+    FILE *f;
+    va_list args;
+    char buf[256];
+    time_t t;
+#if 0
+    strcpy(buf, "/Library/Application Support/test_log.txt");
+#else
+    strcpy(buf, getenv("HOME"));
+    strcat(buf, "/Library/Application Support/BOINC/test_log_gfx_cleanup.txt");
+#endif
+    f = fopen(buf, "a");
+//    f = fopen("/Library/Games_Demo/test_log.txt", "a");
+    if (!f) return;
+
+    time(&t);
+    strcpy(buf, asctime(localtime(&t)));
+    strip_cr(buf);
+
+    fputs(buf, f);
+    fputs("   ", f);
+
+    va_start(args, format);
+    vfprintf(f, format, args);
+    va_end(args);
+    
+    fputs("\n", f);
+
+    fclose(f);
+}
+
+void strip_cr(char *buf)
+{
+    char *theCR;
+
+    theCR = strrchr(buf, '\n');
+    if (theCR)
+        *theCR = '\0';
+    theCR = strrchr(buf, '\r');
+    if (theCR)
+        *theCR = '\0';
+}
+#else
+void print_to_log_file(const char *, ...) {}
+
+#endif    // CREATE_LOG
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void PrintBacktrace(void) {
+// Dummy routine to satisfy linker
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -87,6 +87,7 @@ static CScreensaver* gspScreensaver = NULL;
 extern int gGoToBlank;      // True if we are to blank the screen
 extern int gBlankingTime;   // Delay in minutes before blanking the screen
 extern CFStringRef gPathToBundleResources;
+extern RESULT* graphics_app_result_ptr;
 
 static SaverState saverState = SaverState_Idle;
 // int gQuitCounter = 0;
@@ -101,6 +102,11 @@ static bool ScreenIsBlanked = false;
 static int retryCount = 0;
 static pthread_mutexattr_t saver_mutex_attr;
 pthread_mutex_t saver_mutex;
+static char passwd_buf[256];
+bool gIsHighSierra = false;  // OS 10.13 or later
+bool gIsMojave = false;     // OS 10.14 or later
+bool gIsCatalina = false;   // OS 10.15 or later
+bool gUseLaunchAgent = false;
 
 const char *  CantLaunchCCMsg = "Unable to launch BOINC application.";
 const char *  LaunchingCCMsg = "Launching BOINC application.";
@@ -113,7 +119,8 @@ const char *  CantLaunchDefaultGFXAppMsg = "Can't launch default screensaver mod
 const char *  DefaultGFXAppCantRPCMsg = "Default screensaver module couldn't connect to BOINC application";
 const char *  DefaultGFXAppCrashedMsg = "Default screensaver module had an unrecoverable error";
 const char *  RunningOnBatteryMsg = "Computing and screensaver disabled while running on battery power.";
-const char *  IncompatibleMsg = " is not compatible with this version of OS X.";
+const char *  IncompatibleMsg = "Could not connect to screensaver ";
+const char *  CCNotRunningMsg = "BOINC is not running.";
 
 //const char *  BOINCExitedSaverMode = "BOINC is no longer in screensaver mode.";
 
@@ -204,7 +211,7 @@ void incompatibleGfxApp(char * appPath, pid_t pid, int slot){
             
             retval = gspScreensaver->rpc->get_state(gspScreensaver->state);
             if (!retval) {
-                strlcpy(buf, "Screensaver ", sizeof(buf));
+                strlcpy(buf, IncompatibleMsg, sizeof(buf));
                 for (int i=0; i<gspScreensaver->state.results.size(); i++) {
                     RESULT* r = gspScreensaver->state.results[i];
                     if (r->slot == slot) {
@@ -226,7 +233,6 @@ void incompatibleGfxApp(char * appPath, pid_t pid, int slot){
                 strlcat(buf, p+1, sizeof(buf));
                 strlcat(buf, "\"", sizeof(buf));
             }
-            strlcat(buf, IncompatibleMsg, sizeof(buf));
             gspScreensaver->setSSMessageText(buf);
             gspScreensaver->SetError(0, SCRAPPERR_GFXAPPINCOMPATIBLE);
         }   // End if (msgstartTime == 0.0)
@@ -235,7 +241,7 @@ void incompatibleGfxApp(char * appPath, pid_t pid, int slot){
             gspScreensaver->markAsIncompatible(appPath);
             launchedGfxApp("", 0, -1);
             msgstartTime = 0.0;
-            gspScreensaver->terminate_v6_screensaver(pid);
+            gspScreensaver->terminate_v6_screensaver(pid, graphics_app_result_ptr);
         }
     }
 }
@@ -298,6 +304,7 @@ void doBoinc_Sleep(double seconds) {
 
 CScreensaver::CScreensaver() {
     struct ss_periods periods;
+    char saved_dir[MAXPATHLEN];
     
     m_dwBlankScreen = 0;
     m_dwBlankTime = 0;
@@ -318,6 +325,15 @@ CScreensaver::CScreensaver() {
     m_bResetCoreState = true;
     rpc = 0;
     m_bConnected = false;
+    m_gfx_Cleanup_IPC = NULL;
+    safe_strcpy(passwd_buf, "");
+   
+    if (gUseLaunchAgent) {
+        getcwd(saved_dir, sizeof(saved_dir));
+        chdir("/Library/Application Support/BOINC Data");
+        read_gui_rpc_password(passwd_buf);
+        chdir(saved_dir);
+    }
     
     // Get project-defined default values for GFXDefaultPeriod, GFXSciencePeriod, GFXChangePeriod
     GetDefaultDisplayPeriods(periods);
@@ -379,8 +395,19 @@ int CScreensaver::Create() {
     // against launching multiple instances of the core client
     if (saverState == SaverState_Idle) {
         CFStringGetCString(gPathToBundleResources, m_gfx_Switcher_Path, sizeof(m_gfx_Switcher_Path), kCFStringEncodingMacRoman);
+        strlcpy(m_gfx_Cleanup_Path, "\"", sizeof(m_gfx_Cleanup_Path));
+        strlcat(m_gfx_Cleanup_Path, m_gfx_Switcher_Path, sizeof(m_gfx_Cleanup_Path));
         strlcat(m_gfx_Switcher_Path, "/gfx_switcher", sizeof(m_gfx_Switcher_Path));
+        strlcat(m_gfx_Cleanup_Path, "/gfx_cleanup\"", sizeof(m_gfx_Switcher_Path));
 
+        if (gUseLaunchAgent) {
+            // Launch helper app to work around a bug in OS 10.15 Catalina to
+            // kill current graphics app if ScreensaverEngine exits without 
+            // first calling [ScreenSaverView stopAnimation]
+            //TODO: Should we use this on OS 10.13+ ?
+            m_gfx_Cleanup_IPC = popen(m_gfx_Cleanup_Path, "w");
+        }
+        
         err = initBOINCApp();
 
         CGDisplayHideCursor(kCGNullDirectDisplay);
@@ -416,7 +443,7 @@ OSStatus CScreensaver::initBOINCApp() {
 
     saverState = SaverState_CantLaunchCoreClient;
     
-    m_CoreClientPID = FindProcessPID("boinc", 0);
+    m_CoreClientPID = getClientPID();
     if (m_CoreClientPID) {
         m_wasAlreadyRunning = true;
         saverState = SaverState_LaunchingCoreClient;
@@ -426,6 +453,9 @@ OSStatus CScreensaver::initBOINCApp() {
     
     m_wasAlreadyRunning = false;
     
+    if (gIsCatalina) {
+        return noErr;   // Screensavers can't launch setuid /setgid processes as of Catalina
+    }
     if (++retryCount > 3)   // Limit to 3 relaunches to prevent thrashing
         return -1;
 
@@ -478,6 +508,7 @@ OSStatus CScreensaver::initBOINCApp() {
 
 // Returns new desired Animation Frequency (per second) or 0 for no change
 int CScreensaver::getSSMessage(char **theMessage, int* coveredFreq) {
+    int retval;
     int newFrequency = TEXTLOGOFREQUENCY;
     *coveredFreq = 0;
     pid_t myPid;
@@ -504,11 +535,20 @@ int CScreensaver::getSSMessage(char **theMessage, int* coveredFreq) {
             setSSMessageText(LaunchingCCMsg);
         }
             
-        myPid = FindProcessPID(NULL, m_CoreClientPID);
+        myPid = getClientPID();
         if (myPid) {
             saverState = SaverState_CoreClientRunning;
+
             if (!rpc->init(NULL)) {     // Initialize communications with Core Client
                 m_bConnected = true;
+                
+                if (strlen(passwd_buf)) {
+                    retval = rpc->authorize(passwd_buf);
+                    if (retval) {
+                        fprintf(stderr, "Screensaver RPC authorization failure: %d\n", retval);
+                    }
+                }
+
                 if (IsDualGPUMacbook) {
                     ccstate.clear();
                     ccstate.global_prefs.init_bools();
@@ -529,13 +569,17 @@ int CScreensaver::getSSMessage(char **theMessage, int* coveredFreq) {
             // and running screensaver graphics
             CreateDataManagementThread();
             // ToDo: Add a timeout after which we display error message
-        } else
+        } else {
+            if (gIsCatalina) {
+                return noErr;   // Screensavers can't launch setuid /setgid processes as of Catalina
+            }
             // Take care of the possible race condition where the Core Client was in the  
             // process of shutting down just as ScreenSaver started, so initBOINCApp() 
             // found it already running but now it has shut down.
             if (m_wasAlreadyRunning) { // If we launched it, then just wait for it to start
                 saverState = SaverState_RelaunchCoreClient;
             }
+        }
          break;
 
     case SaverState_CoreClientRunning:
@@ -642,7 +686,12 @@ int CScreensaver::getSSMessage(char **theMessage, int* coveredFreq) {
             break;
         }
         
-        setSSMessageText(CantLaunchCCMsg);
+        if (gIsCatalina) {
+            setSSMessageText(CCNotRunningMsg);
+            break;
+        } else {
+            setSSMessageText(CantLaunchCCMsg);
+        }
         
         // Set up a separate thread for running screensaver graphics 
         // even if we can't communicate with core client
@@ -708,6 +757,11 @@ void CScreensaver::ShutdownSaver() {
     m_bQuitDataManagementProc = false;
     saverState = SaverState_Idle;
     retryCount = 0;
+    if (m_gfx_Cleanup_IPC) {
+        fprintf(m_gfx_Cleanup_IPC, "Quit\n");
+        fflush(m_gfx_Cleanup_IPC);
+        pclose(m_gfx_Cleanup_IPC);
+    }
 }
 
 
@@ -722,12 +776,16 @@ void * CScreensaver::DataManagementProcStub(void* param) {
 void CScreensaver::HandleRPCError() {
     static time_t last_RPC_retry = 0;
     time_t now = time(0);
+    int retval;
    
     // Attempt to restart BOINC Client if needed, reinitialize the RPC client and state
     rpc->close();
     m_bConnected = false;
     
     if (saverState == SaverState_CantLaunchCoreClient) {
+        if (gIsCatalina) {
+            return;   // Screensavers can't launch setuid /setgid processes as of Catalina
+        }
         if ((now - last_RPC_retry) < RPC_RETRY_INTERVAL) {
             return;
         }
@@ -738,7 +796,7 @@ void CScreensaver::HandleRPCError() {
         // found it already running but now it has shut down.  This code takes 
         // care of that and other situations where the Core Client quits unexpectedy.  
         // Code in initBOINC_App() limits # launch retries to 3 to prevent thrashing.
-        if (FindProcessPID("boinc", 0) == 0) {
+        if (getClientPID() == 0) {
             saverState = SaverState_RelaunchCoreClient;
             m_bResetCoreState = true;
          }
@@ -754,6 +812,12 @@ void CScreensaver::HandleRPCError() {
     // Otherwise just reinitialize the RPC client and state and keep trying
     if (!rpc->init(NULL)) {
         m_bConnected = true;
+        if (strlen(passwd_buf)) {
+            retval = rpc->authorize(passwd_buf);
+            if (retval) {
+                fprintf(stderr, "Screensaver RPC authorization failure: %d\n", retval);
+            }
+        }
     }
     // Error message after timeout?
 }
@@ -798,15 +862,16 @@ bool CScreensaver::DestroyDataManagementThread() {
         boinc_sleep(0.1);
     }
 
-    if (rpc) {
-        rpc->close();    // In case DataManagementProc is hung waiting for RPC
-    }
     m_hDataManagementThread = NULL; // Don't delay more if this routine is called again.
+
     if (m_hGraphicsApplication) {
-        terminate_v6_screensaver(m_hGraphicsApplication);
+        terminate_v6_screensaver(m_hGraphicsApplication, graphics_app_result_ptr);
         m_hGraphicsApplication = 0;
     }
 
+    if (rpc) {
+        rpc->close();    // In case DataManagementProc is hung waiting for RPC
+    }
     return true;
 }
 
@@ -887,58 +952,27 @@ int CScreensaver::GetBrandID()
 }
 
 
-char * CScreensaver::PersistentFGets(char *buf, size_t buflen, FILE *f) {
-    char *p = buf;
-    size_t len = buflen;
-    size_t datalen = 0;
-
-    *buf = '\0';
-    while (datalen < (buflen - 1)) {
-        fgets(p, len, f);
-        if (feof(f)) break;
-        if (ferror(f) && (errno != EINTR)) break;
-        if (strchr(buf, '\n')) break;
-        datalen = strlen(buf);
-        p = buf + datalen;
-        len -= datalen;
+pid_t CScreensaver::getClientPID() {
+    int fd;
+    fd = open("/Library/Application Support/BOINC Data/lockfile", O_RDONLY);
+    if (fd<0) {
+        return 0;   // lockfile doesn't exist (probably)
     }
-    return (buf[0] ? buf : NULL);
-}
-
-
-pid_t CScreensaver::FindProcessPID(char* name, pid_t thePID)
-{
-    FILE *f;
-    char buf[1024];
-    size_t n = 0;
-    pid_t aPID;
-    
-    if (name != NULL)     // Search ny name
-        n = strlen(name);
-    
-    f = popen("ps -a -x -c -o command,pid", "r");
-    if (f == NULL)
-        return 0;
-    
-    while (PersistentFGets(buf, sizeof(buf), f))
-    {
-        if (name != NULL) {     // Search ny name
-            if (strncmp(buf, name, n) == 0)
-            {
-                aPID = atol(buf+16);
-                pclose(f);
-                return aPID;
-            }
-        } else {      // Search by PID
-            aPID = atol(buf+16);
-            if (aPID == thePID) {
-                pclose(f);
-                return aPID;
-            }
-        }
+    struct flock fl;
+    fl.l_type = F_WRLCK;
+    fl.l_pid = 0;
+    fl.l_whence = SEEK_SET;
+    fl.l_start = 0;
+    fl.l_len = 0;
+    // fcntl F_GETLK sets fl.l_pid to PID of lock's owner if the
+    // file is locked, else leaves it unchanged
+    if (fcntl(fd, F_GETLK, &fl) != 0) {
+        close(fd);
+        return 0;   // fcntl failed (should never happen)
     }
-    pclose(f);
-    return 0;
+    
+    close(fd);
+    return fl.l_pid;
 }
 
 
@@ -1071,7 +1105,8 @@ void print_to_log_file(const char *format, ...) {
     char buf[256];
     time_t t;
 #if USE_SPECIAL_LOG_FILE
-    safe_strcpy(buf, getenv("HOME"));
+    safe_strcpy(buf, "/Users/");
+    safe_strcat(buf, getlogin());
     safe_strcat(buf, "/Documents/test_log.txt");
     FILE *f;
     f = fopen(buf, "a");

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -326,10 +326,11 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
 //
 int CScreensaver::terminate_v6_screensaver(GFXAPP_ID& graphics_application, RESULT* rp) {
     int retval = 0;
-    pid_t thePID;
     int i;
 
 #ifdef __APPLE__
+    pid_t thePID;
+
     if (gUseLaunchAgent) {
         // As of OS 10.15 (Catalina) screensavers can no longer launch apps
         // that run setuid or setgid. So instead of killing graphics apps 

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -58,6 +58,11 @@ typedef HANDLE GFXAPP_ID;
 #include "Mac_Saver_Module.h"
 typedef int GFXAPP_ID;
 #define DataMgmtProcType void*
+
+char *helper_app_base_path;
+char helper_app_dir[MAXPATHLEN];
+char helper_app_path[MAXPATHLEN];
+char *BOINCPidFilePath = "/Users/Shared/BOINC/BOINCGfxPid.txt";
 #endif
 
 
@@ -78,6 +83,9 @@ typedef int GFXAPP_ID;
 
 // Flags for testing & debugging
 #define SIMULATE_NO_GRAPHICS 0
+
+RESULT* graphics_app_result_ptr = NULL;
+char* default_ss_dir_path = NULL;
 
 
 bool CScreensaver::is_same_task(RESULT* taska, RESULT* taskb) {
@@ -214,30 +222,84 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
     if (strlen(rp->graphics_exec_path)) {
         // V6 Graphics
 #ifdef __APPLE__
-        // For sandbox security, use gfx_switcher to launch gfx app 
-        // as user boinc_project and group boinc_project.
-        //
-        // For unknown reasons, the graphics application exits with 
-        // "RegisterProcess failed (error = -50)" unless we pass its 
-        // full path twice in the argument list to execv.
-        char* argv[5];
-        argv[0] = "gfx_Switcher";
-        argv[1] = "-launch_gfx";
-        argv[2] = strrchr(rp->slot_path, '/');
-        if (*argv[2]) argv[2]++;    // Point to the slot number in ascii
-        
-        argv[3] = "--fullscreen";
-        argv[4] = 0;
+        if (gUseLaunchAgent) {
+            // As of OS 10.15 (Catalina) screensavers can no longer:
+            //  - launch apps that run setuid or setgid
+            //  - launch apps downloaded from the Internet which have not been 
+            //    specifically approved by the user via Gatekeeper.
+            // So instead of launching graphics apps via gfx_switcher, we write 
+            // a file containing the information. The file is detected by 
+            // a LaunchAgent which then launches gfx_switcher for us. Though we
+            // confirmed it works on OS 10.13 High Sierra, we don't use it there.
+            //TODO: Can we use the LaunchAgent method on all our supported
+            //TODO: versions of OS X (OS < 10.13) to simplify this code?
+            //
+            int thePID = -5;
 
-       retval = run_program(
-            rp->slot_path,
-            m_gfx_Switcher_Path,
-            4,
-            argv,
-            0,
-            graphics_application
-        );
+#if 1
+            FILE *f;
+            char *p;
+           
+            safe_strcpy(helper_app_path, helper_app_dir);
+            safe_strcat(helper_app_path, "BOINCSSHelper.txt");
+            f = fopen(helper_app_path, "w");
+            if (!f) return -1;
+            fputs(rp->slot_path, f);
+            fputs("\n-launch_gfx\n", f);
+            p = strrchr(rp->slot_path, '/');
+            if (*p) p++;    // Point to the slot number in ascii
+            fprintf(f, "%s\n", p);
+            fputs("--fullscreen\n", f);
+            fclose(f);
 
+           for (int i=0; i<200; i++) {
+                boinc_sleep(0.1);
+                f = fopen(BOINCPidFilePath, "r");
+                if (f) {
+                    fscanf(f, "%d", &thePID);
+                    if (thePID > 0) {
+                        break;
+                    }
+                }
+            }
+            if (f) {
+                fclose(f);
+            }
+            
+           if (thePID < 1) retval = -1;
+#else            
+            retval = rpc->run_graphics_app(rp->slot, thePID, "runfullscreen");
+#endif
+            graphics_application = thePID;
+            // Inform our helper app what we launched 
+            fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
+            fflush(m_gfx_Cleanup_IPC);
+        } else {
+            // For sandbox security, use gfx_switcher to launch gfx app 
+            // as user boinc_project and group boinc_project.
+            //
+            // For unknown reasons, the graphics application exits with 
+            // "RegisterProcess failed (error = -50)" unless we pass its 
+            // full path twice in the argument list to execv.
+            char* argv[5];
+            argv[0] = "gfx_Switcher";
+            argv[1] = "-launch_gfx";
+            argv[2] = strrchr(rp->slot_path, '/');
+            if (*argv[2]) argv[2]++;    // Point to the slot number in ascii
+            
+            argv[3] = "--fullscreen";
+            argv[4] = 0;
+
+           retval = run_program(
+                rp->slot_path,
+                m_gfx_Switcher_Path,
+                4,
+                argv,
+                0,
+                graphics_application
+            );
+    }
+    
     if (graphics_application) {
         launchedGfxApp(rp->graphics_exec_path, graphics_application, rp->slot);
     }
@@ -262,59 +324,104 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
 
 // Terminate any screensaver graphics application
 //
-int CScreensaver::terminate_v6_screensaver(GFXAPP_ID& graphics_application) {
+int CScreensaver::terminate_v6_screensaver(GFXAPP_ID& graphics_application, RESULT* rp) {
     int retval = 0;
-
-#ifdef __APPLE__
-    // Under sandbox security, use gfx_switcher to kill default gfx app 
-    // as user boinc_master and group boinc_master.  The man page for 
-    // kill() says the user ID of the process sending the signal must 
-    // match that of the target process, though in practice that seems 
-    // not to be true on the Mac.
-    
-    char current_dir[PATH_MAX];
-    char gfx_pid[16];
     pid_t thePID;
     int i;
-    
-    if (graphics_application == 0) return 0;
-    
-    // MUTEX may help prevent crashes when terminating an older gfx app which
-    // we were displaying using CGWindowListCreateImage under OS X >= 10.13
-    // Also prevents reentry when called from our other thread
-    pthread_mutex_lock(&saver_mutex);
 
-    sprintf(gfx_pid, "%d", graphics_application);
-    getcwd( current_dir, sizeof(current_dir));
+#ifdef __APPLE__
+    if (gUseLaunchAgent) {
+        // As of OS 10.15 (Catalina) screensavers can no longer launch apps
+        // that run setuid or setgid. So instead of killing graphics apps 
+        // via gfx_switcher, we send an RPC to the client asking the client 
+        // to kill them via switcher. Though we have confirmed it works on 
+        // OS 10.13 High Sierra, we don't use it there.
+        //TODO: Can we use run_graphics_app() RPC on all our supported versions
+        //TODO: of OS X (OS < 10.13) to simplify this code?
+        //
+        if (graphics_application == 0) return 0;
 
-    char* argv[4];
-    argv[0] = "gfx_switcher";
-    argv[1] = "-kill_gfx";
-    argv[2] = gfx_pid;
-    argv[3] = 0;
+        // MUTEX may help prevent crashes when terminating an older gfx app which
+        // we were displaying using CGWindowListCreateImage under OS X >= 10.13. 
+        // Note however that under OS 10.15 Catalina, CGWindowListCreateImage 
+        // can't copy windows between user boinc_project and the user running 
+        // the screensaver does not work for us.
+        // Also prevents reentry when called from our other thread
+        pthread_mutex_lock(&saver_mutex);
 
-    retval = run_program(
-        current_dir,
-        m_gfx_Switcher_Path,
-        3,
-        argv,
-        0,
-        thePID
-    );
-    
-    if (graphics_application) {
+        thePID = graphics_application;
+        retval = rpc->run_graphics_app(0, thePID, "stop");
+// Inform our helper app that we have stopped current graphics app 
+
+          for (i=0; i<200; i++) {
+            boinc_sleep(0.01);      // Wait 2 seconds max
+            if (!boinc_file_exists(BOINCPidFilePath)) {
+               break;
+            }
+        }   
+
+        pthread_mutex_unlock(&saver_mutex);
+
+        fprintf(m_gfx_Cleanup_IPC, "0\n");
+        fflush(m_gfx_Cleanup_IPC);
+     
         launchedGfxApp("", 0, -1);
+
+        // Just for safety ...
+        if (boinc_file_exists(BOINCPidFilePath)) {
+            boinc_delete_file(BOINCPidFilePath);
+        }
+    } else {    // if (! gUseLaunchAgent)
+    
+        // Under sandbox security, use gfx_switcher to kill default gfx app 
+        // as user boinc_master and group boinc_master (for default gfx app)
+        // or user boinc_project and group boinc_project (for project gfx 
+        // apps.) The man page for kill() says the user ID of the process 
+        // sending the signal must match that of the target process, though 
+        // in practice that seems not to be true on the Mac.
+        
+        char current_dir[PATH_MAX];
+        char gfx_pid[16];
+        
+        if (graphics_application == 0) return 0;
+        
+        // MUTEX may help prevent crashes when terminating an older gfx app which
+        // we were displaying using CGWindowListCreateImage under OS X >= 10.13
+        // Also prevents reentry when called from our other thread
+        pthread_mutex_lock(&saver_mutex);
+
+        sprintf(gfx_pid, "%d", graphics_application);
+        getcwd( current_dir, sizeof(current_dir));
+
+        char* argv[4];
+        argv[0] = "gfx_switcher";
+        argv[1] = "-kill_gfx";
+        argv[2] = gfx_pid;
+        argv[3] = 0;
+
+        retval = run_program(
+            current_dir,
+            m_gfx_Switcher_Path,
+            3,
+            argv,
+            0,
+            thePID
+        );
+
+        if (graphics_application) {
+            launchedGfxApp("", 0, -1);
+        }
+        
+        for (i=0; i<200; i++) {
+            boinc_sleep(0.01);      // Wait 2 seconds max
+            // Prevent gfx_switcher from becoming a zombie
+            if (waitpid(thePID, 0, WNOHANG) == thePID) {
+                break;
+            }
+        }
+        pthread_mutex_unlock(&saver_mutex);
     }
     
-    for (i=0; i<200; i++) {
-        boinc_sleep(0.01);      // Wait 2 seconds max
-        // Prevent gfx_switcher from becoming a zombie
-        if (waitpid(thePID, 0, WNOHANG) == thePID) {
-            break;
-        }
-    }
-
-    pthread_mutex_unlock(&saver_mutex);
 #endif
 
 #ifdef _WIN32
@@ -336,15 +443,14 @@ int CScreensaver::terminate_v6_screensaver(GFXAPP_ID& graphics_application) {
 
 
 // Terminate the project (science) graphics application
-// TODO: get rid of 2nd arg
 //
-int CScreensaver::terminate_screensaver(GFXAPP_ID& graphics_application, RESULT *) {
+int CScreensaver::terminate_screensaver(GFXAPP_ID& graphics_application, RESULT* rp) {
     int retval = 0;
 
     if (graphics_application) {
         // V6 Graphics
         if (m_bScience_gfx_running) {
-            terminate_v6_screensaver(graphics_application);
+            terminate_v6_screensaver(graphics_application, rp);
         }
     }
     return retval;
@@ -358,39 +464,82 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
     int num_args;
     
 #ifdef __APPLE__
-    // For sandbox security, use gfx_switcher to launch default 
-    // gfx app as user boinc_master and group boinc_master.
-    char* argv[6];
+    if (gUseLaunchAgent) {
+        // As of OS 10.15 (Catalina) screensavers can no longer:
+        //  - launch apps that run setuid or setgid
+        //  - launch apps downloaded from the Internet which have not been 
+        //    specifically approved by the user via Gatekeeper.
+        // So instead of launching graphics apps via gfx_switcher, we write 
+        // a file containing the information. The file is detected by 
+        // a LaunchAgent which then launches gfx_switcher for us. Though we
+        // confirmed it works on OS 10.13 High Sierra, we don't use it there.
+        //TODO: Can we use the LaunchAgent method on all our supported
+        //TODO: versions of OS X (OS < 10.13) to simplify this code?
+        //
+        int thePID = -5;
+        FILE *f;
+       
+        safe_strcpy(helper_app_path, helper_app_dir);
+        safe_strcat(helper_app_path, "BOINCSSHelper.txt");
+        f = fopen(helper_app_path, "w");
+        if (!f) return -1;
+        fputs(dir_path, f);
+        fputs("\n-default_gfx\n", f);
+        fputs(THE_DEFAULT_SS_EXECUTABLE, f);
+        fputs("\n--fullscreen\n", f);
+        fclose(f);
+        
+        for (int i=0; i<200; i++) {
+            boinc_sleep(0.1);
+            f = fopen(BOINCPidFilePath, "r");
+            if (f) {
+                fscanf(f, "%d", &thePID);
+                if (thePID > 0) {
+                    break;
+                }
+            }
+        }
+        if (f) {
+            fclose(f);
+        }
 
-    argv[0] = "gfx_switcher";
-    argv[1] = "-default_gfx";
-    argv[2] = THE_DEFAULT_SS_EXECUTABLE;    // Will be changed by gfx_switcher
-    argv[3] = "--fullscreen";
-    argv[4] = 0;
-    argv[5] = 0;
-    if (!m_bConnected) {
-        BOINCTRACE(_T("launch_default_screensaver using --retry_connect argument\n"));
-        argv[4] = "--retry_connect";
-        num_args = 5;
+        if (thePID < 1) retval = -1;
+        graphics_application = thePID;
+        // Inform our helper app what we launched 
+        fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
+        fflush(m_gfx_Cleanup_IPC);
     } else {
-        num_args = 4;
+        // For sandbox security, use gfx_switcher to launch default 
+        // gfx app as user boinc_master and group boinc_master.
+        char* argv[6];
+
+        argv[0] = "gfx_switcher";
+        argv[1] = "-default_gfx";
+        argv[2] = THE_DEFAULT_SS_EXECUTABLE;    // Will be changed by gfx_switcher
+        argv[3] = "--fullscreen";
+        argv[4] = 0;
+        argv[5] = 0;
+        if (!m_bConnected) {
+            BOINCTRACE(_T("launch_default_screensaver using --retry_connect argument\n"));
+            argv[4] = "--retry_connect";
+            num_args = 5;
+        } else {
+            num_args = 4;
+        }
+
+        retval = run_program(
+            dir_path,
+            m_gfx_Switcher_Path,
+            num_args,
+            argv,
+            0,
+            graphics_application
+        );
     }
-
-    retval = run_program(
-        dir_path,
-        m_gfx_Switcher_Path,
-        num_args,
-        argv,
-        0,
-        graphics_application
-    );
-
+    
     if (graphics_application) {
         launchedGfxApp("boincscr", graphics_application, -1);
     }
-
-    BOINCTRACE(_T("launch_default_screensaver returned %d\n"), retval);
-    
 #else
     char* argv[4];
     char full_path[1024];
@@ -433,7 +582,7 @@ int CScreensaver::terminate_default_screensaver(GFXAPP_ID& graphics_application)
     int retval = 0;
 
     if (! graphics_application) return 0;
-    retval = terminate_v6_screensaver(graphics_application);
+    retval = terminate_v6_screensaver(graphics_application, NULL);
     return retval;
 }
 
@@ -452,7 +601,6 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
     int             retval                      = 0;
     int             suspend_reason              = 0;
     RESULT*         theResult                   = NULL;
-    RESULT*         graphics_app_result_ptr     = NULL;
     RESULT          previous_result;
     // previous_result_ptr = &previous_result when previous_result is valid, else NULL
     RESULT*         previous_result_ptr         = NULL;
@@ -471,7 +619,6 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
     bool            killing_default_gfx         = false;
     int             exit_status                 = 0;
     
-    char*           default_ss_dir_path         = NULL;
     char            full_path[1024];
 
     BOINCTRACE(_T("CScreensaver::DataManagementProc - Display screen saver loading message\n"));
@@ -488,10 +635,28 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
     m_bScience_gfx_running = false;
     m_bDefault_gfx_running = false;
     m_bShow_default_ss_first = false;
+    graphics_app_result_ptr = NULL;
 
 #ifdef __APPLE__
     m_vIncompatibleGfxApps.clear();
     default_ss_dir_path = "/Library/Application Support/BOINC Data";
+    if (gIsCatalina) {
+        helper_app_base_path = "Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/";
+    } else {
+        helper_app_base_path = "";
+    }
+    if (gUseLaunchAgent) {
+         if (boinc_file_exists(BOINCPidFilePath)) {
+            boinc_delete_file(BOINCPidFilePath);
+        }
+
+        snprintf(helper_app_dir, sizeof(helper_app_dir), "/Users/%s/Library/%sApplication Support/BOINC/", getlogin(), helper_app_base_path);
+        safe_strcpy(helper_app_path, helper_app_dir);
+        safe_strcat(helper_app_path, "BOINCSSHelper.txt");
+        if (boinc_file_exists(helper_app_path)) {
+            boinc_delete_file(helper_app_path);
+        }
+    }
 #else
     default_ss_dir_path = (char*)m_strBOINCInstallDirectory.c_str();
 #endif
@@ -882,9 +1047,31 @@ BOOL CScreensaver::HasProcessExited(HANDLE pid_handle, int &exitCode) {
 }
 #else
 bool CScreensaver::HasProcessExited(pid_t pid, int &exitCode) {
-    int status;
     pid_t p;
     
+    if (gUseLaunchAgent) {
+            if (boinc_file_exists(BOINCPidFilePath)) return false;
+            m_hGraphicsApplication = 0;
+            graphics_app_result_ptr = NULL;
+            m_bDefault_gfx_running = false;
+            m_bScience_gfx_running = false;
+        return true;
+
+
+    int retval;
+        // Only the process which launched an app can use waitpid() to test 
+        // whether that app is still running. If we sent an RPC to the client 
+        // asking the client to launch a graphics app via switcher, we must 
+        // send another RPC to the client to call waitpid() for that app.
+        //
+        p = pid;
+        retval = rpc->run_graphics_app(0, p, "test");
+        exitCode = 0;
+        if (retval || (p==0)) return true;
+        return false;
+    }
+    
+    int status;
     p = waitpid(pid, &status, WNOHANG);
     exitCode = WEXITSTATUS(status);
     if (p == pid) return true;     // process has exited

--- a/clientscr/screensaver_win.h
+++ b/clientscr/screensaver_win.h
@@ -167,7 +167,7 @@ protected:
     DWORD WINAPI    DataManagementProc();
     static DWORD WINAPI DataManagementProcStub( LPVOID lpParam );
 
-    int             terminate_v6_screensaver(HANDLE& graphics_application);
+    int             terminate_v6_screensaver(HANDLE& graphics_application, RESULT* rp);
     int             terminate_screensaver(HANDLE& graphics_application, RESULT *worker_app);
     int             terminate_default_screensaver(HANDLE& graphics_application);
 	int             launch_screensaver(RESULT* rp, HANDLE& graphics_application);

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -711,6 +711,7 @@ struct RPC_CLIENT {
     int set_network_mode(int mode, double duration);
     int get_screensaver_tasks(int& suspend_reason, RESULTS&);
     int run_benchmarks();
+    int run_graphics_app(int slot, int& id, const char *operation);
     int set_proxy_settings(GR_PROXY_INFO&);
     int get_proxy_settings(GR_PROXY_INFO&);
     int get_messages(int seqno, MESSAGES&, bool translatable=false);

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -179,6 +179,8 @@ void RESULT::print() {
     // stuff for jobs that are running or have run
     //
     if (scheduler_state > CPU_SCHED_UNINITIALIZED) {
+        printf("   slot: %d\n", slot);
+        printf("   PID: %d\n", pid);
         printf("   CPU time at last checkpoint: %f\n", checkpoint_cpu_time);
         printf("   current CPU time: %f\n", current_cpu_time);
         printf("   fraction done: %f\n", fraction_done);

--- a/lib/mac/mac_spawn.cpp
+++ b/lib/mac/mac_spawn.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -105,9 +105,9 @@ int callPosixSpawn(const char *cmdline) {
     }
     
 #if VERBOSE_SPAWN
-    fprintf(stderr, "***********");
+    fprintf(stderr, "***********\n");
     for (int i=0; i<argc; ++i) {
-        fprintf(stderr, "argv[%d]=%s", i, argv[i]);
+        fprintf(stderr, "argv[%d]=%s\n", i, argv[i]);
     }
     fprintf(stderr, "***********\n");
 #endif
@@ -116,8 +116,8 @@ int callPosixSpawn(const char *cmdline) {
 
     result = posix_spawnp(&thePid, progPath, NULL, NULL, argv, environ);
 #if VERBOSE_SPAWN
-    fprintf(stderr, "callPosixSpawn command: %s", cmdline);
-    fprintf(stderr, "callPosixSpawn: posix_spawnp returned %d: %s", result, strerror(result));
+    fprintf(stderr, "callPosixSpawn command: %s\n", cmdline);
+    fprintf(stderr, "callPosixSpawn: posix_spawnp returned %d: %s\n", result, strerror(result));
 #endif
     if (result) {
         return result;
@@ -127,7 +127,7 @@ int callPosixSpawn(const char *cmdline) {
 // CAF        if (val < 0) printf("first waitpid returned %d\n", val);
     if (status != 0) {
 #if VERBOSE_SPAWN
-        fprintf(stderr, "waitpid() returned status=%d", status);
+        fprintf(stderr, "waitpid() returned status=%d\n", status);
 #endif
         result = status;
     } else {
@@ -135,13 +135,13 @@ int callPosixSpawn(const char *cmdline) {
             result = WEXITSTATUS(status);
             if (result == 1) {
 #if VERBOSE_SPAWN
-                fprintf(stderr, "WEXITSTATUS(status) returned 1, errno=%d: %s", errno, strerror(errno));
+                fprintf(stderr, "WEXITSTATUS(status) returned 1, errno=%d: %s\n", errno, strerror(errno));
 #endif
                 result = errno;
             }
 #if VERBOSE_SPAWN
             else if (result) {
-                fprintf(stderr, "WEXITSTATUS(status) returned %d", result);
+                fprintf(stderr, "WEXITSTATUS(status) returned %d\n", result);
             }
 #endif
         }   // end if (WIFEXITED(status)) else

--- a/lib/mac/mac_util.h
+++ b/lib/mac/mac_util.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -36,6 +36,8 @@ extern "C" {
     OSStatus    GetPathToAppFromID(OSType creator, CFStringRef bundleID, char *path, size_t maxLen);
 
     int         compareOSVersionTo(int toMajor, int toMinor);
+
+#define MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT 15
 
 #ifdef __cplusplus
 }	// extern "C"

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 				DDBD681107FA830E0082C20D /* PBXTargetDependency */,
 				DDB874670C850DB600E0DE1F /* PBXTargetDependency */,
 				DD791FF10819063C00BE2906 /* PBXTargetDependency */,
+				DD5F654D23606458009ED2A2 /* PBXTargetDependency */,
 				DDBD681507FA830E0082C20D /* PBXTargetDependency */,
 				DD58247D0B198BDD003B6A2F /* PBXTargetDependency */,
 				DD6178CE1488F09E0042482E /* PBXTargetDependency */,
@@ -74,6 +75,8 @@
 		DD262C811366D35A00C9A187 /* cc_config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4AE04B13652BD700285859 /* cc_config.cpp */; };
 		DD262C821366D35D00C9A187 /* cc_config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4AE04B13652BD700285859 /* cc_config.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DD262C871366D4D200C9A187 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DD26B52B237443BF00206557 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
+		DD26B52C237445DD00206557 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DD2B6C8013149177005D6F3E /* procinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2B6C7E13149177005D6F3E /* procinfo.cpp */; };
 		DD2B6C8113149177005D6F3E /* procinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2B6C7E13149177005D6F3E /* procinfo.cpp */; };
 		DD2B6C8D131491B7005D6F3E /* procinfo_mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDB6934F0ABFE9C600689FD8 /* procinfo_mac.cpp */; };
@@ -186,6 +189,29 @@
 		DD531BC80C193D5200742E50 /* MacUninstaller.icns in Resources */ = {isa = PBXBuildFile; fileRef = DD531BC70C193D5200742E50 /* MacUninstaller.icns */; };
 		DD55AF6D1916248200259439 /* coproc_sched.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD55AF6B1916248200259439 /* coproc_sched.cpp */; };
 		DD5BF77D0D4F3D0C00EDF980 /* mac_icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6381450870DB78007A2F8E /* mac_icon.cpp */; };
+		DD5F6550236064E4009ED2A2 /* gui_rpc_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C5CC07C5D7D90098A04D /* gui_rpc_client.cpp */; };
+		DD5F6551236064E4009ED2A2 /* gui_rpc_client_ops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD73E34E08A0694000656EB1 /* gui_rpc_client_ops.cpp */; };
+		DD5F6552236064F8009ED2A2 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
+		DD5F6553236066B2009ED2A2 /* mfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD207C5B1150043025C /* mfile.cpp */; };
+		DD5F6554236066B2009ED2A2 /* miofile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD507C5B1150043025C /* miofile.cpp */; };
+		DD5F6555236066B2009ED2A2 /* parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B901602AC0A2201FB7237 /* parse.cpp */; };
+		DD5F655623606728009ED2A2 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
+		DD5F655723606728009ED2A2 /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159562029EB02001F5651B /* md5.cpp */; };
+		DD5F655823606728009ED2A2 /* md5_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159564029EB02001F5651B /* md5_file.cpp */; };
+		DD5F6559236067B3009ED2A2 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
+		DD5F655A2360681F009ED2A2 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6D0A8507E9A61B007F882B /* network.cpp */; };
+		DD5F655B2360681F009ED2A2 /* str_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7BF7D70B8E7A9800A009F7 /* str_util.cpp */; };
+		DD5F655C236068AE009ED2A2 /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
+		DD5F655D236069CF009ED2A2 /* cc_config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4AE04B13652BD700285859 /* cc_config.cpp */; };
+		DD5F655E236069CF009ED2A2 /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
+		DD5F655F23606A1F009ED2A2 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
+		DD5F656023606A1F009ED2A2 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
+		DD5F656123606AA3009ED2A2 /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD82D83A1F831E0500EEC6AD /* keyword.cpp */; };
+		DD5F656223606AA3009ED2A2 /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
+		DD5F656323606AA3009ED2A2 /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
+		DD5F656423606AED009ED2A2 /* diagnostics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BA207C5AE5A0043025C /* diagnostics.cpp */; };
+		DD5F656523606AED009ED2A2 /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
+		DD5F656623607472009ED2A2 /* gfx_cleanup in Resources */ = {isa = PBXBuildFile; fileRef = DD5F654123605B41009ED2A2 /* gfx_cleanup */; };
 		DD5FE1B517828887003339DF /* translate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF9350F176B0D0C00A2793C /* translate.cpp */; };
 		DD64D8011F6BE5BA00FEEAAA /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
 		DD6617880A3FFD8C00FFEBEB /* check_security.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6617870A3FFD8C00FFEBEB /* check_security.cpp */; };
@@ -208,7 +234,6 @@
 		DD74B686177074AF005CF7DC /* PutInTrash.icns in Resources */ = {isa = PBXBuildFile; fileRef = DD74B685177074AF005CF7DC /* PutInTrash.icns */; };
 		DD76BF9317CB45A20075936D /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
 		DD76BF9517CB45D20075936D /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
-		DD76BF9617CB465A0075936D /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
 		DD76BF9717CB465C0075936D /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
 		DD76BF9817CB465E0075936D /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
 		DD76BF9917CB46610075936D /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
@@ -339,7 +364,6 @@
 		DD957E5B181B908800ECA34E /* thumbnail.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E59181B908800ECA34E /* thumbnail.png */; };
 		DD957E5C181B908800ECA34E /* thumbnail@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E5A181B908800ECA34E /* thumbnail@2x.png */; };
 		DD9917251E69A4F100555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
-		DD9917261E69A8B300555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917271E69A8D100555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917281E69A90500555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917291E69A90800555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
@@ -375,6 +399,9 @@
 		DDA6BD290BD4551F008F7921 /* QMachOImageList.c in Sources */ = {isa = PBXBuildFile; fileRef = DDA6BD0C0BD4551F008F7921 /* QMachOImageList.c */; };
 		DDA6BD2B0BD4551F008F7921 /* QSymbols.c in Sources */ = {isa = PBXBuildFile; fileRef = DDA6BD0E0BD4551F008F7921 /* QSymbols.c */; };
 		DDA6BD2D0BD4551F008F7921 /* QTaskMemory.c in Sources */ = {isa = PBXBuildFile; fileRef = DDA6BD100BD4551F008F7921 /* QTaskMemory.c */; };
+		DDA70B4023631BF1007097BD /* gfx_cleanup.mm in Sources */ = {isa = PBXBuildFile; fileRef = DD5F654A23605C87009ED2A2 /* gfx_cleanup.mm */; };
+		DDA70B4123632035007097BD /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
+		DDA70B4223632223007097BD /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DDA850A41207EED900B473A6 /* WizardAttach.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDA850A21207EED900B473A6 /* WizardAttach.cpp */; };
 		DDAEB54012F8295800EDEDBE /* LogBOINC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C41407C5D13E0098A04D /* LogBOINC.cpp */; };
 		DDAEC9FF07FA5A5C00A7BC36 /* SetVersion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDAEC9E707FA58A000A7BC36 /* SetVersion.cpp */; };
@@ -417,6 +444,8 @@
 		DDC82FA31A35BB68005FA808 /* DlgHiddenColumns.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC82FA11A35BB68005FA808 /* DlgHiddenColumns.cpp */; };
 		DDC836E60EDEA5DB001C2EF9 /* TermsOfUsePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC836E50EDEA5DB001C2EF9 /* TermsOfUsePage.cpp */; };
 		DDC8FB2A1F6D393C00BE55B8 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
+		DDC918FB236C2ABB009641C8 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
+		DDC918FC236C2AE8009641C8 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
 		DDC988FE0F3BD44100EE8D0E /* gui_rpc_client_ops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD73E34E08A0694000656EB1 /* gui_rpc_client_ops.cpp */; };
 		DDCF84080E1B7C0A005EDC45 /* DlgItemProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDCF84060E1B7C0A005EDC45 /* DlgItemProperties.cpp */; };
 		DDD0697312D70C9400120920 /* sg_TaskPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD0697112D70C9400120920 /* sg_TaskPanel.cpp */; };
@@ -478,7 +507,6 @@
 		DDD8846418E17D7A00BE1E34 /* DlgDiagnosticLogFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD8846218E17D7A00BE1E34 /* DlgDiagnosticLogFlags.cpp */; };
 		DDD93E7313E017B600B92D0F /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2552B07C62F3E008E7D6E /* IOKit.framework */; };
 		DDD9C5A510CCF61F00A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
-		DDD9C5AA10CCF6A000A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
 		DDD9C5AB10CCF6A300A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
 		DDD9C5AC10CCF6AB00A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDDC2055183B560B00CB5845 /* mac_address.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDDC2053183B560B00CB5845 /* mac_address.cpp */; };
@@ -515,6 +543,13 @@
 		DDEEAA991F73D3D70051E8C5 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
 		DDEEAA9A1F73E8630051E8C5 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
 		DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
+		DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
+		DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
+		DDF0776B236C4DD60046EE44 /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
+		DDF0776C236C4E1A0046EE44 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
+		DDF0776D236C4E420046EE44 /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
+		DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
+		DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
 		DDF5E23318B8673E005DEA6E /* uninstall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4688590C1661970089F500 /* uninstall.cpp */; };
 		DDF5E23418B86803005DEA6E /* AddRemoveUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD33709106224E800867C7D /* AddRemoveUser.cpp */; };
 		DDF5F85A10DD05DB006A50CD /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
@@ -524,18 +559,10 @@
 		DDF9EC0B144EB2BB005D6144 /* boinc_opencl.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF9EC09144EB2BB005D6144 /* boinc_opencl.h */; };
 		DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */ = {isa = PBXBuildFile; fileRef = DDFA60D40CB337D40037B88C /* gfx_switcher */; };
 		DDFA60E40CB3396C0037B88C /* gfx_switcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */; };
-		DDFA61520CB347500037B88C /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
-		DDFA61570CB347730037B88C /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
 		DDFA61780CB348660037B88C /* mfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD207C5B1150043025C /* mfile.cpp */; };
 		DDFA617A0CB3486D0037B88C /* miofile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD507C5B1150043025C /* miofile.cpp */; };
 		DDFA617E0CB3487F0037B88C /* parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B901602AC0A2201FB7237 /* parse.cpp */; };
 		DDFA61860CB3489E0037B88C /* str_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7BF7D70B8E7A9800A009F7 /* str_util.cpp */; };
-		DDFA61890CB348A90037B88C /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
-		DDFA618C0CB348C50037B88C /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
-		DDFA618F0CB348E80037B88C /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159562029EB02001F5651B /* md5.cpp */; };
-		DDFA61900CB348E90037B88C /* md5_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159564029EB02001F5651B /* md5_file.cpp */; };
-		DDFA61920CB349020037B88C /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
-		DDFA61940CB349160037B88C /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
 		DDFD5F0F0818F2EE002B23D4 /* gui_rpc_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C5CC07C5D7D90098A04D /* gui_rpc_client.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F270818F329002B23D4 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F280818F33C002B23D4 /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159562029EB02001F5651B /* md5.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -545,7 +572,6 @@
 		DDFD5F2C0818F368002B23D4 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6D0A8507E9A61B007F882B /* network.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F2D0818F372002B23D4 /* parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B901602AC0A2201FB7237 /* parse.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F2E0818F3A1002B23D4 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DDFE4E3D10AB778100919319 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
 		DDFE4E9110AB7C3A00919319 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
 		DDFE84E50B60CD66009B43D9 /* DlgAdvPreferences.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFE84E10B60CD66009B43D9 /* DlgAdvPreferences.cpp */; };
 		DDFE84E70B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFE84E30B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp */; };
@@ -629,6 +655,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = DD3E14D30A774397007E0084;
 			remoteInfo = mgr_boinc;
+		};
+		DD5F654C23606458009ED2A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD5F654023605B41009ED2A2;
+			remoteInfo = gfx_cleanup;
+		};
+		DD5F654E2360648D009ED2A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD5F654023605B41009ED2A2;
+			remoteInfo = gfx_cleanup;
 		};
 		DD6178CD1488F09E0042482E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -805,6 +845,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		DD5F653F23605B41009ED2A2 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -973,6 +1022,8 @@
 		DD58C46A08F334EA00C1DF66 /* wizardex.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = wizardex.h; path = ../clientgui/wizardex.h; sourceTree = SOURCE_ROOT; };
 		DD5EF07007C5B329007CCE8D /* whetstone.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = whetstone.cpp; sourceTree = "<group>"; };
 		DD5EF08807C5B7C7007CCE8D /* version.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = version.h; path = ../version.h; sourceTree = SOURCE_ROOT; };
+		DD5F654123605B41009ED2A2 /* gfx_cleanup */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gfx_cleanup; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD5F654A23605C87009ED2A2 /* gfx_cleanup.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = gfx_cleanup.mm; path = ../clientscr/gfx_cleanup.mm; sourceTree = "<group>"; };
 		DD6381450870DB78007A2F8E /* mac_icon.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = mac_icon.cpp; sourceTree = "<group>"; };
 		DD6381F80870DD83007A2F8E /* make_app_icon_h.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = make_app_icon_h.cpp; sourceTree = "<group>"; };
 		DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.mig; path = MultiGPUMig.defs; sourceTree = "<group>"; };
@@ -1372,6 +1423,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DD5F653E23605B41009ED2A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DDA70B4223632223007097BD /* AppKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD69FEE608416C1300C01361 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1471,6 +1530,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD26B52C237445DD00206557 /* AppKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1507,6 +1567,7 @@
 				DD81C79A144D8DA9000BE61A /* libjpeg.a */,
 				DDF9EC03144EB14B005D6144 /* libboinc_opencl.a */,
 				DD3EAAA6216A25AD00BC673C /* boinc_finish_install */,
+				DD5F654123605B41009ED2A2 /* gfx_cleanup */,
 			);
 			name = Products;
 			sourceTree = SOURCE_ROOT;
@@ -1856,6 +1917,7 @@
 				DDE7A3AF15C6739E002B3B96 /* ttfont.cpp */,
 				DDE7A3B015C6739E002B3B96 /* ttfont.h */,
 				DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */,
+				DD5F654A23605C87009ED2A2 /* gfx_cleanup.mm */,
 			);
 			name = clientscr;
 			sourceTree = SOURCE_ROOT;
@@ -2255,6 +2317,23 @@
 			productReference = DD4688410C165F3C0089F500 /* Uninstall BOINC.app */;
 			productType = "com.apple.product-type.application";
 		};
+		DD5F654023605B41009ED2A2 /* gfx_cleanup */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD5F654723605B41009ED2A2 /* Build configuration list for PBXNativeTarget "gfx_cleanup" */;
+			buildPhases = (
+				DD5F653D23605B41009ED2A2 /* Sources */,
+				DD5F653E23605B41009ED2A2 /* Frameworks */,
+				DD5F653F23605B41009ED2A2 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = gfx_cleanup;
+			productName = gfx_cleanup;
+			productReference = DD5F654123605B41009ED2A2 /* gfx_cleanup */;
+			productType = "com.apple.product-type.tool";
+		};
 		DD69FEE708416C1300C01361 /* cmd_boinc */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD9E2375091CBDAE0048316E /* Build configuration list for PBXNativeTarget "cmd_boinc" */;
@@ -2337,6 +2416,7 @@
 			dependencies = (
 				DDAD19CF09090833004E7DD0 /* PBXTargetDependency */,
 				DDFA60DD0CB338940037B88C /* PBXTargetDependency */,
+				DD5F654F2360648D009ED2A2 /* PBXTargetDependency */,
 			);
 			name = ScreenSaver;
 			productName = ScreenSaver;
@@ -2492,6 +2572,9 @@
 					DD3EAAA5216A25AD00BC673C = {
 						CreatedOnToolsVersion = 9.4.1;
 					};
+					DD5F654023605B41009ED2A2 = {
+						CreatedOnToolsVersion = 10.1;
+					};
 				};
 			};
 			buildConfigurationList = DD9E2381091CBDAE0048316E /* Build configuration list for PBXProject "boinc" */;
@@ -2529,6 +2612,7 @@
 				DDFA60C90CB337D40037B88C /* gfx_switcher */,
 				DD89161C0F3B17E900DE5B1C /* ss_app */,
 				DDD336F51062235D00867C7D /* AddRemoveUser */,
+				DD5F654023605B41009ED2A2 /* gfx_cleanup */,
 			);
 		};
 /* End PBXProject section */
@@ -2576,6 +2660,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */,
+				DD5F656623607472009ED2A2 /* gfx_cleanup in Resources */,
 				DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */,
 				DD48091F081A66F100A174AA /* BOINCSaver.nib in Resources */,
 				DDBC6CA50D5D458700564C49 /* boinc_ss_logo.png in Resources */,
@@ -2610,7 +2695,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/BOINC Installer.app/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/Installer-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/BOINC Installer.app/Contents/Resources/English.lproj/InfoPlist.strings\"";
+			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/BOINC Installer.app/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/Installer-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/BOINC Installer.app/Contents/Resources/English.lproj/InfoPlist.strings\"\n";
 		};
 		DD1B90070A954C9A00FF5591 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2706,7 +2791,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/ScreenSaver-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj/InfoPlist.strings\"";
+			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/ScreenSaver-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj/InfoPlist.strings\"\n";
 		};
 		DD5FD59B0A0234400093C19F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2721,7 +2806,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/Postinstall.app/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/PostInstall-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/Postinstall.app/Contents/Resources/English.lproj/InfoPlist.strings\"";
+			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/Postinstall.app/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/PostInstall-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/Postinstall.app/Contents/Resources/English.lproj/InfoPlist.strings\"\n";
 		};
 		DD73550C0D91105F0006A9D1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3091,6 +3176,37 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DD5F653D23605B41009ED2A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD5F655D236069CF009ED2A2 /* cc_config.cpp in Sources */,
+				DD5F655C236068AE009ED2A2 /* coproc.cpp in Sources */,
+				DD5F656423606AED009ED2A2 /* diagnostics.cpp in Sources */,
+				DD5F655623606728009ED2A2 /* filesys.cpp in Sources */,
+				DDA70B4023631BF1007097BD /* gfx_cleanup.mm in Sources */,
+				DD5F6550236064E4009ED2A2 /* gui_rpc_client.cpp in Sources */,
+				DD5F6551236064E4009ED2A2 /* gui_rpc_client_ops.cpp in Sources */,
+				DD5F656523606AED009ED2A2 /* hostinfo.cpp in Sources */,
+				DD5F656123606AA3009ED2A2 /* keyword.cpp in Sources */,
+				DD5F6559236067B3009ED2A2 /* mac_spawn.cpp in Sources */,
+				DDA70B4123632035007097BD /* mac_util.mm in Sources */,
+				DD5F655723606728009ED2A2 /* md5.cpp in Sources */,
+				DD5F655823606728009ED2A2 /* md5_file.cpp in Sources */,
+				DD5F6553236066B2009ED2A2 /* mfile.cpp in Sources */,
+				DD5F6554236066B2009ED2A2 /* miofile.cpp in Sources */,
+				DD5F655A2360681F009ED2A2 /* network.cpp in Sources */,
+				DD5F656323606AA3009ED2A2 /* notice.cpp in Sources */,
+				DD5F656223606AA3009ED2A2 /* opencl_boinc.cpp in Sources */,
+				DD5F6555236066B2009ED2A2 /* parse.cpp in Sources */,
+				DD5F655E236069CF009ED2A2 /* prefs.cpp in Sources */,
+				DD5F655F23606A1F009ED2A2 /* proxy_info.cpp in Sources */,
+				DD5F655B2360681F009ED2A2 /* str_util.cpp in Sources */,
+				DD5F656023606A1F009ED2A2 /* url.cpp in Sources */,
+				DD5F6552236064F8009ED2A2 /* util.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD69FEE508416C1300C01361 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3435,23 +3551,21 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD9917261E69A8B300555337 /* mac_spawn.cpp in Sources */,
 				DDFA60E40CB3396C0037B88C /* gfx_switcher.cpp in Sources */,
-				DDFA61520CB347500037B88C /* app_ipc.cpp in Sources */,
-				DDFA61570CB347730037B88C /* filesys.cpp in Sources */,
+				DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */,
+				DDF0776D236C4E420046EE44 /* coproc.cpp in Sources */,
+				DDC918FB236C2ABB009641C8 /* filesys.cpp in Sources */,
+				DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */,
+				DD26B52B237443BF00206557 /* mac_util.mm in Sources */,
 				DDFA61780CB348660037B88C /* mfile.cpp in Sources */,
 				DDFA617A0CB3486D0037B88C /* miofile.cpp in Sources */,
+				DDF0776B236C4DD60046EE44 /* opencl_boinc.cpp in Sources */,
 				DDFA617E0CB3487F0037B88C /* parse.cpp in Sources */,
+				DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */,
+				DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */,
 				DDFA61860CB3489E0037B88C /* str_util.cpp in Sources */,
-				DDFA61890CB348A90037B88C /* util.cpp in Sources */,
-				DDFA618C0CB348C50037B88C /* hostinfo.cpp in Sources */,
-				DDFA618F0CB348E80037B88C /* md5.cpp in Sources */,
-				DDFA61900CB348E90037B88C /* md5_file.cpp in Sources */,
-				DDFA61920CB349020037B88C /* proxy_info.cpp in Sources */,
-				DDFA61940CB349160037B88C /* prefs.cpp in Sources */,
-				DDFE4E3D10AB778100919319 /* url.cpp in Sources */,
-				DDD9C5AA10CCF6A000A1E4CD /* coproc.cpp in Sources */,
-				DD76BF9617CB465A0075936D /* opencl_boinc.cpp in Sources */,
+				DDF0776C236C4E1A0046EE44 /* url.cpp in Sources */,
+				DDC918FC236C2AE8009641C8 /* util.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3520,6 +3634,16 @@
 			isa = PBXTargetDependency;
 			target = DD3E14D30A774397007E0084 /* mgr_boinc */;
 			targetProxy = DD58247C0B198BDD003B6A2F /* PBXContainerItemProxy */;
+		};
+		DD5F654D23606458009ED2A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD5F654023605B41009ED2A2 /* gfx_cleanup */;
+			targetProxy = DD5F654C23606458009ED2A2 /* PBXContainerItemProxy */;
+		};
+		DD5F654F2360648D009ED2A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD5F654023605B41009ED2A2 /* gfx_cleanup */;
+			targetProxy = DD5F654E2360648D009ED2A2 /* PBXContainerItemProxy */;
 		};
 		DD6178CE1488F09E0042482E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3918,6 +4042,27 @@
 				);
 				PRODUCT_NAME = "Uninstall BOINC";
 				WRAPPER_EXTENSION = app;
+			};
+			name = Deployment;
+		};
+		DD5F654523605B41009ED2A2 /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Development;
+		};
+		DD5F654623605B41009ED2A2 /* Deployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 			};
 			name = Deployment;
 		};
@@ -4553,6 +4698,15 @@
 			buildConfigurations = (
 				DD4688450C165F3C0089F500 /* Development */,
 				DD4688490C165F3C0089F500 /* Deployment */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Development;
+		};
+		DD5F654723605B41009ED2A2 /* Build configuration list for PBXNativeTarget "gfx_cleanup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD5F654523605B41009ED2A2 /* Development */,
+				DD5F654623605B41009ED2A2 /* Deployment */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Development;

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2019 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -115,6 +115,7 @@ Boolean IsRestartNeeded();
 void CheckUserAndGroupConflicts();
 Boolean SetLoginItemOSAScript(long brandID, Boolean deleteLogInItem, char *userName);
 Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLogInItem, passwd *pw);
+Boolean SetScreenSaverLaunchAgent(passwd *pw);
 OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen);
 OSErr SetScreenSaverSelection(char *moduleName, char *modulePath, int type);
 void SetSkinInUserPrefs(char *userName, char *nameOfSkin);
@@ -170,6 +171,7 @@ static char                     tempDirName[MAXPATHLEN];
 static time_t                   waitPermissionsStartTime;
 static vector<string>           human_user_names;
 static vector<uid_t>            human_user_IDs;
+static Boolean                  useScreenSaverLaunchAgent = false;
 
 
 enum { launchWhenDone,
@@ -217,6 +219,9 @@ int main(int argc, char *argv[])
         ShowMessage(false, (char *)_("Could not get user login name"));
         return 0;
     }
+
+    // MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT is defined in mac_util.h
+    useScreenSaverLaunchAgent = (compareOSVersionTo(10, MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT) >= 0);
 
     printf("login name = %s\n", loginName);
     fflush(stdout);
@@ -1149,7 +1154,6 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
         fprintf(f, "\t\t<string>-a</string>\n");
         fprintf(f, "\t\t<string>%s</string>\n", appName[brandID]);
     }
-    fprintf(f, "</string>\n");
     fprintf(f, "\t</array>\n");
     fprintf(f, "\t<key>RunAtLoad</key>\n");
     fprintf(f, "\t<true/>\n");
@@ -1162,6 +1166,60 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
 
     return true;
 }
+
+
+Boolean SetScreenSaverLaunchAgent(passwd *pw)
+{
+    struct stat             sbuf;
+    char                    s[2048];
+    char                    *helper_app_base_path;
+
+    // Create a LaunchAgent for the specified user, replacing any LaunchAgent created
+    // previously (such as by Uninstaller or by installing a differently branded BOINC.)
+    // SetScreenSaverLaunchAgent will run helper app which will run gfx_switcher whenever 
+    // BOINCSaver writes a file BOINCSSHelper.txt. gfx_switcher reads its command from 
+    // that file and writes a file /Users/Shared/BOINCGfxPid.txt with the new pid if it 
+    // succesfully launched a gfx app.
+    //
+    // Create LaunchAgents directory for this user if it does not yet exist
+    snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents", pw->pw_name);
+    if (stat(s, &sbuf) != 0) {
+        mkdir(s, 0755);
+        chown(s, pw->pw_uid, pw->pw_gid);
+    }
+
+    snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents/edu.berkeley.boinc-sshelper.plist", pw->pw_name);
+    FILE* f = fopen(s, "w");
+    if (!f) return false;
+    fprintf(f, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    fprintf(f, "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n");
+    fprintf(f, "<plist version=\"1.0\">\n");
+    fprintf(f, "<dict>\n");
+    fprintf(f, "\t<key>Label</key>\n");
+    fprintf(f, "\t<string>edu.berkeley.boinc-sshelper</string>\n");
+    fprintf(f, "\t<key>ProgramArguments</key>\n");
+    fprintf(f, "\t<array>\n");
+    fprintf(f, "\t\t<string>/Library/Screen Savers/BOINCSaver.saver/Contents/Resources/gfx_switcher</string>\n");
+    fprintf(f, "\t</array>\n");
+    fprintf(f, "\t<key>WatchPaths</key>\n");
+    fprintf(f, "\t<array>\n");
+    if (compareOSVersionTo(10, 15) >= 0) {
+        helper_app_base_path = "Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/";
+    } else {
+        helper_app_base_path = "";
+    }
+    fprintf(f, "\t\t<string>/Users/%s/Library/%sApplication Support/BOINC/BOINCSSHelper.txt</string>\n", pw->pw_name, helper_app_base_path);
+    fprintf(f, "\t</array>\n");
+    fprintf(f, "</dict>\n");
+    fprintf(f, "</plist>\n");
+    fclose(f);
+
+    chmod(s, 0644);
+    chown(s, pw->pw_uid, pw->pw_gid);
+
+    return true;
+}
+
 
 
 // Sets the skin selection in the specified user's preferences to the specified skin
@@ -1823,6 +1881,63 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                 // sprintf(s, "su -l \"%s\" -c 'defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName \"%s\" path \"/Library/Screen Savers/%s.saver\" type 0'", pw->pw_name, saverName[brandID], s);
                 // callPosixSpawn(s);
             }
+            
+            if (useScreenSaverLaunchAgent) {
+                printf("[2] calling SetScreenSaverLaunchAgent for user %s, euid = %d\n", 
+                    pw->pw_name, geteuid());
+                fflush(stdout);
+                // SetScreenSaverLaunchAgent will run helper app which will run gfx_switcher whenever 
+                // BOINCSaver writes a file BOINCSSHelper.txt. gfx_switcher reads its command from 
+                // that file and writes a file /Users/Shared/BOINCGfxPid.txt with the new pid if it 
+                // succesfully launched a gfx app.
+                //
+                SetScreenSaverLaunchAgent(pw);
+            }
+             
+            if (compareOSVersionTo(10, 15) >= 0) {
+                // Under Catalina, Screensaver output files are put in the user's Containers 
+                // directory. Create the directory if it doesn't exist and create a symbolic
+                // link to it in the normal per-user BOINC directory 
+                snprintf(s, sizeof(s), 
+                    "/Users/%s/Library/Application Support/BOINC", pw->pw_name);
+                if (stat(s, &sbuf) != 0) {
+                    snprintf(cmd, sizeof(cmd), "sudo -u \"%s\" mkdir -p -m 0775 \"/Users/%s/Library/Application Support/BOINC\"",
+                            pw->pw_name, pw->pw_name);
+                    err = callPosixSpawn(cmd);
+                    REPORT_ERROR(err);
+                    printf("[2] %s returned %d\n", cmd, err);
+                    fflush(stdout);
+                }
+                    
+                snprintf(s, sizeof(s), "/Users/%s/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/BOINC", 
+                        pw->pw_name);
+                    if (stat(s, &sbuf) != 0) {
+                        // mkdir -p creates intermediate directories as required
+                        snprintf(cmd, sizeof(cmd), "sudo -u \"%s\" mkdir -p -m 0700 \"/Users/%s/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support\"",
+                                pw->pw_name, pw->pw_name);
+                        err = callPosixSpawn(cmd);
+                        REPORT_ERROR(err);
+                        printf("[2] %s returned %d\n", cmd, err);
+                        fflush(stdout);
+
+                    snprintf(cmd, sizeof(cmd), "sudo -u \"%s\" mkdir -m 0775 \"/Users/%s/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/BOINC\"",
+                            pw->pw_name, pw->pw_name);
+                    err = callPosixSpawn(cmd);
+                    REPORT_ERROR(err);
+                    printf("[2] %s returned %d\n", cmd, err);
+                    fflush(stdout);
+                }
+                snprintf(s, sizeof(s), 
+                    "/Users/%s/Library/Application Support/BOINC/ScreenSaver Logs", 
+                    pw->pw_name);
+                if (lstat(s, &sbuf) != 0) {
+                    snprintf(cmd, sizeof(cmd), "sudo -u \"%s\" ln -s \"/Users/%s/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/BOINC\" \"/Users/%s/Library/Application Support/BOINC/ScreenSaver Logs\"", pw->pw_name, pw->pw_name, pw->pw_name);
+                    err = callPosixSpawn(cmd);
+                    REPORT_ERROR(err);
+                    printf("[2] %s returned %d\n", cmd, err);
+                    fflush(stdout);
+                }
+            }
         }
 
         // Delete the BOINC Manager's wxSingleInstanceChecker lock file, in case
@@ -1839,6 +1954,24 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
 
     }   // End for (userIndex=0; userIndex< human_user_names.size(); ++userIndex)
 
+
+    if (useScreenSaverLaunchAgent) {
+        if (currentUserCanRunBOINC) {
+            pw = getpwnam(loginName);
+            setuid(pw->pw_uid);
+            setgid(pw->pw_gid);
+            printf("[2] loading screensaver LaunchAgent edu.berkeley.boinc-sshelper.plist for current user\n");
+            fflush(stdout);
+            snprintf(cmd, sizeof(cmd), 
+                "launchctl load /Users/%s/Library/LaunchAgents/edu.berkeley.boinc-sshelper.plist", 
+                loginName);
+            err = callPosixSpawn(cmd);
+            REPORT_ERROR(err);
+            printf("[2] %s returned %d\n", cmd, err);
+            fflush(stdout);
+        }
+    }
+    
     ResynchDSSystem();
     
     BOINCTranslationCleanup();

--- a/mac_installer/ReadMe.rtf
+++ b/mac_installer/ReadMe.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf600
+{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf610
 \cocoascreenfonts1{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;\red251\green2\blue7;\red56\green110\blue255;}
 {\*\expandedcolortbl;;\cssrgb\c100000\c14913\c0;\csgenericrgb\c21961\c43137\c100000;}
@@ -18,7 +18,9 @@
 \b0 \
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
-\cf2 New for Mojave\cf0 : If your Mac has more than one user account, each user may see the following dialog upon their first login after you have installed BOINC: "BOINC_Finish_install" wants to control "System Events...." The BOINC installer needs this access to finish adding or removing its login item for each user; please click "OK".\
+\cf2 New for Catalina\cf0 :  If your Mac has more than one user logged in when you run the BOINC installer, the BOINC screensaver may not work for some users until they log out and log in again.\
+\cf2 \
+New for Mojave\cf0 : If your Mac has more than one user account, each user may see the following dialog upon their first login after you have installed BOINC: "BOINC_Finish_install" wants to control "System Events...." The BOINC installer needs this access to finish adding or removing its login item for each user; please click "OK".\
 \
 \cf2 CUDA UPGRADE WARNING\cf0 : Do not upgrade to CUDA 6.5 or later if you have an older NVIDIA GPU with Compute Capability 1.3 or less.  You can check your GPU\'92s Compute Capability at {\field{\*\fldinst{HYPERLINK "https://developer.nvidia.com/cuda-gpus"}}{\fldrslt https://developer.nvidia.com/cuda-gpus}}. \
 \

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # http://boinc.berkeley.edu
-# Copyright (C) 2017 University of California
+# Copyright (C) 2019 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -48,6 +48,7 @@
 ## updated 10/19/17 by Charlie Fenton for different path to boinc_logo_black.jpg
 ## updated 11/11/17 by Charlie Fenton make all user-writable to help auto-attach
 ## updated 11/6/18 by Charlie Fenton to code sign for Apple "notarization"
+## updated 11/4/19 by Charlie Fenton to code sign for new gfx_cleanup helper app
 ##
 ## NOTE: This script requires Mac OS 10.6 or later, and uses XCode developer
 ##   tools.  So you must have installed XCode Developer Tools on the Mac 
@@ -113,6 +114,9 @@
 ## Apple."
 ## 
 ## To notarize the installer and uninstaller:
+## NOTE: Do not use your normal Apple ID password. You must create an 
+## app-specific password at https://appleid.apple.com/account/manage.
+##
 ## - Use the command line tools in Xcode 10 or later
 ## - Provide valid application & installer code signing identities as above
 ## - In Terminal":
@@ -358,6 +362,9 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
 
     # Code Sign the gfx_switcher utility embedded in BOINC screensaver if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver/Contents/Resources/gfx_switcher"
+
+    # Code Sign the gfx_cleanup utility embedded in BOINC screensaver if we have a signing identity
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver/Contents/Resources/gfx_cleanup"
 
     # Code Sign the BOINC screensaver code for OS 10.8 and later if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver"

--- a/mac_installer/release_brand.sh
+++ b/mac_installer/release_brand.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # http://boinc.berkeley.edu
-# Copyright (C) 2018 University of California
+# Copyright (C) 2019 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -80,6 +80,9 @@
 ## Apple."
 ## 
 ## To notarize the installer and uninstaller:
+## NOTE: Do not use your normal Apple ID password. You must create an 
+## app-specific password at https://appleid.apple.com/account/manage.
+##
 ## - Use the command line tools in Xcode 10 or later
 ## - Provide valid application & installer code signing identities as above
 ## - In Terminal":
@@ -379,6 +382,9 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
 
     # Code Sign the gfx_switcher utility embedded in BOINC screensaver if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/${SSAVERAPPNAME}.saver/Contents/Resources/gfx_switcher"
+
+    # Code Sign the gfx_cleanup utility embedded in BOINC screensaver if we have a signing identity
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver/Contents/Resources/gfx_cleanup"
 
     # Code Sign the BOINC screensaver code for OS 10.8 and later if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/${SSAVERAPPNAME}.saver/"


### PR DESCRIPTION
 Under OS 10.15 Catalina:
Problems:
* Screensavers can't launch _setuid_ / _setgid_ executables like `gfx_switcher` or `ps`
 * Screensavers can't launch executables downloaded directly from the Internet unless they have first been vetted by the user via _GateKeeper_, but there is no provision for _GateKeeper_ to offer users that option for bare executables like project graphics apps.

Solution:
 * Instead of launching graphics apps directly via `gfx_switcher`, the BOINC screensaver coordinator writes a file _BOINCSSHelper.txt_ containing the information about what to launch. The file is detected by a LaunchAgent which then launches `gfx_switcher` for us. `gfx_switcher` then deletes the _BOINCSSHelper.txt_ file, and writes a file _BOINCGfxPid.txt_ containing the graphics app's process ID (PID). The BOINC screensaver coordinator waits for the _BOINCGfxPid.txt_ file to exist and reads the PID from it. When the graphics app exits, `gfx_switcher` deletes the _BOINCGfxPid.txt_ file, signaling the BOINC screensaver coordinator that the graphics app has exited. This is rather convoluted, but it works well with no noticeable degradation of performance.
 * Instead of killing graphics apps via `gfx_switcher`, the BOINC screensaver coordinator sends an RPC to the client asking the client to kill them via `switcher`. (Since the graphics app is running as user _boinc_project_, only user _boinc_project_ can send a kill signal to it.) Since `switcher` (not `gfx_switcher`) is called from the client rather than from the screensaver, there is no restriction on launching _setuid_ / _setgid_ apps like `switcher`. 
 * Note that, since this RPC requires the BOINC screensaver coordinator to read the _gui_rpc_auth.cfg_ file, only users authorized to manage BOINC (via BOINC Manager) can run the BOINC screensaver to display graphics apps. (The installer added those users to groups _boinc_master_ and _boinc_project_.)
 * Though we have confirmed these changes work on OS 10.13 High Sierra, we don't use them there (yet). To do: test if we can use these new methods on all our supported versions of OS X (OS < 10.13) to simplify this code. Since I don't have Macs which can run older versions of OS X, I have not been able to test this.

Problem:
 * Apple's ScreenSaverEngine doesn't always call `stopAnimation` before exiting

Solution:
 * BOINC screensaver coordinator launches a new helper app `gfx_cleanup` via `popen()`, communicating via a pipe. When it launches a graphics app it passes that app's process ID (PID) to `gfx_cleanup`. When the graphics app exits, the BOINC screensaver coordinator sends a zero PID to `gfx_cleanup`.  The `gfx_cleanup` helper app detects when the BOINC screensaver coordinator itself exits; if the most recent PID was non-zero it sends an RPC to the client asking the client to kill the graphics app via `switcher`. 
 * In OS 10.13 High Sierra and later, we must use mach-o communication and `IOSurface` to share the graphics app's GPU buffer with our screensaver, so the screensaver can display the graphics. Since the graphics app does not draw directly to the screen, it's own window is all white (blank.) To avoid an annoying momentary white flash when the screensaver quits before the `gfx_cleanup` helper app kills it, `gfx_cleanup` covers the screen temporarily with an all-black window.

Problem:
 * For compatibility with OS 10.13 High Sierra, we required all project graphics apps to be updated to use mach-o communication and `IOSurface`, by linking to version 7.9.2 or later of _libboinc_graphics2.a_. As a temporary transitional measure, we used the `CGWindowList` method to display any project graphics apps which had not yet been updated. This no longer works on OS 10.15, probably because `CGWindowListCopyWindowInfo` and `CGWindowListCreateImage` can no longer copy windows between user _boinc_project_ and the user running the screensaver, due to security concerns with allowing anyone to view another user's windows. (The `IOSurface` method is safer because an app must have specific code to allow sharing its windows with the other app.)

Solution:
 * We can no longer support project graphics apps which have not been updated by linking to version 7.9.2 or later of _libboinc_graphics2.a_. This library has been available since February 2018. The `CGWindowList` method resulted in reduced quality due to a low frame rate and was never intended to be a long-term solution. All projects should have re-linked their graphics app by now (though I suspect that not all have done so.)  

Problem:
 * Apple's ScreenSaverEngine always passes true for `isPreview` argument

 Solution:
* Under OS 10.15 or later, assume it is not a preview if the window width or height is greater than 500.

Problem:
* Under OS 10.15, OpenGL apps use doubled window dimensions on Retina displays (2 pixels per point), but earlier versions of OS X do not.

Solution:
* Under OS 10.15 or later, adjust the drawing routines based on the results of the `[NSScreen backingScaleFactor]` which gives the number of pixels per point on the screen. This works for both Retina and conventional monitors. To do: check that later versions of OS X still require these adjustments; if not, then modify the code to do them only when appropriate.

Problem:
* Screensaver output files _stdoutscr.txt_ and _stderrscr.txt_ are put in an obscure sandboxed directory

Solution:
* The installer creates a symbolic link "_~/Library/Application Support/BOINC/ScreenSaver logs_" to "_~/Library/Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/Application Support/BOINC/_" so users can find these files by looking in the directory which held them in older versions of OS X and use that link. (The older directory "_~/Library/Application Support/BOINC/_" still contains other BOINC logs.)

**Release Notes**
Fixes the BOINC screensaver for Mac OS 10.15 Catalina.