### PR TITLE
[Android] Fix WSL compatibility and improvement to script

### DIFF
--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -112,6 +112,10 @@ if [ "${doclean}" = "yes" ]; then
     echo "cleaning build dir"
     rm -rf "${BUILD_DIR}"
     mkdir -p "${BUILD_DIR}"
+    echo "cleaning downloaded cache files"
+    rm -f /tmp/ndk.zip
+    rm -f /tmp/openssl.tgz
+    rm -f /tmp/curl.tgz
 fi
 
 if [ "${silent}" = "yes" ]; then
@@ -125,20 +129,18 @@ CURL_FLAGFILE="$PREFIX/curl-${CURL_VERSION}-${arch}_done"
 OPENSSL_FLAGFILE="$PREFIX/openssl-${OPENSSL_VERSION}-${arch}_done"
 
 if [ ! -e "${NDK_FLAGFILE}" ]; then
-    rm -f /tmp/ndk.zip
     rm -rf "$HOME/android-ndk-r${NDK_VERSION}"
     rm -rf "${PREFIX}/${arch}"
     rm -f "${CURL_FLAGFILE}" "${OPENSSL_FLAGFILE}"
-    wget --no-verbose -O /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip
+    wget -c --no-verbose -O /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip
     unzip -qq /tmp/ndk.zip -d $HOME
     touch "${NDK_FLAGFILE}"
 fi
 export NDK_ROOT=$HOME/android-ndk-r${NDK_VERSION}
 
 if [ ! -e "${OPENSSL_FLAGFILE}" ]; then
-    rm -f /tmp/openssl.tgz
     rm -rf "$BUILD_DIR/openssl-${OPENSSL_VERSION}"
-    wget --no-verbose -O /tmp/openssl.tgz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+    wget -c --no-verbose -O /tmp/openssl.tgz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
     tar xzf /tmp/openssl.tgz --directory=$BUILD_DIR
     export COMPILEOPENSSL="yes"
     touch "${OPENSSL_FLAGFILE}"
@@ -146,9 +148,8 @@ fi
 export OPENSSL_SRC=$BUILD_DIR/openssl-${OPENSSL_VERSION}
 
 if [ ! -e "${CURL_FLAGFILE}" ]; then
-    rm -f /tmp/curl.tgz
     rm -rf "$BUILD_DIR/curl-${CURL_VERSION}"
-    wget --no-verbose -O /tmp/curl.tgz https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
+    wget -c --no-verbose -O /tmp/curl.tgz https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
     tar xzf /tmp/curl.tgz --directory=$BUILD_DIR
     export COMPILECURL="yes"
     touch "${CURL_FLAGFILE}"

--- a/android/build_all.sh
+++ b/android/build_all.sh
@@ -2,12 +2,12 @@
 set -e
 
 #
-# See: http://boinc.berkeley.edu/trac/wiki/AndroidBuildClient#
+# See: https://boinc.berkeley.edu/trac/wiki/AndroidBuildClient
 #
 
 # Script to compile everything BOINC needs for Android
 
-./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch arm
-./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch arm64
-./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch x86
-./buildAndroidBOINC-CI.sh --cache_dir $ANDROID_TC --build_dir $HOME/3rdParty --arch x86_64
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$HOME/3rdParty" --arch arm
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$HOME/3rdParty" --arch arm64
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$HOME/3rdParty" --arch x86
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$HOME/3rdParty" --arch x86_64


### PR DESCRIPTION
Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
Path does not parse correctly for `build_all.sh` in WSL. Use double quotes.
Eliminate the need to redownload the NDK and source code for OpenSSL and cURL for every new build.

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Virtualbox VM is slower, heavier, bandwidth intensive and time consuming just to set up one. WSL is much lighter and support is improving with the use of Visual Studio Code. Using Windows version of Android Studio should be possible. WSL needs to install the same dependencies listed in Vagrantfile. WSL also needs python2 to deal with `make_standalone_toolchain.py`.

ATM requires copying of entire repo to a readable path after binary compilation as Android Studio does not allow reading project files over WSL network share. However some files may not be copied properly because of symlink files. Certain case sensitive files (mainly Android toolchain files) will overwrite each other when copied. The app can still be compiled in Android Studio.

Or just map it to a network drive. https://github.com/microsoft/WSL/issues/3854#issuecomment-465886991
However that causes IOExecptionError at Gradle.

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
N/A