### PR TITLE
Client: place request_delay log flag under sched_ops control

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -662,7 +662,7 @@ int CLIENT_STATE::handle_scheduler_reply(
         notices.remove_notices(project, REMOVE_SCHEDULER_MSG);
     }
 
-    if (sr.request_delay) {
+    if (log_flags.sched_ops && sr.request_delay) {
         msg_printf(project, MSG_INFO,
             "Project requested delay of %.0f seconds", sr.request_delay
         );


### PR DESCRIPTION
to match other scheduler operations (not sched_op_debug, as before)

Another tweak to #3402
