### PR TITLE
[Android] Add SAXException tests for RPC parser classes.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrInfoParser.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AcctMgrInfoParser.kt
@@ -87,7 +87,7 @@ class AcctMgrInfoParser : BaseParser() {
                 parser.accountMgrInfo
             } catch (e: SAXException) {
                 if (Logging.WARNING) {
-                    Log.w(Logging.TAG, "AcctMgrRPCReplyParser: malformated XML")
+                    Log.w(Logging.TAG, "AcctMgrRPCReplyParser: malformatted XML")
                 }
                 null
             }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountManagerParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountManagerParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.List;
@@ -34,6 +35,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -57,6 +61,18 @@ public class AccountManagerParserTest {
     @Test
     public void testParse_whenRpcStringIsNull_thenExpectEmptyList() {
         mockStatic(Xml.class);
+
+        List<AccountManager> accountManagers = AccountManagerParser.parse(null);
+
+        assertNotNull(accountManagers);
+        assertTrue(accountManagers.isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
 
         List<AccountManager> accountManagers = AccountManagerParser.parse(null);
 

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountOutParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountOutParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import kotlin.UninitializedPropertyAccessException;
@@ -32,6 +33,9 @@ import kotlin.UninitializedPropertyAccessException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -56,6 +60,15 @@ public class AccountOutParserTest {
     @Test(expected = UninitializedPropertyAccessException.class)
     public void testParse_whenRpcStringIsEmpty_thenExpectUninitializedPropertyAccessException() {
         mockStatic(Xml.class);
+
+        AccountOutParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
 
         assertNull(AccountOutParser.parse(""));
     }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrInfoParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrInfoParserTest.java
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc;
 
+import android.util.Log;
 import android.util.Xml;
 
 import org.junit.Before;
@@ -25,17 +26,23 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
+import edu.berkeley.boinc.utils.Logging;
 import kotlin.UninitializedPropertyAccessException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Xml.class)
+@PrepareForTest({Log.class, Xml.class})
 public class AcctMgrInfoParserTest {
     private static final String ACCT_MGR_NAME = "Account Manager Name";
     private static final String ACCT_MGR_URL = "Account Manager URL";
@@ -62,6 +69,17 @@ public class AcctMgrInfoParserTest {
         mockStatic(Xml.class);
 
         AcctMgrInfoParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Log.class);
+        mockStatic(Xml.class);
+
+        Logging.setLogLevel(2);
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(AcctMgrInfoParser.parse(""));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrRPCReplyParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrRPCReplyParserTest.java
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc;
 
+import android.util.Log;
 import android.util.Xml;
 
 import org.junit.Before;
@@ -25,15 +26,20 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
+import edu.berkeley.boinc.utils.Logging;
 import kotlin.UninitializedPropertyAccessException;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Xml.class)
+@PrepareForTest({Log.class, Xml.class})
 public class AcctMgrRPCReplyParserTest {
     private static final String MESSAGE = "Message";
 
@@ -58,6 +64,28 @@ public class AcctMgrRPCReplyParserTest {
         mockStatic(Xml.class);
 
         AcctMgrRPCReplyParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrownAndLogLevelIs1_thenExpectNull() throws Exception {
+        mockStatic(Log.class);
+        mockStatic(Xml.class);
+
+        Logging.setLogLevel(1);
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(AcctMgrRPCReplyParser.parse(""));
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrownAndLogLevelIs2_thenExpectNull() throws Exception {
+        mockStatic(Log.class);
+        mockStatic(Xml.class);
+
+        Logging.setLogLevel(2);
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(AcctMgrRPCReplyParser.parse(""));
     }
 
     @Test
@@ -94,6 +122,8 @@ public class AcctMgrRPCReplyParserTest {
     @Test
     public void testParser_whenXmlAccountManagerRPCReplyWithInvalidErrorNum_thenExpectDefaultEntity()
             throws SAXException {
+        mockStatic(Log.class);
+
         acctMgrRPCReplyParser.startElement(null, AcctMgrRPCReplyParser.ACCT_MGR_RPC_REPLY_TAG, null, null);
         acctMgrRPCReplyParser.startElement(null, RPCCommonTags.ERROR_NUM, null, null);
         acctMgrRPCReplyParser.characters("One".toCharArray(), 0, 3);

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppVersionsParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppVersionsParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Arrays;
@@ -33,6 +34,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -53,7 +57,16 @@ public class AppVersionsParserTest {
     public void testParse_whenRpcStringIsNull_thenExpectEmptyList() {
         mockStatic(Xml.class);
 
-        assertEquals(Collections.emptyList(), AppVersionsParser.parse(null));
+        assertTrue(AppVersionsParser.parse(null).isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertTrue(AppVersionsParser.parse("").isEmpty());
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppsParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppsParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Arrays;
@@ -34,6 +35,9 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -54,7 +58,16 @@ public class AppsParserTest {
     public void testParse_whenRpcStringIsNull_thenExpectEmptyList() {
         mockStatic(Xml.class);
 
-        assertEquals(Collections.emptyList(), AppsParser.parse(null));
+        assertTrue(AppsParser.parse(null).isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertTrue(AppsParser.parse("").isEmpty());
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStateParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStateParserTest.java
@@ -25,11 +25,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -65,6 +70,15 @@ public class CcStateParserTest {
         mockStatic(Xml.class);
 
         assertEquals(expected, CcStateParser.parse(""));
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(CcStateParser.parse(""));
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStatusParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStatusParserTest.java
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc.rpc;
 
+import android.util.Log;
 import android.util.Xml;
 
 import org.junit.Before;
@@ -25,17 +26,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import kotlin.UninitializedPropertyAccessException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(Xml.class)
+@PrepareForTest({Log.class, Xml.class})
 public class CcStatusParserTest {
     private CcStatusParser ccStatusParser;
     private CcStatus expected;
@@ -58,6 +64,26 @@ public class CcStatusParserTest {
         mockStatic(Xml.class);
 
         CcStatusParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionWithoutMessageIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Log.class);
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(CcStatusParser.parse(""));
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionWithMessageIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Log.class);
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException("SAX Exception")).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(CcStatusParser.parse(""));
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GlobalPreferencesParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GlobalPreferencesParserTest.java
@@ -25,11 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import kotlin.UninitializedPropertyAccessException;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -56,6 +60,15 @@ public class GlobalPreferencesParserTest {
         mockStatic(Xml.class);
 
         GlobalPreferencesParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(GlobalPreferencesParser.parse(""));
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/HostInfoParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/HostInfoParserTest.java
@@ -25,13 +25,18 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import kotlin.UninitializedPropertyAccessException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -76,6 +81,15 @@ public class HostInfoParserTest {
         mockStatic(Xml.class);
 
         HostInfoParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(HostInfoParser.parse(""));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageCountParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageCountParserTest.java
@@ -25,9 +25,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -50,6 +55,15 @@ public class MessageCountParserTest {
     @Test
     public void testParse_whenRpcStringIsEmpty_thenExpectMinus1() {
         mockStatic(Xml.class);
+
+        assertEquals(-1, MessageCountParser.getSeqnoOfReply(""));
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectMinus1() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
 
         assertEquals(-1, MessageCountParser.getSeqnoOfReply(""));
     }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessagesParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessagesParserTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Collections;
@@ -33,6 +34,9 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -57,6 +61,15 @@ public class MessagesParserTest {
     @Test
     public void testParse_whenRpcResultIsEmpty_thenExpectEmptyList() {
         mockStatic(Xml.class);
+
+        assertTrue(MessagesParser.parse("").isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
 
         assertTrue(MessagesParser.parse("").isEmpty());
     }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/NoticesParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/NoticesParserTest.java
@@ -26,18 +26,21 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Xml.class, Log.class})
+@PrepareForTest({Log.class, Xml.class})
 public class NoticesParserTest {
     private NoticesParser noticesParser;
     private Notice expected;
@@ -58,6 +61,16 @@ public class NoticesParserTest {
     @Test
     public void testParse_whenRpcStringIsEmpty_thenExpectEmptyList() {
         mockStatic(Xml.class);
+
+        assertTrue(NoticesParser.parse("").isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Log.class);
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
 
         assertTrue(NoticesParser.parse("").isEmpty());
     }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectAttachReplyParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectAttachReplyParserTest.java
@@ -25,11 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import kotlin.UninitializedPropertyAccessException;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -56,6 +60,15 @@ public class ProjectAttachReplyParserTest {
         mockStatic(Xml.class);
 
         ProjectAttachReplyParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(ProjectAttachReplyParser.parse(""));
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectConfigReplyParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectConfigReplyParserTest.java
@@ -25,11 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import kotlin.UninitializedPropertyAccessException;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -56,6 +60,15 @@ public class ProjectConfigReplyParserTest {
         mockStatic(Xml.class);
 
         ProjectConfigReplyParser.parse("");
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(ProjectConfigReplyParser.parse(""));
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoParserTest.java
@@ -25,11 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Collections;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -56,6 +60,15 @@ public class ProjectInfoParserTest {
     @Test
     public void testParse_whenRpcStringIsEmpty_thenExpectEmptyList() {
         mockStatic(Xml.class);
+
+        assertTrue(ProjectInfoParser.parse("").isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
 
         assertTrue(ProjectInfoParser.parse("").isEmpty());
     }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectsParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectsParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Collections;
@@ -32,6 +33,9 @@ import java.util.Collections;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -56,7 +60,16 @@ public class ProjectsParserTest {
     public void testParse_whenRpcStringIsNull_thenExpectEmptyList() {
         mockStatic(Xml.class);
 
-        assertEquals(Collections.emptyList(), ProjectsParser.parse(null));
+        assertTrue(ProjectsParser.parse(null).isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertTrue(ProjectsParser.parse("").isEmpty());
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ResultsParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ResultsParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Collections;
@@ -33,6 +34,9 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -56,7 +60,16 @@ public class ResultsParserTest {
     public void testParse_whenRpcStringIsNull_thenExpectEmptyList() {
         mockStatic(Xml.class);
 
-        assertEquals(Collections.emptyList(), ResultsParser.parse(null));
+        assertTrue(ResultsParser.parse(null).isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertTrue(ResultsParser.parse("").isEmpty());
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/SimpleReplyParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/SimpleReplyParserTest.java
@@ -25,9 +25,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -58,6 +62,15 @@ public class SimpleReplyParserTest {
 
         assertNotNull(result);
         assertFalse(result.getResult());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(SimpleReplyParser.parse(""));
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransfersParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransfersParserTest.java
@@ -25,11 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Collections;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -51,7 +55,16 @@ public class TransfersParserTest {
     public void testParse_whenRpcStringIsNull_thenExpectEmptyList() {
         mockStatic(Xml.class);
 
-        assertEquals(Collections.emptyList(), TransfersParser.parse(null));
+        assertTrue(TransfersParser.parse(null).isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectEmptyList() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertTrue(TransfersParser.parse("").isEmpty());
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/VersionInfoParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/VersionInfoParserTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import kotlin.UninitializedPropertyAccessException;
@@ -33,6 +34,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -52,6 +56,15 @@ public class VersionInfoParserTest {
         mockStatic(Xml.class);
 
         VersionInfoParser.parse(null);
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertNull(VersionInfoParser.parse(""));
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/WorkUnitsParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/WorkUnitsParserTest.java
@@ -25,11 +25,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import java.util.Collections;
 
 import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
@@ -50,7 +54,16 @@ public class WorkUnitsParserTest {
     public void testParse_whenRpcStringIsNull_thenExpectEmptyList() {
         mockStatic(Xml.class);
 
-        assertEquals(Collections.emptyList(), WorkUnitsParser.parse(null));
+        assertTrue(WorkUnitsParser.parse(null).isEmpty());
+    }
+
+    @Test
+    public void testParse_whenSAXExceptionIsThrown_thenExpectNull() throws Exception {
+        mockStatic(Xml.class);
+
+        doThrow(new SAXException()).when(Xml.class, "parse", anyString(), any(ContentHandler.class));
+
+        assertTrue(WorkUnitsParser.parse(null).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
**Description of the Change**
Add tests that cover the catch block for SAXException in the RPC parser classes.

**Release Notes**
N/A