### PR TITLE
[Android] Create local Eclipse Collections list factory constant variables.

### DIFF
--- a/android/BOINC/app/proguard-rules.txt
+++ b/android/BOINC/app/proguard-rules.txt
@@ -1,0 +1,25 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+# Useful for debugging
+-printusage build/usage.txt     # Prints unused APIs removed by ProGuard
+-printmapping build/mapping.txt # Prints mappings of class names to their obfuscated names

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/PrefsFragment.java
@@ -42,7 +42,6 @@ import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
 
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 
@@ -59,6 +58,7 @@ import edu.berkeley.boinc.adapter.PrefsSelectionDialogListAdapter;
 import edu.berkeley.boinc.adapter.SelectionDialogOption;
 import edu.berkeley.boinc.rpc.GlobalPreferences;
 import edu.berkeley.boinc.rpc.HostInfo;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 public class PrefsFragment extends Fragment {
@@ -67,7 +67,7 @@ public class PrefsFragment extends Fragment {
     private ListView lv;
     private PrefsListAdapter listAdapter;
 
-    // Data for the PrefsListAdapter. This is should be HashMap!
+    // Data for the PrefsListAdapter. This should be HashMap!
     private MutableList<PrefsListItemWrapper> data = new FastList<>();
     // Android specific preferences of the client, read on every onResume via RPC
     private GlobalPreferences clientPrefs = null;
@@ -439,7 +439,7 @@ public class PrefsFragment extends Fragment {
         if(item.getId() == R.string.prefs_client_log_flags_header) {
             String[] optionsStr = getResources().getStringArray(R.array.prefs_client_log_flags);
             final MutableList<SelectionDialogOption> options =
-                    Lists.mutable.of(optionsStr).collect(SelectionDialogOption::new);
+                    ECLists.mutable.of(optionsStr).collect(SelectionDialogOption::new);
             ListView lv = dialog.findViewById(R.id.selection);
             new PrefsSelectionDialogListAdapter(getActivity(), lv, R.id.selection, options);
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectDetailsFragment.java
@@ -51,7 +51,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 
 import java.util.ArrayList;
@@ -61,6 +60,7 @@ import edu.berkeley.boinc.rpc.ImageWrapper;
 import edu.berkeley.boinc.rpc.Project;
 import edu.berkeley.boinc.rpc.ProjectInfo;
 import edu.berkeley.boinc.rpc.RpcClient;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 public class ProjectDetailsFragment extends Fragment {
@@ -331,7 +331,7 @@ public class ProjectDetailsFragment extends Fragment {
 
     private void getCurrentProjectData() {
         try {
-            ImmutableList<Project> allProjects = Lists.immutable.ofAll(BOINCActivity.monitor.getProjects());
+            ImmutableList<Project> allProjects = ECLists.immutable.ofAll(BOINCActivity.monitor.getProjects());
             this.project = allProjects.detect(tmpProject -> tmpProject.getMasterURL().equals(url));
             this.projectInfo = BOINCActivity.monitor.getProjectInfo(url);
         }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
@@ -43,7 +43,6 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 
@@ -60,6 +59,7 @@ import edu.berkeley.boinc.rpc.Project;
 import edu.berkeley.boinc.rpc.RpcClient;
 import edu.berkeley.boinc.rpc.Transfer;
 import edu.berkeley.boinc.utils.BOINCErrors;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 public class ProjectsFragment extends Fragment {
@@ -237,7 +237,7 @@ public class ProjectsFragment extends Fragment {
                 continue;
             }
             boolean found =
-                    Lists.immutable.ofAll(latestRpcProjectsList).anySatisfy(project -> project.getMasterURL().equals(listItem.id));
+                    ECLists.immutable.ofAll(latestRpcProjectsList).anySatisfy(project -> project.getMasterURL().equals(listItem.id));
             if(!found) {
                 iData.remove();
             }
@@ -275,7 +275,7 @@ public class ProjectsFragment extends Fragment {
     private List<Transfer> mapTransfersToProject(String id, List<Transfer> allTransfers) {
         // if project ID matches URL in transfer, add to list
         List<Transfer> projectTransfers =
-                Lists.mutable.ofAll(allTransfers).select(transfer -> transfer.getProjectUrl().equals(id));
+                ECLists.mutable.ofAll(allTransfers).select(transfer -> transfer.getProjectUrl().equals(id));
         if(Logging.VERBOSE) {
             Log.d(Logging.TAG, "ProjectsActivity mapTransfersToProject() mapped " + projectTransfers.size() +
                                " transfers to project " + id);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.java
@@ -39,7 +39,6 @@ import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
 
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 
@@ -49,6 +48,7 @@ import edu.berkeley.boinc.adapter.TasksListAdapter;
 import edu.berkeley.boinc.rpc.Result;
 import edu.berkeley.boinc.rpc.RpcClient;
 import edu.berkeley.boinc.utils.BOINCDefs;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 public class TasksFragment extends Fragment {
@@ -143,8 +143,8 @@ public class TasksFragment extends Fragment {
         }
 
         //loop through the list adapter to find removed (ready/aborted) Results
-        data.removeIf(listItem -> Lists.immutable.ofAll(newData)
-                                                 .noneSatisfy(rpcResult -> listItem.id.equals(rpcResult.getName())));
+        data.removeIf(listItem -> ECLists.immutable.ofAll(newData)
+                                                   .noneSatisfy(rpcResult -> listItem.id.equals(rpcResult.getName())));
     }
 
     public class TaskData {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -30,7 +30,6 @@ import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.MutableList;
 
 import java.text.NumberFormat;
@@ -39,6 +38,7 @@ import java.util.List;
 import edu.berkeley.boinc.BOINCActivity;
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.rpc.Project;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 public class NavDrawerListAdapter extends BaseAdapter {
@@ -51,7 +51,7 @@ public class NavDrawerListAdapter extends BaseAdapter {
         this.context = context;
 
         // populate items
-        navDrawerItems = Lists.mutable.of(
+        navDrawerItems = ECLists.mutable.of(
                 new NavDrawerItem(this, R.string.tab_tasks, R.drawable.tabtaskb, true),
                 new NavDrawerItem(this, R.string.tab_notices, R.drawable.mailb, true),
                 new NavDrawerItem(this, R.string.tab_projects, R.drawable.projectsb),

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
@@ -3,7 +3,6 @@ package edu.berkeley.boinc.client;
 import android.util.Log;
 
 import org.eclipse.collections.api.block.predicate.Predicate;
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 
@@ -12,7 +11,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import edu.berkeley.boinc.rpc.AccountIn;
@@ -28,6 +26,7 @@ import edu.berkeley.boinc.rpc.ProjectInfo;
 import edu.berkeley.boinc.rpc.RpcClient;
 import edu.berkeley.boinc.rpc.Transfer;
 import edu.berkeley.boinc.utils.BOINCErrors;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 /**
@@ -506,7 +505,7 @@ public class ClientInterfaceImplementation extends RpcClient {
             lowerBound = 0;
 
         // returns every message with seqNo > lowerBound
-        MutableList<Message> messages = Lists.mutable.ofAll(getMessages(lowerBound));
+        MutableList<Message> messages = ECLists.mutable.ofAll(getMessages(lowerBound));
 
         if (seqNo > 0) {
             // remove messages that are >= seqNo
@@ -535,7 +534,7 @@ public class ClientInterfaceImplementation extends RpcClient {
             Log.d(Logging.TAG, "getAttachableProjects for platform: " + boincPlatformName + " or " + boincAltPlatformName);
 
         // currently attached projects
-        final ImmutableList<Project> attachedProjects = Lists.immutable.ofAll(getState().getProjects());
+        final ImmutableList<Project> attachedProjects = ECLists.immutable.ofAll(getState().getProjects());
 
         // filter out projects that are already attached
         final ImmutableList<ProjectInfo> filteredProjectsList = getAllProjectsList() // all_projects_list.xml
@@ -548,9 +547,9 @@ public class ClientInterfaceImplementation extends RpcClient {
                                                                                    && supportedPlatform.contains(boincAltPlatformName));
         final List<ProjectInfo> attachableProjects = filteredProjectsList
                 //filter out projects that do not support Android
-                .select(candidate -> Lists.immutable.ofAll(candidate.getPlatforms())
-                                                    // project is not yet attached, check whether it supports CPU architecture
-                                                    .anySatisfy(supportedPlatformPredicate))
+                .select(candidate -> ECLists.immutable.ofAll(candidate.getPlatforms())
+                                                      // project is not yet attached, check whether it supports CPU architecture
+                                                      .anySatisfy(supportedPlatformPredicate))
                 .distinct().toList();
 
         if (Logging.DEBUG)

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -31,7 +31,6 @@ import android.util.Log;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
 
@@ -60,6 +59,7 @@ import edu.berkeley.boinc.rpc.Result;
 import edu.berkeley.boinc.rpc.Transfer;
 import edu.berkeley.boinc.utils.BOINCDefs;
 import edu.berkeley.boinc.utils.BOINCUtils;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 /*
@@ -221,8 +221,8 @@ public class ClientStatus {
      */
     synchronized void setClientStatus(CcStatus status, List<Result> results, List<Project> projects, List<Transfer> transfers, HostInfo hostinfo, AcctMgrInfo acctMgrInfo, List<Notice> newNotices) {
         this.status = status;
-        this.results = Lists.mutable.ofAll(results);
-        this.projects = Lists.mutable.ofAll(projects);
+        this.results = ECLists.mutable.ofAll(results);
+        this.projects = ECLists.mutable.ofAll(projects);
         this.transfers = transfers;
         this.hostinfo = hostinfo;
         this.acctMgrInfo = acctMgrInfo;
@@ -413,7 +413,7 @@ public class ClientStatus {
             // check whether path is not empty, and avoid duplicates (slideshow images can
             // re-occur for multiple apps. Since we do not distinguish between apps, skip
             // duplicates.
-            ImmutableList<String> allImagePaths = Lists.immutable.of(foundFiles)
+            ImmutableList<String> allImagePaths = ECLists.immutable.of(foundFiles)
                                                       .collect(file -> parseSoftLinkToAbsPath(file.getAbsolutePath(),
                                                                                               project.getProjectDir()))
                                                       .select(StringUtils::isNotEmpty).distinct();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -25,7 +25,6 @@ import android.util.Log;
 import android.util.Xml;
 
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.collections.api.factory.Lists;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -43,6 +42,7 @@ import java.util.Locale;
 
 import edu.berkeley.boinc.utils.BOINCDefs;
 import edu.berkeley.boinc.utils.BOINCUtils;
+import edu.berkeley.boinc.utils.ECLists;
 import edu.berkeley.boinc.utils.Logging;
 
 import static org.apache.commons.lang3.BooleanUtils.toInteger;
@@ -976,11 +976,11 @@ public class RpcClient {
             mRequest.append("<get_all_projects_list/>");
 
             sendRequest(mRequest.toString());
-            return Lists.immutable.ofAll(ProjectInfoParser.parse(receiveReply()));
+            return ECLists.immutable.ofAll(ProjectInfoParser.parse(receiveReply()));
         } catch (IOException e) {
             if (Logging.WARNING)
                 Log.w(Logging.TAG, "error in getAllProjectsList()", e);
-            return Lists.immutable.empty();
+            return ECLists.immutable.empty();
         }
     }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/ECLists.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/ECLists.java
@@ -1,0 +1,32 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.utils;
+
+import org.eclipse.collections.api.factory.list.ImmutableListFactory;
+import org.eclipse.collections.api.factory.list.MutableListFactory;
+import org.eclipse.collections.impl.list.immutable.ImmutableListFactoryImpl;
+import org.eclipse.collections.impl.list.mutable.MutableListFactoryImpl;
+
+@SuppressWarnings("ConstantNamingConvention")
+public class ECLists {
+    private ECLists() {}
+
+    public static final MutableListFactory mutable = new MutableListFactoryImpl();
+    public static final ImmutableListFactory immutable = new ImmutableListFactoryImpl();
+}


### PR DESCRIPTION
**Description of the Change**
* Add ProGuard configuration file with some useful debugging configurations.
* Create and use local Eclipse Collections list factory constant variables instead of using the ones in Eclipse Collections' `Lists` class, as these variables are not initialized properly in Android - this issue can be reproduced with the current master by long-pressing the BOINC logo on the splash screen, which results in a crash instead of loading the Event Log activity, with an error message stating that an implementation of the `MutableListFactory` interface cannot be found.

**Release Notes**
N/A
