### PR TITLE
Add check for "-L/..." in "$SSL_LIBS"

### DIFF
--- a/m4/libcurl.m4
+++ b/m4/libcurl.m4
@@ -110,6 +110,11 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
                 LIBCURL="${LIBCURL} ${SSL_LIBS}"
               fi
 
+              # fix cannot find -lssl
+              if test "x`echo \""$SSL_LIBS"\" | grep '\-L/'`" != 'x' ; then
+                LIBCURL="${LIBCURL} ${SSL_LIBS}"
+              fi
+
               # This is so silly, but Apple actually has a bug in their
 	      # curl-config script.  Fixed in Tiger, but there are still
 	      # lots of Panther installs around.


### PR DESCRIPTION
Checking for `-lssl` in `$LIBCURL` may not be enough to find where is the SSL lib
The test may fail with `cannot find -lssl` and `cannot find -lcrypto`
Add additional check if `$SSL_LIBS` can provide the SSL lib before moving on

Fixes #3591

**Description of the Change**
In short libcurl link test may fail with `cannot find -lssl` and `cannot find -lcrypto`
`$SSL_LIBS` may have the proper `-L/...` so we add check for that

Note that it is impossible to fail `-lssl` test before and after this patch, the end result is libcurl assumes to have SSL support anyway.

**Alternate Designs**
If there's other ways, please comment.

**Release Notes**
N/A