### PR TITLE
client: make max_std(err/out)_file_size double

### DIFF
--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -419,8 +419,8 @@ int CC_CONFIG::parse_options_client(XML_PARSER& xp) {
         if (xp.parse_int("max_event_log_lines", max_event_log_lines)) continue;
         if (xp.parse_int("max_file_xfers", max_file_xfers)) continue;
         if (xp.parse_int("max_file_xfers_per_project", max_file_xfers_per_project)) continue;
-        if (xp.parse_int("max_stderr_file_size", max_stderr_file_size)) continue;
-        if (xp.parse_int("max_stdout_file_size", max_stdout_file_size)) continue;
+        if (xp.parse_double("max_stderr_file_size", max_stderr_file_size)) continue;
+        if (xp.parse_double("max_stdout_file_size", max_stdout_file_size)) continue;
         if (xp.parse_int("max_tasks_reported", max_tasks_reported)) continue;
         if (xp.parse_int("ncpus", ncpus)) continue;
         if (xp.parse_bool("no_alt_platform", no_alt_platform)) continue;

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -397,8 +397,8 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
         if (xp.parse_int("max_event_log_lines", max_event_log_lines)) continue;
         if (xp.parse_int("max_file_xfers", max_file_xfers)) continue;
         if (xp.parse_int("max_file_xfers_per_project", max_file_xfers_per_project)) continue;
-        if (xp.parse_int("max_stderr_file_size", max_stderr_file_size)) continue;
-        if (xp.parse_int("max_stdout_file_size", max_stdout_file_size)) continue;
+        if (xp.parse_double("max_stderr_file_size", max_stderr_file_size)) continue;
+        if (xp.parse_double("max_stdout_file_size", max_stdout_file_size)) continue;
         if (xp.parse_int("max_tasks_reported", max_tasks_reported)) continue;
         if (xp.parse_int("ncpus", ncpus)) continue;
         if (xp.parse_bool("no_alt_platform", no_alt_platform)) continue;
@@ -629,8 +629,8 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         "        <max_event_log_lines>%d</max_event_log_lines>\n"
         "        <max_file_xfers>%d</max_file_xfers>\n"
         "        <max_file_xfers_per_project>%d</max_file_xfers_per_project>\n"
-        "        <max_stderr_file_size>%d</max_stderr_file_size>\n"
-        "        <max_stdout_file_size>%d</max_stdout_file_size>\n"
+        "        <max_stderr_file_size>%f</max_stderr_file_size>\n"
+        "        <max_stdout_file_size>%f</max_stdout_file_size>\n"
         "        <max_tasks_reported>%d</max_tasks_reported>\n"
         "        <ncpus>%d</ncpus>\n"
         "        <no_alt_platform>%d</no_alt_platform>\n"

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -172,8 +172,8 @@ struct CC_CONFIG {
     int max_event_log_lines;
     int max_file_xfers;
     int max_file_xfers_per_project;
-    int max_stderr_file_size;
-    int max_stdout_file_size;
+    double max_stderr_file_size;
+    double max_stdout_file_size;
     int max_tasks_reported;
     int ncpus;
     bool no_alt_platform;

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -988,7 +988,7 @@ void boinc_info(const char* pszFormat, ...){
 }
 #endif
 
-void diagnostics_set_max_file_sizes(int stdout_size, int stderr_size) {
+void diagnostics_set_max_file_sizes(double stdout_size, double stderr_size) {
     if (stdout_size) max_stdout_file_size = stdout_size;
     if (stderr_size) max_stderr_file_size = stderr_size;
 }

--- a/lib/diagnostics.h
+++ b/lib/diagnostics.h
@@ -104,7 +104,7 @@ extern int diagnostics_set_aborted_via_gui(void);
 
 // Log rotation
 extern int diagnostics_cycle_logs(void);
-extern void diagnostics_set_max_file_sizes(int stdout_size, int stderr_size);
+extern void diagnostics_set_max_file_sizes(double stdout_size, double stderr_size);
 
 // Thread Tracking
 extern int diagnostics_init_thread_list(void);


### PR DESCRIPTION
File sizes should always be double, not int

This fixes #3435

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
