### PR TITLE
be explicit how sched_scheduler was meant to be set

### DIFF
--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -1105,7 +1105,7 @@ int ACTIVE_TASK::start(bool test) {
                 struct sched_param sp;
                 sp.sched_priority = 0;
                 if (sched_setscheduler(0, SCHED_IDLE, &sp)) {
-                    perror("sched_setscheduler");
+                    perror("app_start sched_setscheduler(SCHED_IDLE)");
                 }
             }
 #endif


### PR DESCRIPTION
I repeatedly get an error message that I presume to have this origin - just don't let me guess. 