### PR TITLE
Use writeBoolean() and readBoolean() in Parcelable implementations on Android Q and later.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
@@ -695,8 +695,8 @@ public class ProjectAttachService extends Service {
         }
 
         private AccountIn getAccountIn(String email, String user, String pwd) {
-            return new AccountIn(config.getSecureUrlIfAvailable(), email, user, config.getUsesName(),
-                                 pwd, "");
+            return new AccountIn(config.getSecureUrlIfAvailable(), email, user, pwd, "",
+                                 config.getUsesName());
         }
     }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountIn.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountIn.java
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc;
 
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -25,19 +26,20 @@ public class AccountIn implements Parcelable {
     public String url; // either master_url or web_rpc_url_base (HTTPS), if present
     public String email_addr;
     public String user_name;
-    public boolean uses_name;
     public String passwd;
     public String team_name;
+    public boolean uses_name;
 
-    public static final Parcelable.Creator<AccountIn> CREATOR = new Parcelable.Creator<AccountIn>() {
-        public AccountIn createFromParcel(Parcel in) {
-            return new AccountIn(in);
-        }
+    public static final Parcelable.Creator<AccountIn> CREATOR =
+            new Parcelable.Creator<AccountIn>() {
+                public AccountIn createFromParcel(Parcel in) {
+                    return new AccountIn(in);
+                }
 
-        public AccountIn[] newArray(int size) {
-            return null;
-        }
-    };
+                public AccountIn[] newArray(int size) {
+                    return null;
+                }
+            };
 
     public AccountIn() {
         super();
@@ -53,18 +55,27 @@ public class AccountIn implements Parcelable {
      * @param password password
      * @param teamName name of team, account shall get associated to
      */
-    public AccountIn(String url, String email, String userName, boolean usesName, String password,
-                     String teamName) {
+    public AccountIn(String url, String email, String userName, String password, String teamName,
+                     boolean usesName) {
         this.url = url;
         this.email_addr = email;
         this.user_name = userName;
-        this.uses_name = usesName;
         this.passwd = password;
         this.team_name = teamName;
+        this.uses_name = usesName;
     }
 
     private AccountIn(Parcel in) {
-        readFromParcel(in);
+        this(in.readString(), in.readString(), in.readString(), in.readString(), in.readString(), false);
+
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            boolean[] bArray = in.createBooleanArray();
+            assert bArray != null;
+            uses_name = bArray[0];
+        }
+        else {
+            uses_name = in.readBoolean();
+        }
     }
 
     public int describeContents() {
@@ -77,17 +88,12 @@ public class AccountIn implements Parcelable {
         out.writeString(user_name);
         out.writeString(passwd);
         out.writeString(team_name);
-        out.writeBooleanArray(new boolean[]{
-                uses_name});
-    }
 
-    public void readFromParcel(Parcel in) {
-        url = in.readString();
-        email_addr = in.readString();
-        user_name = in.readString();
-        passwd = in.readString();
-        team_name = in.readString();
-        boolean[] bArray = in.createBooleanArray();
-        uses_name = bArray[0];
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            out.writeBooleanArray(new boolean[]{uses_name});
+        }
+        else {
+            out.writeBoolean(uses_name);
+        }
     }
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountManagerClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountManagerClasses.kt
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 
@@ -81,10 +82,16 @@ data class AcctMgrInfo internal constructor(
             this(parcel.readString() ?: "",
                     parcel.readString() ?: "",
                     parcel.readString() ?: "") {
-        val bArray = parcel.createBooleanArray()!!
-        isHavingCredentials = bArray[0]
-        isCookieRequired = bArray[1]
-        isPresent = bArray[2]
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val bArray = parcel.createBooleanArray()!!
+            isHavingCredentials = bArray[0]
+            isCookieRequired = bArray[1]
+            isPresent = bArray[2]
+        } else {
+            isHavingCredentials = parcel.readBoolean()
+            isCookieRequired = parcel.readBoolean()
+            isPresent = parcel.readBoolean()
+        }
     }
 
     override fun describeContents() = 0
@@ -93,7 +100,14 @@ data class AcctMgrInfo internal constructor(
         dest.writeString(acctMgrName)
         dest.writeString(acctMgrUrl)
         dest.writeString(cookieFailureUrl)
-        dest.writeBooleanArray(booleanArrayOf(isHavingCredentials, isCookieRequired, isPresent))
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            dest.writeBooleanArray(booleanArrayOf(isHavingCredentials, isCookieRequired, isPresent))
+        } else {
+            dest.writeBoolean(isHavingCredentials)
+            dest.writeBoolean(isCookieRequired)
+            dest.writeBoolean(isPresent)
+        }
     }
 
     object Fields {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferences.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/GlobalPreferences.kt
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 
@@ -60,14 +61,24 @@ data class GlobalPreferences(
             parcel.readValue(TimePreferences::class.java.classLoader) as TimePreferences,
             parcel.readValue(TimePreferences::class.java.classLoader) as TimePreferences
     ) {
-        val bArray = parcel.createBooleanArray()!!
-        runOnBatteryPower = bArray[0]
-        runIfUserActive = bArray[1]
-        runGpuIfUserActive = bArray[2]
-        leaveAppsInMemory = bArray[3]
-        doNotVerifyImages = bArray[4]
-        overrideFilePresent = bArray[5]
-        networkWiFiOnly = bArray[6]
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val bArray = parcel.createBooleanArray()!!
+            runOnBatteryPower = bArray[0]
+            runIfUserActive = bArray[1]
+            runGpuIfUserActive = bArray[2]
+            leaveAppsInMemory = bArray[3]
+            doNotVerifyImages = bArray[4]
+            overrideFilePresent = bArray[5]
+            networkWiFiOnly = bArray[6]
+        } else {
+            runOnBatteryPower = parcel.readBoolean()
+            runIfUserActive = parcel.readBoolean()
+            runGpuIfUserActive = parcel.readBoolean()
+            leaveAppsInMemory = parcel.readBoolean()
+            doNotVerifyImages = parcel.readBoolean()
+            overrideFilePresent = parcel.readBoolean()
+            networkWiFiOnly = parcel.readBoolean()
+        }
     }
 
     override fun describeContents() = 0
@@ -94,8 +105,19 @@ data class GlobalPreferences(
         dest.writeInt(dailyTransferPeriodDays)
         dest.writeValue(cpuTimes)
         dest.writeValue(netTimes)
-        dest.writeBooleanArray(booleanArrayOf(runOnBatteryPower, runIfUserActive, runGpuIfUserActive,
-                leaveAppsInMemory, doNotVerifyImages, overrideFilePresent, networkWiFiOnly))
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            dest.writeBooleanArray(booleanArrayOf(runOnBatteryPower, runIfUserActive, runGpuIfUserActive,
+                    leaveAppsInMemory, doNotVerifyImages, overrideFilePresent, networkWiFiOnly))
+        } else {
+            dest.writeBoolean(runOnBatteryPower)
+            dest.writeBoolean(runIfUserActive)
+            dest.writeBoolean(runGpuIfUserActive)
+            dest.writeBoolean(leaveAppsInMemory)
+            dest.writeBoolean(doNotVerifyImages)
+            dest.writeBoolean(overrideFilePresent)
+            dest.writeBoolean(networkWiFiOnly)
+        }
     }
 
     object Fields {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Notice.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Notice.kt
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 
@@ -51,10 +52,16 @@ data class Notice(
             parcel.readString() ?: "", parcel.readString() ?: "",
             parcel.readString()
     ) {
-        val bArray = parcel.createBooleanArray()!!
-        isPrivate = bArray[0]
-        isServerNotice = bArray[1]
-        isClientNotice = bArray[2]
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val bArray = parcel.createBooleanArray()!!
+            isPrivate = bArray[0]
+            isServerNotice = bArray[1]
+            isClientNotice = bArray[2]
+        } else {
+            isPrivate = parcel.readBoolean()
+            isServerNotice = parcel.readBoolean()
+            isClientNotice = parcel.readBoolean()
+        }
     }
 
     override fun describeContents() = 0
@@ -68,7 +75,14 @@ data class Notice(
         dest.writeString(category)
         dest.writeString(link)
         dest.writeString(projectName)
-        dest.writeBooleanArray(booleanArrayOf(isPrivate, isServerNotice, isClientNotice))
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            dest.writeBooleanArray(booleanArrayOf(isPrivate, isServerNotice, isClientNotice))
+        } else {
+            dest.writeBoolean(isPrivate)
+            dest.writeBoolean(isServerNotice)
+            dest.writeBoolean(isClientNotice)
+        }
     }
 
     object Fields {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.kt
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 import java.util.*
@@ -93,46 +94,49 @@ data class Project(
             this(masterURL = parcel.readString() ?: "", projectDir = parcel.readString() ?: "",
                     resourceShare = parcel.readFloat(), projectName = parcel.readString() ?: "",
                     userName = parcel.readString() ?: "", teamName = parcel.readString() ?: "",
-                    hostVenue = parcel.readString() ?: "", hostId = parcel.readInt()) {
+                    hostVenue = parcel.readString() ?: "", hostId = parcel.readInt(),
+                    userTotalCredit = parcel.readDouble(), userExpAvgCredit = parcel.readDouble(),
+                    hostTotalCredit = parcel.readDouble(), hostExpAvgCredit = parcel.readDouble(),
+                    diskUsage = parcel.readDouble(), noOfRPCFailures = parcel.readInt(),
+                    masterFetchFailures = parcel.readInt(), minRPCTime = parcel.readDouble(),
+                    downloadBackoff = parcel.readDouble(), uploadBackoff = parcel.readDouble(),
+                    cpuShortTermDebt = parcel.readDouble(), cpuBackoffTime = parcel.readDouble(),
+                    cpuBackoffInterval = parcel.readDouble(), cudaDebt = parcel.readDouble(),
+                    cudaShortTermDebt = parcel.readDouble(), cudaBackoffTime = parcel.readDouble(),
+                    cudaBackoffInterval = parcel.readDouble(), atiDebt = parcel.readDouble(),
+                    atiShortTermDebt = parcel.readDouble(), atiBackoffTime = parcel.readDouble(),
+                    atiBackoffInterval = parcel.readDouble(), durationCorrectionFactor = parcel.readDouble(),
+                    scheduledRPCPending = parcel.readInt(), projectFilesDownloadedTime = parcel.readDouble(),
+                    lastRPCTime = parcel.readDouble()) {
         parcel.readList(guiURLs.toList(), GuiUrl::class.java.classLoader)
-        userTotalCredit = parcel.readDouble()
-        userExpAvgCredit = parcel.readDouble()
-        hostTotalCredit = parcel.readDouble()
-        hostExpAvgCredit = parcel.readDouble()
-        diskUsage = parcel.readDouble()
-        noOfRPCFailures = parcel.readInt()
-        masterFetchFailures = parcel.readInt()
-        minRPCTime = parcel.readDouble()
-        downloadBackoff = parcel.readDouble()
-        uploadBackoff = parcel.readDouble()
-        cpuShortTermDebt = parcel.readDouble()
-        cpuBackoffTime = parcel.readDouble()
-        cpuBackoffInterval = parcel.readDouble()
-        cudaDebt = parcel.readDouble()
-        cudaShortTermDebt = parcel.readDouble()
-        cudaBackoffTime = parcel.readDouble()
-        cudaBackoffInterval = parcel.readDouble()
-        atiDebt = parcel.readDouble()
-        atiShortTermDebt = parcel.readDouble()
-        atiBackoffTime = parcel.readDouble()
-        atiBackoffInterval = parcel.readDouble()
-        durationCorrectionFactor = parcel.readDouble()
-        scheduledRPCPending = parcel.readInt()
-        projectFilesDownloadedTime = parcel.readDouble()
-        lastRPCTime = parcel.readDouble()
-        val bArray = parcel.createBooleanArray()!!
-        masterURLFetchPending = bArray[0]
-        nonCPUIntensive = bArray[1]
-        suspendedViaGUI = bArray[2]
-        doNotRequestMoreWork = bArray[3]
-        schedulerRPCInProgress = bArray[4]
-        attachedViaAcctMgr = bArray[5]
-        detachWhenDone = bArray[6]
-        ended = bArray[7]
-        trickleUpPending = bArray[8]
-        noCPUPref = bArray[9]
-        noCUDAPref = bArray[10]
-        noATIPref = bArray[11]
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val bArray = parcel.createBooleanArray()!!
+            masterURLFetchPending = bArray[0]
+            nonCPUIntensive = bArray[1]
+            suspendedViaGUI = bArray[2]
+            doNotRequestMoreWork = bArray[3]
+            schedulerRPCInProgress = bArray[4]
+            attachedViaAcctMgr = bArray[5]
+            detachWhenDone = bArray[6]
+            ended = bArray[7]
+            trickleUpPending = bArray[8]
+            noCPUPref = bArray[9]
+            noCUDAPref = bArray[10]
+            noATIPref = bArray[11]
+        } else {
+            masterURLFetchPending = parcel.readBoolean()
+            nonCPUIntensive = parcel.readBoolean()
+            suspendedViaGUI = parcel.readBoolean()
+            doNotRequestMoreWork = parcel.readBoolean()
+            schedulerRPCInProgress = parcel.readBoolean()
+            attachedViaAcctMgr = parcel.readBoolean()
+            detachWhenDone = parcel.readBoolean()
+            ended = parcel.readBoolean()
+            trickleUpPending = parcel.readBoolean()
+            noCPUPref = parcel.readBoolean()
+            noCUDAPref = parcel.readBoolean()
+            noATIPref = parcel.readBoolean()
+        }
     }
 
     override fun equals(other: Any?): Boolean {
@@ -188,7 +192,6 @@ data class Project(
         dest.writeString(teamName)
         dest.writeString(hostVenue)
         dest.writeInt(hostId)
-        dest.writeList(guiURLs.toList())
         dest.writeDouble(userTotalCredit)
         dest.writeDouble(userExpAvgCredit)
         dest.writeDouble(hostTotalCredit)
@@ -214,9 +217,26 @@ data class Project(
         dest.writeInt(scheduledRPCPending)
         dest.writeDouble(projectFilesDownloadedTime)
         dest.writeDouble(lastRPCTime)
-        dest.writeBooleanArray(booleanArrayOf(masterURLFetchPending, nonCPUIntensive,
-                suspendedViaGUI, doNotRequestMoreWork, schedulerRPCInProgress, attachedViaAcctMgr,
-                detachWhenDone, ended, trickleUpPending, noCPUPref, noCUDAPref, noATIPref))
+        dest.writeList(guiURLs.toList())
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            dest.writeBooleanArray(booleanArrayOf(masterURLFetchPending, nonCPUIntensive,
+                    suspendedViaGUI, doNotRequestMoreWork, schedulerRPCInProgress, attachedViaAcctMgr,
+                    detachWhenDone, ended, trickleUpPending, noCPUPref, noCUDAPref, noATIPref))
+        } else {
+            dest.writeBoolean(masterURLFetchPending)
+            dest.writeBoolean(nonCPUIntensive)
+            dest.writeBoolean(suspendedViaGUI)
+            dest.writeBoolean(doNotRequestMoreWork)
+            dest.writeBoolean(schedulerRPCInProgress)
+            dest.writeBoolean(attachedViaAcctMgr)
+            dest.writeBoolean(detachWhenDone)
+            dest.writeBoolean(ended)
+            dest.writeBoolean(trickleUpPending)
+            dest.writeBoolean(noCPUPref)
+            dest.writeBoolean(noCUDAPref)
+            dest.writeBoolean(noATIPref)
+        }
     }
 
     object Fields {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 import java.io.Serializable
@@ -49,13 +50,23 @@ data class ProjectConfig(
                     parcel.readInt(), parcel.readInt(), parcel.readString() ?: "") {
         parcel.readList(platforms.toList(), PlatformInfo::class.java.classLoader)
         termsOfUse = parcel.readString()
-        val bArray = parcel.createBooleanArray()!!
-        usesName = bArray[0]
-        webStopped = bArray[1]
-        schedulerStopped = bArray[2]
-        accountCreationDisabled = bArray[3]
-        clientAccountCreationDisabled = bArray[4]
-        accountManager = bArray[5]
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val bArray = parcel.createBooleanArray()!!
+            usesName = bArray[0]
+            webStopped = bArray[1]
+            schedulerStopped = bArray[2]
+            accountCreationDisabled = bArray[3]
+            clientAccountCreationDisabled = bArray[4]
+            accountManager = bArray[5]
+        } else {
+            usesName = parcel.readBoolean()
+            webStopped = parcel.readBoolean()
+            schedulerStopped = parcel.readBoolean()
+            accountCreationDisabled = parcel.readBoolean()
+            clientAccountCreationDisabled = parcel.readBoolean()
+            accountCreationDisabled = parcel.readBoolean()
+        }
     }
 
     /**
@@ -81,8 +92,18 @@ data class ProjectConfig(
         dest.writeString(rpcPrefix)
         dest.writeList(platforms.toList())
         dest.writeString(termsOfUse)
-        dest.writeBooleanArray(booleanArrayOf(usesName, webStopped, schedulerStopped,
-                accountCreationDisabled, clientAccountCreationDisabled, accountManager))
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            dest.writeBooleanArray(booleanArrayOf(usesName, webStopped, schedulerStopped,
+                    accountCreationDisabled, clientAccountCreationDisabled, accountManager))
+        } else {
+            dest.writeBoolean(usesName)
+            dest.writeBoolean(webStopped)
+            dest.writeBoolean(schedulerStopped)
+            dest.writeBoolean(accountCreationDisabled)
+            dest.writeBoolean(clientAccountCreationDisabled)
+            dest.writeBoolean(accountManager)
+        }
     }
 
     object Fields {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Result.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Result.java
@@ -19,6 +19,7 @@
 
 package edu.berkeley.boinc.rpc;
 
+import android.os.Build;
 import android.os.Parcel;
 import android.os.Parcelable;
 
@@ -126,18 +127,34 @@ public class Result implements Parcelable {
         app = (App) in.readValue(App.class.getClassLoader());
         wup = (WorkUnit) in.readValue(WorkUnit.class.getClassLoader());
 
-        boolean[] bArray = in.createBooleanArray();
-        ready_to_report = bArray[0];
-        got_server_ack = bArray[1];
-        suspended_via_gui = bArray[2];
-        project_suspended_via_gui = bArray[3];
-        coproc_missing = bArray[4];
-        gpu_mem_wait = bArray[5];
-        active_task = bArray[6];
-        supports_graphics = bArray[7];
-        too_large = bArray[8];
-        needs_shmem = bArray[9];
-        edf_scheduled = bArray[10];
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            boolean[] bArray = in.createBooleanArray();
+            assert bArray != null;
+            ready_to_report = bArray[0];
+            got_server_ack = bArray[1];
+            suspended_via_gui = bArray[2];
+            project_suspended_via_gui = bArray[3];
+            coproc_missing = bArray[4];
+            gpu_mem_wait = bArray[5];
+            active_task = bArray[6];
+            supports_graphics = bArray[7];
+            too_large = bArray[8];
+            needs_shmem = bArray[9];
+            edf_scheduled = bArray[10];
+        }
+        else {
+            ready_to_report = in.readBoolean();
+            got_server_ack = in.readBoolean();
+            suspended_via_gui = in.readBoolean();
+            project_suspended_via_gui = in.readBoolean();
+            coproc_missing = in.readBoolean();
+            gpu_mem_wait = in.readBoolean();
+            active_task = in.readBoolean();
+            supports_graphics = in.readBoolean();
+            too_large = in.readBoolean();
+            needs_shmem = in.readBoolean();
+            edf_scheduled = in.readBoolean();
+        }
     }
 
     @Override
@@ -186,19 +203,25 @@ public class Result implements Parcelable {
         dest.writeValue(app);
         dest.writeValue(wup);
 
-        dest.writeBooleanArray(new boolean[]{
-                ready_to_report,
-                got_server_ack,
-                suspended_via_gui,
-                project_suspended_via_gui,
-                coproc_missing,
-                gpu_mem_wait,
-                active_task,
-                supports_graphics,
-                too_large,
-                needs_shmem,
-                edf_scheduled
-        });
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            dest.writeBooleanArray(new boolean[]{ready_to_report, got_server_ack, suspended_via_gui,
+                                                 project_suspended_via_gui, coproc_missing, gpu_mem_wait,
+                                                 active_task, supports_graphics, too_large, needs_shmem,
+                                                 edf_scheduled});
+        }
+        else {
+            dest.writeBoolean(ready_to_report);
+            dest.writeBoolean(got_server_ack);
+            dest.writeBoolean(suspended_via_gui);
+            dest.writeBoolean(project_suspended_via_gui);
+            dest.writeBoolean(coproc_missing);
+            dest.writeBoolean(gpu_mem_wait);
+            dest.writeBoolean(active_task);
+            dest.writeBoolean(supports_graphics);
+            dest.writeBoolean(too_large);
+            dest.writeBoolean(needs_shmem);
+            dest.writeBoolean(edf_scheduled);
+        }
     }
 
     public static final Parcelable.Creator<Result> CREATOR = new Parcelable.Creator<Result>() {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Transfer.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Transfer.kt
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
 import java.io.Serializable
@@ -40,10 +41,16 @@ data class Transfer(
             this(parcel.readString() ?: "", parcel.readString() ?: "",
                     parcel.readLong(), parcel.readInt(), parcel.readLong(), parcel.readLong(),
                     parcel.readLong(), parcel.readFloat(), parcel.readLong()) {
-        val bArray = parcel.createBooleanArray()!!
-        generatedLocally = bArray[0]
-        isTransferActive = bArray[1]
-        isUpload = bArray[2]
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            val bArray = parcel.createBooleanArray()!!
+            generatedLocally = bArray[0]
+            isTransferActive = bArray[1]
+            isUpload = bArray[2]
+        } else {
+            generatedLocally = parcel.readBoolean()
+            isTransferActive = parcel.readBoolean()
+            isUpload = parcel.readBoolean()
+        }
     }
 
     override fun describeContents() = 0
@@ -58,7 +65,14 @@ data class Transfer(
         dest.writeLong(bytesTransferred)
         dest.writeFloat(transferSpeed)
         dest.writeLong(projectBackoff)
-        dest.writeBooleanArray(booleanArrayOf(generatedLocally, isTransferActive, isUpload))
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            dest.writeBooleanArray(booleanArrayOf(generatedLocally, isTransferActive, isUpload))
+        } else {
+            dest.writeBoolean(generatedLocally)
+            dest.writeBoolean(isTransferActive)
+            dest.writeBoolean(isUpload)
+        }
     }
 
     object Fields {


### PR DESCRIPTION
**Description of the Change**
Use the writeBoolean() and readBoolean() methods to write booleans to and read booleans from Parcel objects on Android Q and higher, instead of using the writeBooleanArray() and createBooleanArray() methods.

The aforementioned writeBooleanArray() and createBooleanArray() methods are still called on older Android versions for backward compatibility.

**Release Notes**
N/A
