### PR TITLE
Create notification channel for use on Android Oreo and later.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
@@ -26,6 +26,8 @@ import edu.berkeley.boinc.utils.Logging;
 
 import android.app.Activity;
 import android.app.ActivityManager;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -133,6 +135,18 @@ public class SplashActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash);
+
+        // Create notification channel for use on API 26 and higher.
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            final String name = getString(R.string.main_notification_channel_name);
+
+            final NotificationChannel notificationChannel =
+                    new NotificationChannel("main-channel", name,
+                                            NotificationManager.IMPORTANCE_HIGH);
+            notificationChannel.setDescription(getString(R.string.main_notification_channel_description));
+
+            getSystemService(NotificationManager.class).createNotificationChannel(notificationChannel);
+        }
 
         // Use BOINC logo in Recent Apps Switcher
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) { // API 21

--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -377,4 +377,7 @@
     </string>
     <string name="social_invite_content_url_amazon">http://www.amazon.com/gp/mas/dl/android?p=edu.berkeley.boinc
     </string>
+    <!-- Main notification channel (notices) -->
+    <string name="main_notification_channel_name">Notices</string>
+    <string name="main_notification_channel_description">Displays notices from your projects.</string>
 </resources>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -421,4 +421,8 @@
     </string>
     <string name="social_invite_content_url_amazon">http://www.amazon.com/gp/mas/dl/android?p=edu.berkeley.boinc
     </string>
+
+    <!-- Main notification channel (notices) -->
+    <string name="main_notification_channel_name">Notices</string>
+    <string name="main_notification_channel_description">Displays notices from your projects.</string>
 </resources>


### PR DESCRIPTION
Fixes #

**Description of the Change**
Add code to create a notification channel with the ID "main-channel", which is specified as the channel ID for BOINC notifications. This is required on Android Oreo and later; otherwise, notifications will not be displayed.

**Release Notes**
Fix display of notifications on Android Oreo and later.
