### PR TITLE
avoid error when files to clean are not existing

### DIFF
--- a/client/scripts/Makefile.am
+++ b/client/scripts/Makefile.am
@@ -25,5 +25,5 @@ install-exec-hook:
 	fi
 
 clean:
-	rm boinc-client.service
-	rm boinc-client
+	rm -f boinc-client.service
+	rm -f boinc-client


### PR DESCRIPTION
ran into
```
make[1]: Entering directory '/home/boincdev/boinc-client_release-7.16-7.16.5/client/scripts'
rm boinc-client.service
rm: can't remove 'boinc-client.service': No such file or directory
```