### PR TITLE
Scheduler (client and server): message tweaks

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -662,9 +662,9 @@ int CLIENT_STATE::handle_scheduler_reply(
         notices.remove_notices(project, REMOVE_SCHEDULER_MSG);
     }
 
-    if (log_flags.sched_op_debug && sr.request_delay) {
+    if (sr.request_delay) {
         msg_printf(project, MSG_INFO,
-            "[sched_op] Project requested delay of %.0f seconds", sr.request_delay
+            "Project requested delay of %.0f seconds", sr.request_delay
         );
     }
 

--- a/sched/handle_request.cpp
+++ b/sched/handle_request.cpp
@@ -1416,13 +1416,12 @@ void process_request(char* code_sign_key) {
             if (config.min_sendwork_interval) {
                 double diff = dtime() - last_rpc_time;
                 if (diff < config.min_sendwork_interval) {
-                    double t_left = config.min_sendwork_interval - diff;
                     ok_to_send_work = false;
                     log_messages.printf(MSG_NORMAL,
-                        "Not sending work - last request too recent, please wait: %f\n", t_left
+                        "Not sending work - last request too recent, please wait: %f\n", config.min_sendwork_interval
                     );
                     sprintf(buf,
-                        "Not sending work - last request too recent, please wait: %d sec", (int)t_left
+                        "Not sending work - last request too recent, please wait: %d sec", (int)config.min_sendwork_interval
                     );
                     g_reply->insert_message(buf, "low");
 


### PR DESCRIPTION
client - show requested delay always (why hide it?)
server - ignore residual delay from previous RPC

Fixes #3375