### PR TITLE
Mac: allow 32-bit applications only if OS X version < 10.15

### DIFF
--- a/client/cs_platforms.cpp
+++ b/client/cs_platforms.cpp
@@ -42,6 +42,7 @@ LPFN_ISWOW64PROCESS fnIsWow64Process;
 
 #if defined(__APPLE__) && (defined(__i386__) || defined(__x86_64__))
 #include <sys/sysctl.h>
+extern int compareOSVersionTo(int toMajor, int toMinor);
 #endif
 
 #include "error_numbers.h"
@@ -100,7 +101,9 @@ void CLIENT_STATE::detect_platforms() {
 
 #ifdef __x86_64__
     add_platform("x86_64-apple-darwin");
-    add_platform("i686-apple-darwin");
+    if (compareOSVersionTo(10, 15) < 0) {
+        add_platform("i686-apple-darwin");
+    }
 #else
 #error Mac client now requires a 64-bit system
 #endif

--- a/client/gpu_opencl.cpp
+++ b/client/gpu_opencl.cpp
@@ -145,7 +145,7 @@ static bool compare_pci_slots(int NVIDIA_GPU_Index1, int NVIDIA_GPU_Index2) {
 // -1 if the OS version we are running on is less than x.y
 //  0 if the OS version we are running on is equal to x.y
 // +1 if the OS version we are running on is lgreater than x.y
-static int compareOSVersionTo(int toMajor, int toMinor) {
+int compareOSVersionTo(int toMajor, int toMinor) {
     static SInt32 major = -1;
     static SInt32 minor = -1;
 


### PR DESCRIPTION
**Description of the Change**
Don't allow 32-bit project applications if running on Mac OS 10.15 or later

**Alternate Designs**
none

**Release Notes**
N/A
