### PR TITLE
client: fix bug in GPU detection

### DIFF
--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -426,7 +426,7 @@ int main(int argc, char** argv) {
         }
     } else if (!strcmp(cmd, "--set_host_info")) {
         HOST_INFO h;
-        h.clear();
+        h.clear_host_info();
         char* pn = next_arg(argc, argv, i);
         safe_strcpy(h.product_name, pn);
         retval = rpc.set_host_info(h);

--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -465,7 +465,10 @@ leave:
 #endif
 }
 
-
+// Find the most capable instance; copy to *this.
+// set is_used (USED, UNUSED, IGNORED) for each instance.
+// Don't use less-capable instances (unless use_all is set)
+//
 void COPROC_NVIDIA::correlate(
     bool use_all,    // if false, use only those equivalent to most capable
     vector<int>& ignore_devs

--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -269,7 +269,7 @@ void APP_INIT_DATA::clear() {
     host_total_credit = 0;
     host_expavg_credit = 0;
     resource_share_fraction = 0;
-    host_info.clear();
+    host_info.clear_host_info();
     proxy_info.clear();
     global_prefs.defaults();
     starting_elapsed_time = 0;

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -304,7 +304,7 @@ struct COPROC_NVIDIA : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
-    COPROC_NVIDIA(): COPROC() {}
+    COPROC_NVIDIA(): COPROC() {clear();}
     void get(std::vector<std::string>& warnings);
     void correlate(
         bool use_all,
@@ -339,7 +339,7 @@ struct COPROC_ATI : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
-    COPROC_ATI(): COPROC() {}
+    COPROC_ATI(): COPROC() {clear();}
     void get(std::vector<std::string>& warnings);
     void correlate(
         bool use_all,
@@ -361,7 +361,7 @@ struct COPROC_INTEL : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
-    COPROC_INTEL(): COPROC() {}
+    COPROC_INTEL(): COPROC() {clear();}
     void get(std::vector<std::string>& warnings);
     void correlate(
         bool use_all,

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1052,7 +1052,7 @@ void CC_STATE::clear() {
     results.clear();
     platforms.clear();
     executing_as_daemon = false;
-    host_info.clear();
+    host_info.clear_host_info();
     have_nvidia = false;
     have_ati = false;
 }

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -39,8 +39,54 @@
 
 #include "hostinfo.h"
 
+HOST_INFO::HOST_INFO() {
+    clear_host_info();
+}
+
+// this must NOT clear coprocs
+// (initialization logic assumes that)
+//
+void HOST_INFO::clear_host_info() {
+    timezone = 0;
+    safe_strcpy(domain_name, "");
+    safe_strcpy(serialnum, "");
+    safe_strcpy(ip_addr, "");
+    safe_strcpy(host_cpid, "");
+
+    p_ncpus = 0;
+    safe_strcpy(p_vendor, "");
+    safe_strcpy(p_model, "");
+    safe_strcpy(p_features, "");
+    p_fpops = 0;
+    p_iops = 0;
+    p_membw = 0;
+    p_calculated = 0;
+    p_vm_extensions_disabled = false;
+
+    m_nbytes = 0;
+    m_cache = 0;
+    m_swap = 0;
+
+    d_total = 0;
+    d_free = 0;
+
+    safe_strcpy(os_name, "");
+    safe_strcpy(os_version, "");
+
+    wsl_available = false;
+#ifdef _WIN64
+    wsls.clear();
+#endif
+
+    safe_strcpy(product_name, "");
+    safe_strcpy(mac_address, "");
+
+    safe_strcpy(virtualbox_version, "");
+    num_opencl_cpu_platforms = 0;
+}
+
 int HOST_INFO::parse(XML_PARSER& xp, bool static_items_only) {
-    clear();
+    clear_host_info();
     while (!xp.get_tag()) {
         if (xp.match_tag("/host_info")) return 0;
         if (xp.parse_double("p_fpops", p_fpops)) {

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -95,12 +95,9 @@ public:
     int num_opencl_cpu_platforms;
     OPENCL_CPU_PROP opencl_cpu_prop[MAX_OPENCL_CPU_PLATFORMS];
 
-    HOST_INFO(int){}
-    HOST_INFO(){}
-    void clear() {
-        static const HOST_INFO x(0);
-        *this = x;
-    }
+    void clear_host_info();
+    HOST_INFO();
+
     int parse(XML_PARSER&, bool static_items_only = false);
     int write(MIOFILE&, bool include_net_info, bool include_coprocs);
     int parse_cpu_benchmarks(FILE*);


### PR DESCRIPTION
PR #3364 changed the way we clear structures.
This introduced a bug: HOST_INFO::clear_host_info()
intentionally didn't clear HOST_INFO::coprocs.
But it was replaced with HOST_INFO::clear(), which did.
This caused the client to lose GPU info.

Fix: restore HOST_INFO::clear_host_info(), and add a comment
to avoid future errors like this.

Also add some comments in GPU detection,
which is woefully lacking in them.
