### PR TITLE
Install project_specific_defines.h if configured (required by config.h)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,8 @@ EXTRA_DIST =                                    \
 if INSTALL_HEADERS
 pkginclude_HEADERS = \
     version.h \
-    svn_version.h
+    svn_version.h \
+    project_specific_defines.h
 endif
 
 # svn_version.h should always be rebuilt.


### PR DESCRIPTION
Fixes #3471

**Description of the Change**
Installs `project_specific_defines.h` in `PREFIX/include/boinc` if `--enable-install-headers` is `configure`d. It's `include`d by `config.h` which in turn gets used when building science apps or screensavers. Right now `config.h` isn't installed, but that's a separate issue dealt with in #2964.

**Release Notes**
n/a