### PR TITLE
[Android] Update to LTS dependencies

### DIFF
--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -19,7 +19,7 @@ set -e
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-export OPENSSL_VERSION=1.0.2s
+export OPENSSL_VERSION=1.1.1f
 export CURL_VERSION=7.62.0
 export NDK_VERSION=18b
 

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -21,7 +21,7 @@ set -e
 
 export OPENSSL_VERSION=1.1.1f
 export CURL_VERSION=7.62.0
-export NDK_VERSION=18b
+export NDK_VERSION=21
 
 export ANDROID_HOME=$HOME/Android/Sdk
 export NDK_ROOT=$HOME/Android/Ndk

--- a/android/build_boinc_arm.sh
+++ b/android/build_boinc_arm.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_ARM:-$ANDROID_TC/arm}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/arm-linux-androideabi"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/armv7-a/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/arm-linux-androideabi/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=arm-linux-androideabi-clang

--- a/android/build_boinc_arm64.sh
+++ b/android/build_boinc_arm64.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_ARM64-$ANDROID_TC/arm64}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/aarch64-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/aarch64-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=aarch64-linux-android-clang

--- a/android/build_boinc_x86.sh
+++ b/android/build_boinc_x86.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_X86-$ANDROID_TC/x86}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/i686-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/i686-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=i686-linux-android-clang
@@ -61,6 +61,6 @@ if [ -n "$COMPILEBOINC" ]; then
     cp "$BOINC/win_build/installerv2/redist/all_projects_list.xml" "BOINC/app/src/main/assets/all_projects_list.xml"
     cp "$BOINC/curl/ca-bundle.crt" "BOINC/app/src/main/assets/ca-bundle.crt"
 
-    echo "===== BOINC for 86 build done ====="
+    echo "===== BOINC for x86 build done ====="
 
 fi

--- a/android/build_boinc_x86_64.sh
+++ b/android/build_boinc_x86_64.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_X86_64-$ANDROID_TC/x86_64}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/x86_64-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib64/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/x86_64-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=x86_64-linux-android-clang

--- a/android/build_curl_arm.sh
+++ b/android/build_curl_arm.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_ARM:-$ANDROID_TC/arm}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/arm-linux-androideabi"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/arm-linux-androideabi/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=arm-linux-androideabi-clang

--- a/android/build_curl_arm64.sh
+++ b/android/build_curl_arm64.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_ARM64:-$ANDROID_TC/arm64}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/aarch64-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/aarch64-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=aarch64-linux-android-clang

--- a/android/build_curl_x86.sh
+++ b/android/build_curl_x86.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_X86:-$ANDROID_TC/x86}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/i686-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/i686-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=i686-linux-android-clang

--- a/android/build_curl_x86_64.sh
+++ b/android/build_curl_x86_64.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_X86_64:-$ANDROID_TC/x86_64}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/x86_64-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/x86_64-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=x86_64-linux-android-clang

--- a/android/build_openssl_arm.sh
+++ b/android/build_openssl_arm.sh
@@ -10,7 +10,7 @@ set -e
 COMPILEOPENSSL="${COMPILEOPENSSL:-yes}"
 STDOUT_TARGET="${STDOUT_TARGET:-/dev/stdout}"
 CONFIGURE="yes"
-MAKECLEAN="yes"
+MAKECLEAN=""
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 

--- a/android/build_openssl_arm.sh
+++ b/android/build_openssl_arm.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_ARM:-$ANDROID_TC/arm}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/arm-linux-androideabi"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/arm-linux-androideabi/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=arm-linux-androideabi-clang

--- a/android/build_openssl_arm64.sh
+++ b/android/build_openssl_arm64.sh
@@ -10,7 +10,7 @@ set -e
 COMPILEOPENSSL="${COMPILEOPENSSL:-yes}"
 STDOUT_TARGET="${STDOUT_TARGET:-/dev/stdout}"
 CONFIGURE="yes"
-MAKECLEAN="yes"
+MAKECLEAN=""
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 

--- a/android/build_openssl_arm64.sh
+++ b/android/build_openssl_arm64.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_ARM64:-$ANDROID_TC/arm64}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/aarch64-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/aarch64-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=aarch64-linux-android-clang

--- a/android/build_openssl_x86.sh
+++ b/android/build_openssl_x86.sh
@@ -10,7 +10,7 @@ set -e
 COMPILEOPENSSL="${COMPILEOPENSSL:-yes}"
 STDOUT_TARGET="${STDOUT_TARGET:-/dev/stdout}"
 CONFIGURE="yes"
-MAKECLEAN="yes"
+MAKECLEAN=""
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 

--- a/android/build_openssl_x86.sh
+++ b/android/build_openssl_x86.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_X86:-$ANDROID_TC/x86}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/i686-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/i686-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=i686-linux-android-clang

--- a/android/build_openssl_x86_64.sh
+++ b/android/build_openssl_x86_64.sh
@@ -10,7 +10,7 @@ set -e
 COMPILEOPENSSL="${COMPILEOPENSSL:-yes}"
 STDOUT_TARGET="${STDOUT_TARGET:-/dev/stdout}"
 CONFIGURE="yes"
-MAKECLEAN="yes"
+MAKECLEAN=""
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 

--- a/android/build_openssl_x86_64.sh
+++ b/android/build_openssl_x86_64.sh
@@ -19,7 +19,7 @@ export ANDROIDTC="${ANDROID_TC_X86_64:-$ANDROID_TC/x86_64}"
 export TCBINARIES="$ANDROIDTC/bin"
 export TCINCLUDES="$ANDROIDTC/x86_64-linux-android"
 export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export STDCPPTC="$ANDROIDTC/sysroot/usr/lib/x86_64-linux-android/libc++_static.a"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=x86_64-linux-android-clang


### PR DESCRIPTION
Fixes #

**Description of the Change**
Drop in update to use LTS dependencies in Android build, should buy us some time.
This shouldn't break anything

**Alternate Designs**
It still relies on the creation of Standalone Toolchain. It should no longer be necessary in the future because the NDK \*\*\*IS\*\*\* the toolchain now. This commit does not attempt to do away ST yet.

**Release Notes**
N/A
