### PR TITLE
scheduler: fix crashing bug in anonymous platform case.

### DIFF
--- a/sched/handle_request.cpp
+++ b/sched/handle_request.cpp
@@ -1418,10 +1418,12 @@ void process_request(char* code_sign_key) {
                 if (diff < config.min_sendwork_interval) {
                     ok_to_send_work = false;
                     log_messages.printf(MSG_NORMAL,
-                        "Not sending work - last request too recent, please wait: %f\n", config.min_sendwork_interval
+                        "Not sending work. Last request too recent. Please wait %d seconds.\n",
+                        (int)(config.min_sendwork_interval - diff)
                     );
                     sprintf(buf,
-                        "Not sending work - last request too recent, please wait: %d sec", (int)config.min_sendwork_interval
+                        "Not sending work. Last request too recent. Please wait %d seconds.\n",
+                        (int)(config.min_sendwork_interval - diff)
                     );
                     g_reply->insert_message(buf, "low");
 

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -151,7 +151,9 @@ inline bool daily_quota_exceeded(DB_ID_TYPE gavid, HOST_USAGE& hu) {
 }
 
 bool daily_quota_exceeded(BEST_APP_VERSION* bavp) {
-    return daily_quota_exceeded(bavp->avp->id, bavp->host_usage);
+    DB_HOST_APP_VERSION* havp = bavp->host_app_version();
+    if (!havp) return false;
+    return daily_quota_exceeded(havp->app_version_id, bavp->host_usage);
 }
 
 // scan through client's anonymous apps and pick the best one


### PR DESCRIPTION
My change a while back to enforce job limits correctly
didn't work with anonymous platform requests.

Also fixed wrong message and int/double format error when
reporting last request too soon.
