### PR TITLE
Convert uses of concatenated string resources to string resources with placeholders.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.java
@@ -315,8 +315,8 @@ public class BOINCActivity extends AppCompatActivity {
                     Button returnB = dialog.findViewById(R.id.returnB);
                     TextView tvVersion = dialog.findViewById(R.id.version);
                     try {
-                        tvVersion.setText(getString(R.string.about_version) + " "
-                                          + getPackageManager().getPackageInfo(getPackageName(), 0).versionName);
+                        tvVersion.setText(getString(R.string.about_version,
+                                                    getPackageManager().getPackageInfo(getPackageName(), 0).versionName));
                     }
                     catch(NameNotFoundException e) {
                         if(Logging.WARNING) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
@@ -237,7 +237,7 @@ public class ProjectDetailsFragment extends Fragment {
             tvMessage.setText(getString(R.string.projects_confirm_message,
                                         removeStr.toLowerCase(),
                                         project.project_name + " "
-                                        + getString(R.string.projects_confirm_detach_message2)));
+                                        + getString(R.string.projects_confirm_detach_message)));
             confirm.setText(removeStr);
         }
         else if(operation == RpcClient.PROJECT_RESET) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
@@ -229,18 +229,24 @@ public class ProjectDetailsFragment extends Fragment {
         TextView tvTitle = dialog.findViewById(R.id.title);
         TextView tvMessage = dialog.findViewById(R.id.message);
 
-        // operation dependend texts
+        // operation-dependent texts
         if(operation == RpcClient.PROJECT_DETACH) {
-            tvTitle.setText(R.string.projects_confirm_detach_title);
-            tvMessage.setText(getString(R.string.projects_confirm_detach_message) + " "
-                              + project.project_name + " " + getString(R.string.projects_confirm_detach_message2));
-            confirm.setText(R.string.projects_confirm_detach_confirm);
+            final String removeStr = getString(R.string.projects_confirm_detach_confirm);
+
+            tvTitle.setText(getString(R.string.projects_confirm_title, removeStr));
+            tvMessage.setText(getString(R.string.projects_confirm_message,
+                                        removeStr.toLowerCase(),
+                                        project.project_name + " "
+                                        + getString(R.string.projects_confirm_detach_message2)));
+            confirm.setText(removeStr);
         }
         else if(operation == RpcClient.PROJECT_RESET) {
-            tvTitle.setText(R.string.projects_confirm_reset_title);
-            tvMessage.setText(getString(R.string.projects_confirm_reset_message) + " "
-                              + project.project_name + getString(R.string.projects_confirm_reset_message2));
-            confirm.setText(R.string.projects_confirm_reset_confirm);
+            final String resetStr = getString(R.string.projects_confirm_reset_confirm);
+
+            tvTitle.setText(getString(R.string.projects_confirm_title, resetStr));
+            tvMessage.setText(getString(R.string.projects_confirm_message, resetStr.toLowerCase(),
+                                        project.project_name));
+            confirm.setText(resetStr);
         }
 
         confirm.setOnClickListener(view -> {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
@@ -434,27 +434,30 @@ public class ProjectsFragment extends Fragment {
                 TextView tvTitle = dialog.findViewById(R.id.title);
                 TextView tvMessage = dialog.findViewById(R.id.message);
 
-                // operation dependend texts
+                // operation-dependent texts
                 if(operation == RpcClient.PROJECT_DETACH) {
-                    tvTitle.setText(R.string.projects_confirm_detach_title);
-                    tvMessage.setText(getString(R.string.projects_confirm_detach_message) + " "
-                                      + data.project.project_name + " " +
-                                      getString(R.string.projects_confirm_detach_message2));
-                    confirm.setText(R.string.projects_confirm_detach_confirm);
+                    final String removeStr = getString(R.string.projects_confirm_detach_confirm);
+
+                    tvTitle.setText(getString(R.string.projects_confirm_title, removeStr));
+                    tvMessage.setText(getString(R.string.projects_confirm_message,
+                                                removeStr.toLowerCase(),
+                                                data.project.project_name + " "
+                                                + getString(R.string.projects_confirm_detach_message2)));
+                    confirm.setText(removeStr);
                 }
                 else if(operation == RpcClient.PROJECT_RESET) {
-                    tvTitle.setText(R.string.projects_confirm_reset_title);
-                    tvMessage.setText(getString(R.string.projects_confirm_reset_message) + " "
-                                      + data.project.project_name +
-                                      getString(R.string.projects_confirm_reset_message2));
-                    confirm.setText(R.string.projects_confirm_reset_confirm);
+                    final String resetStr = getString(R.string.projects_confirm_reset_confirm);
+
+                    tvTitle.setText(getString(R.string.projects_confirm_title, resetStr));
+                    tvMessage.setText(getString(R.string.projects_confirm_message, resetStr.toLowerCase(),
+                                                data.project.project_name));
+                    confirm.setText(resetStr);
                 }
                 else if(operation == RpcClient.MGR_DETACH) {
                     tvTitle.setText(R.string.projects_confirm_remove_acctmgr_title);
-                    tvMessage.setText(
-                            getString(R.string.projects_confirm_remove_acctmgr_message) + " "
-                            + data.acctMgrInfo.acct_mgr_name +
-                            getString(R.string.projects_confirm_remove_acctmgr_message2));
+                    tvMessage.setText(getString(R.string.projects_confirm_message,
+                                                getString(R.string.projects_confirm_remove_acctmgr_message),
+                                                data.acctMgrInfo.acct_mgr_name));
                     confirm.setText(R.string.projects_confirm_remove_acctmgr_confirm);
                 }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
@@ -442,7 +442,7 @@ public class ProjectsFragment extends Fragment {
                     tvMessage.setText(getString(R.string.projects_confirm_message,
                                                 removeStr.toLowerCase(),
                                                 data.project.project_name + " "
-                                                + getString(R.string.projects_confirm_detach_message2)));
+                                                + getString(R.string.projects_confirm_detach_message)));
                     confirm.setText(removeStr);
                 }
                 else if(operation == RpcClient.PROJECT_RESET) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
@@ -239,8 +239,7 @@ public class TasksFragment extends Fragment {
                         TextView tvMessage = dialog.findViewById(R.id.message);
 
                         tvTitle.setText(R.string.confirm_abort_task_title);
-                        tvMessage.setText(getString(R.string.confirm_abort_task_message) + " "
-                                          + result.name);
+                        tvMessage.setText(getString(R.string.confirm_abort_task_message, result.name));
                         confirm.setText(R.string.confirm_abort_task_confirm);
                         confirm.setOnClickListener(view1 -> {
                             nextState = BOINCDefs.RESULT_ABORTED;

--- a/android/BOINC/app/src/main/res/values-ar/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ar/strings.xml
@@ -244,17 +244,11 @@
     <string name="projects_control_sync_acctmgr">مزامنة</string>
     <string name="projects_control_remove_acctmgr">معطّل</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">إزالة المشروع؟</string>
     <string name="projects_confirm_detach_message">هل أنت متأكد من رغبتك في إزالة</string>
-    <string name="projects_confirm_detach_message2">من BOINC؟</string>
     <string name="projects_confirm_detach_confirm">إزالة</string>
-    <string name="projects_confirm_reset_title">صفِّر المشروع</string>
-    <string name="projects_confirm_reset_message">هل أنت متأكد من رغبتك فى إعادة الضبط؟</string>
-    <string name="projects_confirm_reset_message2">/؟</string>
     <string name="projects_confirm_reset_confirm">إعادة الضبط</string>
     <string name="projects_confirm_remove_acctmgr_title">تعطيل مدير الحسابات</string>
     <string name="projects_confirm_remove_acctmgr_message">هل انت متأكد من رغبتك في إيقاف استخدام</string>
-    <string name="projects_confirm_remove_acctmgr_message2">/؟</string>
     <string name="projects_confirm_remove_acctmgr_confirm">معطّل</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">اسم المهمة:</string>

--- a/android/BOINC/app/src/main/res/values-ar/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ar/strings.xml
@@ -345,7 +345,7 @@
     <string name="about_button">العودة</string>
     <string name="about_title">عن</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">اصدار</string>
+    <string name="about_version">اصدار %1$s</string>
     <string name="about_name_long">بنية بركلي التحتية المفتوحة للحوسبة الشبكية Berkeley Open Infrastructure for Network
         Computing
     </string>

--- a/android/BOINC/app/src/main/res/values-az/strings.xml
+++ b/android/BOINC/app/src/main/res/values-az/strings.xml
@@ -354,7 +354,7 @@
     <string name="about_button">Qayıt</string>
     <string name="about_title">Haqqında</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Versiya</string>
+    <string name="about_version">Versiya %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">Bütün hüquqlar qorunur.</string>
     <string name="about_credits">Dəstək üçün Max Planck Qravitasiya Fizika İnstitutu, IBM və HTC şirkətlərinəsayəsində

--- a/android/BOINC/app/src/main/res/values-az/strings.xml
+++ b/android/BOINC/app/src/main/res/values-az/strings.xml
@@ -252,17 +252,11 @@
     <string name="projects_control_sync_acctmgr">Sinxronizasiya</string>
     <string name="projects_control_remove_acctmgr">Çıxarın</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Layihə silinsin?</string>
     <string name="projects_confirm_detach_message">Silmək istədiyizdən əminsinizmi?</string>
-    <string name="projects_confirm_detach_message2">BOINC-dan?</string>
     <string name="projects_confirm_detach_confirm">Sil</string>
-    <string name="projects_confirm_reset_title">Layihəni sıfırla</string>
-    <string name="projects_confirm_reset_message">Sifariş etmək istədiyinizə əminsinizmi?</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Sıfırla</string>
     <string name="projects_confirm_remove_acctmgr_title">Hesab menecerini söndürün</string>
     <string name="projects_confirm_remove_acctmgr_message">Istifadəni dayandırmaq istədiyinizə əminsinizmi?</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Çıxarın</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">İşin adı:</string>

--- a/android/BOINC/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/android/BOINC/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -226,17 +226,11 @@
     <string name="projects_control_sync_acctmgr">Sinhronizuj</string>
     <string name="projects_control_remove_acctmgr">Isključi</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Ukloni projekat?</string>
     <string name="projects_confirm_detach_message">Sigurno želite da uklonite</string>
-    <string name="projects_confirm_detach_message2">od BOINC?</string>
     <string name="projects_confirm_detach_confirm">Ukloni</string>
-    <string name="projects_confirm_reset_title">Počni projekat ispočetka</string>
-    <string name="projects_confirm_reset_message">Jeste li sigurni da želite sve ispočetka</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Počni ispočetka</string>
     <string name="projects_confirm_remove_acctmgr_title">Isključi menadžer naloga</string>
     <string name="projects_confirm_remove_acctmgr_message">Jeste li sigurni da želite da prekinete upotrebu</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Isključi</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Ime zadatka:</string>

--- a/android/BOINC/app/src/main/res/values-b+sr+Latn/strings.xml
+++ b/android/BOINC/app/src/main/res/values-b+sr+Latn/strings.xml
@@ -328,7 +328,7 @@
     <string name="about_button">Povratak</string>
     <string name="about_title">O</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Verzija</string>
+    <string name="about_version">Verzija %1$s</string>
     <string name="about_name_long">Otvorena Infrastrukutra za mrežna računanja Berkelija</string>
     <string name="about_copyright_reserved">Sva prava zadržana.</string>
     <string name="about_credits">Hvala Maks Plankovom Institutu za gravitacionu fiziku, IBM Korporaciji i HTC Korporaciji na njihovoj podršci.</string>

--- a/android/BOINC/app/src/main/res/values-bg/strings.xml
+++ b/android/BOINC/app/src/main/res/values-bg/strings.xml
@@ -257,17 +257,11 @@
     <string name="projects_control_sync_acctmgr">Синхронизирай</string>
     <string name="projects_control_remove_acctmgr">Деактивирай</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Премахване на проект?</string>
     <string name="projects_confirm_detach_message">Сигурни ли сте, че искате да премахнете</string>
-    <string name="projects_confirm_detach_message2">от BOINC?</string>
     <string name="projects_confirm_detach_confirm">Премахни</string>
-    <string name="projects_confirm_reset_title">Нулиране на проект</string>
-    <string name="projects_confirm_reset_message">Сигурни ли сте, че искате да нулирате</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Нулиране</string>
     <string name="projects_confirm_remove_acctmgr_title">Деактивирайте акаунт мениджъра</string>
     <string name="projects_confirm_remove_acctmgr_message">Сигурни ли сте, че искате да спрете да използвате</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Деактивирай</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Име на Задача:</string>

--- a/android/BOINC/app/src/main/res/values-bg/strings.xml
+++ b/android/BOINC/app/src/main/res/values-bg/strings.xml
@@ -361,7 +361,7 @@
     <string name="about_button">Връщане</string>
     <string name="about_title">Относно</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Версия</string>
+    <string name="about_version">Версия %1$s</string>
     <string name="about_name_long">Бъркли Отворена Инфраструктура за Споделени Изчисления</string>
     <string name="about_copyright_reserved">Всички Права Запазени.</string>
     <string name="about_credits">Благодарности към Института Макс Планк за Гравитационна Физика, IBM Corporation и HTC

--- a/android/BOINC/app/src/main/res/values-ca/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ca/strings.xml
@@ -360,7 +360,7 @@
     <string name="about_button">Retorna</string>
     <string name="about_title">Sobre</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Versió</string>
+    <string name="about_version">Versió %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">Reservats tots els drets.</string>
     <string name="about_credits">Gràcies a l\'Institut Max Planck de Física Gravitacional, IBM Corporation i HTC

--- a/android/BOINC/app/src/main/res/values-ca/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ca/strings.xml
@@ -257,17 +257,11 @@
     <string name="projects_control_sync_acctmgr">Sincronitzar</string>
     <string name="projects_control_remove_acctmgr">Desactivar</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Eliminar el projecte?</string>
     <string name="projects_confirm_detach_message">Estàs segur que voleu eliminar</string>
-    <string name="projects_confirm_detach_message2">de BOINC?</string>
     <string name="projects_confirm_detach_confirm">Elimina</string>
-    <string name="projects_confirm_reset_title">Reinicia el projecte</string>
-    <string name="projects_confirm_reset_message">Estàs segur que vols reiniciar</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Reinicia</string>
     <string name="projects_confirm_remove_acctmgr_title">Desactivar el gestor de comptes</string>
     <string name="projects_confirm_remove_acctmgr_message">Està segur de voler finalitzar la utilització de</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Desactivar</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Nom de la tasca:</string>

--- a/android/BOINC/app/src/main/res/values-cs/strings.xml
+++ b/android/BOINC/app/src/main/res/values-cs/strings.xml
@@ -242,17 +242,11 @@ Tuto hodnotu nedoporučujeme měnit.
   <string name="projects_control_sync_acctmgr">Synchronizovat</string>
   <string name="projects_control_remove_acctmgr">Zakázat</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Odebrat projekt?</string>
   <string name="projects_confirm_detach_message">Jste si jisti, že chcete odstranit</string>
-  <string name="projects_confirm_detach_message2">z BOINCu?</string>
   <string name="projects_confirm_detach_confirm">Odebrat</string>
-  <string name="projects_confirm_reset_title">Restartovat projekt</string>
-  <string name="projects_confirm_reset_message">Jste si jisti, že chcete restartovat</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Restartovat</string>
   <string name="projects_confirm_remove_acctmgr_title">Vypnout správce účtu</string>
   <string name="projects_confirm_remove_acctmgr_message">Jste si jisti, že chcete přestat používat</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Zakázat</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Název úkolu:</string>

--- a/android/BOINC/app/src/main/res/values-cs/strings.xml
+++ b/android/BOINC/app/src/main/res/values-cs/strings.xml
@@ -345,7 +345,7 @@ Tuto hodnotu nedoporučujeme měnit.
   <string name="about_button">Návrat</string>
   <string name="about_title">O programu</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Verze</string>
+  <string name="about_version">Verze %1$s</string>
   <string name="about_name_long">Berkeley Open Infrastructure for Network Computing 
 (Berkeleyská Otevřená Infrastruktura pro Síťové Výpočty)</string>
   <string name="about_copyright">/u00A9 2003-2019 Univerzita v Kalifornii, Berkeley.</string>

--- a/android/BOINC/app/src/main/res/values-da/strings.xml
+++ b/android/BOINC/app/src/main/res/values-da/strings.xml
@@ -349,7 +349,7 @@
     <string name="about_button">Tilbage</string>
     <string name="about_title">Om</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Version</string>
+    <string name="about_version">Version %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">Alle rettigheder forbeholdes.</string>
     <string name="about_credits">Tak til Max Planck Institute for Gravitational Physics, IBM Corporation og HTC

--- a/android/BOINC/app/src/main/res/values-da/strings.xml
+++ b/android/BOINC/app/src/main/res/values-da/strings.xml
@@ -247,17 +247,11 @@
     <string name="projects_control_sync_acctmgr">Synkronisér</string>
     <string name="projects_control_remove_acctmgr">Deaktivér</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Fjern projekt?</string>
     <string name="projects_confirm_detach_message">Er du sikker på, at du vil fjerne</string>
-    <string name="projects_confirm_detach_message2">fra BOINC?</string>
     <string name="projects_confirm_detach_confirm">Fjern</string>
-    <string name="projects_confirm_reset_title">Nulstil projekt</string>
-    <string name="projects_confirm_reset_message">Er du sikker på, at du vil nulstille</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Nulstil</string>
     <string name="projects_confirm_remove_acctmgr_title">Deaktivér kontohåndtering</string>
     <string name="projects_confirm_remove_acctmgr_message">Er du sikker på, du vil stoppe med at bruge</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Deaktivér</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Opgavenavn:</string>

--- a/android/BOINC/app/src/main/res/values-de/strings.xml
+++ b/android/BOINC/app/src/main/res/values-de/strings.xml
@@ -334,7 +334,7 @@
   <string name="about_button">Zurück</string>
   <string name="about_title">Über</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Version</string>
+  <string name="about_version">Version %1$s</string>
   <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
   <string name="about_copyright">\u00A9 2003–2019 Universität von Kalifornien, Berkeley.</string>
   <string name="about_copyright_reserved">Alle Rechte vorbehalten.</string>

--- a/android/BOINC/app/src/main/res/values-de/strings.xml
+++ b/android/BOINC/app/src/main/res/values-de/strings.xml
@@ -231,17 +231,11 @@
   <string name="projects_control_sync_acctmgr">Synchronisieren</string>
   <string name="projects_control_remove_acctmgr">Deaktivieren</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Projekt entfernen?</string>
   <string name="projects_confirm_detach_message">Wollen Sie wirklich</string>
-  <string name="projects_confirm_detach_message2">von BOINC entfernen?</string>
   <string name="projects_confirm_detach_confirm">Entfernen</string>
-  <string name="projects_confirm_reset_title">Projekt zurücksetzen</string>
-  <string name="projects_confirm_reset_message">Sind Sie sicher, dass Projekt neu zu initialisieren</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Zurücksetzen</string>
   <string name="projects_confirm_remove_acctmgr_title">Kontoverwaltung deaktivieren</string>
   <string name="projects_confirm_remove_acctmgr_message">Sind Sie sicher die Kontoverwaltung zu entfernen</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Deaktivieren</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Aufgabenname:</string>

--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -243,16 +243,18 @@
     <string name="projects_control_sync_acctmgr">Synchronize</string>
     <string name="projects_control_remove_acctmgr">Disable</string>
     <!--project confirm dialog-->
+    <string name="projects_confirm_title">%1$s project?</string>
+    <string name="projects_confirm_message">Are you sure you want to %1$s %2$s?</string>
     <string name="projects_confirm_detach_title">Remove project?</string>
     <string name="projects_confirm_detach_message">Are you sure you want to remove</string>
-    <string name="projects_confirm_detach_message2">from BOINC?</string>
+    <string name="projects_confirm_detach_message2">from BOINC</string>
     <string name="projects_confirm_detach_confirm">Remove</string>
     <string name="projects_confirm_reset_title">Reset project</string>
     <string name="projects_confirm_reset_message">Are you sure you want to reset</string>
     <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Reset</string>
     <string name="projects_confirm_remove_acctmgr_title">Disable account manager</string>
-    <string name="projects_confirm_remove_acctmgr_message">Are you sure you want to stop using</string>
+    <string name="projects_confirm_remove_acctmgr_message">stop using</string>
     <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Disable</string>
     <!--tasks tab strings-->

--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -347,7 +347,7 @@
     <string name="about_button">Return</string>
     <string name="about_title">About</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Version</string>
+    <string name="about_version">Version %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright">\u00A9 2003–2016 University of California, Berkeley.</string>
     <string name="about_copyright_reserved">All Rights Reserved.</string>

--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -245,17 +245,11 @@
     <!--project confirm dialog-->
     <string name="projects_confirm_title">%1$s project?</string>
     <string name="projects_confirm_message">Are you sure you want to %1$s %2$s?</string>
-    <string name="projects_confirm_detach_title">Remove project?</string>
     <string name="projects_confirm_detach_message">Are you sure you want to remove</string>
-    <string name="projects_confirm_detach_message2">from BOINC</string>
     <string name="projects_confirm_detach_confirm">Remove</string>
-    <string name="projects_confirm_reset_title">Reset project</string>
-    <string name="projects_confirm_reset_message">Are you sure you want to reset</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Reset</string>
     <string name="projects_confirm_remove_acctmgr_title">Disable account manager</string>
     <string name="projects_confirm_remove_acctmgr_message">stop using</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Disable</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Task Name:</string>

--- a/android/BOINC/app/src/main/res/values-es/strings.xml
+++ b/android/BOINC/app/src/main/res/values-es/strings.xml
@@ -249,17 +249,11 @@
     <string name="projects_control_sync_acctmgr">Sincronizar</string>
     <string name="projects_control_remove_acctmgr">Deshabilitar</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">¿Borrar proyecto?</string>
     <string name="projects_confirm_detach_message">Seguro que quieres borrarlo</string>
-    <string name="projects_confirm_detach_message2">de BOINC?</string>
     <string name="projects_confirm_detach_confirm">Eliminar</string>
-    <string name="projects_confirm_reset_title">Reiniciar proyecto</string>
-    <string name="projects_confirm_reset_message">Seguro que quieres reinciar</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Reset</string>
     <string name="projects_confirm_remove_acctmgr_title">Deshabilitar el administrador de cuentas</string>
     <string name="projects_confirm_remove_acctmgr_message">Está seguro de que quiere dejar de usar</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Deshabilitar</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Nombre de la tarea:</string>

--- a/android/BOINC/app/src/main/res/values-es/strings.xml
+++ b/android/BOINC/app/src/main/res/values-es/strings.xml
@@ -351,7 +351,7 @@
     <string name="about_button">Volver</string>
     <string name="about_title">Acerca de</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Versión</string>
+    <string name="about_version">Versión %1$s</string>
     <string name="about_name_long">Infraestructura Abierta de Berkeley para Computación en Red</string>
     <string name="about_copyright_reserved">Todos los derechos reservados.</string>
     <string name="about_credits">Gracias al \"Max Planck Institute for Gravitational Physics\", IBM Corporation y HTC

--- a/android/BOINC/app/src/main/res/values-eu/strings.xml
+++ b/android/BOINC/app/src/main/res/values-eu/strings.xml
@@ -252,17 +252,11 @@ gehigarria
   <string name="projects_control_sync_acctmgr">Sinkronizatu</string>
   <string name="projects_control_remove_acctmgr">Desgaitu</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Proiektua kendu?</string>
   <string name="projects_confirm_detach_message">Ziur al zaude ezabatu nahi duzula</string>
-  <string name="projects_confirm_detach_message2">BOINCetik?</string>
   <string name="projects_confirm_detach_confirm">Kendu</string>
-  <string name="projects_confirm_reset_title">Berrabiarazi proiektua </string>
-  <string name="projects_confirm_reset_message">Ziur al zaude berrabiarazi nahi duzula</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Berrezarri</string>
   <string name="projects_confirm_remove_acctmgr_title">Desgaitu kontu-administratzailea</string>
   <string name="projects_confirm_remove_acctmgr_message">Ziur al zaude erabiltzeari utzi nahi diozula</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Desgaitu</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Atazaren izena: </string>

--- a/android/BOINC/app/src/main/res/values-eu/strings.xml
+++ b/android/BOINC/app/src/main/res/values-eu/strings.xml
@@ -355,7 +355,7 @@ gehigarria
   <string name="about_button">Itzuli</string>
   <string name="about_title">Honi buruz</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Bertsioa</string>
+  <string name="about_version">Bertsioa %1$s</string>
   <string name="about_name_long">Sare bidezko Konputaziorako Berkeleyko Azpiegitura Irekia</string>
   <string name="about_copyright">\u00A9 2003–2019 Kaliforniako Unibertsitatea Berkeleyn.</string>
   <string name="about_copyright_reserved">Eskubide guztiak erreserbatuta.</string>

--- a/android/BOINC/app/src/main/res/values-fi/strings.xml
+++ b/android/BOINC/app/src/main/res/values-fi/strings.xml
@@ -252,17 +252,11 @@
   <string name="projects_control_sync_acctmgr">Synkronoi</string>
   <string name="projects_control_remove_acctmgr">Poista</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Poista projekti?</string>
   <string name="projects_confirm_detach_message">Haluatko varmasti poistaa</string>
-  <string name="projects_confirm_detach_message2">BOINCista?</string>
   <string name="projects_confirm_detach_confirm">Poista</string>
-  <string name="projects_confirm_reset_title">Nollaa projekti</string>
-  <string name="projects_confirm_reset_message">Haluatko varmasti nollata</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Nollaa</string>
   <string name="projects_confirm_remove_acctmgr_title">Poista tilihallitsija käytöstä</string>
   <string name="projects_confirm_remove_acctmgr_message">Haluatko lopettaa käyttämästä</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Poista käytöstä</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Tehtävän nimi:</string>

--- a/android/BOINC/app/src/main/res/values-fi/strings.xml
+++ b/android/BOINC/app/src/main/res/values-fi/strings.xml
@@ -354,7 +354,7 @@
   <string name="about_button">Takaisin</string>
   <string name="about_title">Tietoja</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Versio</string>
+  <string name="about_version">Versio %1$s</string>
   <string name="about_name_long">Berkeleyn avoin infrastruktuuri verkkolaskentaan</string>
   <string name="about_copyright">\u00A9 2003–2019 Kalifornian yliopisto, Berkeley.</string>
   <string name="about_copyright_reserved">Kaikki oikeudet pidätetään.</string>

--- a/android/BOINC/app/src/main/res/values-fr/strings.xml
+++ b/android/BOINC/app/src/main/res/values-fr/strings.xml
@@ -252,17 +252,11 @@
   <string name="projects_control_sync_acctmgr">Synchroniser</string>
   <string name="projects_control_remove_acctmgr">Désactiver</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Supprimer le projet ?</string>
   <string name="projects_confirm_detach_message">Êtes-vous sûr de vouloir supprimer </string>
-  <string name="projects_confirm_detach_message2">de BOINC ?</string>
   <string name="projects_confirm_detach_confirm">Supprimer</string>
-  <string name="projects_confirm_reset_title">Recommencer le projet</string>
-  <string name="projects_confirm_reset_message">Êtes-vous sûr de vouloir recommencer </string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Réinitialiser</string>
   <string name="projects_confirm_remove_acctmgr_title">Désactiver le gestionnaire de compte</string>
   <string name="projects_confirm_remove_acctmgr_message">Êtes-vous sûr de vouloir cesser d\'utiliser </string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Désactiver</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Nom de la tâche :</string>

--- a/android/BOINC/app/src/main/res/values-fr/strings.xml
+++ b/android/BOINC/app/src/main/res/values-fr/strings.xml
@@ -355,7 +355,7 @@
   <string name="about_button">Retour</string>
   <string name="about_title">À propos</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Version</string>
+  <string name="about_version">Version %1$s</string>
   <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
   <string name="about_copyright">\u00A9 2003–2019 Université de Californie, Berkeley.</string>
   <string name="about_copyright_reserved">Tous droits réservés.</string>

--- a/android/BOINC/app/src/main/res/values-he/strings.xml
+++ b/android/BOINC/app/src/main/res/values-he/strings.xml
@@ -236,17 +236,11 @@
     <string name="projects_control_sync_acctmgr">סנכרן</string>
     <string name="projects_control_remove_acctmgr">השבת</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">להסיר את המיזם?</string>
     <string name="projects_confirm_detach_message">האם אתה בטוח שברצונך להסיר</string>
-    <string name="projects_confirm_detach_message2">מ-BOINC?</string>
     <string name="projects_confirm_detach_confirm">הסר</string>
-    <string name="projects_confirm_reset_title">אפס את המיזם</string>
-    <string name="projects_confirm_reset_message">האם אתה בטוח שברצונך לאפס</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">אפס</string>
     <string name="projects_confirm_remove_acctmgr_title">השבת את מנהל חשבונות</string>
     <string name="projects_confirm_remove_acctmgr_message">האם אתה בטוח שברצונך להפסיק את השימוש ב-</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">השבת</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">שם המשימה:</string>

--- a/android/BOINC/app/src/main/res/values-he/strings.xml
+++ b/android/BOINC/app/src/main/res/values-he/strings.xml
@@ -338,7 +338,7 @@
     <string name="about_button">חזור</string>
     <string name="about_title">על אודות</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">גירסה</string>
+    <string name="about_version">גירסה %1$s</string>
     <string name="about_name_long">התשתית הפתוחה של ברקלי עבור מחשוב רשת</string>
     <string name="about_copyright_reserved">כל הזכויות שמורות.</string>
     <string name="about_credits">תודות למכון מקס פלנק לפיסיקה כבידתית, תאגיד IBM וחברת HTC על תמיכתם.</string>

--- a/android/BOINC/app/src/main/res/values-hu/strings.xml
+++ b/android/BOINC/app/src/main/res/values-hu/strings.xml
@@ -251,17 +251,11 @@
     <string name="projects_control_sync_acctmgr">Szinkronizáció</string>
     <string name="projects_control_remove_acctmgr">Kikapcsolva</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Törlöd a projektet?</string>
     <string name="projects_confirm_detach_message">Biztosan le akarod törölni</string>
-    <string name="projects_confirm_detach_message2">BOINC-ról?</string>
     <string name="projects_confirm_detach_confirm">Eltávolítás</string>
-    <string name="projects_confirm_reset_title">Projekt nullázása</string>
-    <string name="projects_confirm_reset_message">Biztosan újrakezded</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Visszaállítás</string>
     <string name="projects_confirm_remove_acctmgr_title">Fiókkezelő kikapcsolása</string>
     <string name="projects_confirm_remove_acctmgr_message">Biztosan le akarod állítani a használatot</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Kikapcsolva</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Feladat neve:</string>

--- a/android/BOINC/app/src/main/res/values-hu/strings.xml
+++ b/android/BOINC/app/src/main/res/values-hu/strings.xml
@@ -353,7 +353,7 @@
     <string name="about_button">Vissza</string>
     <string name="about_title">Névjegy</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Verzió</string>
+    <string name="about_version">Verzió %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing\n(Berkeley Nyílt Infrastruktúra a
         Hálózati Számításért)
     </string>

--- a/android/BOINC/app/src/main/res/values-it-rIT/strings.xml
+++ b/android/BOINC/app/src/main/res/values-it-rIT/strings.xml
@@ -247,17 +247,11 @@
   <string name="projects_control_sync_acctmgr">Sincronizza</string>
   <string name="projects_control_remove_acctmgr">Disabilita</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Rimuovere il progetto?</string>
   <string name="projects_confirm_detach_message">Sei sicuro di voler rimuovere</string>
-  <string name="projects_confirm_detach_message2">da BOINC?</string>
   <string name="projects_confirm_detach_confirm">Rimuovi</string>
-  <string name="projects_confirm_reset_title">Resetta il progetto</string>
-  <string name="projects_confirm_reset_message">Sei sicuro di voler resettare</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Resetta</string>
   <string name="projects_confirm_remove_acctmgr_title">Disabilita l\'account manager</string>
   <string name="projects_confirm_remove_acctmgr_message">Sei sicuro di voler terminare l\'utilizzo</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Disabilita</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Nome attività:</string>

--- a/android/BOINC/app/src/main/res/values-it-rIT/strings.xml
+++ b/android/BOINC/app/src/main/res/values-it-rIT/strings.xml
@@ -350,7 +350,7 @@
   <string name="about_button">Invio</string>
   <string name="about_title">Informazioni</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Versione</string>
+  <string name="about_version">Versione %1$s</string>
   <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
   <string name="about_copyright">\u00A9 2003–2019 Università della California, Berkeley.</string>
   <string name="about_copyright_reserved">Tutti i diritti riservati.</string>

--- a/android/BOINC/app/src/main/res/values-ja/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ja/strings.xml
@@ -329,7 +329,7 @@
     <string name="about_button">戻る</string>
     <string name="about_title">バージョン情報</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">バージョン</string>
+    <string name="about_version">バージョン %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">All Rights Reserved.</string>
     <string name="about_credits">The Max Planck Institute for Gravitational Physics, IBM Corporation, HTC Corporation

--- a/android/BOINC/app/src/main/res/values-ja/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ja/strings.xml
@@ -227,17 +227,11 @@
     <string name="projects_control_sync_acctmgr">同期</string>
     <string name="projects_control_remove_acctmgr">無効</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">プロジェクトを削除しますか？</string>
     <string name="projects_confirm_detach_message">本当に削除しますか</string>
-    <string name="projects_confirm_detach_message2">BOINCから?</string>
     <string name="projects_confirm_detach_confirm">削除</string>
-    <string name="projects_confirm_reset_title">プロジェクトをリセット</string>
-    <string name="projects_confirm_reset_message">本当にリセットしますか</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">リセット</string>
     <string name="projects_confirm_remove_acctmgr_title">アカウント・マネージャを無効にする</string>
     <string name="projects_confirm_remove_acctmgr_message">本当に使用を停止しますか</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">無効</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">タスク名:</string>

--- a/android/BOINC/app/src/main/res/values-ka/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ka/strings.xml
@@ -255,17 +255,11 @@
     <string name="projects_control_sync_acctmgr">სინქრონიზირება</string>
     <string name="projects_control_remove_acctmgr">გათიშვა</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">გსურთ პროექტის წაშლა?</string>
     <string name="projects_confirm_detach_message">დარწმუნებული ხართ, რომ გსურთ წაშალოთ</string>
-    <string name="projects_confirm_detach_message2">BOINC-იდან?</string>
     <string name="projects_confirm_detach_confirm">წაშლა</string>
-    <string name="projects_confirm_reset_title">პროექტის ჩამოგდება</string>
-    <string name="projects_confirm_reset_message">დარწმუნებული ხართ, რომ გსურთ ჩამოაგდოთ</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">ჩამოგდება</string>
     <string name="projects_confirm_remove_acctmgr_title">ანგარიშის მმართველის გათიშვა</string>
     <string name="projects_confirm_remove_acctmgr_message">დარწმუნებული ხართ, რომ გსურთ აღარ გამოიყენოთ</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">გათიშვა</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">დავალების სახელი:</string>

--- a/android/BOINC/app/src/main/res/values-ka/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ka/strings.xml
@@ -357,7 +357,7 @@
     <string name="about_button">დაბრუნება</string>
     <string name="about_title">პროგრამის შესახებ</string>
     <string name="about_name">BOINC-ი</string>
-    <string name="about_version">ვერსია</string>
+    <string name="about_version">ვერსია %1$s</string>
     <string name="about_name_long">ქსელური გამოთვლების ბერკელეის ღია ინფრასტრუქტურა</string>
     <string name="about_copyright_reserved">ყველა უფლება დაცულია.</string>
     <string name="about_credits">მადლობა გრავიტაცული ფიზიკის მაქს პლანკის ინსტიტუტს, აი-ბი-ემ კორპორაციას და ეიჩ-თი-სი

--- a/android/BOINC/app/src/main/res/values-ko/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ko/strings.xml
@@ -228,17 +228,11 @@
     <string name="projects_control_sync_acctmgr">동기화</string>
     <string name="projects_control_remove_acctmgr">비활성</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">프로젝트를 제거할까요?</string>
     <string name="projects_confirm_detach_message">BOINC상에서 정말로 프로젝트명:</string>
-    <string name="projects_confirm_detach_message2">를 제거하시겠습니까?</string>
     <string name="projects_confirm_detach_confirm">제거</string>
-    <string name="projects_confirm_reset_title">프로젝트 재설정</string>
-    <string name="projects_confirm_reset_message">다음 프로젝트가 재설정됩니다 괘찮습니까:</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">재설정</string>
     <string name="projects_confirm_remove_acctmgr_title">계정 관리자 비활성화</string>
     <string name="projects_confirm_remove_acctmgr_message">정말로 다음 항목 사용을 중지합니까</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">비활성화</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">태스크 이름:</string>

--- a/android/BOINC/app/src/main/res/values-ko/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ko/strings.xml
@@ -330,7 +330,7 @@
     <string name="about_button">뒤로</string>
     <string name="about_title">정보</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">버전</string>
+    <string name="about_version">버전 %1$s</string>
     <string name="about_name_long">네트워크 컴퓨팅을 위한 Berkeley 개방형 하부구조체</string>
     <string name="about_copyright_reserved">모든 권리 보유</string>
     <string name="about_credits">막스 플랑크 중력 물리학 연구소, IBM Corporation, HTC의 지원에 감사드립니다.</string>

--- a/android/BOINC/app/src/main/res/values-lt/strings.xml
+++ b/android/BOINC/app/src/main/res/values-lt/strings.xml
@@ -339,7 +339,7 @@ Nerekomenduojama keisti šios reikšmės.</string>
   <string name="about_button">Grįžti</string>
   <string name="about_title">Apie</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Versija</string>
+  <string name="about_version">Versija %1$s</string>
   <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
   <string name="about_copyright">\u00A9 2003–2019 University of California, Berkeley.</string>
   <string name="about_copyright_reserved">Visos teisės saugomos</string>

--- a/android/BOINC/app/src/main/res/values-lt/strings.xml
+++ b/android/BOINC/app/src/main/res/values-lt/strings.xml
@@ -236,17 +236,11 @@ Nerekomenduojama keisti šios reikšmės.</string>
   <string name="projects_control_sync_acctmgr">Sinchronizuoti</string>
   <string name="projects_control_remove_acctmgr">Išjungti</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Pašalinti projektą?</string>
   <string name="projects_confirm_detach_message">Ar tikrai norite pašalinti </string>
-  <string name="projects_confirm_detach_message2">iš BOINC?</string>
   <string name="projects_confirm_detach_confirm">Pašalinti</string>
-  <string name="projects_confirm_reset_title">Perkrauti projektą</string>
-  <string name="projects_confirm_reset_message">Ar tikrai norite perkrauti</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Atstatyti</string>
   <string name="projects_confirm_remove_acctmgr_title">Išjungti abonemento valdiklį</string>
   <string name="projects_confirm_remove_acctmgr_message">Ar tikrai norite nebenaudoti</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Išjungti</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Užduoties pavadinimas:</string>

--- a/android/BOINC/app/src/main/res/values-lv/strings.xml
+++ b/android/BOINC/app/src/main/res/values-lv/strings.xml
@@ -247,17 +247,11 @@
     <string name="projects_control_sync_acctmgr">Sinhronizēt</string>
     <string name="projects_control_remove_acctmgr">Atspējot</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Vai noņemt projektu?</string>
     <string name="projects_confirm_detach_message">Vai tiešām vēlaties noņemt projektu</string>
-    <string name="projects_confirm_detach_message2">no BOINC?</string>
     <string name="projects_confirm_detach_confirm">Izņemt</string>
-    <string name="projects_confirm_reset_title">Atjaunināt projektu</string>
-    <string name="projects_confirm_reset_message">Vai tiešām vēlaties atiestatīt projektu</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Atiestatīt</string>
     <string name="projects_confirm_remove_acctmgr_title">Atspējot konta pārvaldnieku</string>
     <string name="projects_confirm_remove_acctmgr_message">Vai tiešām vēlaties pārtraukt lietot</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Atspējot</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Uzdevuma nosaukums:</string>

--- a/android/BOINC/app/src/main/res/values-lv/strings.xml
+++ b/android/BOINC/app/src/main/res/values-lv/strings.xml
@@ -350,7 +350,7 @@
     <string name="about_button">Atgriezties</string>
     <string name="about_title">Par</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Versija</string>
+    <string name="about_version">Versija %1$s</string>
     <string name="about_name_long">Bērkli atvērtā infrastruktūra tīklskaitļošanai</string>
     <string name="about_copyright">\u00A9 2003–2018 Kalifornijas universitāte, Bērkli.</string>
     <string name="about_copyright_reserved">Visas tiesības aizsargātas.</string>

--- a/android/BOINC/app/src/main/res/values-nb/strings.xml
+++ b/android/BOINC/app/src/main/res/values-nb/strings.xml
@@ -347,7 +347,7 @@
     <string name="about_button">Returner</string>
     <string name="about_title">Om</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Versjon</string>
+    <string name="about_version">Versjon %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">All Rights Reserved.</string>
     <string name="about_credits">Takk til Max Planck Institute for Gravitational Physics, IBM Corporation og HTC

--- a/android/BOINC/app/src/main/res/values-nb/strings.xml
+++ b/android/BOINC/app/src/main/res/values-nb/strings.xml
@@ -246,17 +246,11 @@
     <string name="projects_control_sync_acctmgr">Synkroniser</string>
     <string name="projects_control_remove_acctmgr">Deaktiver</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Fjern prosjekt?</string>
     <string name="projects_confirm_detach_message">Er du sikker på at du vil fjerne</string>
-    <string name="projects_confirm_detach_message2">fra BOINC</string>
     <string name="projects_confirm_detach_confirm">Fjern</string>
-    <string name="projects_confirm_reset_title">Nullstill prosjekt</string>
-    <string name="projects_confirm_reset_message">Er du sikker på at du vil nullstille</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Nullstill</string>
     <string name="projects_confirm_remove_acctmgr_title">Deaktiver kontobehandler</string>
     <string name="projects_confirm_remove_acctmgr_message">Er du sikker på at du vil slutte å bruke</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Deaktiver</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Oppgavenavn:</string>

--- a/android/BOINC/app/src/main/res/values-nl/strings.xml
+++ b/android/BOINC/app/src/main/res/values-nl/strings.xml
@@ -231,17 +231,11 @@
   <string name="projects_control_sync_acctmgr">Bijwerken</string>
   <string name="projects_control_remove_acctmgr">Uitzetten</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Project verwijderen?</string>
   <string name="projects_confirm_detach_message">Weet je zeker dat je</string>
-  <string name="projects_confirm_detach_message2">uit BOINC wilt verwijderen?</string>
   <string name="projects_confirm_detach_confirm">Verwijderen</string>
-  <string name="projects_confirm_reset_title">Project resetten</string>
-  <string name="projects_confirm_reset_message">Weet je zeker dat je</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Resetten</string>
   <string name="projects_confirm_remove_acctmgr_title">Accountmanager uitzetten</string>
   <string name="projects_confirm_remove_acctmgr_message">Weet je zeker dat je wilt stoppen met het gebruik van</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Uitzetten</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Taaknaam:</string>

--- a/android/BOINC/app/src/main/res/values-nl/strings.xml
+++ b/android/BOINC/app/src/main/res/values-nl/strings.xml
@@ -334,7 +334,7 @@
   <string name="about_button">Terug</string>
   <string name="about_title">Over</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Versie</string>
+  <string name="about_version">Versie %1$s</string>
   <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
   <string name="about_copyright">\u00A9 2003–2019 University of California, Berkeley.</string>
   <string name="about_copyright_reserved">Alle rechten voorbehouden.</string>

--- a/android/BOINC/app/src/main/res/values-pl/strings.xml
+++ b/android/BOINC/app/src/main/res/values-pl/strings.xml
@@ -224,17 +224,11 @@
     <string name="projects_control_sync_acctmgr">Synchronizuj</string>
     <string name="projects_control_remove_acctmgr">Wyłącz</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Usuwanie projektu</string>
     <string name="projects_confirm_detach_message">Czy na pewno chcesz usunąć</string>
-    <string name="projects_confirm_detach_message2">z BOINC?</string>
     <string name="projects_confirm_detach_confirm">Usuń</string>
-    <string name="projects_confirm_reset_title">Wyzerowanie projektu</string>
-    <string name="projects_confirm_reset_message">Czy na pewno chcesz wyzerować</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Wyzeruj</string>
     <string name="projects_confirm_remove_acctmgr_title">Wyłączenie zarządcy kont</string>
     <string name="projects_confirm_remove_acctmgr_message">Czy na pewno chcesz przestać używać</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Wyłącz</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Nazwa zadania:</string>

--- a/android/BOINC/app/src/main/res/values-pl/strings.xml
+++ b/android/BOINC/app/src/main/res/values-pl/strings.xml
@@ -326,7 +326,7 @@
     <string name="about_button">Wróć</string>
     <string name="about_title">O BOINC</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Wersja</string>
+    <string name="about_version">Wersja %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">Wszelkie prawa zastrzeżone.</string>
     <string name="about_credits">Dziękujemy Instytutowi Fizyki Grawitacyjnej Max Plancka, korporacjom IBM i HTC za wsparcie.</string>

--- a/android/BOINC/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/BOINC/app/src/main/res/values-pt-rBR/strings.xml
@@ -334,7 +334,7 @@
   <string name="about_button">Voltar</string>
   <string name="about_title">Sobre</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Versão</string>
+  <string name="about_version">Versão %1$s</string>
   <string name="about_name_long">Infraestrutura Aberta para Computação em Rede de Berkeley</string>
   <string name="about_copyright">\u00A9 2003-2019 Universidade da Califórnia, Berkeley.</string>
   <string name="about_copyright_reserved">Todos os Direitos Reservados.</string>

--- a/android/BOINC/app/src/main/res/values-pt-rBR/strings.xml
+++ b/android/BOINC/app/src/main/res/values-pt-rBR/strings.xml
@@ -231,17 +231,11 @@
   <string name="projects_control_sync_acctmgr">Sincronizar</string>
   <string name="projects_control_remove_acctmgr">Desativar</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Remover projeto?</string>
   <string name="projects_confirm_detach_message">Você tem certeza que quer remover</string>
-  <string name="projects_confirm_detach_message2">do BOINC?</string>
   <string name="projects_confirm_detach_confirm">Remover</string>
-  <string name="projects_confirm_reset_title">Reiniciar projeto</string>
-  <string name="projects_confirm_reset_message">Você tem certeza que quer reiniciar</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Reiniciar</string>
   <string name="projects_confirm_remove_acctmgr_title">Desabilitar gerenciador de conta</string>
   <string name="projects_confirm_remove_acctmgr_message">Você tem certeza que quer parar de usar</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Desativar</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Nome da Tarefa:</string>

--- a/android/BOINC/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/BOINC/app/src/main/res/values-pt-rPT/strings.xml
@@ -237,17 +237,11 @@ permitido que o BOINC utilize?</string>
   <string name="projects_control_sync_acctmgr">Sincronizar</string>
   <string name="projects_control_remove_acctmgr">Desativar</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Remover projeto?</string>
   <string name="projects_confirm_detach_message">Tem a certeza que deseja remover</string>
-  <string name="projects_confirm_detach_message2">do BOINC?</string>
   <string name="projects_confirm_detach_confirm">Remover</string>
-  <string name="projects_confirm_reset_title">Reiniciar projeto</string>
-  <string name="projects_confirm_reset_message">Tem a certeza que deseja reiniciar</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Reiniciar</string>
   <string name="projects_confirm_remove_acctmgr_title">Desativar gestor de conta</string>
   <string name="projects_confirm_remove_acctmgr_message">Tem a certeza que deseja parar de utilizar o</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Desativar</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Nome da tarefa:</string>

--- a/android/BOINC/app/src/main/res/values-pt-rPT/strings.xml
+++ b/android/BOINC/app/src/main/res/values-pt-rPT/strings.xml
@@ -340,7 +340,7 @@ permitido que o BOINC utilize?</string>
   <string name="about_button">Regressar</string>
   <string name="about_title">Sobre</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Versão</string>
+  <string name="about_version">Versão %1$s</string>
   <string name="about_name_long">Infraestrutura Aberta Berkeley para a Rede de Computação</string>
   <string name="about_copyright">\u00A9 2003–2019 Universidade da Califórnia, Berkeley.</string>
   <string name="about_copyright_reserved">Todos os Direitos Reservados.</string>

--- a/android/BOINC/app/src/main/res/values-ro/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ro/strings.xml
@@ -326,7 +326,7 @@
     <string name="about_button">Înapoi</string>
     <string name="about_title">Despre</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Versiune</string>
+    <string name="about_version">Versiune %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">Toate Drepturile Rezervate.</string>
     <string name="about_credits">Mulțumiri Institutului Max Planck pentru Fizică Gravitațională, IBM Corporation și HTC Corporation pentru suportul lor.</string>

--- a/android/BOINC/app/src/main/res/values-ro/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ro/strings.xml
@@ -224,17 +224,11 @@
     <string name="projects_control_sync_acctmgr">Sincronizează</string>
     <string name="projects_control_remove_acctmgr">Dezactivează</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Şterge proiect?</string>
     <string name="projects_confirm_detach_message">Sunteţi sigur că doriţi să ştergeţi</string>
-    <string name="projects_confirm_detach_message2">din BOINC?</string>
     <string name="projects_confirm_detach_confirm">Șterge</string>
-    <string name="projects_confirm_reset_title">Resetează proiect</string>
-    <string name="projects_confirm_reset_message">Sunteţi sigur că doriţi să resetaţi</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Resetează</string>
     <string name="projects_confirm_remove_acctmgr_title">Dezactivează manager de cont</string>
     <string name="projects_confirm_remove_acctmgr_message">Sunteţi sigur că doriţi să nu mai folosiţi</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Dezactivează</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">Nume Task:</string>

--- a/android/BOINC/app/src/main/res/values-ru/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ru/strings.xml
@@ -334,7 +334,7 @@
   <string name="about_button">Вернуться</string>
   <string name="about_title">О</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Версия</string>
+  <string name="about_version">Версия %1$s</string>
   <string name="about_name_long">BOINC - Berkeley Open Infrastructure for Network Computing\nОткрытая Инфраструктура для Распределенных Вычислений университета Беркли</string>
   <string name="about_copyright">\u00A9 2003–2019 Калифорнийский университет, Беркли.</string>
   <string name="about_copyright_reserved">Все права защищены.</string>

--- a/android/BOINC/app/src/main/res/values-ru/strings.xml
+++ b/android/BOINC/app/src/main/res/values-ru/strings.xml
@@ -231,17 +231,11 @@
   <string name="projects_control_sync_acctmgr">Синхронизировать</string>
   <string name="projects_control_remove_acctmgr">Отключить</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Удалить проект?</string>
   <string name="projects_confirm_detach_message">Вы действительно хотите удалить</string>
-  <string name="projects_confirm_detach_message2">из BOINC?</string>
   <string name="projects_confirm_detach_confirm">Удалить</string>
-  <string name="projects_confirm_reset_title">Перезапустить проект</string>
-  <string name="projects_confirm_reset_message">Вы действительно хотите перезапустить</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Сбросить</string>
   <string name="projects_confirm_remove_acctmgr_title">Отключить менеджер проектов</string>
   <string name="projects_confirm_remove_acctmgr_message">Вы уверены, что хотите прекратить использование</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Отключить</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Название задания:</string>

--- a/android/BOINC/app/src/main/res/values-sk/strings.xml
+++ b/android/BOINC/app/src/main/res/values-sk/strings.xml
@@ -340,7 +340,7 @@
   <string name="about_button">Návrat</string>
   <string name="about_title">O</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Verzia</string>
+  <string name="about_version">Verzia %1$s</string>
   <string name="about_name_long">(Otvorená infraštruktúra pre sieťové výpočty z Berkeley)
 (Berkeley Open Infrastructure for Network Computing)</string>
   <string name="about_copyright_reserved">Všetky práva vyhradené.</string>

--- a/android/BOINC/app/src/main/res/values-sk/strings.xml
+++ b/android/BOINC/app/src/main/res/values-sk/strings.xml
@@ -237,17 +237,11 @@
   <string name="projects_control_sync_acctmgr">Sychronizovať</string>
   <string name="projects_control_remove_acctmgr">Deaktivovať</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Odstrániť projekt?</string>
   <string name="projects_confirm_detach_message">Skutočne chcete odstrániť</string>
-  <string name="projects_confirm_detach_message2">z BOINC?</string>
   <string name="projects_confirm_detach_confirm">Odobrať</string>
-  <string name="projects_confirm_reset_title">Resetovať projekt</string>
-  <string name="projects_confirm_reset_message">Skutočne chcete resetovať</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Resetovať</string>
   <string name="projects_confirm_remove_acctmgr_title">Deaktivovať Správcu konta</string>
   <string name="projects_confirm_remove_acctmgr_message">Skutočne chcete prestať používať</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Deaktivovať</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Názov úlohy:</string>

--- a/android/BOINC/app/src/main/res/values-sl/strings.xml
+++ b/android/BOINC/app/src/main/res/values-sl/strings.xml
@@ -220,8 +220,6 @@
     <string name="projects_control_remove_acctmgr">Dezactivează</string>
     <!--project confirm dialog-->
     <string name="projects_confirm_detach_confirm">Odstrani</string>
-    <string name="projects_confirm_reset_title">Перезапустить проект</string>
-    <string name="projects_confirm_reset_message">Вы действительно хотите перезапустить</string>
     <string name="projects_confirm_reset_confirm">Сбросить</string>
     <string name="projects_confirm_remove_acctmgr_title">Dezactivează manager de cont</string>
     <string name="projects_confirm_remove_acctmgr_message">Sunteţi sigur că doriţi să nu mai folosiţi</string>

--- a/android/BOINC/app/src/main/res/values-sl/strings.xml
+++ b/android/BOINC/app/src/main/res/values-sl/strings.xml
@@ -300,7 +300,7 @@
     <!--about dialog-->
     <string name="about_title">О</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Različica</string>
+    <string name="about_version">Različica %1$s</string>
     <string name="about_name_long">Berkeleyeva odprta infrastruktura za mrežno računanje</string>
     <!--notice notification e.g. New notice from SETI@HOME OR 3 new notices-->
     <!--multi BOINC compatibility-->

--- a/android/BOINC/app/src/main/res/values-sv/strings.xml
+++ b/android/BOINC/app/src/main/res/values-sv/strings.xml
@@ -342,7 +342,7 @@ arbete</string>
   <string name="about_button">Återvänd</string>
   <string name="about_title">Om</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Version</string>
+  <string name="about_version">Version %1$s</string>
   <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
   <string name="about_copyright">\u00A9 2003–2019 Kaliforniens universitet, Berkeley.</string>
   <string name="about_copyright_reserved">Alla rättigheter reserverade.</string>

--- a/android/BOINC/app/src/main/res/values-sv/strings.xml
+++ b/android/BOINC/app/src/main/res/values-sv/strings.xml
@@ -239,17 +239,11 @@ arbete</string>
   <string name="projects_control_sync_acctmgr">Synkronisera</string>
   <string name="projects_control_remove_acctmgr">Koppla bort</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Ta bort projekt?</string>
   <string name="projects_confirm_detach_message">Är du säker på att du vill ta bort</string>
-  <string name="projects_confirm_detach_message2">från BOINC?</string>
   <string name="projects_confirm_detach_confirm">Ta bort</string>
-  <string name="projects_confirm_reset_title">Återställ projekt</string>
-  <string name="projects_confirm_reset_message">Är du säker på att du vill återställa</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Nollställ</string>
   <string name="projects_confirm_remove_acctmgr_title">Avaktivera kontohanterare</string>
   <string name="projects_confirm_remove_acctmgr_message">Är du säker på att du vill sluta använda</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Avaktivera</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Uppgiftsnamn:</string>

--- a/android/BOINC/app/src/main/res/values-tr/strings.xml
+++ b/android/BOINC/app/src/main/res/values-tr/strings.xml
@@ -326,7 +326,7 @@
     <string name="about_button">Geri dön</string>
     <string name="about_title">Hakkında</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Sürüm</string>
+    <string name="about_version">Sürüm %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright_reserved">Tüm Hakları Saklıdır.</string>
     <string name="about_credits">Verdikleri destek için Max Planck Enstitüsü Yerçekimi Fizik Bölümü\'ne, IBM ve HTC şirketlerine teşekkürler.</string>

--- a/android/BOINC/app/src/main/res/values-tr/strings.xml
+++ b/android/BOINC/app/src/main/res/values-tr/strings.xml
@@ -224,17 +224,11 @@
     <string name="projects_control_sync_acctmgr">Eşitle</string>
     <string name="projects_control_remove_acctmgr">Devredışı bırak</string>
     <!--project confirm dialog-->
-    <string name="projects_confirm_detach_title">Proje kaldırılsın mı?</string>
     <string name="projects_confirm_detach_message">Kaldırmak istediğinizden emin misiniz?</string>
-    <string name="projects_confirm_detach_message2">BOINC\'ten?</string>
     <string name="projects_confirm_detach_confirm">Kaldır</string>
-    <string name="projects_confirm_reset_title">Projeyi sıfırla</string>
-    <string name="projects_confirm_reset_message">Bu proje sıfırlansın mı:</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Sıfırla</string>
     <string name="projects_confirm_remove_acctmgr_title">Hesap Yöneticisini devredışı bırak</string>
     <string name="projects_confirm_remove_acctmgr_message">Bu hesap yöneticisini kullanmayı bırakmak istiyor musunuz:</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Devredışı bırak</string>
     <!--tasks tab strings-->
     <string name="tasks_header_name">İş adı:</string>

--- a/android/BOINC/app/src/main/res/values-uk/strings.xml
+++ b/android/BOINC/app/src/main/res/values-uk/strings.xml
@@ -356,7 +356,7 @@
   <string name="about_button">Повернутися</string>
   <string name="about_title">Про додаток</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">Версія</string>
+  <string name="about_version">Версія %1$s</string>
   <string name="about_name_long">Відкрита інфраструктура для розподілених обчислень університету Берклі</string>
   <string name="about_copyright">\u00A9 2003–2019 Каліфорнійський університет, Берклі.</string>
   <string name="about_copyright_reserved">Всі права захищені.</string>

--- a/android/BOINC/app/src/main/res/values-uk/strings.xml
+++ b/android/BOINC/app/src/main/res/values-uk/strings.xml
@@ -253,17 +253,11 @@
   <string name="projects_control_sync_acctmgr">Синхронізувати</string>
   <string name="projects_control_remove_acctmgr">Відключити</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">Видалити проект?</string>
   <string name="projects_confirm_detach_message">Ви справді хочете видалити</string>
-  <string name="projects_confirm_detach_message2">із BOINC?</string>
   <string name="projects_confirm_detach_confirm">Видалити</string>
-  <string name="projects_confirm_reset_title">Перезапустити проект</string>
-  <string name="projects_confirm_reset_message">Ви справді хочете перезапустити</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">Перезапустити</string>
   <string name="projects_confirm_remove_acctmgr_title">Відключити менеджер проектів</string>
   <string name="projects_confirm_remove_acctmgr_message">Ви впевнені, що бажаєте припинити використання</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">Відключити</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">Назва завдання:</string>

--- a/android/BOINC/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/BOINC/app/src/main/res/values-zh-rCN/strings.xml
@@ -252,17 +252,11 @@ BOINC应当暂停运算？
   <string name="projects_control_sync_acctmgr">同步</string>
   <string name="projects_control_remove_acctmgr">已禁用</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">移除项目？</string>
   <string name="projects_confirm_detach_message">您确定要删除项目吗？</string>
-  <string name="projects_confirm_detach_message2">移除？</string>
   <string name="projects_confirm_detach_confirm">删除</string>
-  <string name="projects_confirm_reset_title">重置项目</string>
-  <string name="projects_confirm_reset_message">您确定要重置项目吗？</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">重置</string>
   <string name="projects_confirm_remove_acctmgr_title">禁用帐户管理器</string>
   <string name="projects_confirm_remove_acctmgr_message">您确定要重置</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">已禁用</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">任务名称：</string>

--- a/android/BOINC/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/BOINC/app/src/main/res/values-zh-rCN/strings.xml
@@ -355,7 +355,7 @@ BOINC应当暂停运算？
   <string name="about_button">返回</string>
   <string name="about_title">关于</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">版本</string>
+  <string name="about_version">版本 %1$s</string>
   <string name="about_name_long">伯克利开放式网络计算平台 ( BOINC )</string>
   <string name="about_copyright">\u00A9 2003–2019 加州大学伯克利分校。</string>
   <string name="about_copyright_reserved">所有权利保留。</string>

--- a/android/BOINC/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/BOINC/app/src/main/res/values-zh-rTW/strings.xml
@@ -338,7 +338,7 @@
   <string name="about_button">返回</string>
   <string name="about_title">關於</string>
   <string name="about_name">BOINC</string>
-  <string name="about_version">版本</string>
+  <string name="about_version">版本 %1$s</string>
   <string name="about_name_long">柏克萊開放式網路運算平台</string>
   <string name="about_copyright">\u00A9 2003–2019 美國加州大學柏克萊分校</string>
   <string name="about_copyright_reserved">All Rights Reserved.</string>

--- a/android/BOINC/app/src/main/res/values-zh-rTW/strings.xml
+++ b/android/BOINC/app/src/main/res/values-zh-rTW/strings.xml
@@ -235,17 +235,11 @@
   <string name="projects_control_sync_acctmgr">同步</string>
   <string name="projects_control_remove_acctmgr">停用</string>
   <!--project confirm dialog-->
-  <string name="projects_confirm_detach_title">移除專案?</string>
   <string name="projects_confirm_detach_message">您確定從BOINC將</string>
-  <string name="projects_confirm_detach_message2">移除?</string>
   <string name="projects_confirm_detach_confirm">移除</string>
-  <string name="projects_confirm_reset_title">重置專案</string>
-  <string name="projects_confirm_reset_message">您確定要重置</string>
-  <string name="projects_confirm_reset_message2">\?</string>
   <string name="projects_confirm_reset_confirm">重置</string>
   <string name="projects_confirm_remove_acctmgr_title">來自帳號管理員的請求</string>
   <string name="projects_confirm_remove_acctmgr_message">您確定要重置</string>
-  <string name="projects_confirm_remove_acctmgr_message2">\?</string>
   <string name="projects_confirm_remove_acctmgr_confirm">停用</string>
   <!--tasks tab strings-->
   <string name="tasks_header_name">任務名稱:</string>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -308,7 +308,7 @@
 
     <!-- confirmation dialog -->
     <string name="confirm_abort_task_title">Abort task?</string>
-    <string name="confirm_abort_task_message">Abort task:</string>
+    <string name="confirm_abort_task_message">Abort task: %1$s</string>
     <string name="confirm_abort_task_confirm">Abort</string>
     <string name="confirm_cancel">Cancel</string>
     <string name="confirm_image_desc">Confirmation dialog</string>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -278,8 +278,7 @@
     <string name="projects_confirm_title">%1$s project?</string>
     <string name="projects_confirm_message">Are you sure you want to %1$s %2$s?</string>
     <string name="projects_confirm_detach_title">Remove project?</string>
-    <string name="projects_confirm_detach_message">Are you sure you want to remove</string>
-    <string name="projects_confirm_detach_message2">from BOINC</string>
+    <string name="projects_confirm_detach_message">from BOINC</string>
     <string name="projects_confirm_detach_confirm">Remove</string>
     <string name="projects_confirm_reset_title">Reset project</string>
     <string name="projects_confirm_reset_message">Are you sure you want to reset</string>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -277,16 +277,11 @@
     <!-- project confirm dialog -->
     <string name="projects_confirm_title">%1$s project?</string>
     <string name="projects_confirm_message">Are you sure you want to %1$s %2$s?</string>
-    <string name="projects_confirm_detach_title">Remove project?</string>
     <string name="projects_confirm_detach_message">from BOINC</string>
     <string name="projects_confirm_detach_confirm">Remove</string>
-    <string name="projects_confirm_reset_title">Reset project</string>
-    <string name="projects_confirm_reset_message">Are you sure you want to reset</string>
-    <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Reset</string>
     <string name="projects_confirm_remove_acctmgr_title">Disable account manager</string>
     <string name="projects_confirm_remove_acctmgr_message">stop using</string>
-    <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Disable</string>
 
     <!-- tasks tab strings -->

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -275,16 +275,18 @@
     <string name="projects_control_sync_acctmgr">Synchronize</string>
     <string name="projects_control_remove_acctmgr">Disable</string>
     <!-- project confirm dialog -->
+    <string name="projects_confirm_title">%1$s project?</string>
+    <string name="projects_confirm_message">Are you sure you want to %1$s %2$s?</string>
     <string name="projects_confirm_detach_title">Remove project?</string>
     <string name="projects_confirm_detach_message">Are you sure you want to remove</string>
-    <string name="projects_confirm_detach_message2">from BOINC?</string>
+    <string name="projects_confirm_detach_message2">from BOINC</string>
     <string name="projects_confirm_detach_confirm">Remove</string>
     <string name="projects_confirm_reset_title">Reset project</string>
     <string name="projects_confirm_reset_message">Are you sure you want to reset</string>
     <string name="projects_confirm_reset_message2">\?</string>
     <string name="projects_confirm_reset_confirm">Reset</string>
     <string name="projects_confirm_remove_acctmgr_title">Disable account manager</string>
-    <string name="projects_confirm_remove_acctmgr_message">Are you sure you want to stop using</string>
+    <string name="projects_confirm_remove_acctmgr_message">stop using</string>
     <string name="projects_confirm_remove_acctmgr_message2">\?</string>
     <string name="projects_confirm_remove_acctmgr_confirm">Disable</string>
 

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -389,7 +389,7 @@
     <string name="about_button">Return</string>
     <string name="about_title">About</string>
     <string name="about_name">BOINC</string>
-    <string name="about_version">Version</string>
+    <string name="about_version">Version %1$s</string>
     <string name="about_name_long">Berkeley Open Infrastructure for Network Computing</string>
     <string name="about_copyright">\u00A9 2003&#8211;2020 University of California, Berkeley.</string>
     <string name="about_copyright_reserved">All Rights Reserved.</string>


### PR DESCRIPTION
Fixes #

**Description of the Change**
Convert string resources which are concatenated with other values to string resources with placeholders. This reduces the number of string resources needed in the Android app and allows it to be localized more easily.

**Release Notes**
N/A
