### PR TITLE
Use getActiveNetwork() to retrieve current network on Android Marshmallow and later.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
@@ -22,11 +22,13 @@ package edu.berkeley.boinc.attach;
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.utils.*;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.fragment.app.DialogFragment;
 import android.util.Log;
@@ -82,11 +84,21 @@ public class ManualUrlInputFragment extends DialogFragment {
     // as needed for AttachProjectLoginActivity (retrieval of ProjectConfig)
     // note: available internet does not imply connection to project server
     // is possible!
-    private Boolean checkDeviceOnline() {
-        ConnectivityManager connectivityManager =
-                (ConnectivityManager) getActivity().getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-        Boolean online = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
+    private boolean checkDeviceOnline() {
+        final Activity activity = getActivity();
+        assert activity != null;
+        final ConnectivityManager connectivityManager =
+                (ConnectivityManager) activity.getSystemService(Context.CONNECTIVITY_SERVICE);
+        assert connectivityManager != null;
+
+        final boolean online;
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            final NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+            online = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
+        }
+        else {
+            online = connectivityManager.getActiveNetwork() != null;
+        }
         if(!online) {
             Toast toast = Toast.makeText(getActivity(), R.string.attachproject_list_no_internet, Toast.LENGTH_SHORT);
             toast.show();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
@@ -19,6 +19,7 @@
 package edu.berkeley.boinc.attach;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.client.IMonitor;
@@ -163,7 +164,7 @@ public class ProjectAttachService extends Service {
      * @param selected list of selected projects
      * @return success
      */
-    public boolean setSelectedProjects(ArrayList<ProjectInfo> selected) {
+    public boolean setSelectedProjects(List<ProjectInfo> selected) {
         if(!projectConfigRetrievalFinished) {
             if(Logging.ERROR) {
                 Log.e(Logging.TAG, "ProjectAttachService.setSelectedProjects: stop, async task already running.");

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
@@ -27,6 +27,7 @@ import android.content.ServiceConnection;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.RemoteException;
@@ -47,12 +48,13 @@ import edu.berkeley.boinc.utils.Logging;
 import java.text.Collator;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class SelectionListActivity extends FragmentActivity {
 
     private ListView lv;
-    ArrayList<ProjectListEntry> entries = new ArrayList<>();
-    ArrayList<ProjectInfo> selected = new ArrayList<>();
+    List<ProjectListEntry> entries = new ArrayList<>();
+    List<ProjectInfo> selected = new ArrayList<>();
 
     // services
     private IMonitor monitor = null;
@@ -104,10 +106,19 @@ public class SelectionListActivity extends FragmentActivity {
     // as needed for AttachProjectLoginActivity (retrieval of ProjectConfig)
     // note: available internet does not guarantee connection to project server
     // is possible!
-    private Boolean checkDeviceOnline() {
-        ConnectivityManager connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-        Boolean online = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
+    private boolean checkDeviceOnline() {
+        final ConnectivityManager connectivityManager =
+                (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        assert connectivityManager != null;
+
+        final boolean online;
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            final NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
+            online = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
+        }
+        else {
+            online = connectivityManager.getActiveNetwork() != null;
+        }
         if(!online) {
             Toast toast =
                     Toast.makeText(getApplicationContext(), R.string.attachproject_list_no_internet, Toast.LENGTH_SHORT);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
@@ -40,11 +40,10 @@ import edu.berkeley.boinc.attach.SelectionListActivity.ProjectListEntry;
 import edu.berkeley.boinc.utils.Logging;
 
 public class SelectionListAdapter extends ArrayAdapter<ProjectListEntry> {
-
     private List<ProjectListEntry> entries;
     private FragmentActivity activity;
 
-    SelectionListAdapter(FragmentActivity a, int textViewResourceId, List<ProjectListEntry> entries) {
+    public SelectionListAdapter(FragmentActivity a, int textViewResourceId, List<ProjectListEntry> entries) {
         super(a, textViewResourceId, entries);
         this.entries = entries;
         this.activity = a;


### PR DESCRIPTION
Fixes #

**Description of the Change**
The NetworkInfo class that is currently used in the Android app, together with its associated methods (e.g. getActiveNetworkInfo() in ConnectivityManager), have been deprecated starting with API level 29 (Android Q), so this provides a supported mechanism of detecting network changes that works on API level 23 (Marshmallow) and higher. The deprecated version is still used on API levels 19 through 22 (KitKat and Lollipop).

**Release Notes**
N/A