### PR TITLE
Added Estimated Completion column to Advanced view > Tasks

### DIFF
--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -2721,16 +2721,22 @@ wxString FormatTime(double secs) {
     if (secs <= 0) {
         return wxT("---");
     }
-    wxInt32 iHour = (wxInt32)(secs / (60 * 60));
-    wxInt32 iMin  = (wxInt32)(secs / 60) % 60;
-    wxInt32 iSec  = (wxInt32)(secs) % 60;
-    wxTimeSpan ts = wxTimeSpan(iHour, iMin, iSec);
+    
+    wxTimeSpan ts = convert_to_timespan(secs);
     return ts.Format((secs>=86400)?"%Dd %H:%M:%S":"%H:%M:%S");
 }
 
 wxString format_number(double x, int nprec) {
     return wxNumberFormatter::ToString(x, nprec);
 
+}
+
+wxTimeSpan convert_to_timespan(double secs) {
+    wxInt32 iHour = (wxInt32)(secs / (60 * 60));
+    wxInt32 iMin  = (wxInt32)(secs / 60) % 60;
+    wxInt32 iSec  = (wxInt32)(secs) % 60;
+    wxTimeSpan ts = wxTimeSpan(iHour, iMin, iSec);
+    return (ts);
 }
 
 // the autoattach process deletes the installer filename file when done

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -419,6 +419,7 @@ extern void remove_eols(wxString& strMessage);
 extern void https_to_http(wxString& strMessage);
 extern void color_cycle(int i, int n, wxColour& color);
 extern wxString FormatTime(double secs);
+extern wxTimeSpan convert_to_timespan(double secs);
 extern bool autoattach_in_progress();
 
 #ifdef __WXMSW__

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -1218,6 +1218,7 @@ void CViewWork::GetDocTimeToCompletion(wxInt32 item, double& fBuffer) const {
     }
 }
 
+
 void CViewWork::GetDocReportDeadline(wxInt32 item, time_t& time) const {
     RESULT*        result = wxGetApp().GetDocument()->result(item);
 

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -767,16 +767,18 @@ wxString CViewWork::OnListGetItemText(long item, long column) const {
                 strBuffer = work->m_strStatus;
                 break;
             case COLUMN_ESTIMATEDCOMPLETION:
-                if (work->m_fCPUTime > 0) {
+                if ((work->m_fCPUTime > 0) && (work->m_strStatus.IsSameAs("Running"))) {
                     wxDateTime now = wxDateTime::Now();
                     wxTimeSpan time_to_completion = convert_to_timespan(work->m_fTimeToCompletion);
                     wxDateTime estimated_completion = now.Add(time_to_completion);
                     FormatDateTime(estimated_completion.GetTicks(), strBuffer);
+                    // Only display the Estimated Completion time if the task has
+                    // been started and is currently running.
                 } else {
                     strBuffer = FormatTime(0);
-                    // If the task has not started (CPUTime <= 0), passing
-                    // 0 to FormatTime will return "---" as the estimated
-                    // completion time
+                    // If the task has not started (CPUTime <= 0) or is not currently
+                    // running, pass 0 to FormatTime to display "---" as the Estimated
+                    // Completion time
                 }
                 break;
         }

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -767,7 +767,8 @@ wxString CViewWork::OnListGetItemText(long item, long column) const {
                 strBuffer = work->m_strStatus;
                 break;
             case COLUMN_ESTIMATEDCOMPLETION:
-                if ((work->m_fCPUTime > 0) && (work->m_strStatus.IsSameAs("Running"))) {
+                //if ((work->m_fCPUTime > 0) && (work->m_strStatus.IsSameAs("Running"))) {
+                if ((work->m_fCPUTime > 0) && (work->m_strStatus.Contains("Running"))) {
                     wxDateTime now = wxDateTime::Now();
                     wxTimeSpan time_to_completion = convert_to_timespan(work->m_fTimeToCompletion);
                     wxDateTime estimated_completion = now.Add(time_to_completion);

--- a/clientgui/ViewWork.h
+++ b/clientgui/ViewWork.h
@@ -107,7 +107,7 @@ protected:
     wxInt32                 FormatProgress( double fBuffer, wxString& strBuffer ) const;
     void                    GetDocTimeToCompletion(wxInt32 item, double& fBuffer) const;
     void                    GetDocReportDeadline(wxInt32 item, time_t& time) const;
-    wxInt32                 FormatReportDeadline( time_t deadline, wxString& strBuffer ) const;
+    wxInt32                 FormatDateTime( time_t datetime, wxString& strBuffer ) const;
     wxInt32                 FormatStatus( wxInt32 item, wxString& strBuffer ) const;
     void                    GetDocProjectURL(wxInt32 item, wxString& strBuffer) const;
     virtual double          GetProgressValue(long item);

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -222,6 +222,7 @@ struct APP_VERSION {
     PROJECT* project;
 
     APP_VERSION();
+    APP_VERSION(int) {}
 
     int parse(XML_PARSER&);
     int parse_coproc(XML_PARSER&);

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -590,7 +590,7 @@ int APP_VERSION::parse(XML_PARSER& xp) {
 }
 
 void APP_VERSION::clear() {
-    static const APP_VERSION x;
+    static const APP_VERSION x(0);
     *this = x;
 }
 


### PR DESCRIPTION
Fixes #2115

**Description of the Change**
Added a new column -- "Estimated Completion" -- to the Advanced > Tasks screen to show the calculated date and time by which a task should complete. It is positioned immediately next to the existing "Deadline" column to make it easier for users to visually assess which task(s) may not complete by the deadline.

**Alternate Designs**
I opted to design "estimated completion" as a derived field. It is calculated as "current date and time" + "remaining time". Therefore, I opted to *not* add a new saved field to the data model for it.

Also, the original issue (#2115) had specified another new field to be added, to explicitly calculate and display the delta between the estimated completion date/time and the deadline date/time. However, it is my opinion that this additional field is not necessary and that having the estimated completion date/time displayed right next to the deadline date/time is enough information for a user to assess whether a task is likely to complete by the deadline, or not. Therefore, I opted to not implement this part of the issue for now.

**Release Notes**
Added "Estimated Completion" as a new column in Advanced view > Tasks to show the date and time by which a task should complete.
