### PR TITLE
client: add the acct_mgr_info authenticator response

### DIFF
--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -664,6 +664,7 @@ static void handle_acct_mgr_info(GUI_RPC_CONN& grc) {
         || strlen(gstate.acct_mgr_info.authenticator)
     ) {
         grc.mfout.printf("   <have_credentials/>\n");
+	grc.mfout.printf("   <authenticator>%s</authenticator>\n", gstate.acct_mgr_info.authenticator);
     }
 
     if (gstate.acct_mgr_info.cookie_required) {

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -664,7 +664,7 @@ static void handle_acct_mgr_info(GUI_RPC_CONN& grc) {
         || strlen(gstate.acct_mgr_info.authenticator)
     ) {
         grc.mfout.printf("   <have_credentials/>\n");
-	grc.mfout.printf("   <authenticator>%s</authenticator>\n", gstate.acct_mgr_info.authenticator);
+        grc.mfout.printf("   <authenticator>%s</authenticator>\n", gstate.acct_mgr_info.authenticator);
     }
 
     if (gstate.acct_mgr_info.cookie_required) {


### PR DESCRIPTION
We use our account manager and use HTTP for additional communication, so the authenticator is needed for response,