### PR TITLE
[lib][mac] Add missing files to Makefile.am

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -96,6 +96,7 @@ if OS_DARWIN
 mac_sources = \
     procinfo_mac.cpp \
     mac/mac_backtrace.cpp \
+    mac/mac_branding.cpp \
     mac/mac_spawn.cpp \
     mac/QBacktrace.c \
     mac/QCrashReport.c \
@@ -106,6 +107,7 @@ mac_sources = \
 mac_headers = \
     mac/dyld_gdb.h \
     mac/mac_backtrace.h \
+    mac/mac_branding.h \
     mac/mac_spawn.h \
     mac/QBacktrace.h \
     mac/QCrashReport.h \


### PR DESCRIPTION
* Should have been part of #2597

**Description of the Change**
Add missing files to Makefile.am, required for building `libboinc` on macOS using `make`.

**Release Notes**
n/a