### PR TITLE
[Android] Make BOINC always run foreground service

### DIFF
--- a/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
+++ b/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
@@ -97,11 +97,9 @@ List<ImageWrapper> getSlideshowForProject(in String url);   // clientStatus.getS
 ////// app preference ////////////////////////////////////////////
 void setAutostart(in boolean isAutoStart);          // Monitor.getAppPrefs().setAutostart(boolean);
 void setShowNotificationForNotices(in boolean isShow);   // Monitor.getAppPrefs().setShowNotificationForNotices(boolean);
-void setShowNotificationDuringSuspend(in boolean isShow);   // Monitor.getAppPrefs().setShowNotificationDuringSuspend(boolean);
 boolean getShowAdvanced();           // Monitor.getAppPrefs().getShowAdvanced();
 boolean getAutostart();              // Monitor.getAppPrefs().getAutostart();
 boolean getShowNotificationForNotices();       // Monitor.getAppPrefs().getShowNotificationForNotices();
-boolean getShowNotificationDuringSuspend();       // Monitor.getAppPrefs().getShowNotificationDuringSuspend();
 int getLogLevel();                   // Monitor.getAppPrefs().getLogLevel();
 void setLogLevel(in int level);               // Monitor.getAppPrefs().setLogLevel(int);
 void setPowerSourceAc(in boolean src);      // Monitor.getAppPrefs().setPowerSourceAc(boolean);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
@@ -194,7 +194,6 @@ public class PrefsFragment extends Fragment {
         data.add(new PrefsListItemWrapper(getActivity(), R.string.prefs_category_general, true));
         data.add(new PrefsListItemWrapperBool(getActivity(), R.string.prefs_autostart_header, R.string.prefs_category_general, BOINCActivity.monitor.getAutostart()));
         data.add(new PrefsListItemWrapperBool(getActivity(), R.string.prefs_show_notification_notices_header, R.string.prefs_category_general, BOINCActivity.monitor.getShowNotificationForNotices()));
-        data.add(new PrefsListItemWrapperBool(getActivity(), R.string.prefs_show_notification_suspended_header, R.string.prefs_category_general, BOINCActivity.monitor.getShowNotificationDuringSuspend()));
         data.add(new PrefsListItemWrapperBool(getActivity(), R.string.prefs_show_advanced_header, R.string.prefs_category_general, BOINCActivity.monitor.getShowAdvanced()));
         if(!stationaryDeviceMode) {
             data.add(new PrefsListItemWrapperBool(getActivity(), R.string.prefs_suspend_when_screen_on, R.string.prefs_category_general, BOINCActivity.monitor.getSuspendWhenScreenOn()));
@@ -694,11 +693,6 @@ public class PrefsFragment extends Fragment {
                         break;
                     case R.string.prefs_show_notification_notices_header: //app pref
                         BOINCActivity.monitor.setShowNotificationForNotices(isSet);
-                        updateBoolPreference(ID, isSet);
-                        updateLayout();
-                        break;
-                    case R.string.prefs_show_notification_suspended_header: //app pref
-                        BOINCActivity.monitor.setShowNotificationDuringSuspend(isSet);
                         updateBoolPreference(ID, isSet);
                         updateLayout();
                         break;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.java
@@ -32,7 +32,6 @@ public class AppPreferences {
 
     private Boolean autostart;
     private Boolean showNotificationForNotices;
-    private Boolean showNotificationDuringSuspend;
     private Boolean showAdvanced;
     private Integer logLevel;
     private Boolean powerSourceAc;
@@ -49,8 +48,6 @@ public class AppPreferences {
         autostart = prefs.getBoolean("autostart", ctx.getResources().getBoolean(R.bool.prefs_default_autostart));
         showNotificationForNotices =
                 prefs.getBoolean("showNotification", ctx.getResources().getBoolean(R.bool.prefs_default_notification_notices));
-        showNotificationDuringSuspend =
-                prefs.getBoolean("showNotificationDuringSuspend", ctx.getResources().getBoolean(R.bool.prefs_default_notification_suspended));
         showAdvanced = prefs.getBoolean("showAdvanced", ctx.getResources().getBoolean(R.bool.prefs_default_advanced));
         logLevel = prefs.getInt("logLevel", ctx.getResources().getInteger(R.integer.prefs_default_loglevel));
         Logging.setLogLevel(logLevel);
@@ -91,17 +88,6 @@ public class AppPreferences {
 
     public Boolean getShowNotificationForNotices() {
         return this.showNotificationForNotices;
-    }
-
-    public void setShowNotificationDuringSuspend(Boolean ns) {
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putBoolean("showNotificationDuringSuspend", ns);
-        editor.apply();
-        this.showNotificationDuringSuspend = ns;
-    }
-
-    public Boolean getShowNotificationDuringSuspend() {
-        return this.showNotificationDuringSuspend;
     }
 
     public void setShowAdvanced(Boolean as) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
@@ -72,25 +72,9 @@ public class ClientNotification {
             return;
         }
 
-        // stop service foreground, if not active anymore
-        if(!active && foreground) {
-            setForegroundState(service, false);
-        }
-
-        // if not active, check preference whether to show notification during suspension
-        if(!active && !Monitor.getAppPrefs().getShowNotificationDuringSuspend()) {
-            // cancel notification if necessary
-            if(notificationShown) {
-                Log.d(Logging.TAG, "ClientNotification: cancel suspension notification due to preference.");
-                nm.cancel(notificationId);
-                notificationShown = false;
-            }
-            return;
-        }
-
         //check if active tasks have changed to force update
         Boolean activeTasksChanged = false;
-        if(updatedStatus.computingStatus == ClientStatus.COMPUTING_STATUS_COMPUTING) {
+        if(active && updatedStatus.computingStatus == ClientStatus.COMPUTING_STATUS_COMPUTING) {
             ArrayList<Result> activeTasks = updatedStatus.getExecutingTasks();
             if(activeTasks.size() != mOldActiveTasks.size()) {
                 activeTasksChanged = true;
@@ -107,6 +91,10 @@ public class ClientNotification {
             if(activeTasksChanged) {
                 mOldActiveTasks = activeTasks;
             }
+        }
+        else if (!mOldActiveTasks.isEmpty()) {
+            mOldActiveTasks.clear();
+            activeTasksChanged = true;
         }
 
         // update notification, only

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -1389,17 +1389,6 @@ public class Monitor extends Service {
         }
 
         @Override
-        public void setShowNotificationDuringSuspend(boolean isShow) throws RemoteException {
-            Monitor.getAppPrefs().setShowNotificationDuringSuspend(isShow);
-
-        }
-
-        @Override
-        public boolean getShowNotificationDuringSuspend() throws RemoteException {
-            return Monitor.getAppPrefs().getShowNotificationDuringSuspend();
-        }
-
-        @Override
         public boolean runBenchmarks() throws RemoteException {
             return clientInterface.runBenchmarks();
         }


### PR DESCRIPTION
On the latest Android SDKs there are a lot of restrictions for background processes.
So if the service is run in background, it could be killed too early and BOINC will not start.
Removed setting to show notification when running only because now it makes no sense since Notification should be shown always when foreground service is running.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
