### PR TITLE
Add retina display support for BOINC Manager

### DIFF
--- a/clientgui/mac/templates/Info.plist
+++ b/clientgui/mac/templates/Info.plist
@@ -18,6 +18,8 @@
 	<string>BNC!</string>
 	<key>CFBundleVersion</key>
 	<string>7.15.0</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Fixes #3383

Please note: I am currently unable to build BOINC using Xcode 11.4 for Catalina due to a build error with WxWidgets, so I cannot test this change. Until I can fix this issue, if anyone with retina hardware is able to build and test this I would appreciate it.

**Description of the Change**
This simply adds the `NSPrincipleClass` key to `Info.plist` to allow retina support as described [here](https://wiki.wxwidgets.org/WxMac-specific_topics#Retina_display_support).

**Alternate Designs**
This may need to be added to other `.plist` files in [clientgui/mac/templates](../tree/master/clientgui/mac/templates) to offer retina support for the installer, screensaver, etc. Without being able to test this I don't know.

**Release Notes**
Add support for macOS retina displays.