### PR TITLE
client: allow specifying device name in cc_config.xml

### DIFF
--- a/client/hostinfo_network.cpp
+++ b/client/hostinfo_network.cpp
@@ -96,6 +96,9 @@ int HOST_INFO::get_local_network_info() {
         inet_ntop(AF_INET6, (void*)(&sin->sin6_addr), ip_addr, 256);
     }
 #endif
+    if (!cc_config.device_name.empty()) {
+        strncpy(domain_name, cc_config.device_name.c_str(), sizeof(domain_name)-1);
+    }
     return 0;
 }
 

--- a/client/hostinfo_network.cpp
+++ b/client/hostinfo_network.cpp
@@ -97,7 +97,7 @@ int HOST_INFO::get_local_network_info() {
     }
 #endif
     if (!cc_config.device_name.empty()) {
-        strncpy(domain_name, cc_config.device_name.c_str(), sizeof(domain_name)-1);
+        safe_strcpy(domain_name, cc_config.device_name.c_str());
     }
     return 0;
 }

--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -295,6 +295,9 @@ void CC_CONFIG::show() {
             "Config: ignore tty: %s", ignore_tty[i].c_str()
         );
     }
+    if (!device_name.empty()) {
+        msg_printf(NULL, MSG_INFO, "Config: device name is %s", device_name.c_str());
+    }
 }
 
 // This is used by the BOINC client.
@@ -462,11 +465,13 @@ int CC_CONFIG::parse_options_client(XML_PARSER& xp) {
             ignore_tty.push_back(s);
             continue;
         }
+        if (xp.parse_string("device_name", device_name)) continue;
 
-        // The following 3 tags have been moved to nvc_config and
-        // NVC_CONFIG_FILE, but CC_CONFIG::write() in older clients 
+        // The following tags have been moved to nvc_config and NVC_CONFIG_FILE,
+        // but CC_CONFIG::write() in older clients 
         // may have written their default values to CONFIG_FILE. 
         // Silently skip them if present.
+        //
         if (xp.parse_string("client_download_url", s)) continue;
         if (xp.parse_string("client_new_version_text", s)) continue;
         if (xp.parse_string("client_version_check_url", s)) continue;

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -437,11 +437,13 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
             ignore_tty.push_back(s);
             continue;
         }
+        if (xp.parse_string("device_name", device_name)) continue;
 
-        // The following 3 tags have been moved to nvc_config and
-        // NVC_CONFIG_FILE, but CC_CONFIG::write() in older clients 
+        // The following tags have been moved to nvc_config and NVC_CONFIG_FILE,
+        // but CC_CONFIG::write() in older clients 
         // may have written their default values to CONFIG_FILE. 
         // Silently skip them if present.
+        //
         if (xp.parse_string("client_download_url", s)) continue;
         if (xp.parse_string("client_new_version_text", s)) continue;
         if (xp.parse_string("client_version_check_url", s)) continue;

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -201,6 +201,7 @@ struct CC_CONFIG {
         // overrides use_certs
     bool vbox_window;
     std::vector<std::string> ignore_tty;
+    std::string device_name;
 
     CC_CONFIG();
     void defaults();


### PR DESCRIPTION
If cc_config.xml contains <device_name>x</device_name>,
report that to projects rather than the name returned by gethostname()

Fixes #3587
