### PR TITLE
Client: restore default Event Log settings

### DIFF
--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -39,15 +39,10 @@
 
 using std::string;
 
-void LOG_FLAGS::init() {
-    static const LOG_FLAGS x;
-    *this = x;
+static const LOG_FLAGS log_flag_defaults;
 
-    // on by default (others are off by default)
-    //
-    task = true;
-    file_xfer = true;
-    sched_ops = true;
+void LOG_FLAGS::init() {
+	*this = log_flag_defaults;
 }
 
 // Parse log flag preferences

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -45,11 +45,11 @@ struct LOG_FLAGS {
 
     // on by default; intended for all users
     //
-    bool file_xfer;
+    bool file_xfer = true;
         // file transfer start and finish
-    bool sched_ops;
+    bool sched_ops = true;
         // interactions with schedulers
-    bool task;
+    bool task = true;
         // task start and finish, and suspend/resume
 
     // off by default; intended for developers and testers


### PR DESCRIPTION
Fixes #3606

**Description of the Change**
cc_config.cpp: following discussion in https://boinc.berkeley.edu/forum_thread.php?id=13588, this seems  a more normal place to put the 'static' declaration.
cc_config.h: empirical, Can't set defaults in init(), so put them here instead.

**Tested on**
Windows (VS2013)
Linux Mint, based on Ubuntu (configure/make)