### PR TITLE
Web: fix ReCaptcha problem

### DIFF
--- a/html/inc/recaptchalib.php
+++ b/html/inc/recaptchalib.php
@@ -45,7 +45,7 @@ function boinc_recaptcha_get_html($publickey) {
 function boinc_recaptcha_isValidated($privatekey) {
     if ($privatekey) {
         // tells ReCaptcha to use fsockopen() instead of get_file_contents()
-        $recaptcha = new \ReCaptcha\ReCaptcha($privatekey, new \ReCaptcha\RequestMethod\SocketPost());
+        $recaptcha = new \ReCaptcha\ReCaptcha($privatekey, new \ReCaptcha\RequestMethod\CurlPost());
         $resp = $recaptcha->verify($_POST['g-recaptcha-response'], $_SERVER['REMOTE_ADDR']);
         return $resp->isSuccess();
     }


### PR DESCRIPTION
I have no idea why, but out of nowhere ReCaptcha stopped working on both SU and S@h.
Changing an arg to the recaptcha constructor
(from a Stack Overflow entry from 2015) fixed the problem.
