### PR TITLE
Use network callback implementation to determine network connectivity on Android Lollipop and higher.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
@@ -19,6 +19,7 @@
 package edu.berkeley.boinc.attach;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.client.IMonitor;
@@ -163,7 +164,7 @@ public class ProjectAttachService extends Service {
      * @param selected list of selected projects
      * @return success
      */
-    public boolean setSelectedProjects(ArrayList<ProjectInfo> selected) {
+    public boolean setSelectedProjects(List<ProjectInfo> selected) {
         if(!projectConfigRetrievalFinished) {
             if(Logging.ERROR) {
                 Log.e(Logging.TAG, "ProjectAttachService.setSelectedProjects: stop, async task already running.");

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
@@ -19,6 +19,7 @@
 package edu.berkeley.boinc.attach;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.attach.SelectionListActivity.ProjectListEntry;
@@ -39,10 +40,10 @@ import android.widget.TextView;
 
 public class SelectionListAdapter extends ArrayAdapter<ProjectListEntry> {
 
-    private ArrayList<ProjectListEntry> entries;
+    private List<ProjectListEntry> entries;
     private FragmentActivity activity;
 
-    public SelectionListAdapter(FragmentActivity a, int textViewResourceId, ArrayList<ProjectListEntry> entries) {
+    public SelectionListAdapter(FragmentActivity a, int textViewResourceId, List<ProjectListEntry> entries) {
         super(a, textViewResourceId, entries);
         this.entries = entries;
         this.activity = a;
@@ -50,7 +51,6 @@ public class SelectionListAdapter extends ArrayAdapter<ProjectListEntry> {
 
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-
         View v;
 
         LayoutInflater vi = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
@@ -100,7 +100,6 @@ public class SelectionListAdapter extends ArrayAdapter<ProjectListEntry> {
                 ProjectInfoFragment dialog = ProjectInfoFragment.newInstance(listItem.info);
                 dialog.show(activity.getSupportFragmentManager(), "ProjectInfoFragment");
             });
-
         }
         return v;
     }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/callbacks/BOINCNetworkCallback.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/callbacks/BOINCNetworkCallback.kt
@@ -1,0 +1,52 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.attach.callbacks
+
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkInfo
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+/**
+ * Extending ConnectivityManager.NetworkCallback is the recommended mechanism of
+ * detecting any network changes, replacing the ConnectivityManager methods that
+ * return [NetworkInfo].
+ *
+ * Since the minimum API level for the app is 19 (KitKat), the old mechanism is used
+ * on KitKat, as ConnectivityManager.NetworkCallback is only compatible with API level
+ * 21 (Lollipop) and higher.
+ */
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+class BOINCNetworkCallback : NetworkCallback() {
+    var isOnline = false
+        private set
+
+    override fun onAvailable(network: Network) {
+        isOnline = true
+    }
+
+    override fun onLost(network: Network) {
+        isOnline = false
+    }
+
+    override fun onUnavailable() {
+        isOnline = false
+    }
+}


### PR DESCRIPTION
Fixes #

**Description of the Change**
The NetworkInfo class that is currently used in the Android app, together with its associated methods (e.g. getActiveNetworkInfo() in ConnectivityManager), have been deprecated starting with API level 29 (Android Q), so this provides a supported mechanism of detecting network changes that works on API level 21 (Lollipop) and higher. The deprecated version is still used on API levels 19 and 20 (KitKat).

**Release Notes**
N/A
