### PR TITLE
Mac: Fixes for 7.14

### DIFF
--- a/clientgui/mac/templates/Info.plist
+++ b/clientgui/mac/templates/Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -17,6 +17,8 @@
 	<key>CFBundleSignature</key>
 	<string>BNC!</string>
 	<key>CFBundleVersion</key>
-	<string>7.1.0</string>
+	<string>7.14.3</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fix BOINC 7.14 to prevent OS X Mojave from trying to display BOINC Manager in Dark Mode

Add missing file clientscr/gfx_cleanup.mm