### PR TITLE
[Manager] Fix Manager crash in APP_VERSION::clear()

### DIFF
--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -222,6 +222,7 @@ struct APP_VERSION {
     PROJECT* project;
 
     APP_VERSION();
+    APP_VERSION(int) {}
 
     int parse(XML_PARSER&);
     int parse_coproc(XML_PARSER&);

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -590,7 +590,7 @@ int APP_VERSION::parse(XML_PARSER& xp) {
 }
 
 void APP_VERSION::clear() {
-    static const APP_VERSION x;
+    static const APP_VERSION x(0);
     *this = x;
 }
 


### PR DESCRIPTION
In 219a540 a circular dependency was introduced.
This commit fixes it in a similar way from the commit mentioned above for another structures.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>