### PR TITLE
network.cpp: getaddrinfo error msg: "\n" added

### DIFF
--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -173,7 +173,7 @@ int resolve_hostname(const char* hostname, sockaddr_storage &ip_addr) {
         if (retval == EAI_SYSTEM) {
             perror(buf);
         } else {
-            fprintf(stderr, "%s: %s", buf, gai_strerror(retval));
+            fprintf(stderr, "%s: %s\n", buf, gai_strerror(retval));
         }
         return ERR_GETADDRINFO;
     }


### PR DESCRIPTION
Today, it looks like
```
04-Apr-2020 00:33:45 [TN-Grid Platform] Project requested delay of 121 seconds
04-Apr-2020 03:13:20 getaddrinfo(OpenWrt): Name does not resolve04-Apr-2020 03:13:22 [TN-Grid Platform] Project requested delay of 121 seconds
04-Apr-2020 04:36:43 getaddrinfo(OpenWrt): Name does not resolve04-Apr-2020 04:36:45 [TN-Grid Platform] Project requested delay of 121 seconds
04-Apr-2020 06:14:09 getaddrinfo(OpenWrt): Name does not resolve04-Apr-2020 06:14:11 [TN-Grid Platform] Project requested delay of 121 seconds
04-Apr-2020 07:36:18 getaddrinfo(OpenWrt): Name does not resolve04-Apr-2020 07:36:20 [TN-Grid Platform] Project requested delay of 121 seconds
```
which connects two messages that are unrelated - the first being caused by the host or its name server and the second by the project server.

**Description of the Change**
A newline was introduced.

**Release Notes**
Fix line termination of error message to better support line filters.