### PR TITLE
[AppVeyor] Add Win32 build configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ matrix:
   fast_finish: true
 
 platform:
-#  - Win32
+  - Win32
   - x64
 
 pull_requests:
@@ -66,6 +66,7 @@ environment:
       depends_path: C:\projects\boinc_depends_win_vs2013
   BINTRAY_API_KEY:
     secure: kZI9k0Kh2bFSCbXfkz+J16fGNAee1ToRMl10D8QPQsKpC2PqhF/uVMpd6gRC+OSI
+  APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma2 -mx=9 -ms=on"
 
 cache:
   - C:\projects\boinc_depends_win_vs2013 -> appveyor.yml, win_build\load_dependencies.bat
@@ -73,10 +74,10 @@ cache:
 before_build:
   - call win_build\load_dependencies.bat %depends_git_path% %depends_path% %platform% %configuration%
   - if %TOOLCHAIN_VERSION%==12.0 call "%VS120COMNTOOLS%\vsvars32.bat"
-  - rmdir /S /Q %localappdata%\Microsoft\VisualStudio\%TOOLCHAIN_VERSION%\ComponentModelCache
+  - if %TOOLCHAIN_VERSION%==12.0 call rmdir /S /Q %localappdata%\Microsoft\VisualStudio\%TOOLCHAIN_VERSION%\ComponentModelCache
 
 build_script:
-  - devenv %solution_name% /Build "%configuration%|%platform%"
+  - msbuild %solution_name% /p:Configuration=%configuration%;Platform=%platform%
 
 after_build:
   - call deploy\prepare_deployment.bat

--- a/deploy/deploy_to_bintray.bat
+++ b/deploy/deploy_to_bintray.bat
@@ -69,17 +69,17 @@ echo Creating version !pkg_version!...
 set data={\"name\": \"!pkg_version!\", \"desc\": \"!pkg_version_desc!\"}
 %CURL% -H Content-Type:application/json -X POST -d "%data%" "%API%/packages/%BINTRAY_REPO_OWNER%/%BINTRAY_REPO%/!pkg_name!/versions"
 
-if exist "deploy\win-apps\win-apps_!pkg_version!.7z" (
+if exist "deploy\win-apps\win-apps_!pkg_version!_%platform%.7z" (
     echo Uploading and publishing "deploy\win-apps\win-apps_!pkg_version!.7z"
     %CURL% -H Content-Type:application/octet-stream -T "deploy\win-apps\win-apps_!pkg_version!.7z" "%API%/content/%BINTRAY_REPO_OWNER%/%BINTRAY_REPO%/!pkg_name!/!pkg_version!/win-apps_!pkg_version!.7z?publish=1&override=1"
 )
 
-if exist "deploy\win-client\win-client_!pkg_version!.7z" (
+if exist "deploy\win-client\win-client_!pkg_version!_%platform%.7z" (
     echo Uploading and publishing "deploy\win-client\win-client_!pkg_version!.7z"
     %CURL% -H Content-Type:application/octet-stream -T "deploy\win-client\win-client_!pkg_version!.7z" "%API%/content/%BINTRAY_REPO_OWNER%/%BINTRAY_REPO%/!pkg_name!/!pkg_version!/win-client_!pkg_version!.7z?publish=1&override=1"
 )
 
-if exist "deploy\win-manager\win-manager_!pkg_version!.7z" (
+if exist "deploy\win-manager\win-manager_!pkg_version!_%platform%.7z" (
     echo Uploading and publishing "deploy\win-manager\win-manager_!pkg_version!.7z"
     %CURL% -H Content-Type:application/octet-stream -T "deploy\win-manager\win-manager_!pkg_version!.7z" "%API%/content/%BINTRAY_REPO_OWNER%/%BINTRAY_REPO%/!pkg_name!/!pkg_version!/win-manager_!pkg_version!.7z?publish=1&override=1"
 )

--- a/deploy/prepare_deployment.bat
+++ b/deploy/prepare_deployment.bat
@@ -38,7 +38,7 @@ copy "win_build\Build\%platform%\%configuration%\example_app.exe" "deploy\win-ap
 copy "win_build\Build\%platform%\%configuration%\worker.exe" "deploy\win-apps\"
 copy "win_build\Build\%platform%\%configuration%\sleeper.exe" "deploy\win-apps\"
 cd deploy\win-apps
-7z a win-apps_!pkg_version!.7z *.exe
+7z a win-apps_!pkg_version!_%platform%.7z *.exe
 cd ..\..
 
 if not exist "deploy\win-client" mkdir deploy\win-client
@@ -48,14 +48,14 @@ copy "win_build\Build\%platform%\%configuration%\boinccmd.exe" "deploy\win-clien
 copy "win_build\Build\%platform%\%configuration%\boincscr.exe" "deploy\win-client\"
 copy "win_build\Build\%platform%\%configuration%\boinc.scr" "deploy\win-client\"
 cd deploy\win-client
-7z a win-client_!pkg_version!.7z *.exe *.scr
+7z a win-client_!pkg_version!_%platform%.7z *.exe *.scr
 cd ..\..
 
 if not exist "deploy\win-manager" mkdir deploy\win-manager
 copy "win_build\Build\%platform%\%configuration%\boinctray.exe" "deploy\win-manager\"
 copy "win_build\Build\%platform%\%configuration%\boincmgr.exe" "deploy\win-manager\"
 cd deploy\win-manager
-7z a win-manager_!pkg_version!.7z *.exe
+7z a win-manager_!pkg_version!_%platform%.7z *.exe
 cd ..\..
 
 rem setlocal mode is very 'interesting'


### PR DESCRIPTION
Change build with devenv to more common used msbuild
Change AppVeyor cache saving from zip to 7zip with maximal compression

Fixes #2620

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>