### PR TITLE
[Android] Use Apache Commons static methods to avoid potential NPEs and simplify null checks.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ProjectsFragment.java
@@ -43,6 +43,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.impl.list.mutable.FastList;
 
@@ -353,7 +354,7 @@ public class ProjectsFragment extends Fragment {
                 ((TextView) dialogControls.findViewById(R.id.title)).setText(R.string.projects_control_dialog_title);
 
                 controls.add(new ProjectControl(listEntry, ProjectControl.VISIT_WEBSITE));
-                if(projectTransfers != null && !projectTransfers.isEmpty()) {
+                if(ObjectUtils.isNotEmpty(projectTransfers)) {
                     controls.add(new ProjectControl(listEntry, RpcClient.TRANSFER_RETRY));
                 }
                 controls.add(new ProjectControl(listEntry, RpcClient.PROJECT_UPDATE));

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
@@ -32,6 +32,8 @@ import android.widget.ListView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.text.NumberFormat;
 import java.util.Calendar;
 import java.util.List;
@@ -190,11 +192,11 @@ public class ProjectsListAdapter extends ArrayAdapter<ProjectsListData> {
 
             ImageView ivIcon = vi.findViewById(R.id.project_icon);
             String finalIconId = (String) ivIcon.getTag();
-            if(finalIconId == null || !finalIconId.equals(data.id)) {
+            if(!StringUtils.equals(finalIconId, data.id)) {
                 Bitmap icon = getIcon(position);
                 // if available set icon, if not boinc logo
                 if(icon == null) {
-                    // boinc logo
+                    // BOINC logo
                     ivIcon.setImageDrawable(getContext().getResources().getDrawable(R.drawable.boinc));
                 }
                 else {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
@@ -35,6 +35,8 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.text.DateFormat;
 import java.text.NumberFormat;
 import java.util.Date;
@@ -110,7 +112,7 @@ public class TasksListAdapter extends ArrayAdapter<TaskData> {
         // --- set up view elements that are independent of "active" and "expanded" state
         ImageView ivIcon = v.findViewById(R.id.projectIcon);
         String finalIconId = (String) ivIcon.getTag();
-        if(finalIconId == null || !finalIconId.equals(listItem.id)) {
+        if(!StringUtils.equals(finalIconId, listItem.id)) {
             Bitmap icon = getIcon(position);
             // if available set icon, if not boinc logo
             if(icon == null) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
@@ -52,6 +52,8 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -348,7 +350,7 @@ public class AcctMgrFragment extends DialogFragment {
                 ongoingWrapper.setVisibility(View.GONE);
                 continueB.setVisibility(View.VISIBLE);
                 warning.setVisibility(View.VISIBLE);
-                if (result.description != null && !result.description.isEmpty()) {
+                if (StringUtils.isNotEmpty(result.description)) {
                     warning.setText(result.description);
                 } else {
                     warning.setText(mapErrorNumToString(result.code));
@@ -356,5 +358,4 @@ public class AcctMgrFragment extends DialogFragment {
             }
         }
     }
-
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListActivity.java
@@ -44,6 +44,8 @@ import android.view.View;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class BatchConflictListActivity extends FragmentActivity implements IndividualCredentialInputFragmentListener {
 
     private ListView lv;
@@ -134,7 +136,7 @@ public class BatchConflictListActivity extends FragmentActivity implements Indiv
             asIsBound = true;
 
             // set data, if manual url
-            if(manualUrl != null && !manualUrl.isEmpty()) {
+            if(StringUtils.isNotEmpty(manualUrl)) {
                 if(Logging.DEBUG) {
                     Log.d(Logging.TAG, "BatchConflictListActivity manual URL found: " + manualUrl);
                 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/CredentialInputActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/CredentialInputActivity.java
@@ -86,12 +86,10 @@ public class CredentialInputActivity extends Activity {
 
         // set credentials in service
         if(asIsBound) {
-            // verfiy input, return if failed.
-            if(!attachService.verifyInput(emailET.getText().toString(), nameET.getText().toString(), pwdET.getText().toString())) {
-                return;
+            // verify input and set credentials if valid.
+            if(attachService.verifyInput(emailET.getText().toString(), nameET.getText().toString(), pwdET.getText().toString())) {
+                attachService.setCredentials(emailET.getText().toString(), nameET.getText().toString(), pwdET.getText().toString());
             }
-            // set credentials
-            attachService.setCredentials(emailET.getText().toString(), nameET.getText().toString(), pwdET.getText().toString());
         }
         else {
             if(Logging.ERROR) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectAttachService.java
@@ -45,6 +45,8 @@ import android.os.RemoteException;
 import android.util.Log;
 import android.widget.Toast;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class ProjectAttachService extends Service {
 
     // life-cycle
@@ -268,20 +270,20 @@ public class ProjectAttachService extends Service {
      * @param pwd   password
      * @return true if input verified
      */
-    public Boolean verifyInput(String email, String user, String pwd) {
+    public boolean verifyInput(String email, String user, String pwd) {
         int stringResource = 0;
 
         // check input
-        if(email.length() == 0) {
+        if(email.isEmpty()) {
             stringResource = R.string.attachproject_error_no_email;
         }
-        else if(user.length() == 0) {
+        else if(user.isEmpty()) {
             stringResource = R.string.attachproject_error_no_name;
         }
-        else if(pwd != null && pwd.length() == 0) {
+        else if(StringUtils.isEmpty(pwd)) {
             stringResource = R.string.attachproject_error_no_pwd;
         }
-        else if(pwd != null && pwd.length() < 6) { // appropriate for min pwd length?!
+        else if(pwd.length() < 6) { // appropriate for min pwd length?!
             stringResource = R.string.attachproject_error_short_pwd;
         }
 
@@ -367,7 +369,7 @@ public class ProjectAttachService extends Service {
             }
         }
 
-        if(reply.code != BOINCErrors.ERR_OK || (reply.description != null && !reply.description.isEmpty())) {
+        if(reply.code != BOINCErrors.ERR_OK || StringUtils.isNotEmpty(reply.description)) {
             return reply;
         }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectInfoFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectInfoFragment.java
@@ -43,6 +43,8 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import org.apache.commons.lang3.StringUtils;
+
 public class ProjectInfoFragment extends DialogFragment {
 
     ProjectInfo info;
@@ -124,7 +126,7 @@ public class ProjectInfoFragment extends DialogFragment {
         @Override
         protected Bitmap doInBackground(String... params) {
             String url = params[0];
-            if(url == null || url.isEmpty()) {
+            if(StringUtils.isEmpty(url)) {
                 if(Logging.ERROR) {
                     Log.e(Logging.TAG, "ProjectInfoFragment DownloadLogoAsync url is empty, return.");
                 }


### PR DESCRIPTION
**Description of the Change**
Use the static methods included in the Apache Commons Lang library to avoid potential NullPointerExceptions and to simplify some null checks.

**Release Notes**
N/A
