### PR TITLE
Mac: Improved screensaver logic for OS 10.15 Catalina

### DIFF
--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -96,7 +96,8 @@ Commands:\n\
  --run_graphics_app id op         run, test or stop graphics app\n\
    op = run | runfullscreen | stop | test\n\
    id = slot # for run or runfullscreen, process ID for stop or test\n\
-   --set_gpu_mode mode duration       set GPU run mode for given duration\n\
+   id = -1 for default screensaver (boincscr)\n\
+ --set_gpu_mode mode duration       set GPU run mode for given duration\n\
    mode = always | auto | never\n\
  --set_host_info product_name\n\
  --set_network_mode mode duration   set network mode for given duration\n\
@@ -176,6 +177,8 @@ int main(int argc, char** argv) {
 
 #ifdef _WIN32
     chdir_to_data_dir();
+#elif defined(__APPLE__)
+    chdir("/Library/Application Support/BOINC Data");
 #endif
     safe_strcpy(passwd_buf, "");
     read_gui_rpc_password(passwd_buf);
@@ -426,7 +429,7 @@ int main(int argc, char** argv) {
         }
     } else if (!strcmp(cmd, "--set_host_info")) {
         HOST_INFO h;
-        h.clear_host_info();
+        memset(&h, 0, sizeof(h));
         char* pn = next_arg(argc, argv, i);
         safe_strcpy(h.product_name, pn);
         retval = rpc.set_host_info(h);
@@ -546,16 +549,10 @@ int main(int argc, char** argv) {
     } else if (!strcmp(cmd, "--run_benchmarks")) {
         retval = rpc.run_benchmarks();
     } else if (!strcmp(cmd, "--run_graphics_app")) {
-        int slot = 0;
-        if (!strcmp(argv[3], "test") || (!strcmp(argv[3], "stop"))) {
-            i = atoi(argv[2]);
-        } else {
-            slot = atoi(argv[2]);
-            i = 0;
-        }
-        retval = rpc.run_graphics_app(slot, i, argv[3]);
-        if (strcmp(argv[3], "stop") & !retval) {
-            printf("pid: %d\n", i);
+        int operand = atoi(argv[2]);
+        retval = rpc.run_graphics_app(argv[3], operand, getlogin());
+        if (!strcmp(argv[3], "test") & !retval) {
+            printf("pid: %d\n", operand);
         }
     } else if (!strcmp(cmd, "--get_project_config")) {
         char* gpc_url = next_arg(argc, argv,i);

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -93,7 +93,7 @@ Commands:\n\
  --read_cc_config\n\
  --read_global_prefs_override\n\
  --run_benchmarks\n\
- --run_graphics_app id op         run, test or stop graphics app\n\
+ --run_graphics_app id op         (Macintosh only) run, test or stop graphics app\n\
    op = run | runfullscreen | stop | test\n\
    id = slot # for run or runfullscreen, process ID for stop or test\n\
    id = -1 for default screensaver (boincscr)\n\
@@ -548,12 +548,14 @@ int main(int argc, char** argv) {
         retval = rpc.acct_mgr_rpc("", "", "");
     } else if (!strcmp(cmd, "--run_benchmarks")) {
         retval = rpc.run_benchmarks();
+#ifdef __APPLE__
     } else if (!strcmp(cmd, "--run_graphics_app")) {
         int operand = atoi(argv[2]);
         retval = rpc.run_graphics_app(argv[3], operand, getlogin());
         if (!strcmp(argv[3], "test") & !retval) {
             printf("pid: %d\n", operand);
         }
+#endif
     } else if (!strcmp(cmd, "--get_project_config")) {
         char* gpc_url = next_arg(argc, argv,i);
         retval = rpc.get_project_config(string(gpc_url));

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1334,6 +1334,7 @@ static void handle_get_daily_xfer_history(GUI_RPC_CONN& grc) {
     daily_xfer_history.write_xml(grc.mfout);
 }
 
+#ifdef __APPLE__
 static void stop_graphics_app(pid_t thePID, 
                             long iBrandID, 
                             char current_dir[], 
@@ -1385,6 +1386,7 @@ static void stop_graphics_app(pid_t thePID,
     grc.mfout.printf("<success/>\n");
     return;
 }
+#endif
 
 // start, stop or get status of a graphics app on behalf of the screensaver.
 // (needed for Mac OS X 10.15+; "stop & "test" are used for Mac OS X 10.13+)

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -23,6 +23,7 @@
 #include <Carbon/Carbon.h>
 #include <libproc.h>
 #include "sandbox.h"
+#include "mac_branding.h"
 #endif
 
 #ifdef _WIN32
@@ -1333,43 +1334,94 @@ static void handle_get_daily_xfer_history(GUI_RPC_CONN& grc) {
     daily_xfer_history.write_xml(grc.mfout);
 }
 
+static void stop_graphics_app(pid_t thePID, 
+                            long iBrandID, 
+                            char current_dir[], 
+                            char switcher_path[], 
+                            string theScreensaverLoginUser, 
+                            GUI_RPC_CONN& grc
+                            ) {
+    char* argv[16];
+    int argc;
+    char screensaverLoginUser[256];
+    int newPID = 0;
+    int retval;
+
+    if (g_use_sandbox) {
+        char pidString[10];
+        
+        snprintf(pidString, sizeof(pidString), "%d", thePID);
+    #if 1
+        argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
+        argv[1] = saverName[iBrandID];
+        argv[2] = "-kill_gfx";
+        argv[3] = pidString;
+        argc = 4;
+    #else 
+        argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
+        argv[1] = "/bin/kill";
+        argv[2] = "-kill";
+        argv[3] = (char *)pidString;
+        argc = 4;
+    #endif
+        if (!theScreensaverLoginUser.empty()) {
+            argv[argc++] = "--ScreensaverLoginUser";
+            safe_strcpy(screensaverLoginUser, theScreensaverLoginUser.c_str());
+            argv[argc++] = screensaverLoginUser;
+        }
+        argv[argc] = 0;
+
+        retval = run_program(
+            current_dir, switcher_path,
+            argc, argv, 0, newPID
+        );
+    } else {
+        retval = kill_program(thePID);
+    }
+    if (retval) {
+        grc.mfout.printf("<error>attempt to kill graphics app failed</error>\n");
+        return;
+    }
+    grc.mfout.printf("<success/>\n");
+    return;
+}
+
 // start, stop or get status of a graphics app on behalf of the screensaver.
-// (needed for Mac OS X 10.5+)
+// (needed for Mac OS X 10.15+; "stop & "test" are used for Mac OS X 10.13+)
 //
 // <slot>n</slot> { <run/> | <runfullscreen/> }
 // <graphics_pid>p</graphics_pid> { <stop/> | <test/> }
 //
 // n is the slot number:
 //   if slot = -1, start the default screensaver
-// p is the process id to stop or test
+// p is the process id to stop
 //   test returns 0 for the pid if it has exited, else returns the child's pid
-//
-// As of 3 November 2019, only the "stop" verb is being used, because the client 
-// can't launch or test gfx apps outside the user session within which the client
-// is running. So if another user is logged in and runs the screensaver, that
-// sure would not see the graphics. But I'm leaving code for all the verbs for 
-// now as a possible starting point for future development.
-//
-// The stop verb still works because it calls kill_via_switcher(), which calls 
-// kill(pid, SIGKILL) after setting user and group to pbionc_project. That does 
-// work across different login sessions.
 //
 static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
 #ifndef __APPLE__
     grc.mfout.printf("<error>run_graphics_app RPC is currently available only on Mac OS</error>\n");
 #else
-    static int boincscr_pid = 0;
     bool run = false;
     bool runfullscreen = false;
     bool stop = false;
     bool test = false;
     int slot = -2, retval;
-    int status;
     pid_t p;
-    char* argv[5];
+    char* argv[16];
     int argc;
     int thePID = 0;
-
+    FILE *f;
+    long iBrandID;
+    string theScreensaverLoginUser;
+    char screensaverLoginUser[256];
+    char switcher_path[MAXPATHLEN];
+    char *execName, *execPath;
+    char current_dir[MAXPATHLEN];
+    char *execDir;
+    int newPID = 0;
+    ACTIVE_TASK* atp = NULL;
+    char cmd[256];
+    
     while (!grc.xp.get_tag()) {
         if (grc.xp.match_tag("/run_graphics_app")) break;
         if (grc.xp.parse_int("slot", slot)) continue;
@@ -1378,6 +1430,7 @@ static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
         if (grc.xp.parse_bool("stop", stop)) continue;
         if (grc.xp.parse_bool("test", test)) continue;
         if (grc.xp.parse_int("graphics_pid", thePID)) continue;
+        if (grc.xp.parse_string("ScreensaverLoginUser", theScreensaverLoginUser)) continue;
     }
     
     if (stop || test) {
@@ -1397,134 +1450,137 @@ static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
 
     if (test) {
         // returns 0 for the pid if it has exited, else returns the child's pid
-        p = waitpid(thePID, &status, WNOHANG);
-        if (p != 0) thePID = 0;
-        grc.mfout.printf(
-            "<graphics_pid>%d</graphics_pid>\n",
-            thePID
-        );
+        p = 0;
+        snprintf(cmd, sizeof(cmd), "ps -p %d -o pid", thePID);
+        f = popen(cmd, "r");
+        if (f) {
+            fgets(cmd, sizeof(cmd), f); // Skip the header line
+            fscanf(f, "%d", &p);
+            pclose(f);
+            grc.mfout.printf(
+                "<graphics_pid>%d</graphics_pid>\n<success/>\n",
+                p
+            );
+        }
         return;
     }
 
-    if (stop) {
-        if (g_use_sandbox && (thePID != boincscr_pid )) {
-            retval = kill_via_switcher(thePID);
-        } else {
-            retval = kill_program(thePID);
-        }
-        if (retval) {
-            grc.mfout.printf("<error>attempt to kill graphics app failed</error>\n");
-            return;
-        }
-        if (thePID == boincscr_pid) boincscr_pid = 0;
-        grc.mfout.printf("<success/>\n");
-        return;
+    // For branded installs, the Mac installer put a branding file in our data directory
+    iBrandID = 0;   // Default value
+    f = fopen("/Library/Application Support/BOINC Data/Branding", "r");
+    if (f) {
+        fscanf(f, "BrandId=%ld\n", &iBrandID);
+        fclose(f);
+    }
+    if ((iBrandID < 0) || (iBrandID > (NUMBRANDS-1))) {
+        iBrandID = 0;
     }
 
-    // start boincscr
-    //
-    if (slot == -1) {
-        char path[MAXPATHLEN];
-
-#ifdef __APPLE__
-        safe_strcpy(path, "./boincscr");
-#else
-        if (get_real_executable_path(path, sizeof(path))) {
-            grc.mfout.printf("<error>can't get client path</error>\n");
-            return;
-        }
-        char *p = strrchr(path, '/');
-        if (!p) {
-            grc.mfout.printf("<error>no / in client path</error>\n");
-            return;
-        }
-        safe_strcpy(p, "/boincscr");
-#endif
-        argv[0] = (char*)"boincscr";
-        if (runfullscreen) {
-            argv[1] = (char*)"--fullscreen";
-            argc = 2;
-        } else {
-            argv[1] = 0;
-            argc = 1;
-        }
-        argv[2] = 0;
-        retval = run_program(NULL, path, argc, argv, 0, boincscr_pid);
-    
-        if (retval) {
-            grc.mfout.printf("<error>couldn't run boincscr</error>\n");
-            return;
-        }
-        grc.mfout.printf(
-            "<graphics_pid>%d</graphics_pid>\n",
-            boincscr_pid
-        );
-        return;
-    }   // end if (slot == -1)
-
-    // start a graphics app
-    //
-    ACTIVE_TASK* atp = gstate.active_tasks.lookup_slot(slot);
-    if (!atp) {
-        grc.mfout.printf("<error>no job in slot</error>\n");
-        return;
-    }
-    if (atp->scheduler_state != CPU_SCHED_SCHEDULED) {
-        grc.mfout.printf("<error>job not running</error>\n");
-        return;
-    }
-    if (!strlen(atp->app_version->graphics_exec_path)) {
-        grc.mfout.printf("<error>job has no graphics app</error>\n");
-        return;
-    }
+    getcwd(current_dir, sizeof(current_dir));
 
     if (g_use_sandbox) {
-        char current_dir[MAXPATHLEN], switcher_path[MAXPATHLEN];
-        getcwd( current_dir, sizeof(current_dir));
         snprintf(switcher_path, sizeof(switcher_path), 
             "%s/%s/%s",
             current_dir, SWITCHER_DIR, SWITCHER_FILE_NAME
         );
-        argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
-        argv[1] = atp->app_version->graphics_exec_path;
-        argv[2] = atp->app_version->graphics_exec_file;
-        if (runfullscreen) {
-            argv[3] = (char*)"--fullscreen";
-            argc = 3;
-        } else {
-            argv[3] = 0;
-            argc = 2;
+    }
+
+    if (stop) {
+        stop_graphics_app(thePID, iBrandID, current_dir, switcher_path, 
+                            theScreensaverLoginUser, grc);
+        grc.mfout.printf("<success/>\n");
+        return;
+    }
+
+    if (slot == -1) {
+        // start boincscr
+        //
+        execPath = (char*)"./boincscr";
+        execName = (char*)"boincscr";
+        execDir = current_dir;
+    } else {   // if (slot != -1)
+        // start a graphics app
+        //
+        atp = gstate.active_tasks.lookup_slot(slot);
+        if (!atp) {
+            grc.mfout.printf("<error>no job in slot</error>\n");
+            return;
         }
-        argv[4] = 0;
+        if (atp->scheduler_state != CPU_SCHED_SCHEDULED) {
+            grc.mfout.printf("<error>job not running</error>\n");
+            return;
+        }
+        if (!strlen(atp->app_version->graphics_exec_path)) {
+            grc.mfout.printf("<error>job has no graphics app</error>\n");
+            return;
+        }
+        
+        execPath = atp->app_version->graphics_exec_path;
+        execName = atp->app_version->graphics_exec_file;
+        execDir = atp->slot_path;
+    }
+
+    if (g_use_sandbox) {
+        if (slot == -1) {
+            argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
+            argv[1] = execDir;
+            argv[2] = saverName[iBrandID];
+            argv[3] = "-default_gfx";
+            argv[4] = "boincscr";
+            argc = 5;
+        } else {
+            char theSlot[10];
+            sprintf(theSlot, "%d", slot);
+            argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
+            argv[1] = execDir;
+            argv[2] = saverName[iBrandID];
+            argv[3] = "-launch_gfx";
+            argv[4] = (char *)theSlot;
+            argc = 5;
+        }
+        
+        if (runfullscreen) {
+            argv[argc++] = "--fullscreen";
+        }
+        if (!theScreensaverLoginUser.empty()) {
+            argv[argc++] = "--ScreensaverLoginUser";
+            safe_strcpy(screensaverLoginUser, theScreensaverLoginUser.c_str());
+            argv[argc++] = screensaverLoginUser;
+        }
+        argv[argc] = 0;
+
         retval = run_program(
-            atp->slot_path, switcher_path,
-            argc, argv, 0, atp->graphics_pid
+            execDir, switcher_path,
+            argc, argv, 0, newPID
         );
     } else {    // not g_use_sandbox
-        argv[0] = atp->app_version->graphics_exec_file;
+        argv[0] = execName;
         if (runfullscreen) {
             argv[1] = (char*)"--fullscreen";
             argc = 2;
         } else {
-            argv[2] = 0;
             argc = 1;
         }
-        argv[2] = 0;
+        if (!theScreensaverLoginUser.empty()) {
+            argv[argc++] = "--ScreensaverLoginUser";
+            safe_strcpy(screensaverLoginUser, theScreensaverLoginUser.c_str());
+            argv[argc++] = screensaverLoginUser;
+        }
+        argv[argc] = 0;
         retval = run_program(
-            atp->slot_path, atp->app_version->graphics_exec_path,
-            argc, argv, 0, atp->graphics_pid
+            execDir, execPath,
+            argc, argv, 0, newPID
         );
     }
     
     if (retval) {
         grc.mfout.printf("<error>couldn't run graphics app</error>\n");
-        return;
+        stop_graphics_app(thePID, iBrandID, current_dir, switcher_path, 
+                            theScreensaverLoginUser, grc);
+    } else {
+        grc.mfout.printf("<success/>\n");
     }
-    
-    grc.mfout.printf(
-        "<graphics_pid>%d</graphics_pid>\n",
-        atp->graphics_pid
-    );
+    return;
 #endif  // __APPLE__
 }
 

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -20,7 +20,7 @@
 // When run as
 // switcher Full-Path Executable-Name X1 ... Xn
 // runs program at Full-Path with args X1. ... Xn
-// note that the executable name nust be specified twice:
+// note that the executable name must be specified twice:
 //  once as part of the Full_Path and again as just the name
 
 #include <unistd.h>
@@ -29,70 +29,97 @@
 #include <cerrno>
 #include <pwd.h>    // getpwuid
 #include <grp.h>
+#include <sys/stat.h>  // for chmod
 
 #include "app_ipc.h"
 #include "filesys.h"
 #include "str_replace.h"
+#include "mac_spawn.h"
 
 using std::strcpy;
 
 int main(int /*argc*/, char** argv) {
     passwd          *pw;
     group           *grp;
-    char            user_name[256], group_name[256];
+    char            boinc_project_user_name[256], boinc_project_group_name[256];
+    char            boinc_master_user_name[256];
     APP_INIT_DATA   aid;
     FILE            *f;
     int             retval = -1;
+    int             i;
     char            libpath[8192];
     char            newlibs[256];
     char            *projectDirName;
+    const char      *screensaverLoginUser = NULL;
+    bool            launching_gfx=false;
+    char            current_dir[MAXPATHLEN];
 
-    strcpy(user_name, "boinc_project");
-    strcpy(group_name, "boinc_project");
+
+    strcpy(boinc_project_user_name, "boinc_project");
+    strcpy(boinc_project_group_name, "boinc_project");
+    strcpy(boinc_master_user_name, "boinc_master");
 
 #if 0           // For debugging only
-    char    current_dir[MAXPATHLEN];
-
+    fprintf(stderr, "\n\nEntered switcher with euid %d, egid %d, uid %d and gid %d\n", geteuid(), getegid(), getuid(), getgid());       
     getcwd( current_dir, sizeof(current_dir));
     fprintf(stderr, "current directory = %s\n", current_dir);
-
-    int i = 0;
+    fflush(stderr);
+    
+    i = 0;
     while(argv[i]) {
         fprintf(stderr, "switcher arg %d: %s\n", i, argv[i]);
+        fflush(stderr);
         ++i;
     }
-    fflush(stderr);
 #endif
 
 #if 0       // For debugging only
     // Allow debugging without running as user or group boinc_project
     pw = getpwuid(getuid());
-    if (pw) strcpy(user_name, pw->pw_name);
+    if (pw) {
+        strcpy(boinc_project_user_name, pw->pw_name);
+        strcpy(boinc_master_user_name, pw->pw_name);
+    }
     grp = getgrgid(getgid());
     if (grp) {
-        strcpy(group_name, grp->gr_gid);
+        strcpy(boinc_project_group_name, grp->gr_gid);
     }
 
 #endif
 
-    // Satisfy an error / warning from rpmlint: ensure that
-    // we drop any supplementary groups associated with root
-    setgroups(0, NULL);
-
-    // We are running setuid root, so setgid() sets real group ID,
-    // effective group ID and saved set_group-ID for this process
-    grp = getgrnam(group_name);
-    if (grp) {
-        (void) setgid(grp->gr_gid);
+    // Under fast user switching, the BOINC client may be running under a
+    // different login than the screensaver 
+    //
+    // If we need to join a different process group, it must be the last argument.
+    // This is currently used for OS 10.15+
+    i = 0;
+    while(argv[i]) {
+        if (!strcmp(argv[i], "--ScreensaverLoginUser")) {
+            screensaverLoginUser = argv[i+1];
+            break;
+        }
+        ++i;
     }
+ 
+    if (!screensaverLoginUser) {
+        // Satisfy an error / warning from rpmlint: ensure that
+        // we drop any supplementary groups associated with root
+        setgroups(0, NULL);
 
-    // We are running setuid root, so setuid() sets real user ID,
-    // effective user ID and saved set_user-ID for this process
-    pw = getpwnam(user_name);
-    if (pw) {
-        (void) setuid(pw->pw_uid);
+        // We are running setuid root, so setgid() sets real group ID,
+        // effective group ID and saved set_group-ID for this process
+        grp = getgrnam(boinc_project_group_name);
+        if (grp) {
+            (void) setgid(grp->gr_gid);
+        }
+
+        // We are running setuid root, so setuid() sets real user ID,
+        // effective user ID and saved set_user-ID for this process
+        pw = getpwnam(boinc_project_user_name);
+        if (pw) {
+            (void) setuid(pw->pw_uid);
+        }
     }
-
     // For unknown reasons, the LD_LIBRARY_PATH and DYLD_LIBRARY_PATH
     // environment variables are not passed in to switcher, though all
     // other environment variables do get propagated.  So we recreate
@@ -135,6 +162,75 @@ int main(int /*argc*/, char** argv) {
         setenv("DYLD_LIBRARY_PATH", libpath, 1);
 #endif
     }
+
+   if (screensaverLoginUser) {
+       // Used under OS 10.15 Catalina and later to launch screensaver graphics apps
+       //
+       // BOINC screensaver plugin BOINCSaver.saver (BOINC Screensaver Coordinator)
+       // sends a run_graphics_app RPC to the BOINC client. The BOINC client then 
+       // launches switcher, which submits a script to launchd as a LaunchAgent
+       // for the user that invoked the screensaver (the currently logged in user.)
+       //
+       // We must go through launchd to establish a connection to the windowserver 
+       // in the currently logged in user's space for use by the project graphics
+       // app. This script then launches gfx_switcher, which uses fork and execv to 
+       // launch the project graphics app. gfx_switcher writes the graphics app's 
+       // process ID to shared memory, to be read by the Screensaver Coordinator. 
+       // gfx_switcher waits for the graphics app to exit and notifies then notifies 
+       // the Screensaver Coordinator by writing 0 to the shared memory.
+       //
+       // This Rube Goldberg process is necessary due to limitations on screensavers
+       // introduced in OS 10.15 Catalina.
+        char cmd[1024];
+
+        // We are running setuid root, so setuid() sets real user ID, 
+        // effective user ID and saved set_user-ID for this process
+        setuid(geteuid());
+        // We are running setuid root, so setgid() sets real group ID, 
+        // effective group ID and saved set_group-ID for this process
+        setgid(getegid());
+        
+        getcwd(current_dir, sizeof(current_dir));
+
+        i = 0;
+        while(argv[i]) {
+            if (strcmp(argv[i], "/bin/kill")) {
+                launching_gfx = true;   // not KILL command
+                break;
+            }
+            ++i;
+        }
+
+        if (!strcmp(argv[2], "-kill_gfx")) {
+            snprintf(cmd, sizeof(cmd), "\"/Library/Screen Savers/%s.saver/Contents/Resources/gfx_switcher\" %s %s", argv[1], argv[2], argv[3]);
+            retval = callPosixSpawn(cmd);
+            return retval;
+       } else {
+            // A new submit of edu.berkeley.boinc-ss_helper will be ignored if for some reason 
+            // edu.berkeley.boinc-ss_helper is still loaded, so ensure it is removed.
+            snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl remove edu.berkeley.boinc-ss_helper'", screensaverLoginUser);
+            retval = callPosixSpawn(cmd);
+
+            snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl submit -l edu.berkeley.boinc-ss_helper -- \"/Library/Screen Savers/%s.saver/Contents/Resources/boinc_ss_helper.sh\" \"%s\"", screensaverLoginUser, argv[2], argv[1]);
+            i = 2;
+            while(argv[i]) {
+                safe_strcat(cmd, " ");
+                safe_strcat(cmd, argv[i++]);
+            }
+        }
+        safe_strcat(cmd, "\'");
+#if 0       // For debugging only
+        fprintf(stderr, "About to call Posix Spawn (%s)\n", cmd);
+        fflush(stderr);
+#endif
+        if (launching_gfx) {
+            // Suppress "killed" message from bash in stderrdae.txt
+            freopen("/dev/null", "a", stderr);
+        }
+        retval = callPosixSpawn(cmd);
+        return retval;
+    }
+
 
     retval = execv(argv[1], argv+2);
     if (retval == -1) {

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -203,13 +203,13 @@ int main(int /*argc*/, char** argv) {
 
         if (!strcmp(argv[2], "-kill_gfx")) {
             snprintf(cmd, sizeof(cmd), "\"/Library/Screen Savers/%s.saver/Contents/Resources/gfx_switcher\" %s %s", argv[1], argv[2], argv[3]);
-            retval = callPosixSpawn(cmd);
+            retval = callPosixSpawn((const char*)cmd);
             return retval;
        } else {
             // A new submit of edu.berkeley.boinc-ss_helper will be ignored if for some reason 
             // edu.berkeley.boinc-ss_helper is still loaded, so ensure it is removed.
             snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl remove edu.berkeley.boinc-ss_helper'", screensaverLoginUser);
-            retval = callPosixSpawn(cmd);
+            retval = callPosixSpawn((const char*)cmd);
 
             snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl submit -l edu.berkeley.boinc-ss_helper -- \"/Library/Screen Savers/%s.saver/Contents/Resources/boinc_ss_helper.sh\" \"%s\"", screensaverLoginUser, argv[2], argv[1]);
             i = 2;
@@ -227,7 +227,7 @@ int main(int /*argc*/, char** argv) {
             // Suppress "killed" message from bash in stderrdae.txt
             freopen("/dev/null", "a", stderr);
         }
-        retval = callPosixSpawn(cmd);
+        retval = callPosixSpawn((const char*)cmd);
         return retval;
     }
 

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -87,6 +87,7 @@ int main(int /*argc*/, char** argv) {
 
 #endif
 
+#ifdef __APPLE__
     // Under fast user switching, the BOINC client may be running under a
     // different login than the screensaver 
     //
@@ -100,6 +101,7 @@ int main(int /*argc*/, char** argv) {
         }
         ++i;
     }
+#endif
  
     if (!screensaverLoginUser) {
         // Satisfy an error / warning from rpmlint: ensure that
@@ -120,6 +122,7 @@ int main(int /*argc*/, char** argv) {
             (void) setuid(pw->pw_uid);
         }
     }
+
     // For unknown reasons, the LD_LIBRARY_PATH and DYLD_LIBRARY_PATH
     // environment variables are not passed in to switcher, though all
     // other environment variables do get propagated.  So we recreate
@@ -163,6 +166,7 @@ int main(int /*argc*/, char** argv) {
 #endif
     }
 
+#ifdef __APPLE__
    if (screensaverLoginUser) {
        // Used under OS 10.15 Catalina and later to launch screensaver graphics apps
        //
@@ -203,13 +207,13 @@ int main(int /*argc*/, char** argv) {
 
         if (!strcmp(argv[2], "-kill_gfx")) {
             snprintf(cmd, sizeof(cmd), "\"/Library/Screen Savers/%s.saver/Contents/Resources/gfx_switcher\" %s %s", argv[1], argv[2], argv[3]);
-            retval = callPosixSpawn((const char*)cmd);
+            retval = callPosixSpawn(cmd);
             return retval;
        } else {
             // A new submit of edu.berkeley.boinc-ss_helper will be ignored if for some reason 
             // edu.berkeley.boinc-ss_helper is still loaded, so ensure it is removed.
             snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl remove edu.berkeley.boinc-ss_helper'", screensaverLoginUser);
-            retval = callPosixSpawn((const char*)cmd);
+            retval = callPosixSpawn(cmd);
 
             snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl submit -l edu.berkeley.boinc-ss_helper -- \"/Library/Screen Savers/%s.saver/Contents/Resources/boinc_ss_helper.sh\" \"%s\"", screensaverLoginUser, argv[2], argv[1]);
             i = 2;
@@ -227,10 +231,10 @@ int main(int /*argc*/, char** argv) {
             // Suppress "killed" message from bash in stderrdae.txt
             freopen("/dev/null", "a", stderr);
         }
-        retval = callPosixSpawn((const char*)cmd);
+        retval = callPosixSpawn(cmd);
         return retval;
     }
-
+#endif
 
     retval = execv(argv[1], argv+2);
     if (retval == -1) {

--- a/clientscr/Mac_Saver_Module.h
+++ b/clientscr/Mac_Saver_Module.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -56,10 +56,10 @@ void            launchedGfxApp(char * appPath, pid_t thePID, int slot);
 void            print_to_log_file(const char *format, ...);
 void            strip_cr(char *buf);
 void            PrintBacktrace(void);
+extern char     gUserName[64];
 extern bool     gIsMojave;
 extern bool     gIsCatalina;
 extern bool     gIsHighSierra;
-extern bool     gUseLaunchAgent;
 
 #ifdef __cplusplus
 }	// extern "C"

--- a/clientscr/Mac_Saver_ModuleView.h
+++ b/clientscr/Mac_Saver_ModuleView.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -98,7 +98,6 @@ void            PrintBacktrace(void);
 extern bool     gIsCatalina;
 extern bool     gIsHighSierra;
 extern bool     gIsMojave;
-extern bool     gUseLaunchAgent;
 
 #ifdef __cplusplus
 }    // extern "C"

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -206,10 +206,6 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
     gIsHighSierra = (compareOSVersionTo(10, 13) >= 0);
     gIsMojave = (compareOSVersionTo(10, 14) >= 0);
     gIsCatalina = (compareOSVersionTo(10, 15) >= 0);
-
-    // MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT is defined in mac_util.h
-    gUseLaunchAgent = (compareOSVersionTo(10, MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT) >= 0);
-
     if (gIsCatalina) {
         // Under OS 10.15, isPreview is often true even when it shouldn't be
         // so we use this hack instead
@@ -220,7 +216,7 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
     
     // OpenGL apps built under Xcode 11 apparently use window dimensions based 
     // on the number of backing store pixels. That is, they double the window 
-    // dimensiona for Retina displays (which have two pixels per point.) But 
+    // dimensions for Retina displays (which have two pixels per point.) But 
     // OpenGL apps built under earlier versions of Xcode don't.
     // Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
     // older builds at half width and height, unless we compensate in our code.
@@ -391,6 +387,7 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
         [imageView removeFromSuperview];   // Releases imageView
         imageView = nil;
     }
+
     if (!myIsPreview) {
         closeBOINCSaver();
     }

--- a/clientscr/boinc_ss_helper.sh
+++ b/clientscr/boinc_ss_helper.sh
@@ -1,0 +1,72 @@
+# This file is part of BOINC.
+# http:#boinc.berkeley.edu
+# Copyright (C) 2020 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http:#www.gnu.org/licenses/>.
+#
+#  boinc_ss_helper.sh
+#
+# Used under OS 10.15 Catalina and later to launch screensaver graphics apps
+#
+# BOINC screensaver plugin BOINCSaver.saver (BOINC Screensaver Coordinator)
+# sends a run_graphics_app RPC to the BOINC client. The BOINC client then 
+# launches switcher, which submits this script to launchd as a LaunchAgent
+# for the user that invoked the screensaver (the currently logged in user.)
+# This script then launches gfx_switcher, which uses fork and execv to 
+# launch the project graphics app. gfx_switcher writes the graphics app's 
+# process ID to shared memory, to be read by the Screensaver Coordinator. 
+# gfx_switcher waits for the graphics app to exit and notifies then notifies 
+# the Screensaver Coordinator by writing 0 to the shared memory.
+#
+# We must go through launchd to establish a connection to the windowserver 
+# in the currently logged in user's space for use by the project graphics
+# app. This script then launches gfx_switcher, which uses execv to launch 
+# the project graphics app.
+# This Rube Goldberg process is necessary due to limitations on screensavers
+# introduced in OS 10.15 Catalina.
+
+#!/bin/sh
+
+# argv[0] = path to this script
+# argv[1] = directory
+# argv[2] = branded screensaver name
+# argv[3] = command for gfx_switcher: -default_gfx, -launch_gfx or -kill_gfx
+# argv[4] = "boincscr", slot # or pid
+# argv[5] = --fullscreen (not used for -kill_gfx)
+# argv[6] = --ScreensaverLoginUser (not used for -kill_gfx)
+# argv[7] = login user name (not used for -kill_gfx)
+
+## For testing only:
+## echo "number of args after argv[0] = $#" >> /Users/Shared/boinc_helper_script.txt
+## echo "arg[1] = $1" >> /Users/Shared/boinc_helper_script.txt
+## echo "arg[2] = $2" >> /Users/Shared/boinc_helper_script.txt
+## echo "arg[3] = $3" >> /Users/Shared/boinc_helper_script.txt
+## echo "arg[4] = $4" >> /Users/Shared/boinc_helper_script.txt
+## if [ $# -eq 7 ]; then   ## bash does not count argv[0] in $#
+## echo "arg[5] = $5" >> /Users/Shared/boinc_helper_script.txt
+## echo "arg[6] = $6" >> /Users/Shared/boinc_helper_script.txt
+## echo "arg[7] = $7" >> /Users/Shared/boinc_helper_script.txt
+## fi
+
+cd "$1"
+pwd
+if [ $# -eq 7 ]; then   ## bash does not count argv[0] in $#
+"/Library/Screen Savers/$2.saver/Contents/Resources/gfx_switcher" $3 $4 $5 $6 $7
+else
+"/Library/Screen Savers/$2.saver/Contents/Resources/gfx_switcher" $3 $4
+fi
+
+# A new submit of edu.berkeley.boinc-ss_helper will be ignored if for some reason 
+# edu.berkeley.boinc-ss_helper is still loaded, so ensure it is removed.
+launchctl remove edu.berkeley.boinc-ss_helper

--- a/clientscr/gfx_cleanup.mm
+++ b/clientscr/gfx_cleanup.mm
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -27,6 +27,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#include <SystemConfiguration/SystemConfiguration.h>
 
 #include <stdio.h>
 #include <pthread.h>
@@ -40,6 +41,8 @@
 
 #if CREATE_LOG
 void print_to_log_file(const char *format, ...);
+#else
+#define print_to_log_file(...)
 #endif
 
 pid_t parentPid;
@@ -54,21 +57,26 @@ time_t elapsedTime = 0;
 #endif
 
 void killGfxApp(pid_t thePID) {
-    char passwd_buf[256];
+#if 0
+    print_to_log_file("in gfx_cleanup: killGfxApp()");
+    kill(thePID, SIGKILL);
+#else
+    char buf[256];
+    char userName[64];
     RPC_CLIENT *rpc;
     int retval;
     
     chdir("/Library/Application Support/BOINC Data");
-    safe_strcpy(passwd_buf, "");
-    read_gui_rpc_password(passwd_buf);
+    safe_strcpy(buf, "");
+    read_gui_rpc_password(buf);
     
     rpc = new RPC_CLIENT;
     if (rpc->init(NULL)) {     // Initialize communications with Core Client
         fprintf(stderr, "in gfx_cleanup: killGfxApp(): rpc->init(NULL) failed");
         return;
     }
-    if (strlen(passwd_buf)) {
-        retval = rpc->authorize(passwd_buf);
+    if (strlen(buf)) {
+        retval = rpc->authorize(buf);
         if (retval) {
             fprintf(stderr, "in gfx_cleanup: killGfxApp(): authorization failure: %d\n", retval);
             rpc->close();
@@ -76,27 +84,47 @@ void killGfxApp(pid_t thePID) {
         }
     }
 
-    retval = rpc->run_graphics_app(0, thePID, "stop");
-    // fprintf(stderr, "in gfx_cleanup: killGfxApp(): rpc->run_graphics_app() returned retval=%d", retval);   
- 
+    CFStringRef cf_gUserName = SCDynamicStoreCopyConsoleUser(NULL, NULL, NULL);
+    CFStringGetCString(cf_gUserName, userName, sizeof(userName), kCFStringEncodingUTF8);
+
+    retval = rpc->run_graphics_app("stop", thePID, userName);
+    print_to_log_file("in gfx_cleanup: killGfxApp(): rpc->run_graphics_app(stop) returned retval=%d", retval);   
+
+    // Wait until graphics app has exited before closing our own black fullscreen
+    // window to prevent an ugly white flash [see comment in main() below].
+    int i;
+    pid_t p = 0;
+    for (i=0; i<100; ++i) {
+        boinc_sleep(0.1);
+        p = thePID;
+        // On OS 10.15+ (Catalina), it might be more efficient to get this from shared memory
+        retval = rpc->run_graphics_app("test", p, userName);
+        if (retval || (p==0)) break;
+    }
+ print_to_log_file("in gfx_cleanup: killGfxApp(%d): rpc->run_graphics_app(test) returned pid %d, retval %d when i = %d", thePID, p, retval, i);   
+
     rpc->close();
+#endif
+    return;
 }
 
 void * MonitorParent(void* param) {
-    // fprintf(stderr, "in gfx_cleanup: Starting MonitorParent");
+    print_to_log_file("in gfx_cleanup: Starting MonitorParent");
     while (true) {
         boinc_sleep(0.25);  // Test every 1/4 second
         if (getppid() != parentPid) {
-#if USE_TIMER
-            endTime = time(NULL);
-#endif
             if (GFX_PidFromScreensaver) {
                 killGfxApp(GFX_PidFromScreensaver);
             }
             if (quit_MonitorParentThread) {
                 return 0;
             }
-            // fprintf(stderr, "in gfx_cleanup: parent died, exiting (child) after handling %d, elapsed time=%d",GFX_PidFromScreensaver, (int) elapsedTime);
+            print_to_log_file("in gfx_cleanup: parent died, exiting (child) after handling %d",GFX_PidFromScreensaver);
+#if USE_TIMER
+            endTime = time(NULL);
+            elapsedTime = endTime - startTime;
+            print_to_log_file("elapsed time=%d", (int) elapsedTime);
+#endif
             exit(0);
         }
     }
@@ -122,9 +150,9 @@ NSWindow* myWindow;
 
     while (true) {
         fgets(buf, sizeof(buf), stdin);
-        // fprintf(stderr, "in gfx_cleanup: parent sent %d to child buf=%s", GFX_PidFromScreensaver, buf);
+        print_to_log_file("in gfx_cleanup: parent sent %d to child buf=%s", GFX_PidFromScreensaver, buf);
         if (feof(stdin)) {
-            // fprintf(stderr, "in gfx_cleanup: got eof");
+            print_to_log_file("in gfx_cleanup: got eof");
             break;
         }
         if (ferror(stdin) && (errno != EINTR)) {
@@ -136,7 +164,7 @@ NSWindow* myWindow;
             break;
         }
         GFX_PidFromScreensaver = atoi(buf);
-        // fprintf(stderr, "in gfx_cleanup: parent sent %d to child buf=%s", GFX_PidFromScreensaver, buf);
+        print_to_log_file("in gfx_cleanup: parent sent %d to child buf=%s", GFX_PidFromScreensaver, buf);
     }
 
     if (GFX_PidFromScreensaver) {
@@ -152,7 +180,7 @@ NSWindow* myWindow;
 @end
 
 int main(int argc, char* argv[]) {
-    // fprintf(stderr, "Entered gfx_cleanup");
+    print_to_log_file("Entered gfx_cleanup");
 #if USE_TIMER
     startTime = time(NULL);
 #endif
@@ -163,7 +191,7 @@ int main(int argc, char* argv[]) {
     // Create shared app instance
     [NSApplication sharedApplication];
 
-     // Because prpject graphics applications under OS 10.13+ draw to an IOSurface, 
+    // Because prpject graphics applications under OS 10.13+ draw to an IOSurface, 
     // the application's own window is white, but is normally covered by the 
     // ScreensaverEngine's window. If the ScreensaverEngine exits without first
     // calling [ScreenSaverView stopAnimation], the white fullscreen window will 
@@ -188,11 +216,12 @@ int main(int argc, char* argv[]) {
     
     [NSApp run];
 
+    print_to_log_file("exiting gfx_cleanup after handling %d",GFX_PidFromScreensaver);
 #if USE_TIMER
     endTime = time(NULL);
     elapsedTime = endTime - startTime;
+    print_to_log_file("elapsed time=%d", (int) elapsedTime);
 #endif
-    // fprintf(stderr, "exiting gfx_cleanup after handling %d, elapsed time=%d",GFX_PidFromScreensaver, (int)elapsedTime);
 
     return 0;
 }
@@ -213,9 +242,6 @@ int main(int argc, char* argv[]) {
 
 void strip_cr(char *buf);
 
-#endif    // CREATE_LOG
-
-#if CREATE_LOG
 // print_to_log_file - use for debugging.
 // prints time stamp plus a formatted string to log file.
 // calling syntax: same as printf.
@@ -261,9 +287,6 @@ void strip_cr(char *buf)
     if (theCR)
         *theCR = '\0';
 }
-#else
-void print_to_log_file(const char *, ...) {}
-
 #endif    // CREATE_LOG
 
 

--- a/clientscr/gfx_switcher.cpp
+++ b/clientscr/gfx_switcher.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -22,6 +22,28 @@
 //  - launch default graphics application as user & group boinc_project
 //  - kill graphics application with given process ID as user & group boinc_project
 //
+
+// Special logic used only under OS 10.15 Catalina and later:
+//
+// BOINC screensaver plugin BOINCSaver.saver (BOINC Screensaver Coordinator)
+// sends a run_graphics_app RPC to the BOINC client. The BOINC client then 
+// launches switcher, which submits a script to launchd as a LaunchAgent
+// for the user that invoked the screensaver (the currently logged in user.)
+//
+// We must go through launchd to establish a connection to the windowserver 
+// in the currently logged in user's space for use by the project graphics
+// app. This script then launches gfx_switcher, which uses fork and execv to 
+// launch the project graphics app. gfx_switcher writes the graphics app's 
+// process ID to shared memory, to be read by the Screensaver Coordinator. 
+// gfx_switcher waits for the graphics app to exit and notifies then notifies 
+// the Screensaver Coordinator by writing 0 to the shared memory.
+//
+// This Rube Goldberg process is necessary due to limitations on screensavers
+// introduced in OS 10.15 Catalina.
+//
+
+
+#include <SystemConfiguration/SystemConfiguration.h>
 #include <unistd.h>
 #include <cstdio>
 #include <cstring>
@@ -29,21 +51,21 @@
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>  // for MAXPATHLEN
 #endif
-#include <pwd.h>	    // getpwuid
+#include <pwd.h>	// getpwuid
 #include <grp.h>
-#include <signal.h>     // For kill()
-#include <sys/stat.h>   // for chmod
+#include <signal.h> // For kill()
 #include <pthread.h>
 
 #include "boinc_api.h"
 #include "common_defs.h"
 #include "util.h"
 #include "mac_util.h"
+#include "shmem.h"
 
-#define CREATE_LOG 0
-#define VERBOSE_DEBUG 0 
+#define VERBOSE 0
+#define CREATE_LOG VERBOSE
 
-#if CREATE_LOG
+#if VERBOSE
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,98 +75,60 @@ static void print_to_log_file(const char *format, ...);
 
 static void strip_cr(char *buf);
 #endif
-#endif  // if CREATE_LOG
+#else
+#define print_to_log_file(...)
+#endif
 
 void * MonitorScreenSaverEngine(void* param);
 
-#define MAXARGS 16
+pid_t* pid_for_shmem = NULL;
 
 int main(int argc, char** argv) {
-    char        *args[MAXARGS];
-    char        argString[MAXARGS][MAXPATHLEN];
-    Boolean     useScreenSaverLaunchAgent = false;
-    FILE        *f = NULL;
-    char        helper_app_dir[MAXPATHLEN], helper_app_path[MAXPATHLEN];
-    char        *helper_app_base_path;
-    char        *ptr;
-    int         argsCount = 0;
     passwd      *pw;
     group       *grp;
     char        user_name[256], group_name[256];
-    char        gfx_app_path[MAXPATHLEN], resolved_path[MAXPATHLEN];
+    char	    gfx_app_path[MAXPATHLEN], resolved_path[MAXPATHLEN];
     char        *BOINCDatSlotsPath = "/Library/Application Support/BOINC Data/slots/";
-    char        *BOINCPidFilePath = "/Users/Shared/BOINC/BOINCGfxPid.txt";
-    int         retval = 0;
+    int         retval;
     int         pid;
+    int         i;
+    const char  *screensaverLoginUser = NULL;
     pthread_t   monitorScreenSaverEngineThread = 0;
 
-    // As of OS 10.15 (Catalina) screensavers can no longer:
-    //  - launch apps that run setuid or setgid
-    //  - launch apps downloaded from the Internet which have not been 
-    //    specifically approved by the user via Gatekeeper.
-    // So instead of launching graphics apps via gfx_switcher, we write 
-    // a file containing the information. The file is detected by 
-    // a LaunchAgent which then launches gfx_switcher for us. Though we
-    // confirmed it works on OS 10.13 High Sierra, we don't use it there.
-    //
-    // MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT is defined in mac_util.h
-    useScreenSaverLaunchAgent = compareOSVersionTo(10, MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT) >= 0;
- 
-    if (useScreenSaverLaunchAgent) {
-        if (compareOSVersionTo(10, 15) >= 0) {
-            helper_app_base_path = "Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/";
-        } else {
-            helper_app_base_path = "";
-        }
+    if (argc < 2) return EINVAL;
 
-        pw = getpwuid(getuid());
-        if (pw) {
-            snprintf(helper_app_dir, sizeof(helper_app_dir), "/Users/%s/Library/%sApplication Support/BOINC/", pw->pw_name, helper_app_base_path);
-        }
-#if 0
-        safe_strcpy(helper_app_path, BOINCPidFilePath);
-        if (boinc_file_exists(helper_app_path)) {
-            boinc_delete_file(helper_app_path);
-        }
+    CFStringRef cf_gUserName = SCDynamicStoreCopyConsoleUser(NULL, NULL, NULL);
+    CFStringGetCString(cf_gUserName, user_name, sizeof(user_name), kCFStringEncodingUTF8);
+//    strlcpy(user_name, getlogin(), sizeof(user_name));
+    strlcpy(group_name, "boinc_project", sizeof(group_name));
+
+    // Under fast user switching, the BOINC client may be running under a
+    // different login than the screensaver 
+    //
+    // If we need to join a different process group, it must be the last argument.
+    i = 0;
+    while(argv[i]) {
+        if (!strcmp(argv[i], "--ScreensaverLoginUser")) {
+           screensaverLoginUser = argv[i+1];
+ //          strlcpy(user_name, screensaverLoginUser, sizeof(user_name));
+            argv[i] = 0;    // Strip off the --ScreensaverLoginUser argument
+            argc -= 2;
+#if VERBOSE           // For debugging only
+            print_to_log_file("\n\ngfx_switcher: screensaverLoginUser = %s", screensaverLoginUser);
 #endif
-        safe_strcpy(helper_app_path, helper_app_dir);
-        safe_strcat(helper_app_path, "BOINCSSHelper.txt");
-        f = fopen(helper_app_path, "r");
-        if (f) {
-            for (argsCount=0; argsCount<MAXARGS; argsCount++) {
-                args[argsCount] = fgets(argString[argsCount], sizeof(argString[argsCount]), f);
-                if (args[argsCount]) {
-                    ptr = strrchr(args[argsCount], '\n');
-                    if (ptr) *ptr = '\0';  // Remove newline character if present
-                    ptr = strrchr(args[argsCount], '\r');
-                    if (ptr) *ptr = '\0';  // Remove return character if present
-                }
-                if (argsCount) chdir(argString[0]);
-            }
-            fclose(f);
-            f = NULL;
-        } else {
-            retval = -1;
+            break;
         }
-        boinc_delete_file(helper_app_path);
-        if (retval) return EINVAL;
-    } else {
-        for (argsCount=0; argsCount<=argc; argsCount++) {
-            args[argsCount] = argv[argsCount];
-        }
+        ++i;
     }
-    
-    strlcpy(user_name, "boinc_project", sizeof(user_name));
-    strlcpy(group_name, user_name, sizeof(group_name));
 
 #if 0       // For debugging only
     // Allow debugging without running as user or group boinc_project
     pw = getpwuid(getuid());
     if (pw) strlcpy(user_name, pw->pw_name, sizeof(user_name));
     grp = getgrgid(getgid());
-    if (grp) strlcpy(group_name, grp->gr_name, sizeof(group_name));
-#endif
+    if (grp) strlcpy(group_name, grp->gr_gid, sizeof(group_name));
 
+#endif
     // We are running setuid root, so setgid() sets real group ID, 
     // effective group ID and saved set_group-ID for this process
     grp = getgrnam(group_name);
@@ -152,135 +136,132 @@ int main(int argc, char** argv) {
 
     // We are running setuid root, so setuid() sets real user ID, 
     // effective user ID and saved set_user-ID for this process
+    strlcpy(user_name, "boinc_project", sizeof(user_name));
     pw = getpwnam(user_name);
     if (pw) setuid(pw->pw_uid);
 
     // NOTE: call print_to_log_file only after switching user and group
-#if VERBOSE_DEBUG           // For debugging only
+#if VERBOSE           // For debugging only
     char	current_dir[MAXPATHLEN];
 
     getcwd( current_dir, sizeof(current_dir));
-    print_to_log_file( "current directory = %s", current_dir);
+    print_to_log_file("current directory = %s", current_dir);
+    print_to_log_file("user_name is %s, euid=%d, uid=%d, egid=%d, gid=%d", user_name, geteuid(), getuid(), getegid(), getgid());
     
-    for (int i=0; i<argsCount; i++) {
-         print_to_log_file("gfx_switcher arg %d: %s", i, args[i]);
-         if (!args[i]) break;
+    for (int i=0; i<argc; i++) {
+         print_to_log_file("gfx_switcher arg %d: %s", i, argv[i]);
     }
 #endif
 
-    if (strcmp(args[1], "-default_gfx") == 0) {
+    if (strcmp(argv[1], "-default_gfx") == 0) {
         strlcpy(resolved_path, "/Library/Application Support/BOINC Data/boincscr", sizeof(resolved_path));
-
-        args[2] = resolved_path;
+        argv[2] = resolved_path;
         
-#if VERBOSE_DEBUG           // For debugging only
+#if VERBOSE           // For debugging only
         for (int i=2; i<argc; i++) {
-            print_to_log_file("calling execv with arg %d: %s", i-2, args[i]);
+            print_to_log_file("gfx_switcher calling execv with arg %d: %s", i-2, argv[i]);
         }
 #endif
-        if (! useScreenSaverLaunchAgent) {
-            // For unknown reasons, the graphics application exits with 
-            // "RegisterProcess failed (error = -50)" unless we pass its 
-            // full path twice in the argument list to execv.
-            execv(resolved_path, args+2);
+
+        // For unknown reasons, the graphics application exits with 
+        // "RegisterProcess failed (error = -50)" unless we pass its 
+        // full path twice in the argument list to execv.
+        if (! screensaverLoginUser) {
+            execv(resolved_path, argv+2);
             // If we got here execv failed
             fprintf(stderr, "Process creation (%s) failed: errno=%d\n", resolved_path, errno);
             return errno;
-        } else {   // if useScreenSaverLaunchAgent
+        } else {   // if screensaverLoginUser
+#if VERBOSE           // For debugging only
+            print_to_log_file("gfx_switcher using fork()");;
+#endif
             int pid = fork();
             if (pid == 0) {
                // For unknown reasons, the graphics application exits with 
                 // "RegisterProcess failed (error = -50)" unless we pass its 
                 // full path twice in the argument list to execv.
-                execv(resolved_path, args+2);
+                execv(resolved_path, argv+2);
                 // If we got here execv failed
                 fprintf(stderr, "Process creation (%s) failed: errno=%d\n", resolved_path, errno);
                 return errno;
             } else {
-                if (!boinc_file_exists("/Users/Shared/BOINC")) {
-                    boinc_mkdir("/Users/Shared/BOINC");
-                    chmod("/Users/Shared/BOINC", 0777);
+                char shmem_name[MAXPATHLEN];
+                snprintf(shmem_name, sizeof(shmem_name), "/tmp/boinc_ss_%s", screensaverLoginUser);
+                retval = attach_shmem_mmap(shmem_name, (void**)&pid_for_shmem);
+                if (pid_for_shmem != 0) {
+                    *pid_for_shmem = pid;
                 }
-                safe_strcpy(helper_app_path, BOINCPidFilePath);
-                f = fopen(helper_app_path, "w");
-                if (f) {
-                    fprintf(f, "%d\n", pid);
-                    fclose(f);
-                    f = NULL;
-                    chmod(helper_app_path, 0644);
-                }
-
                 pthread_create(&monitorScreenSaverEngineThread, NULL, MonitorScreenSaverEngine, &pid);
                 waitpid(pid, 0, 0);
-                boinc_delete_file(helper_app_path);
                 pthread_cancel(monitorScreenSaverEngineThread);
+                if (pid_for_shmem != 0) {
+                    *pid_for_shmem = 0;
+                }
                 return 0;
             }
         }
     }
     
-    if (strcmp(args[1], "-launch_gfx") == 0) {
+    if (strcmp(argv[1], "-launch_gfx") == 0) {
         strlcpy(gfx_app_path, BOINCDatSlotsPath, sizeof(gfx_app_path));
-        strlcat(gfx_app_path, args[2], sizeof(gfx_app_path));
+        strlcat(gfx_app_path, argv[2], sizeof(gfx_app_path));
         strlcat(gfx_app_path, "/", sizeof(gfx_app_path));
         strlcat(gfx_app_path, GRAPHICS_APP_FILENAME, sizeof(gfx_app_path));
         retval = boinc_resolve_filename(gfx_app_path, resolved_path, sizeof(resolved_path));
         if (retval) return retval;
         
-        args[2] = resolved_path;
-
-#if VERBOSE_DEBUG   // For debugging only
-            for (int i=2; i<argc; i++) {
-                print_to_log_file("calling execv with arg %d: %s", i-2, args[i]);
-            }
+        argv[2] = resolved_path;
+        
+#if VERBOSE           // For debugging only
+        for (int i=2; i<argc; i++) {
+             print_to_log_file("gfx_switcher calling execv with arg %d: %s", i-2, argv[i]);
+        }
 #endif
-        if (! useScreenSaverLaunchAgent) {
+
+        if (! screensaverLoginUser) {
             // For unknown reasons, the graphics application exits with 
             // "RegisterProcess failed (error = -50)" unless we pass its 
             // full path twice in the argument list to execv.
-            execv(resolved_path, args+2);
+            execv(resolved_path, argv+2);
             // If we got here execv failed
             fprintf(stderr, "Process creation (%s) failed: errno=%d\n", resolved_path, errno);
             return errno;
-        } else {   // if useScreenSaverLaunchAgent            
+         } else {   // if useScreenSaverLaunchAgent            
+#if VERBOSE           // For debugging only
+            print_to_log_file("gfx_switcher using fork()");;
+#endif
             int pid = fork();
             if (pid == 0) {
-                   // For unknown reasons, the graphics application exits with 
-                    // "RegisterProcess failed (error = -50)" unless we pass its 
-                    // full path twice in the argument list to execv.
-                    execv(resolved_path, args+2);
-                    // If we got here execv failed
-                    fprintf(stderr, "Process creation (%s) failed: errno=%d\n", resolved_path, errno);
-                    return errno;
-                } else {
-                    if (!boinc_file_exists("/Users/Shared/BOINC")) {
-                        boinc_mkdir("/Users/Shared/BOINC");
-                        chmod("/Users/Shared/BOINC", 0777);
-                    }
-                    safe_strcpy(helper_app_path, BOINCPidFilePath);
-                    f = fopen(helper_app_path, "w");
-                    if (f) {
-                        fprintf(f, "%d\n", pid);
-                        fclose(f);
-                        f = NULL;
-                        chmod(helper_app_path, 0644);
-                    }
-                
-                    pthread_create(&monitorScreenSaverEngineThread, NULL, MonitorScreenSaverEngine, &pid);
-
-                    waitpid(pid, 0, 0);
-                    boinc_delete_file(helper_app_path);
-                    pthread_cancel(monitorScreenSaverEngineThread);
-                    return 0;
+               // For unknown reasons, the graphics application exits with 
+                // "RegisterProcess failed (error = -50)" unless we pass its 
+                // full path twice in the argument list to execv.
+                execv(resolved_path, argv+2);
+                // If we got here execv failed
+                fprintf(stderr, "Process creation (%s) failed: errno=%d\n", resolved_path, errno);
+                return errno;
+            } else {
+                char shmem_name[MAXPATHLEN];
+                snprintf(shmem_name, sizeof(shmem_name), "/tmp/boinc_ss_%s", screensaverLoginUser);
+                retval = attach_shmem_mmap(shmem_name, (void**)&pid_for_shmem);
+                if (pid_for_shmem != 0) {
+                    *pid_for_shmem = pid;
                 }
+                pthread_create(&monitorScreenSaverEngineThread, NULL, MonitorScreenSaverEngine, &pid);
+                waitpid(pid, 0, 0);
+                pthread_cancel(monitorScreenSaverEngineThread);
+                if (pid_for_shmem != 0) {
+                    *pid_for_shmem = 0;
+                }
+                return 0;
             }
+        }
     }
-    
-    if (strcmp(args[1], "-kill_gfx") == 0) {
-        pid = atoi(args[2]);
+
+    if (strcmp(argv[1], "-kill_gfx") == 0) {
+        pid = atoi(argv[2]);
         if (! pid) return EINVAL;
         if ( kill(pid, SIGKILL)) {
-#if VERBOSE_DEBUG           // For debugging only
+#if VERBOSE           // For debugging only
      print_to_log_file("kill(%d, SIGKILL) returned error %d", pid, errno);
 #endif
             return errno;
@@ -301,7 +282,7 @@ void * MonitorScreenSaverEngine(void* param) {
         ScreenSaverEngine_Pid = getPidIfRunning("com.apple.ScreenSaver.Engine");
         if (ScreenSaverEngine_Pid == 0) {
             kill(graphics_Pid, SIGKILL);
-#if VERBOSE_DEBUG           // For debugging only
+#if VERBOSE           // For debugging only
             print_to_log_file("MonitorScreenSaverEngine calling kill(%d, SIGKILL", graphics_Pid);
 #endif
             return 0;
@@ -310,6 +291,8 @@ void * MonitorScreenSaverEngine(void* param) {
 }
 
 #if CREATE_LOG
+
+#include <sys/stat.h>
 
 static void print_to_log_file(const char *format, ...) {
     FILE *f;

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -23,6 +23,7 @@
 #include <IOKit/IOKitLib.h>
 #include <Carbon/Carbon.h>
 #include <CoreFoundation/CoreFoundation.h>
+#include <SystemConfiguration/SystemConfiguration.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,6 +44,7 @@ extern "C" {
 #include <sys/stat.h>
 #include <sys/param.h>  // for MAXPATHLEN
 #include <pthread.h>
+#include <pwd.h>    // getpwuid
 
 #include "gui_rpc_client.h"
 #include "common_defs.h"
@@ -103,10 +105,10 @@ static int retryCount = 0;
 static pthread_mutexattr_t saver_mutex_attr;
 pthread_mutex_t saver_mutex;
 static char passwd_buf[256];
+char gUserName[64];
 bool gIsHighSierra = false;  // OS 10.13 or later
 bool gIsMojave = false;     // OS 10.14 or later
 bool gIsCatalina = false;   // OS 10.15 or later
-bool gUseLaunchAgent = false;
 
 const char *  CantLaunchCCMsg = "Unable to launch BOINC application.";
 const char *  LaunchingCCMsg = "Launching BOINC application.";
@@ -119,7 +121,7 @@ const char *  CantLaunchDefaultGFXAppMsg = "Can't launch default screensaver mod
 const char *  DefaultGFXAppCantRPCMsg = "Default screensaver module couldn't connect to BOINC application";
 const char *  DefaultGFXAppCrashedMsg = "Default screensaver module had an unrecoverable error";
 const char *  RunningOnBatteryMsg = "Computing and screensaver disabled while running on battery power.";
-const char *  IncompatibleMsg = "Could not connect to screensaver ";
+const char *  IncompatibleMsg = " is not compatible with this version of OS X.";
 const char *  CCNotRunningMsg = "BOINC is not running.";
 
 //const char *  BOINCExitedSaverMode = "BOINC is no longer in screensaver mode.";
@@ -211,7 +213,7 @@ void incompatibleGfxApp(char * appPath, pid_t pid, int slot){
             
             retval = gspScreensaver->rpc->get_state(gspScreensaver->state);
             if (!retval) {
-                strlcpy(buf, IncompatibleMsg, sizeof(buf));
+                strlcpy(buf, "Screensaver ", sizeof(buf));
                 for (int i=0; i<gspScreensaver->state.results.size(); i++) {
                     RESULT* r = gspScreensaver->state.results[i];
                     if (r->slot == slot) {
@@ -233,6 +235,7 @@ void incompatibleGfxApp(char * appPath, pid_t pid, int slot){
                 strlcat(buf, p+1, sizeof(buf));
                 strlcat(buf, "\"", sizeof(buf));
             }
+            strlcat(buf, IncompatibleMsg, sizeof(buf));
             gspScreensaver->setSSMessageText(buf);
             gspScreensaver->SetError(0, SCRAPPERR_GFXAPPINCOMPATIBLE);
         }   // End if (msgstartTime == 0.0)
@@ -328,11 +331,14 @@ CScreensaver::CScreensaver() {
     m_gfx_Cleanup_IPC = NULL;
     safe_strcpy(passwd_buf, "");
    
-    if (gUseLaunchAgent) {
+    if (gIsCatalina) {
         getcwd(saved_dir, sizeof(saved_dir));
         chdir("/Library/Application Support/BOINC Data");
         read_gui_rpc_password(passwd_buf);
         chdir(saved_dir);
+        
+        CFStringRef cf_gUserName = SCDynamicStoreCopyConsoleUser(NULL, NULL, NULL);
+        CFStringGetCString(cf_gUserName, gUserName, sizeof(gUserName), kCFStringEncodingUTF8);
     }
     
     // Get project-defined default values for GFXDefaultPeriod, GFXSciencePeriod, GFXChangePeriod
@@ -400,7 +406,7 @@ int CScreensaver::Create() {
         strlcat(m_gfx_Switcher_Path, "/gfx_switcher", sizeof(m_gfx_Switcher_Path));
         strlcat(m_gfx_Cleanup_Path, "/gfx_cleanup\"", sizeof(m_gfx_Switcher_Path));
 
-        if (gUseLaunchAgent) {
+        if (gIsCatalina) {
             // Launch helper app to work around a bug in OS 10.15 Catalina to
             // kill current graphics app if ScreensaverEngine exits without 
             // first calling [ScreenSaverView stopAnimation]
@@ -538,7 +544,6 @@ int CScreensaver::getSSMessage(char **theMessage, int* coveredFreq) {
         myPid = getClientPID();
         if (myPid) {
             saverState = SaverState_CoreClientRunning;
-
             if (!rpc->init(NULL)) {     // Initialize communications with Core Client
                 m_bConnected = true;
                 
@@ -954,7 +959,7 @@ int CScreensaver::GetBrandID()
 
 pid_t CScreensaver::getClientPID() {
     int fd;
-    fd = open("/Library/Application Support/BOINC Data/lockfile", O_RDONLY);
+    fd = open("//Library/Application Support/BOINC Data/lockfile", O_RDONLY);
     if (fd<0) {
         return 0;   // lockfile doesn't exist (probably)
     }
@@ -1106,7 +1111,7 @@ void print_to_log_file(const char *format, ...) {
     time_t t;
 #if USE_SPECIAL_LOG_FILE
     safe_strcpy(buf, "/Users/");
-    safe_strcat(buf, getenv("USER"));
+    safe_strcat(buf, getlogin());
     safe_strcat(buf, "/Documents/test_log.txt");
     FILE *f;
     f = fopen(buf, "a");

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -31,6 +31,7 @@
 #include <app_ipc.h>
 #include <malloc/malloc.h>
 #include <pthread.h>
+#include <sys/stat.h>
 
 extern pthread_mutex_t saver_mutex;
 #endif
@@ -56,13 +57,9 @@ typedef HANDLE GFXAPP_ID;
 #define DataMgmtProcType DWORD WINAPI
 #elif defined(__APPLE__)
 #include "Mac_Saver_Module.h"
+#include "shmem.h"
 typedef int GFXAPP_ID;
 #define DataMgmtProcType void*
-
-char *helper_app_base_path;
-char helper_app_dir[MAXPATHLEN];
-char helper_app_path[MAXPATHLEN];
-char *BOINCPidFilePath = "/Users/Shared/BOINC/BOINCGfxPid.txt";
 #endif
 
 
@@ -85,8 +82,10 @@ char *BOINCPidFilePath = "/Users/Shared/BOINC/BOINCGfxPid.txt";
 #define SIMULATE_NO_GRAPHICS 0
 
 RESULT* graphics_app_result_ptr = NULL;
-char* default_ss_dir_path = NULL;
 
+#ifdef __APPLE__
+pid_t* pid_from_shmem = NULL;
+#endif
 
 bool CScreensaver::is_same_task(RESULT* taska, RESULT* taskb) {
     if ((taska == NULL) || (taskb == NULL)) return false;
@@ -222,51 +221,25 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
     if (strlen(rp->graphics_exec_path)) {
         // V6 Graphics
 #ifdef __APPLE__
-        if (gUseLaunchAgent) {
+        if (gIsCatalina) {
             // As of OS 10.15 (Catalina) screensavers can no longer:
             //  - launch apps that run setuid or setgid
             //  - launch apps downloaded from the Internet which have not been 
-            //    specifically approved by the user via Gatekeeper.
-            // So instead of launching graphics apps via gfx_switcher, we write 
-            // a file containing the information. The file is detected by 
-            // a LaunchAgent which then launches gfx_switcher for us. Though we
-            // confirmed it works on OS 10.13 High Sierra, we don't use it there.
-            //TODO: Can we use the LaunchAgent method on all our supported
-            //TODO: versions of OS X (OS < 10.13) to simplify this code?
+            //    specifically approved by the  user via Gatekeeper.
+            // So instead of launching graphics apps via gfx_switcher, we send an 
+            // RPC to the client asking the client to launch them via gfx_switcher.
+            // See comments in gfx_switcher.cpp for a more detailed explanation.
+            // We have tested this on OS 10.13 High Sierra and it works there, too
             //
-            int thePID = -5;
-
-            FILE *f;
-            char *p;
-           
-            safe_strcpy(helper_app_path, helper_app_dir);
-            safe_strcat(helper_app_path, "BOINCSSHelper.txt");
-            f = fopen(helper_app_path, "w");
-            if (!f) return -1;
-            fputs(rp->slot_path, f);
-            fputs("\n-launch_gfx\n", f);
-            p = strrchr(rp->slot_path, '/');
-            if (*p) p++;    // Point to the slot number in ascii
-            fprintf(f, "%s\n", p);
-            fputs("--fullscreen\n", f);
-            fclose(f);
-
-           for (int i=0; i<200; i++) {
-                boinc_sleep(0.1);
-                f = fopen(BOINCPidFilePath, "r");
-                if (f) {
-                    fscanf(f, "%d", &thePID);
-                    if (thePID > 0) {
-                        break;
-                    }
+            retval = rpc->run_graphics_app("runfullscreen", rp->slot, gUserName);
+            for (int i=0; i<800; i++) {
+                boinc_sleep(0.01);      // Wait 8 seconds max
+                if (*pid_from_shmem != 0) {
+                    graphics_application = *pid_from_shmem;
+                    break;
                 }
             }
-            if (f) {
-                fclose(f);
-            }
-            
-            if (thePID < 1) retval = -1;
-            graphics_application = thePID;
+            // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
             // Inform our helper app what we launched 
             fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
             fflush(m_gfx_Cleanup_IPC);
@@ -326,50 +299,43 @@ int CScreensaver::terminate_v6_screensaver(GFXAPP_ID& graphics_application, RESU
 
 #ifdef __APPLE__
     pid_t thePID;
-
-    if (gUseLaunchAgent) {
+    
+    if (gIsCatalina) {
         // As of OS 10.15 (Catalina) screensavers can no longer launch apps
         // that run setuid or setgid. So instead of killing graphics apps 
         // via gfx_switcher, we send an RPC to the client asking the client 
-        // to kill them via switcher. Though we have confirmed it works on 
-        // OS 10.13 High Sierra, we don't use it there.
-        //TODO: Can we use run_graphics_app() RPC on all our supported versions
-        //TODO: of OS X (OS < 10.13) to simplify this code?
+        // to kill them via switcher.
+        // We have tested this on OS 10.13 High Sierra and it works there, too
         //
+        int ignore;
+
         if (graphics_application == 0) return 0;
 
         // MUTEX may help prevent crashes when terminating an older gfx app which
-        // we were displaying using CGWindowListCreateImage under OS X >= 10.13. 
-        // Note however that under OS 10.15 Catalina, CGWindowListCreateImage 
-        // can't copy windows between user boinc_project and the user running 
-        // the screensaver does not work for us.
+        // we were displaying using CGWindowListCreateImage under OS X >= 10.13
         // Also prevents reentry when called from our other thread
         pthread_mutex_lock(&saver_mutex);
 
         thePID = graphics_application;
-        retval = rpc->run_graphics_app(0, thePID, "stop");
-// Inform our helper app that we have stopped current graphics app 
+        // fprintf(stderr, "stopping pid %d\n", thePID);
+        retval = rpc->run_graphics_app("stop", thePID, gUserName);
+        //kill_program(graphics_application);
 
-          for (i=0; i<200; i++) {
-            boinc_sleep(0.01);      // Wait 2 seconds max
-            if (!boinc_file_exists(BOINCPidFilePath)) {
-               break;
-            }
-        }   
-
-        pthread_mutex_unlock(&saver_mutex);
-
+        // Inform our helper app that we have stopped current graphics app 
         fprintf(m_gfx_Cleanup_IPC, "0\n");
         fflush(m_gfx_Cleanup_IPC);
-     
+
         launchedGfxApp("", 0, -1);
 
-        // Just for safety ...
-        if (boinc_file_exists(BOINCPidFilePath)) {
-            boinc_delete_file(BOINCPidFilePath);
+        for (i=0; i<200; i++) {
+            boinc_sleep(0.01);      // Wait 2 seconds max
+            if (HasProcessExited(graphics_application, ignore)) {
+                break;
+            }
         }
-    } else {    // if (! gUseLaunchAgent)
+        pthread_mutex_unlock(&saver_mutex);
     
+    } else {
         // Under sandbox security, use gfx_switcher to kill default gfx app 
         // as user boinc_master and group boinc_master (for default gfx app)
         // or user boinc_project and group boinc_project (for project gfx 
@@ -461,47 +427,26 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
     int num_args;
     
 #ifdef __APPLE__
-    if (gUseLaunchAgent) {
+    if (gIsCatalina) {
         // As of OS 10.15 (Catalina) screensavers can no longer:
         //  - launch apps that run setuid or setgid
         //  - launch apps downloaded from the Internet which have not been 
-        //    specifically approved by the user via Gatekeeper.
-        // So instead of launching graphics apps via gfx_switcher, we write 
-        // a file containing the information. The file is detected by 
-        // a LaunchAgent which then launches gfx_switcher for us. Though we
-        // confirmed it works on OS 10.13 High Sierra, we don't use it there.
-        //TODO: Can we use the LaunchAgent method on all our supported
-        //TODO: versions of OS X (OS < 10.13) to simplify this code?
+        //    specifically approved by the  user via Gatekeeper.
+        // So instead of launching graphics apps via gfx_switcher, we send an 
+        // RPC to the client asking the client to launch them via gfx_switcher.
+        // See comments in gfx_switcher.cpp for a more detailed explanation.
+        // We have tested this on OS 10.13 High Sierra and it works there, too
         //
-        int thePID = -5;
-        FILE *f;
-       
-        safe_strcpy(helper_app_path, helper_app_dir);
-        safe_strcat(helper_app_path, "BOINCSSHelper.txt");
-        f = fopen(helper_app_path, "w");
-        if (!f) return -1;
-        fputs(dir_path, f);
-        fputs("\n-default_gfx\n", f);
-        fputs(THE_DEFAULT_SS_EXECUTABLE, f);
-        fputs("\n--fullscreen\n", f);
-        fclose(f);
-        
-        for (int i=0; i<200; i++) {
-            boinc_sleep(0.1);
-            f = fopen(BOINCPidFilePath, "r");
-            if (f) {
-                fscanf(f, "%d", &thePID);
-                if (thePID > 0) {
-                    break;
-                }
+        int thePID = -1;
+        retval = rpc->run_graphics_app("runfullscreen", thePID, gUserName);
+        for (int i=0; i<800; i++) {
+            boinc_sleep(0.01);      // Wait 8 seconds max
+            if (*pid_from_shmem != 0) {
+                graphics_application = *pid_from_shmem;
+                break;
             }
         }
-        if (f) {
-            fclose(f);
-        }
-
-        if (thePID < 1) retval = -1;
-        graphics_application = thePID;
+        // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
         // Inform our helper app what we launched 
         fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
         fflush(m_gfx_Cleanup_IPC);
@@ -537,6 +482,9 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
     if (graphics_application) {
         launchedGfxApp("boincscr", graphics_application, -1);
     }
+
+    BOINCTRACE(_T("launch_default_screensaver returned %d\n"), retval);
+    
 #else
     char* argv[4];
     char full_path[1024];
@@ -616,6 +564,7 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
     bool            killing_default_gfx         = false;
     int             exit_status                 = 0;
     
+    char*           default_ss_dir_path         = NULL;
     char            full_path[1024];
 
     BOINCTRACE(_T("CScreensaver::DataManagementProc - Display screen saver loading message\n"));
@@ -638,20 +587,17 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
     m_vIncompatibleGfxApps.clear();
     default_ss_dir_path = "/Library/Application Support/BOINC Data";
     if (gIsCatalina) {
-        helper_app_base_path = "Containers/com.apple.ScreenSaver.Engine.legacyScreenSaver/Data/Library/";
-    } else {
-        helper_app_base_path = "";
-    }
-    if (gUseLaunchAgent) {
-         if (boinc_file_exists(BOINCPidFilePath)) {
-            boinc_delete_file(BOINCPidFilePath);
+        char shmem_name[MAXPATHLEN];
+        snprintf(shmem_name, sizeof(shmem_name), "/tmp/boinc_ss_%s", gUserName);
+        retval = create_shmem_mmap(shmem_name, sizeof(int), (void**)&pid_from_shmem);
+        // make sure user/group RW permissions are set, but not other.
+        //
+        if (retval == 0) {
+            chmod(shmem_name, 0666);
+            retval = attach_shmem_mmap(shmem_name, (void**)&pid_from_shmem);
         }
-
-        snprintf(helper_app_dir, sizeof(helper_app_dir), "/Users/%s/Library/%sApplication Support/BOINC/", getenv("USER"), helper_app_base_path);
-        safe_strcpy(helper_app_path, helper_app_dir);
-        safe_strcat(helper_app_path, "BOINCSSHelper.txt");
-        if (boinc_file_exists(helper_app_path)) {
-            boinc_delete_file(helper_app_path);
+        if (retval == 0) {
+            *pid_from_shmem = 0;
         }
     }
 #else
@@ -1044,31 +990,22 @@ BOOL CScreensaver::HasProcessExited(HANDLE pid_handle, int &exitCode) {
 }
 #else
 bool CScreensaver::HasProcessExited(pid_t pid, int &exitCode) {
+    int status;
     pid_t p;
     
-    if (gUseLaunchAgent) {
-            if (boinc_file_exists(BOINCPidFilePath)) return false;
-            m_hGraphicsApplication = 0;
-            graphics_app_result_ptr = NULL;
-            m_bDefault_gfx_running = false;
-            m_bScience_gfx_running = false;
-        return true;
-
-
-    int retval;
+    if (gIsCatalina) {
         // Only the process which launched an app can use waitpid() to test 
         // whether that app is still running. If we sent an RPC to the client 
         // asking the client to launch a graphics app via switcher, we must 
         // send another RPC to the client to call waitpid() for that app.
         //
-        p = pid;
-        retval = rpc->run_graphics_app(0, p, "test");
-        exitCode = 0;
-        if (retval || (p==0)) return true;
-        return false;
+        if (pid_from_shmem) {
+            //fprintf(stderr, "screensaver HasProcessExited got pid_from_shmem = %d\n", *pid_from_shmem);
+            if (*pid_from_shmem != 0) return false;
+        }
+        return true;
     }
     
-    int status;
     p = waitpid(pid, &status, WNOHANG);
     exitCode = WEXITSTATUS(status);
     if (p == pid) return true;     // process has exited

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -222,7 +222,6 @@ struct APP_VERSION {
     PROJECT* project;
 
     APP_VERSION();
-    APP_VERSION(int) {}
 
     int parse(XML_PARSER&);
     int parse_coproc(XML_PARSER&);
@@ -661,7 +660,6 @@ struct OLD_RESULT {
     double completed_time;
     double create_time;
 
-    OLD_RESULT(){}
     int parse(XML_PARSER&);
     void print();
 };
@@ -713,7 +711,7 @@ struct RPC_CLIENT {
     int set_network_mode(int mode, double duration);
     int get_screensaver_tasks(int& suspend_reason, RESULTS&);
     int run_benchmarks();
-    int run_graphics_app(int slot, int& id, const char *operation);
+    int run_graphics_app(const char *operation, int& operand, const char *screensaverLoginUser);
     int set_proxy_settings(GR_PROXY_INFO&);
     int get_proxy_settings(GR_PROXY_INFO&);
     int get_messages(int seqno, MESSAGES&, bool translatable=false);

--- a/lib/mac/mac_util.h
+++ b/lib/mac/mac_util.h
@@ -37,8 +37,6 @@ extern "C" {
 
     int         compareOSVersionTo(int toMajor, int toMinor);
 
-#define MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT 15
-
 #ifdef __cplusplus
 }	// extern "C"
 #endif

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -75,8 +75,6 @@
 		DD262C811366D35A00C9A187 /* cc_config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4AE04B13652BD700285859 /* cc_config.cpp */; };
 		DD262C821366D35D00C9A187 /* cc_config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4AE04B13652BD700285859 /* cc_config.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DD262C871366D4D200C9A187 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DD26B52B237443BF00206557 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
-		DD26B52C237445DD00206557 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DD2B6C8013149177005D6F3E /* procinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2B6C7E13149177005D6F3E /* procinfo.cpp */; };
 		DD2B6C8113149177005D6F3E /* procinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2B6C7E13149177005D6F3E /* procinfo.cpp */; };
 		DD2B6C8D131491B7005D6F3E /* procinfo_mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDB6934F0ABFE9C600689FD8 /* procinfo_mac.cpp */; };
@@ -92,6 +90,10 @@
 		DD35353607E1E13F00C4718D /* boinc_api.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5755AD302FE063A012012A7 /* boinc_api.cpp */; };
 		DD3741D610FC948C001257EB /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
 		DD3741D910FC94BA001257EB /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
+		DD39C56C244C681A00FBE22E /* boinc_ss_helper.sh in Resources */ = {isa = PBXBuildFile; fileRef = DD39C56B244C643F00FBE22E /* boinc_ss_helper.sh */; };
+		DD3A54E424519F96006A7249 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD22BD1C23A9029500829495 /* SystemConfiguration.framework */; };
+		DD3A54E524519FC9006A7249 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD22BD1C23A9029500829495 /* SystemConfiguration.framework */; };
+		DD3A54E62451A1A1006A7249 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD22BD1C23A9029500829495 /* SystemConfiguration.framework */; };
 		DD3E14DB0A774397007E0084 /* boinc in Resources */ = {isa = PBXBuildFile; fileRef = DDD74D8707CF482E0065AC9D /* boinc */; };
 		DD3E14DC0A774397007E0084 /* BOINCMgr.icns in Resources */ = {isa = PBXBuildFile; fileRef = DDF3028907CCCE2C00701169 /* BOINCMgr.icns */; };
 		DD3E14DF0A774397007E0084 /* AccountInfoPage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD58C41808F3343F00C1DF66 /* AccountInfoPage.cpp */; };
@@ -218,7 +220,6 @@
 		DD67F8140ADB9DD000B0015E /* wxPieCtrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD40E75D0ADB87BC00214518 /* wxPieCtrl.cpp */; };
 		DD6802310E701ACD0067D009 /* cert_sig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD68022E0E701ACD0067D009 /* cert_sig.cpp */; };
 		DD6803440E70A61D0067D009 /* diagnostics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BA207C5AE5A0043025C /* diagnostics.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DD69D09C23ACBD9E00304FD0 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD69FEF508416C6B00C01361 /* gui_rpc_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C5CC07C5D7D90098A04D /* gui_rpc_client.cpp */; };
 		DD69FEF708416C9A00C01361 /* boinc_cmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD69FEF608416C9A00C01361 /* boinc_cmd.cpp */; };
 		DD69FF0C084171CF00C01361 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6D0A8507E9A61B007F882B /* network.cpp */; };
@@ -352,6 +353,9 @@
 		DD8917E90F3B216000DE5B1C /* gutil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD40825507D3076400163EF5 /* gutil.cpp */; };
 		DD8917EE0F3B21CE00DE5B1C /* macglutfix.m in Sources */ = {isa = PBXBuildFile; fileRef = DD6D82DA08131AB1008F7200 /* macglutfix.m */; };
 		DD8917F00F3B21DA00DE5B1C /* mac_icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6381450870DB78007A2F8E /* mac_icon.cpp */; };
+		DD8A88F6244EF22700D9D64A /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD8A88F5244EF22600D9D64A /* AppKit.framework */; };
+		DD8A88F7244F0D7700D9D64A /* shmem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAA31C97042157A800A80164 /* shmem.cpp */; };
+		DD8A88F8244F0D9F00D9D64A /* shmem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAA31C97042157A800A80164 /* shmem.cpp */; };
 		DD93854520F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
 		DD93854620F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
 		DD93854720F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
@@ -365,6 +369,7 @@
 		DD957E5B181B908800ECA34E /* thumbnail.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E59181B908800ECA34E /* thumbnail.png */; };
 		DD957E5C181B908800ECA34E /* thumbnail@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E5A181B908800ECA34E /* thumbnail@2x.png */; };
 		DD9917251E69A4F100555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
+		DD9917261E69A8B300555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917271E69A8D100555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917281E69A90500555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917291E69A90800555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
@@ -445,9 +450,9 @@
 		DDC82FA31A35BB68005FA808 /* DlgHiddenColumns.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC82FA11A35BB68005FA808 /* DlgHiddenColumns.cpp */; };
 		DDC836E60EDEA5DB001C2EF9 /* TermsOfUsePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC836E50EDEA5DB001C2EF9 /* TermsOfUsePage.cpp */; };
 		DDC8FB2A1F6D393C00BE55B8 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
-		DDC918FB236C2ABB009641C8 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
-		DDC918FC236C2AE8009641C8 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
 		DDC988FE0F3BD44100EE8D0E /* gui_rpc_client_ops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD73E34E08A0694000656EB1 /* gui_rpc_client_ops.cpp */; };
+		DDC99C82244EEF6100D617D8 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
+		DDC99C83244EF03700D617D8 /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
 		DDCF84080E1B7C0A005EDC45 /* DlgItemProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDCF84060E1B7C0A005EDC45 /* DlgItemProperties.cpp */; };
 		DDD0697312D70C9400120920 /* sg_TaskPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD0697112D70C9400120920 /* sg_TaskPanel.cpp */; };
 		DDD095490A3EDF2D00C95BA4 /* switcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD095480A3EDF2D00C95BA4 /* switcher.cpp */; };
@@ -508,6 +513,7 @@
 		DDD8846418E17D7A00BE1E34 /* DlgDiagnosticLogFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD8846218E17D7A00BE1E34 /* DlgDiagnosticLogFlags.cpp */; };
 		DDD93E7313E017B600B92D0F /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2552B07C62F3E008E7D6E /* IOKit.framework */; };
 		DDD9C5A510CCF61F00A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
+		DDD9C5AA10CCF6A000A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
 		DDD9C5AB10CCF6A300A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
 		DDD9C5AC10CCF6AB00A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDDC2055183B560B00CB5845 /* mac_address.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDDC2053183B560B00CB5845 /* mac_address.cpp */; };
@@ -544,13 +550,6 @@
 		DDEEAA991F73D3D70051E8C5 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
 		DDEEAA9A1F73E8630051E8C5 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
 		DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
-		DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
-		DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
-		DDF0776B236C4DD60046EE44 /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
-		DDF0776C236C4E1A0046EE44 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
-		DDF0776D236C4E420046EE44 /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
-		DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
-		DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
 		DDF5E23318B8673E005DEA6E /* uninstall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4688590C1661970089F500 /* uninstall.cpp */; };
 		DDF5E23418B86803005DEA6E /* AddRemoveUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD33709106224E800867C7D /* AddRemoveUser.cpp */; };
 		DDF5F85A10DD05DB006A50CD /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
@@ -560,10 +559,18 @@
 		DDF9EC0B144EB2BB005D6144 /* boinc_opencl.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF9EC09144EB2BB005D6144 /* boinc_opencl.h */; };
 		DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */ = {isa = PBXBuildFile; fileRef = DDFA60D40CB337D40037B88C /* gfx_switcher */; };
 		DDFA60E40CB3396C0037B88C /* gfx_switcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */; };
+		DDFA61520CB347500037B88C /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
+		DDFA61570CB347730037B88C /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
 		DDFA61780CB348660037B88C /* mfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD207C5B1150043025C /* mfile.cpp */; };
 		DDFA617A0CB3486D0037B88C /* miofile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD507C5B1150043025C /* miofile.cpp */; };
 		DDFA617E0CB3487F0037B88C /* parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B901602AC0A2201FB7237 /* parse.cpp */; };
 		DDFA61860CB3489E0037B88C /* str_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7BF7D70B8E7A9800A009F7 /* str_util.cpp */; };
+		DDFA61890CB348A90037B88C /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
+		DDFA618C0CB348C50037B88C /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
+		DDFA618F0CB348E80037B88C /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159562029EB02001F5651B /* md5.cpp */; };
+		DDFA61900CB348E90037B88C /* md5_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159564029EB02001F5651B /* md5_file.cpp */; };
+		DDFA61920CB349020037B88C /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
+		DDFA61940CB349160037B88C /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
 		DDFD5F0F0818F2EE002B23D4 /* gui_rpc_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C5CC07C5D7D90098A04D /* gui_rpc_client.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F270818F329002B23D4 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F280818F33C002B23D4 /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159562029EB02001F5651B /* md5.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -573,6 +580,7 @@
 		DDFD5F2C0818F368002B23D4 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6D0A8507E9A61B007F882B /* network.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F2D0818F372002B23D4 /* parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B901602AC0A2201FB7237 /* parse.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F2E0818F3A1002B23D4 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DDFE4E3D10AB778100919319 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
 		DDFE4E9110AB7C3A00919319 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
 		DDFE84E50B60CD66009B43D9 /* DlgAdvPreferences.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFE84E10B60CD66009B43D9 /* DlgAdvPreferences.cpp */; };
 		DDFE84E70B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFE84E30B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp */; };
@@ -893,6 +901,7 @@
 		DD1E4B7A14DCA83F0093C711 /* async_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_file.h; sourceTree = "<group>"; };
 		DD1F0ACD0822069E00AFC5FA /* MacGUI.pch */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = MacGUI.pch; path = ../clientgui/mac/MacGUI.pch; sourceTree = SOURCE_ROOT; };
 		DD2049DC0D862516009EEE7A /* coproc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = coproc.h; path = ../lib/coproc.h; sourceTree = SOURCE_ROOT; };
+		DD22BD1C23A9029500829495 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = ../../../../../System/Library/Frameworks/SystemConfiguration.framework; sourceTree = "<group>"; };
 		DD22DF5C1A235F58007FB597 /* DlgExclusiveApps.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DlgExclusiveApps.cpp; sourceTree = "<group>"; };
 		DD22DF5D1A235F58007FB597 /* DlgExclusiveApps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DlgExclusiveApps.h; sourceTree = "<group>"; };
 		DD247AF70AEA308A0034104A /* SkinManager.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = SkinManager.cpp; path = ../clientgui/SkinManager.cpp; sourceTree = SOURCE_ROOT; };
@@ -955,6 +964,7 @@
 		DD344BEE07C5B1770043025C /* proxy_info.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = proxy_info.h; path = ../lib/proxy_info.h; sourceTree = SOURCE_ROOT; };
 		DD344BEF07C5B1770043025C /* proxy_info.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_info.cpp; sourceTree = "<group>"; };
 		DD35353107E1E05C00C4718D /* libboinc_api.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboinc_api.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD39C56B244C643F00FBE22E /* boinc_ss_helper.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = boinc_ss_helper.sh; path = ../clientscr/boinc_ss_helper.sh; sourceTree = "<group>"; };
 		DD3E15420A774397007E0084 /* BOINCManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BOINCManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3EAAA6216A25AD00BC673C /* boinc_finish_install */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = boinc_finish_install; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3EAAAE216A268500BC673C /* finish_install.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = finish_install.cpp; path = ../mac_installer/finish_install.cpp; sourceTree = "<group>"; };
@@ -1172,6 +1182,7 @@
 		DD89163C0F3B182700DE5B1C /* ss_app.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ss_app.cpp; path = ../clientscr/ss_app.cpp; sourceTree = SOURCE_ROOT; };
 		DD89165D0F3B1BC200DE5B1C /* GLUT.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLUT.framework; path = /System/Library/Frameworks/GLUT.framework; sourceTree = "<absolute>"; };
 		DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
+		DD8A88F5244EF22600D9D64A /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		DD8DD4A509D9432F0043019E /* BOINCDialupManager.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = BOINCDialupManager.cpp; path = ../clientgui/BOINCDialupManager.cpp; sourceTree = SOURCE_ROOT; };
 		DD8DD4A609D9432F0043019E /* BOINCDialupManager.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = BOINCDialupManager.h; path = ../clientgui/BOINCDialupManager.h; sourceTree = SOURCE_ROOT; };
 		DD93854320F609C7008EDE5A /* mac_branding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mac_branding.cpp; path = ../lib/mac/mac_branding.cpp; sourceTree = "<group>"; };
@@ -1429,6 +1440,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDA70B4223632223007097BD /* AppKit.framework in Frameworks */,
+				DD3A54E524519FC9006A7249 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1476,6 +1488,7 @@
 				DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */,
 				DDB74A6C0D74259E00E97A40 /* AppKit.framework in Frameworks */,
 				DDD93E7313E017B600B92D0F /* IOKit.framework in Frameworks */,
+				DD3A54E424519F96006A7249 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1531,7 +1544,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD26B52C237445DD00206557 /* AppKit.framework in Frameworks */,
+				DD8A88F6244EF22700D9D64A /* AppKit.framework in Frameworks */,
+				DD3A54E62451A1A1006A7249 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1593,6 +1607,7 @@
 				DD1AFE8F0A512D2600EE5B82 /* Installer-Info.plist */,
 				DD4688430C165F3C0089F500 /* Uninstaller-Info.plist */,
 				DDB219A610B3BB6200417AEF /* WaitPermissions-Info.plist */,
+				DD8A88F4244EF22600D9D64A /* Frameworks */,
 			);
 			name = "¬´PROJECTNAME¬ª";
 			sourceTree = "<group>";
@@ -1629,6 +1644,7 @@
 				DD89165D0F3B1BC200DE5B1C /* GLUT.framework */,
 				DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */,
 				DD0BB7A11F62B105000151B2 /* IOSurface.framework */,
+				DD22BD1C23A9029500829495 /* SystemConfiguration.framework */,
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = SOURCE_ROOT;
@@ -1875,6 +1891,14 @@
 			path = ../api;
 			sourceTree = "<group>";
 		};
+		DD8A88F4244EF22600D9D64A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DD8A88F5244EF22600D9D64A /* AppKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		DDA6BCED0BD4546D008F7921 /* mac */ = {
 			isa = PBXGroup;
 			children = (
@@ -1919,6 +1943,7 @@
 				DDE7A3B015C6739E002B3B96 /* ttfont.h */,
 				DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */,
 				DD5F654A23605C87009ED2A2 /* gfx_cleanup.mm */,
+				DD39C56B244C643F00FBE22E /* boinc_ss_helper.sh */,
 			);
 			name = clientscr;
 			sourceTree = SOURCE_ROOT;
@@ -2411,6 +2436,7 @@
 				DD96AFF60811075000A06F22 /* Sources */,
 				DD96AFF70811075000A06F22 /* Frameworks */,
 				DD5FD5990A0233D60093C19F /* ShellScript */,
+				DD39C56D244C6AF300FBE22E /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -2662,6 +2688,7 @@
 			files = (
 				DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */,
 				DD5F656623607472009ED2A2 /* gfx_cleanup in Resources */,
+				DD39C56C244C681A00FBE22E /* boinc_ss_helper.sh in Resources */,
 				DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */,
 				DD48091F081A66F100A174AA /* BOINCSaver.nib in Resources */,
 				DDBC6CA50D5D458700564C49 /* boinc_ss_logo.png in Resources */,
@@ -2725,6 +2752,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/Uninstall BOINC.app/Contents/Resources/English.lproj/\"\ncp -fpRv \"${SRCROOT}/English.lproj/Uninstaller-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/Uninstall BOINC.app/Contents/Resources/English.lproj/InfoPlist.strings\"";
+		};
+		DD39C56D244C6AF300FBE22E /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/boinc_sshelper.sh",
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "chmod u+x,g+x,o+x \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/boinc_ss_helper.sh\"\n";
 		};
 		DD3B67F6140CFFA20088683F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2822,7 +2867,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n  ## echo \"Starting script 1\"\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Deployment_Dir\"\nelse\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Development_Dir\"\nfi\n\n";
+			shellScript = "if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n  ## echo \"Starting script 1\"\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Deployment_Dir\"\n  mkdir -p \"${BUILT_PRODUCTS_DIR}/SymbolTables\"\n  if [ \"${BUILT_PRODUCTS_DIR}/BOINCManager.app/Contents/MacOS/BOINCManager\" -nt \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager.dSYM\" ]; then\n    ## echo \"${BUILT_PRODUCTS_DIR}/BOINCManager.app/Contents/MacOS/BOINCManager is newer than ${TARGET_BUILD_DIR}/SymbolTables/BOINCManager.dSYM\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager_i386\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager_x86_64\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager_ppc\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager.dSYM\"\n    cp -fp \"${BUILT_PRODUCTS_DIR}/BOINCManager.app.dSYM\" \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager.app.dSYM\"\n    touch \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager.app.dSYM\"\n    strip \"${BUILT_PRODUCTS_DIR}/BOINCManager.app/Contents/MacOS/BOINCManager\"\n  fi\nelse\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Development_Dir\"\nfi\n\n";
 		};
 		DD7355180D9110AE0006A9D1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2837,7 +2882,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n  ## echo \"Starting script 1\"\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Deployment_Dir\"\nelse\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Development_Dir\"\n\nfi\n\n";
+			shellScript = "if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n  ## echo \"Starting script 1\"\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Deployment_Dir\"\n  mkdir -p \"${BUILT_PRODUCTS_DIR}/SymbolTables\"\n  if [ \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" -nt \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}.dSYM\" ]; then\n    ## echo \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME} is newer than ${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}.dSYM\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}_i386\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}_ppc\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}_x86_64\"\n    rm -f \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}.dSYM\"\n    cp -fp \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}.dSYM\"\n    touch \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}.dSYM\"\n##    strip \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\"\n  fi\nelse\n  echo ${BUILT_PRODUCTS_DIR}  > \"${PROJECT_DIR}/Build_Development_Dir\"\n\nfi\n\n";
 		};
 		DD73551E0D9111150006A9D1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3378,6 +3423,7 @@
 				DD262C871366D4D200C9A187 /* proxy_info.cpp in Sources */,
 				DDA165E513B49B0D00CB4DD5 /* url.cpp in Sources */,
 				DD76BF9A17CB46830075936D /* opencl_boinc.cpp in Sources */,
+				DD8A88F8244F0D9F00D9D64A /* shmem.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3552,22 +3598,25 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD9917261E69A8B300555337 /* mac_spawn.cpp in Sources */,
 				DDFA60E40CB3396C0037B88C /* gfx_switcher.cpp in Sources */,
-				DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */,
-				DDF0776D236C4E420046EE44 /* coproc.cpp in Sources */,
-				DDC918FB236C2ABB009641C8 /* filesys.cpp in Sources */,
-				DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */,
-				DD69D09C23ACBD9E00304FD0 /* mac_spawn.cpp in Sources */,
-				DD26B52B237443BF00206557 /* mac_util.mm in Sources */,
+				DDFA61520CB347500037B88C /* app_ipc.cpp in Sources */,
+				DDFA61570CB347730037B88C /* filesys.cpp in Sources */,
 				DDFA61780CB348660037B88C /* mfile.cpp in Sources */,
 				DDFA617A0CB3486D0037B88C /* miofile.cpp in Sources */,
-				DDF0776B236C4DD60046EE44 /* opencl_boinc.cpp in Sources */,
 				DDFA617E0CB3487F0037B88C /* parse.cpp in Sources */,
-				DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */,
-				DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */,
 				DDFA61860CB3489E0037B88C /* str_util.cpp in Sources */,
-				DDF0776C236C4E1A0046EE44 /* url.cpp in Sources */,
-				DDC918FC236C2AE8009641C8 /* util.cpp in Sources */,
+				DDFA61890CB348A90037B88C /* util.cpp in Sources */,
+				DDFA618C0CB348C50037B88C /* hostinfo.cpp in Sources */,
+				DDFA618F0CB348E80037B88C /* md5.cpp in Sources */,
+				DDFA61900CB348E90037B88C /* md5_file.cpp in Sources */,
+				DDFA61920CB349020037B88C /* proxy_info.cpp in Sources */,
+				DDFA61940CB349160037B88C /* prefs.cpp in Sources */,
+				DDFE4E3D10AB778100919319 /* url.cpp in Sources */,
+				DDD9C5AA10CCF6A000A1E4CD /* coproc.cpp in Sources */,
+				DDC99C83244EF03700D617D8 /* opencl_boinc.cpp in Sources */,
+				DDC99C82244EEF6100D617D8 /* mac_util.mm in Sources */,
+				DD8A88F7244F0D7700D9D64A /* shmem.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3799,6 +3848,9 @@
 		DD3E153E0A774397007E0084 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = NO;
+				DEPLOYMENT_POSTPROCESSING = YES;
 				GCC_INCREASE_PRECOMPILED_HEADER_SHARING = YES;
 				GCC_PFE_FILE_C_DIALECTS = "c++";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3838,6 +3890,7 @@
 				);
 				PRODUCT_NAME = BOINCManager;
 				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
 				USER_HEADER_SEARCH_PATHS = "../lib/**";
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -3851,6 +3904,9 @@
 		DD3E15410A774397007E0084 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = NO;
+				DEPLOYMENT_POSTPROCESSING = YES;
 				GCC_INCREASE_PRECOMPILED_HEADER_SHARING = YES;
 				GCC_PFE_FILE_C_DIALECTS = "c++";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -3892,6 +3948,7 @@
 				);
 				PRODUCT_NAME = BOINCManager;
 				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
 				USER_HEADER_SEARCH_PATHS = "../lib/**";
 				WARNING_CFLAGS = (
 					"-Wmost",
@@ -4248,6 +4305,8 @@
 		DD9843DE09920F220090855B /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEPLOYMENT_POSTPROCESSING = YES;
 				HEADER_SEARCH_PATHS = (
 					"../../curl-7.58.0/include",
 					"../../openssl-1.1.0g/include",
@@ -4276,6 +4335,7 @@
 					"-lz",
 				);
 				PRODUCT_NAME = boinc;
+				STRIP_INSTALLED_PRODUCT = NO;
 				USER_HEADER_SEARCH_PATHS = "../../curl-7.58.0/include ../../openssl-1.1.0g/include ../lib/**";
 			};
 			name = Deployment;
@@ -4411,6 +4471,8 @@
 		DD9E2366091CBDAE0048316E /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEPLOYMENT_POSTPROCESSING = YES;
 				HEADER_SEARCH_PATHS = (
 					"../../curl-7.58.0/include",
 					"../../openssl-1.1.0g/include",
@@ -4438,6 +4500,7 @@
 					"-lz",
 				);
 				PRODUCT_NAME = boinc;
+				STRIP_INSTALLED_PRODUCT = NO;
 				USER_HEADER_SEARCH_PATHS = "../../curl-7.58.0/include ../../openssl-1.1.0g/include ../lib/**";
 			};
 			name = Development;

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -1044,6 +1044,8 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
     return true;
 }
 
+// Some older versions of BOINC installed a Screensaver LaunchAgent for each user.
+// Even though we no longer do this, delete it if it exists, for backward compatibility
 void DeleteScreenSaverLaunchAgent(passwd *pw) {
     char                    cmd[MAXPATHLEN];
 


### PR DESCRIPTION
Fixes #

**Description of the Change**
Significantly cleaner implementation of BOINC screensaver for Mac OS 10.15 Catalina than my original #3369

**Alternate Designs**
The previous implementation required installing a LaunchAgent for each user. The BOINC Screensaver Coordinator would write a data file to trigger the LaunchAgent. The LaunchAgent launched _gfx_switcher_. This data file contained information on which project graphics app to run. It was read by _gfx_switcher_ which then launched the requested project graphics app, deleted the data file, and wrote another data file with the graphic app's process ID. The Screensaver Coordinator read the process ID from the file. When the graphics app exited, _gfx_switcher_ deleted the process ID file to signal the Screensaver Coordinator. 

Please see my comments in #3369 for more details on the problems adapting BOINC's screensaver to run under OS 10.15 Catalina, and a fuller explanation of the method employed.

This new implementation eliminates both the need for a LaunchAgent and the rather ugly former method of communicating between the modules by writing and deleting disk files.

**Release Notes**
A much cleaner and more efficient implementation of BOINC's screensaver support on Mac OS 10.15.
