### PR TITLE
transitioner: Fix race condition with file_upload_handler

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -1800,8 +1800,11 @@ int DB_TRANSITIONER_ITEM_SET::update_workunit(
         sprintf(buf, " file_delete_state=%d,", ti.file_delete_state);
         strcat(updates, buf);
     }
+    // Don't update transition_time if it changed in database because something
+    // happened in background (usually, another result was uploaded).
+    // Instead, force another run of transitioner to handle these changes.
     if (ti.transition_time != ti_original.transition_time) {
-        sprintf(buf, " transition_time=%d,", ti.transition_time);
+        sprintf(buf, " transition_time=if(transition_time=%d,%d,%d),", ti_original.transition_time, ti.transition_time, (int)time(NULL));
         strcat(updates, buf);
     }
     if (ti.hr_class != ti_original.hr_class) {


### PR DESCRIPTION
**Description of the Change**
Fixes race condition between transitoner and file_upload_handler, leading to following symptoms:

 - The workunit have two results successfully uploaded, but it's "stuck" and not requested to validate;
 - User are complaining "why it's not validating";
 - Eventually, workunit will be validated when what-should-be a "no reply" timeout on one of results expires. which may be days or even weeks.

The problem is caused by incorrect value of transition_time of affected workunit. One of possible, but not limited to, sequences of events leading to race condition in standard scenario (min_quorum=2) is:

 - Transitioner started processing a workunit which has one completed and one "in progress" result;
 - Transitioner did a database scan and recorded that WU have one good result;
 - A result which was "in progress" state has been uploaded;
 - File_upload_handler updated database with "transition_time=now" to signal changes;
 - Transitioner is not aware of these changes. It updates transition_time database field again, but in this case with transitioner's default value (in this scenario it'll be "no reply" timeout of ex-"in progress" result).
 - Finally, we have a workunit with two uploaded results but transition_time set far in the future.

The problem has been widely exposed on my Private GFN Server which have to deal with high amount of short tasks.

**Solution**
Since transitioner knows original transition_time of workunit it processes, check that it wasn't changed in progress. If it was, something has been updated in background and workunit will be scheduled for immediate retransition on the next scan. This operation must be atomic so it is done at database level (in SQL).

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
