### PR TITLE
[WIP] User option to exclude a task from being scheduled to run if it is simulated to likely miss its deadline

### DIFF
--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -146,6 +146,8 @@ struct PROC_RESOURCES {
                 atp->needs_shmem = false;
             }
         }
+        if (rp->rr_sim_misses_deadline) return false;
+            // Don't schedule if the result is simulated to miss its deadline
         if (rp->schedule_backoff > gstate.now) return false;
         if (rp->uses_gpu()) {
             if (gpu_suspend_reason) return false;


### PR DESCRIPTION
Fixes #2957 

**Description of the Change**
Whenever BOINC main() polls to generate the list of tasks to run - and the order in which to run them - any tasks that are at risk of slipping past its deadline (as simulated by BOINC) is excluded.

This is a WIP and simply adds the logic to exclude a task from being scheduled if the result is simulated to likely slip past the deadline. I will work on the user configuration option next, e.g. "Exclude jobs if it is at risk of missing its deadline (Y/N)"?

**Alternate Designs**
The original Feature Request was to add an option to explicitly **abort** a task. In my view, this is a cleaner solution to the problem the Feature Request is looking to solve. It relies on the existing, underlying logic for scheduling, prioritizing, and clean-up of tasks, i.e. nothing is explicitly aborted, only excluded from the run list. Thus, the only change would be in the logic applied in cpu_sched->can_schedule().

**Release Notes**
Add user-configurable option to exclude tasks that are likely to miss their deadline from being scheduled to run.
