### PR TITLE
client: fix stall when --skip_cpu_benchmarks used

### DIFF
--- a/client/cs_account.cpp
+++ b/client/cs_account.cpp
@@ -332,8 +332,8 @@ int CLIENT_STATE::parse_account_files() {
         if (!f) continue;
         project = new PROJECT;
 
-        // Assume master_url_fetch_pending, sched_rpc_pending are
-        // true until we read client_state.xml
+        // Assume we need to fetch master file and do sched RPC
+        // unless client_state.xml says otherwise
         //
         project->master_url_fetch_pending = true;
         project->sched_rpc_pending = RPC_REASON_INIT;
@@ -427,10 +427,10 @@ int CLIENT_STATE::parse_statistics_files() {
 
     DirScanner dir(".");
     while (dir.scan(name)) {
-        PROJECT temp;
         if (is_statistics_file(name.c_str())) {
             f = boinc_fopen(name.c_str(), "r");
             if (!f) continue;
+            PROJECT temp;
             retval = temp.parse_statistics(f);
             fclose(f);
             if (retval) {
@@ -542,6 +542,8 @@ int CLIENT_STATE::add_project(
     safe_strcpy(project->authenticator, auth);
     safe_strcpy(project->project_name, project_name);
     project->attached_via_acct_mgr = attached_via_acct_mgr;
+    project->master_url_fetch_pending = true;
+    project->sched_rpc_pending = RPC_REASON_INIT;
 
     retval = project->write_account_file();
     if (retval) {

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -311,7 +311,13 @@ void CLIENT_STATE::check_if_need_benchmarks() {
     if (diff < 0) {
         run_cpu_benchmarks = true;
     } else if (diff > BENCHMARK_PERIOD) {
-        msg_printf(NULL, MSG_INFO, "Last benchmark was %s ago", timediff_format(diff).c_str());
+        if (host_info.p_calculated) {
+            msg_printf(NULL, MSG_INFO,
+                "Last CPU benchmark was %s ago", timediff_format(diff).c_str()
+            );
+        } else {
+            msg_printf(NULL, MSG_INFO, "No CPU benchmark yet");
+        }
         run_cpu_benchmarks = true;
     }
 }
@@ -584,4 +590,5 @@ void CLIENT_STATE::cpu_benchmarks_set_defaults() {
     if (!host_info.p_iops) host_info.p_iops = DEFAULT_IOPS;
     if (!host_info.p_membw) host_info.p_membw = DEFAULT_MEMBW;
     if (!host_info.m_cache) host_info.m_cache = DEFAULT_CACHE;
+    host_info.p_calculated = now;
 }

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1496,11 +1496,12 @@ int HOST_INFO::get_os_info() {
 
     string libc_version(""), libc_extra_info("");
     if (!get_libc_version(libc_version, libc_extra_info)) {
-        // This will be part of the normal startup messages to show to the user
         msg_printf(NULL, MSG_INFO,
-                "[libc detection] gathered: %s, %s", libc_version.c_str(), libc_extra_info.c_str()
-            );
+            "libc: %s version %s",
+            libc_extra_info.c_str(), libc_version.c_str()
+        );
         // add info to os_version_extra
+        //
         if (!os_version_extra.empty()) {
             os_version_extra += "|";
         }

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -408,7 +408,7 @@ void COPROC_NVIDIA::write_xml(MIOFILE& f, bool scheduler_rpc) {
 #endif
 
 void COPROC_NVIDIA::clear() {
-    static const COPROC_NVIDIA x;
+    static const COPROC_NVIDIA x(0);
     *this = x;
     safe_strcpy(type, proc_type_name_xml(PROC_TYPE_NVIDIA_GPU));
     estimated_delay = -1;   // mark as absent
@@ -717,7 +717,7 @@ void COPROC_ATI::write_xml(MIOFILE& f, bool scheduler_rpc) {
 #endif
 
 void COPROC_ATI::clear() {
-    static const COPROC_ATI x;
+    static const COPROC_ATI x(0);
     *this = x;
     safe_strcpy(type, proc_type_name_xml(PROC_TYPE_AMD_GPU));
     estimated_delay = -1;
@@ -924,7 +924,7 @@ void COPROC_INTEL::write_xml(MIOFILE& f, bool scheduler_rpc) {
 #endif
 
 void COPROC_INTEL::clear() {
-    static const COPROC_INTEL x;
+    static const COPROC_INTEL x(0);
     *this = x;
     safe_strcpy(type, proc_type_name_xml(PROC_TYPE_INTEL_GPU));
     estimated_delay = -1;

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -305,6 +305,7 @@ struct COPROC_NVIDIA : public COPROC {
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
     COPROC_NVIDIA(): COPROC() {clear();}
+    COPROC_NVIDIA(int): COPROC() {}
     void get(std::vector<std::string>& warnings);
     void correlate(
         bool use_all,
@@ -339,6 +340,7 @@ struct COPROC_ATI : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
+    COPROC_ATI(int): COPROC() {}
     COPROC_ATI(): COPROC() {clear();}
     void get(std::vector<std::string>& warnings);
     void correlate(
@@ -361,6 +363,7 @@ struct COPROC_INTEL : public COPROC {
 #ifndef _USING_FCGI_
     void write_xml(MIOFILE&, bool scheduler_rpc);
 #endif
+    COPROC_INTEL(int): COPROC() {}
     COPROC_INTEL(): COPROC() {clear();}
     void get(std::vector<std::string>& warnings);
     void correlate(


### PR DESCRIPTION
Fixes #3454

There were two problems:
1) We weren't fetching work unless benchmarks had been run
(since a scheduler request must include a p_fpops value).
Fix: if --skip_cpu_benchmarks set, pretend that we ran benchmarks
and p_fpops is 1 GFLOPS

2) adding a project via the cmdline (--attach_project)
wasn't setting a flag to fetch the project's scheduler list.

Also: the new way of clearing structures (copying a static instance to *this)
causes a startup hang if the default constructor calls clear().
To fix this, have the static instance use a constructor
that doesn't call clear()

Also: fix message about libc version.
"[foobar] ...." means that the message is conditional on <debug_foobar>
