### PR TITLE
Add sched_op debug flag tag to log messages

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -465,7 +465,7 @@ bool CLIENT_STATE::scheduler_rpc_poll() {
     p = next_project_sched_rpc_pending();
     if (p) {
         if (log_flags.sched_op_debug) {
-            msg_printf(p, MSG_INFO, "sched RPC pending: %s",
+            msg_printf(p, MSG_INFO, "[sched_op] sched RPC pending: %s",
                 rpc_reason_string(p->sched_rpc_pending)
             );
         }
@@ -664,7 +664,7 @@ int CLIENT_STATE::handle_scheduler_reply(
 
     if (log_flags.sched_op_debug && sr.request_delay) {
         msg_printf(project, MSG_INFO,
-            "Project requested delay of %.0f seconds", sr.request_delay
+            "[sched_op] Project requested delay of %.0f seconds", sr.request_delay
         );
     }
 
@@ -690,7 +690,7 @@ int CLIENT_STATE::handle_scheduler_reply(
         if (gstate.acct_mgr_info.using_am() && p && q && !strcmp(p, q)) {
             if (log_flags.sched_op_debug) {
                 msg_printf(project, MSG_INFO,
-                    "ignoring prefs from project; using prefs from AM"
+                    "[sched_op] ignoring prefs from project; using prefs from AM"
                 );
             }
         } else if (!global_prefs.host_specific || sr.scheduler_version >= 507) {
@@ -707,7 +707,7 @@ int CLIENT_STATE::handle_scheduler_reply(
         } else {
             if (log_flags.sched_op_debug) {
                 msg_printf(project, MSG_INFO,
-                    "ignoring prefs from old server; we have host-specific prefs"
+                    "[sched_op] ignoring prefs from old server; we have host-specific prefs"
                 );
             }
         }


### PR DESCRIPTION
[sched_op] tag was missing for some debug messages.

Fixes #3360 

**Release Notes**
Add missing sched_op tag for some of the debug messages.
