### PR TITLE
[Android] Migrate unit tests not using PowerMock to JUnit 5.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -88,8 +88,10 @@ android {
         }
     }
 }
-
-ext.powermock_version = '2.0.5'
+ext {
+    powermock_version = '2.0.5'
+    junit5_version = '5.6.2'
+}
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
@@ -102,9 +104,11 @@ dependencies {
     testImplementation 'com.google.guava:guava-testlib:28.2-jre'
     testImplementation 'commons-io:commons-io:2.6'
     testImplementation 'junit:junit:4.13'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"
     testImplementation "org.powermock:powermock-module-junit4:$powermock_version"
     testImplementation "org.powermock:powermock-api-mockito2:$powermock_version"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
 }
 repositories {
     mavenCentral()

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountManagerTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountManagerTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AccountManagerTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountOutTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountOutTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AccountOutTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrInfoTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrInfoTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AcctMgrInfoTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrRPCReplyTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrRPCReplyTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AcctMgrRPCReplyTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppTest.kt
@@ -19,29 +19,29 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class AppTest {
     @Test
     fun `Expect name when user-friendly name is null`() {
         val app = App("Name", null)
 
-        JUnitAsserter.assertEquals("Expected 'Name'", "Name", app.displayName)
+        JUnit5Asserter.assertEquals("Expected 'Name'", "Name", app.displayName)
     }
 
     @Test
     fun `Expect name when user-friendly name is empty`() {
         val app = App("Name")
 
-        JUnitAsserter.assertEquals("Expected 'Name'", "Name", app.displayName)
+        JUnit5Asserter.assertEquals("Expected 'Name'", "Name", app.displayName)
     }
 
     @Test
     fun `Expect user-friendly name when user-friendly name is not empty`() {
         val app = App("Name", "User-friendly name")
 
-        JUnitAsserter.assertEquals("Expected 'User-friendly name'", "User-friendly name", app.displayName)
+        JUnit5Asserter.assertEquals("Expected 'User-friendly name'", "User-friendly name", app.displayName)
     }
 
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppVersionTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppVersionTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AppVersionTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/BaseParserTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/BaseParserTest.java
@@ -18,24 +18,24 @@
  */
 package edu.berkeley.boinc.rpc;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BaseParserTest {
+class BaseParserTest {
     private static final String TEST_STRING = "This is a test string.";
 
     private BaseParser baseParser;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         baseParser = new BaseParser();
     }
 
     @Test
-    public void testCharacters_whenBufferIsEmptyAndStringHasNoLeadingWhitespace_thenExpectIdenticalStringToInput()
+    void testCharacters_whenBufferIsEmptyAndStringHasNoLeadingWhitespace_thenExpectIdenticalStringToInput()
             throws SAXException {
         baseParser.mElementStarted = true;
         baseParser.characters(TEST_STRING.toCharArray(), 0, TEST_STRING.length());
@@ -44,7 +44,7 @@ public class BaseParserTest {
     }
 
     @Test
-    public void testCharacters_whenBufferIsEmptyAndStringHasLeadingWhitespace_thenExpectStringWithoutLeadingWhitespace()
+    void testCharacters_whenBufferIsEmptyAndStringHasLeadingWhitespace_thenExpectStringWithoutLeadingWhitespace()
             throws SAXException {
         baseParser.mElementStarted = true;
         baseParser.characters((" " + TEST_STRING).toCharArray(), 0, TEST_STRING.length() + 1);
@@ -53,7 +53,7 @@ public class BaseParserTest {
     }
 
     @Test
-    public void testCharacters_whenBufferIsNotEmptyAndStringHasNoLeadingWhitespace_thenExpectConcatenatedString()
+    void testCharacters_whenBufferIsNotEmptyAndStringHasNoLeadingWhitespace_thenExpectConcatenatedString()
             throws SAXException {
         baseParser.mCurrentElement.append(TEST_STRING);
         baseParser.mElementStarted = true;
@@ -63,7 +63,7 @@ public class BaseParserTest {
     }
 
     @Test
-    public void testCharacters_whenBufferIsNotEmptyAndStringHasLeadingWhitespace_thenExpectConcatenatedStringSeparatedBySpace()
+    void testCharacters_whenBufferIsNotEmptyAndStringHasLeadingWhitespace_thenExpectConcatenatedStringSeparatedBySpace()
             throws SAXException {
         baseParser.mCurrentElement.append(TEST_STRING);
         baseParser.mElementStarted = true;
@@ -73,7 +73,7 @@ public class BaseParserTest {
     }
 
     @Test
-    public void testTrimEnd_whenStringHasNoTrailingWhitespace_thenExpectIdenticalStringToInput() {
+    void testTrimEnd_whenStringHasNoTrailingWhitespace_thenExpectIdenticalStringToInput() {
         baseParser.mCurrentElement.append(TEST_STRING);
         baseParser.trimEnd();
 
@@ -81,7 +81,7 @@ public class BaseParserTest {
     }
 
     @Test
-    public void testTrimEnd_whenStringHasTrailingWhitespace_thenExpectStringWithoutTrailingWhitespace() {
+    void testTrimEnd_whenStringHasTrailingWhitespace_thenExpectStringWithoutTrailingWhitespace() {
         baseParser.mCurrentElement.append(TEST_STRING + " ");
         baseParser.trimEnd();
 

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStateTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStateTest.kt
@@ -19,9 +19,9 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Before
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class CcStateTest {
     private lateinit var ccState: CcState
@@ -30,7 +30,7 @@ class CcStateTest {
     private lateinit var project: Project
     private lateinit var project1: Project
 
-    @Before
+    @BeforeEach
     fun setUp() {
         ccState = CcState()
         project = Project()
@@ -74,109 +74,109 @@ class CcStateTest {
     @Test
     fun `Expect lookupApp() to return null when app list is empty`() {
         ccState.clearArrays()
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupApp(null, null))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(null, null))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app and parameters are null`() {
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupApp(null, null))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(null, null))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app, project matches app project and app name is null`() {
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupApp(project, null))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(project, null))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app and project doesn't match`() {
         val project1 = Project(masterURL = URL_2)
 
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupApp(project1, APP))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(project1, APP))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app and app name doesn't match`() {
         val project1 = Project(masterURL = URL_1)
 
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupApp(project1, "$APP 2"))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(project1, "$APP 2"))
     }
 
     @Test
     fun `Expect lookupApp() to return app when app list has one app and project and app name match`() {
         val appFound = ccState.lookupApp(project, APP)
 
-        JUnitAsserter.assertEquals("Expected '$APP'", APP, appFound!!.name)
-        JUnitAsserter.assertEquals(PROJECT_MSG, project, appFound.project)
+        JUnit5Asserter.assertEquals("Expected '$APP'", APP, appFound!!.name)
+        JUnit5Asserter.assertEquals(PROJECT_MSG, project, appFound.project)
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list is empty`() {
         ccState.clearArrays()
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(null, null))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(null, null))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list has one work unit and parameters are null`() {
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(null, null))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(null, null))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list has one work unit and project doesn't match`() {
         project1.masterURL = URL_2
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(project1, WORK_UNIT))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(project1, WORK_UNIT))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list has one work unit and work unit name doesn't match`() {
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(project1, "$WORK_UNIT 2"))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(project1, "$WORK_UNIT 2"))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return work unit when work unit list has one work unit and parameters match`() {
         val workUnitFound = ccState.lookupWorkUnit(project1, WORK_UNIT)
-        JUnitAsserter.assertEquals(PROJECT_MSG, project, workUnitFound!!.project)
-        JUnitAsserter.assertEquals("Expected work unit", WORK_UNIT, workUnitFound.name)
+        JUnit5Asserter.assertEquals(PROJECT_MSG, project, workUnitFound!!.project)
+        JUnit5Asserter.assertEquals("Expected work unit", WORK_UNIT, workUnitFound.name)
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list is empty`() {
         ccState.clearArrays()
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupAppVersion(null, null, 0, null))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(null, null, 0, null))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and parameters are null`() {
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupAppVersion(null, null, 0, null))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(null, null, 0, null))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and project doesn't match`() {
         project1.masterURL = URL_2
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and app doesn't match`() {
         app1.name = "App 2"
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and version number doesn't match`() {
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 0, PLAN_CLASS))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 0, PLAN_CLASS))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and plan class doesn't match`() {
-        JUnitAsserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 0, "$PLAN_CLASS 2"))
+        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 0, "$PLAN_CLASS 2"))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return app version when app version list has one app version and parameters match`() {
         val foundAppVersion = ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS)
-        JUnitAsserter.assertEquals(PROJECT_MSG, project, foundAppVersion!!.project)
-        JUnitAsserter.assertEquals("Expected app", app, foundAppVersion.app)
-        JUnitAsserter.assertEquals("Expected plan class", PLAN_CLASS, foundAppVersion.planClass)
+        JUnit5Asserter.assertEquals(PROJECT_MSG, project, foundAppVersion!!.project)
+        JUnit5Asserter.assertEquals("Expected app", app, foundAppVersion.app)
+        JUnit5Asserter.assertEquals("Expected plan class", PLAN_CLASS, foundAppVersion.planClass)
     }
 
     companion object {

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStatusTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStatusTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class CcStatusTest {
     @Test
@@ -47,6 +47,6 @@ class CcStatusTest {
     fun `Test serialization`() {
         val original = CcStatus()
         val copy = SerializationUtils.clone(original)
-        JUnitAsserter.assertEquals("Expected to be identical", original, copy)
+        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GlobalPreferencesTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GlobalPreferencesTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class GlobalPreferencesTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GuiUrlTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GuiUrlTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class GuiUrlTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/HostInfoTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/HostInfoTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class HostInfoTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class MessageTest {
     @Test
@@ -39,6 +39,6 @@ class MessageTest {
     fun `Test serialization`() {
         val original = Message()
         val copy = SerializationUtils.clone(original)
-        JUnitAsserter.assertEquals("Expected to be identical", original, copy)
+        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/NoticeTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/NoticeTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NoticeTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/PlatformInfoTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/PlatformInfoTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class PlatformInfoTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectAttachReplyTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectAttachReplyTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ProjectAttachReplyTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectConfigTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectConfigTest.kt
@@ -19,33 +19,25 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Before
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class ProjectConfigTest {
-    private lateinit var projectConfig: ProjectConfig
-
-    @Before
-    fun setUp() {
-        projectConfig = ProjectConfig(masterUrl = MASTER_URL)
-    }
-
     @Test
     fun `Expect master URL when RPC URL base is empty`() {
-        JUnitAsserter.assertEquals("Expected $MASTER_URL", MASTER_URL, projectConfig.secureUrlIfAvailable)
+        val projectConfig = ProjectConfig(masterUrl = MASTER_URL)
+        JUnit5Asserter.assertEquals("Expected $MASTER_URL", MASTER_URL, projectConfig.secureUrlIfAvailable)
     }
 
     @Test
     fun `Expect RPC URL base when RPC URL base is not empty`() {
-        projectConfig.webRpcUrlBase = RPC_URL_BASE
-        JUnitAsserter.assertEquals("Expected $RPC_URL_BASE", RPC_URL_BASE, projectConfig.secureUrlIfAvailable)
+        val projectConfig = ProjectConfig(masterUrl = MASTER_URL, webRpcUrlBase = RPC_URL_BASE)
+        JUnit5Asserter.assertEquals("Expected $RPC_URL_BASE", RPC_URL_BASE, projectConfig.secureUrlIfAvailable)
     }
 
     @Test
     fun `Test equals() and hashCode()`() {
-        projectConfig.masterUrl = ""
-        EqualsTester().addEqualityGroup(this.projectConfig, ProjectConfig())
+        EqualsTester().addEqualityGroup(ProjectConfig(), ProjectConfig())
                 .addEqualityGroup(ProjectConfig(1))
                 .addEqualityGroup(ProjectConfig(name = "Name"))
                 .addEqualityGroup(ProjectConfig(masterUrl = MASTER_URL))

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class ProjectInfoTest {
     @Test
@@ -43,6 +43,6 @@ class ProjectInfoTest {
     fun `Test serialization`() {
         val original = ProjectInfo()
         val copy = SerializationUtils.clone(original)
-        JUnitAsserter.assertEquals("Expected to be identical", original, copy)
+        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectTest.kt
@@ -18,26 +18,19 @@
  */
 package edu.berkeley.boinc.rpc
 
-import org.junit.Before
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class ProjectTest {
-    private lateinit var project: Project
-
-    @Before
-    fun setUp() {
-        project = Project(masterURL = "Master URL")
-    }
-
     @Test
     fun `Expect getName() to return master URL when project name is empty`() {
-        JUnitAsserter.assertEquals("Expected to be equal.","Master URL", project.name)
+        val project = Project(masterURL = "Master URL")
+        JUnit5Asserter.assertEquals("Expected to be equal.","Master URL", project.name)
     }
 
     @Test
     fun `Expect getName() to return project name when project name is not empty`() {
-        project.projectName = "Project"
-        JUnitAsserter.assertEquals("Expected to be equal.","Project", project.name)
+        val project = Project(masterURL = "Master URL", projectName = "Project")
+        JUnit5Asserter.assertEquals("Expected to be equal.","Project", project.name)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ResultTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ResultTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ResultTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TimePreferencesTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TimePreferencesTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TimePreferencesTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TimeSpanTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TimeSpanTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class TimeSpanTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransferTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransferTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
-import org.junit.Test
-import kotlin.test.junit.JUnitAsserter
+import org.junit.jupiter.api.Test
+import kotlin.test.junit5.JUnit5Asserter
 
 class TransferTest {
     @Test
@@ -46,6 +46,6 @@ class TransferTest {
     fun `Test serialization`() {
         val original = Transfer()
         val copy = SerializationUtils.clone(original)
-        JUnitAsserter.assertEquals("Expected to be identical", original, copy)
+        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/VersionInfoTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/VersionInfoTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class VersionInfoTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/WorkUnitTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/WorkUnitTest.kt
@@ -19,7 +19,7 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class WorkUnitTest {
     @Test

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsTest.java
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsTest.java
@@ -19,29 +19,30 @@
 package edu.berkeley.boinc.utils;
 
 import org.apache.commons.io.input.CharSequenceReader;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Reader;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BOINCUtilsTest {
+class BOINCUtilsTest {
     private StringBuilder stringBuilder;
     private Reader reader;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         stringBuilder = new StringBuilder("This is a string.");
         reader = new CharSequenceReader(stringBuilder);
     }
 
     @Test
-    public void testReadLineLimit_whenReaderIsNullAndLimitIs0_thenExpectEmptyString()
+    void testReadLineLimit_whenReaderIsNullAndLimitIs0_thenExpectEmptyString()
             throws IOException {
         String result = BOINCUtils.readLineLimit(null, 0);
 
@@ -49,14 +50,13 @@ public class BOINCUtilsTest {
         assertTrue(result.isEmpty());
     }
 
-    @Test(expected = NullPointerException.class)
-    public void testReadLineLimit_whenReaderIsNullAndLimitIs1_thenExpectNullPointerException()
-            throws IOException {
-        BOINCUtils.readLineLimit(null, 1);
+    @Test
+    void testReadLineLimit_whenReaderIsNullAndLimitIs1_thenExpectNullPointerException() {
+        assertThrows(NullPointerException.class, () -> BOINCUtils.readLineLimit(null, 1));
     }
 
     @Test
-    public void testReadLineLimit_whenReaderHasEmptyStringAndLimitIs1_thenExpectNull()
+    void testReadLineLimit_whenReaderHasEmptyStringAndLimitIs1_thenExpectNull()
             throws IOException {
         stringBuilder.setLength(0);
 
@@ -64,30 +64,30 @@ public class BOINCUtilsTest {
     }
 
     @Test
-    public void testReadLineLimit_whenReaderHasNonEmptyStringAndLimitIsLengthOfString_thenExpectReaderString()
+    void testReadLineLimit_whenReaderHasNonEmptyStringAndLimitIsLengthOfString_thenExpectReaderString()
             throws IOException {
-        assertEquals(BOINCUtils.readLineLimit(reader, stringBuilder.length()), "This is a string.");
+        assertEquals("This is a string.", BOINCUtils.readLineLimit(reader, stringBuilder.length()));
     }
 
     @Test
-    public void testReadLineLimit_whenReaderHasNonEmptyStringAndLimitIsLengthOfStringPlus1_thenExpectReaderString()
+    void testReadLineLimit_whenReaderHasNonEmptyStringAndLimitIsLengthOfStringPlus1_thenExpectReaderString()
             throws IOException {
-        assertEquals(BOINCUtils.readLineLimit(reader, stringBuilder.length() + 1), "This is a string.");
+        assertEquals("This is a string.", BOINCUtils.readLineLimit(reader, stringBuilder.length() + 1));
     }
 
     @Test
-    public void testReadLineLimit_whenReaderHasStringWithNewlineAndLimitIsLengthOfString_thenExpectStringWithoutNewline()
+    void testReadLineLimit_whenReaderHasStringWithNewlineAndLimitIsLengthOfString_thenExpectStringWithoutNewline()
             throws IOException {
         stringBuilder.setCharAt(4, '\n');
 
-        assertEquals(BOINCUtils.readLineLimit(reader, stringBuilder.length()), "This");
+        assertEquals("This", BOINCUtils.readLineLimit(reader, stringBuilder.length()));
     }
 
     @Test
-    public void testReadLineLimit_whenReaderHasStringWithCarriageReturnAndLimitIsLengthOfString_thenExpectStringWithoutCarriageReturn()
+    void testReadLineLimit_whenReaderHasStringWithCarriageReturnAndLimitIsLengthOfString_thenExpectStringWithoutCarriageReturn()
             throws IOException {
         stringBuilder.setCharAt(4, '\r');
 
-        assertEquals(BOINCUtils.readLineLimit(reader, stringBuilder.length()), "This");
+        assertEquals("This", BOINCUtils.readLineLimit(reader, stringBuilder.length()));
     }
 }


### PR DESCRIPTION
**Description of the Change**
Alter tests that do not rely on PowerMock to use JUnit 5 instead of JUnit 4. JUnit 5 allows for a wider variety of tests to be written and fixes some issues with JUnit 4: https://www.baeldung.com/junit-5-migration

Tests that rely on PowerMock have not been altered as PowerMock is not yet compatible with JUnit 5: https://github.com/powermock/powermock/issues/830

**Release Notes**
N/A
