### PR TITLE
db_purge: fix truncated mod_time data (field too small for timestamp)

### DIFF
--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -489,7 +489,7 @@ struct WORKUNIT {
         // without consensus (i.e. WU is nondeterministic)
     char result_template_file[64];
     int priority;
-    char mod_time[16];
+    char mod_time[20];
     double rsc_bandwidth_bound;
         // send only to hosts with at least this much download bandwidth
     DB_ID_TYPE fileset_id;
@@ -618,7 +618,7 @@ struct RESULT {
     int exit_status;                // application exit status, if any
     DB_ID_TYPE teamid;
     int priority;
-    char mod_time[16];
+    char mod_time[20];
     double elapsed_time;
         // AKA runtime; returned by 6.10+ clients
     double flops_estimate;


### PR DESCRIPTION
**Description of the Change**

Full timestamp is 19 characters long, so it need a 20-bytes buffer.
This is minor issue - this field is used only by db_purge. It causes db_purge output of this field to be truncated.

<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
N/A
