### PR TITLE
Moved max_cpus check

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -915,10 +915,16 @@ bool PLAN_CLASS_SPEC::check(
             hu.avg_ncpus = avg_ncpus;
         } else {
             if (can_use_multicore) {
-                if (max_threads > g_wreq->effective_ncpus) {
-                    hu.avg_ncpus = g_wreq->effective_ncpus;
-                } else {
-                    hu.avg_ncpus = max_threads;
+                hu.avg_ncpus = max_threads;
+	        // Limits the number of threads to the number of CPUs                                                                   
+		if (max_threads > g_wreq->effective_ncpus) {
+	            hu.avg_ncpus = g_wreq->effective_ncpus;
+                }
+                // Limits the number of threads to the max_cpus volunteer's project preference                                          
+	        if (g_wreq->project_prefs.max_cpus) {
+                    if (hu.avg_ncpus > g_wreq->project_prefs.max_cpus) {
+                        hu.avg_ncpus = g_wreq->project_prefs.max_cpus;
+                    }
                 }
 
                 // if per-CPU mem usage given

--- a/sched/sched_send.cpp
+++ b/sched/sched_send.cpp
@@ -145,11 +145,6 @@ void WORK_REQ::get_job_limits() {
     if (n > config.max_ncpus) n = config.max_ncpus;
     if (n < 1) n = 1;
     if (n > MAX_CPUS) n = MAX_CPUS;
-    if (project_prefs.max_cpus) {
-        if (n > project_prefs.max_cpus) {
-            n = project_prefs.max_cpus;
-        }
-    }
     ninstances[PROC_TYPE_CPU] = n;
     effective_ncpus = n;
 


### PR DESCRIPTION
Moving the max_cpus check to address #3386.

The max_cpus preference is used to set the maximum number of CPUs (threads) to be used by a VM application.