### PR TITLE
Make the upgrade and make_project scripts work again.

### DIFF
--- a/py/Boinc/tools.py
+++ b/py/Boinc/tools.py
@@ -62,21 +62,15 @@ def file_size(path):
     f.seek(0,2)
     return f.tell()
 
-def query_yesno(question):
+def query_yesno(str):
     '''Query user; default Yes'''
-    valid = ('yes', 'y', '')
-    choice = input(question + "[Y/n] ").lower()
-    if choice in valid:
-        return True
-    return False
+    print str, "[Y/n] ",
+    return not raw_input().strip().lower().startswith('n')
 
-def query_noyes(question):
+def query_noyes(str):
     '''Query user; default No'''
-    valid = ('yes', 'y')
-    choice = input(question + "[y/N] ").lower()
-    if choice in valid:
-        return True
-    return False
+    print str, "[y/N] ",
+    return raw_input().strip().lower().startswith('y')
 
 def get_output_file_path(filename):
     """ Return the filename's path in the upload directory

--- a/tools/make_project
+++ b/tools/make_project
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # $Id$
 # Creates a new BOINC project.

--- a/tools/upgrade
+++ b/tools/upgrade
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 # $Id$
 


### PR DESCRIPTION
These scripts use the python mysqldb module, which is available only for Python 2.

To use Python 3 for these scripts, we'd need to find a new MySQL interface module,
and change our Python code to use it.