### PR TITLE
Add extra freetype lib only when required

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -506,8 +506,10 @@ SAH_CHECK_LIB([dl], [dlopen],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
 SAH_CHECK_LIB([nsl], [gethostbyname],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
+if test "${enable_manager}" = yes ; then
 SAH_CHECK_LIB([freetype], [fopen],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
+fi
 SAH_CHECK_LIB([socket], [bind],
     [BOINC_EXTRA_LIBS="${BOINC_EXTRA_LIBS} ${sah_lib_last}"])
 SAH_CHECK_LIB([z], [gzopen],


### PR DESCRIPTION
The BOINC manager needs to deal with fonts, but nothing else, really.  To always include it may have unexpected side-effects, as reported for the CLI-only build for OpenWrt: https://github.com/openwrt/packages/pull/11768#issuecomment-610513948

**Description of the Change**
BOINC_EXTRA_LIBS are grasping all libraries of a list manually aggregated in configure.ac. Since the freetype library is only dealing with fonts, and fonts are used only the GUI, these should not be linked against if only building the command-line interface.

Admittedly, I am not really liking this patch but to do more may require a bit of an extra discussion. The BOINC_EXTRA_LIBS shall possibly be divided up - one set of libs for the command line, one for the GUI, and one that the two share.

**Release Notes**
N/A