### PR TITLE
Use StringUtils methods in PackageReplacedReceiver.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PackageReplacedReceiver.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PackageReplacedReceiver.java
@@ -18,17 +18,17 @@
  */
 package edu.berkeley.boinc.receiver;
 
-import edu.berkeley.boinc.utils.*;
-
-import edu.berkeley.boinc.client.Monitor;
-
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
-public class PackageReplacedReceiver extends BroadcastReceiver {
+import org.apache.commons.lang3.StringUtils;
 
+import edu.berkeley.boinc.client.Monitor;
+import edu.berkeley.boinc.utils.Logging;
+
+public class PackageReplacedReceiver extends BroadcastReceiver {
     /*
      * Receiver for android.intent.action.PACKAGE_REPLACED
      * This intent is protected and can only be triggered by the system
@@ -37,8 +37,8 @@ public class PackageReplacedReceiver extends BroadcastReceiver {
      */
     @Override
     public void onReceive(Context context, Intent intent) {
-        if(intent.getAction().equals(Intent.ACTION_PACKAGE_REPLACED)) {
-            if(intent.getDataString().contains("edu.berkeley.boinc")) {
+        if(StringUtils.equals(intent.getAction(), Intent.ACTION_PACKAGE_REPLACED)) {
+            if(StringUtils.contains(intent.getDataString(), "edu.berkeley.boinc")) {
                 if(Logging.ERROR) {
                     Log.d(Logging.TAG, "PackageReplacedReceiver: starting service...");
                 }
@@ -51,4 +51,3 @@ public class PackageReplacedReceiver extends BroadcastReceiver {
         }
     }
 }
-

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PackageReplacedReceiver.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/receiver/PackageReplacedReceiver.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2012 University of California
+ * Copyright (C) 2020 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -50,4 +50,5 @@ public class PackageReplacedReceiver extends BroadcastReceiver {
             }
         }
     }
+
 }


### PR DESCRIPTION
**Description of the Change**
Avoid potential NPEs in PackageReplacedReceiver by using the StringUtils equals() and contains() methods.

**Release Notes**
N/A