### PR TITLE
Enable code shrinking and update Android Gradle plugin.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -61,13 +61,16 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
         debug {
-            minifyEnabled false
+            // Without this, a build error occurs for debug.
+            minifyEnabled true
             debuggable true
             testCoverageEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
     compileOptions {

--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0'
     }


### PR DESCRIPTION
**Description of the Change**
Enable code and resource shrinking for release builds and code shrinking for debug builds (the latter is needed to prevent a build error) and update the Android Gradle plugin to 3.6.2.

**Release Notes**
N/A
