### PR TITLE
[Android] Add parameterized tests and remove kotlin-test-junit5 dependency.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -108,9 +108,9 @@ dependencies {
     testImplementation 'commons-io:commons-io:2.6'
     testImplementation 'junit:junit:4.13'
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5_version"
     testImplementation "org.powermock:powermock-module-junit4:$powermock_version"
     testImplementation "org.powermock:powermock-api-mockito2:$powermock_version"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
 }
 repositories {

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStateTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStateTest.kt
@@ -19,9 +19,9 @@
 package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import kotlin.test.junit5.JUnit5Asserter
 
 class CcStateTest {
     private lateinit var ccState: CcState
@@ -74,109 +74,109 @@ class CcStateTest {
     @Test
     fun `Expect lookupApp() to return null when app list is empty`() {
         ccState.clearArrays()
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(null, null))
+        Assertions.assertNull(ccState.lookupApp(null, null))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app and parameters are null`() {
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(null, null))
+        Assertions.assertNull(ccState.lookupApp(null, null))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app, project matches app project and app name is null`() {
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(project, null))
+        Assertions.assertNull(ccState.lookupApp(project, null))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app and project doesn't match`() {
         val project1 = Project(masterURL = URL_2)
 
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(project1, APP))
+        Assertions.assertNull(ccState.lookupApp(project1, APP))
     }
 
     @Test
     fun `Expect lookupApp() to return null when app list has one app and app name doesn't match`() {
         val project1 = Project(masterURL = URL_1)
 
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupApp(project1, "$APP 2"))
+        Assertions.assertNull(ccState.lookupApp(project1, "$APP 2"))
     }
 
     @Test
     fun `Expect lookupApp() to return app when app list has one app and project and app name match`() {
         val appFound = ccState.lookupApp(project, APP)
 
-        JUnit5Asserter.assertEquals("Expected '$APP'", APP, appFound!!.name)
-        JUnit5Asserter.assertEquals(PROJECT_MSG, project, appFound.project)
+        Assertions.assertEquals(APP, appFound!!.name)
+        Assertions.assertEquals(project, appFound.project)
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list is empty`() {
         ccState.clearArrays()
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(null, null))
+        Assertions.assertNull(ccState.lookupWorkUnit(null, null))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list has one work unit and parameters are null`() {
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(null, null))
+        Assertions.assertNull(ccState.lookupWorkUnit(null, null))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list has one work unit and project doesn't match`() {
         project1.masterURL = URL_2
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(project1, WORK_UNIT))
+        Assertions.assertNull(ccState.lookupWorkUnit(project1, WORK_UNIT))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return null when work unit list has one work unit and work unit name doesn't match`() {
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupWorkUnit(project1, "$WORK_UNIT 2"))
+        Assertions.assertNull(ccState.lookupWorkUnit(project1, "$WORK_UNIT 2"))
     }
 
     @Test
     fun `Expect lookupWorkUnit() to return work unit when work unit list has one work unit and parameters match`() {
         val workUnitFound = ccState.lookupWorkUnit(project1, WORK_UNIT)
-        JUnit5Asserter.assertEquals(PROJECT_MSG, project, workUnitFound!!.project)
-        JUnit5Asserter.assertEquals("Expected work unit", WORK_UNIT, workUnitFound.name)
+        Assertions.assertEquals(project, workUnitFound!!.project)
+        Assertions.assertEquals(WORK_UNIT, workUnitFound.name)
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list is empty`() {
         ccState.clearArrays()
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(null, null, 0, null))
+        Assertions.assertNull(ccState.lookupAppVersion(null, null, 0, null))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and parameters are null`() {
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(null, null, 0, null))
+        Assertions.assertNull(ccState.lookupAppVersion(null, null, 0, null))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and project doesn't match`() {
         project1.masterURL = URL_2
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
+        Assertions.assertNull(ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and app doesn't match`() {
         app1.name = "App 2"
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
+        Assertions.assertNull(ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and version number doesn't match`() {
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 0, PLAN_CLASS))
+        Assertions.assertNull(ccState.lookupAppVersion(project1, app1, 0, PLAN_CLASS))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return null when app version list has one app version and plan class doesn't match`() {
-        JUnit5Asserter.assertNull(NULL_MSG, ccState.lookupAppVersion(project1, app1, 0, "$PLAN_CLASS 2"))
+        Assertions.assertNull(ccState.lookupAppVersion(project1, app1, 0, "$PLAN_CLASS 2"))
     }
 
     @Test
     fun `Expect lookupAppVersion() to return app version when app version list has one app version and parameters match`() {
         val foundAppVersion = ccState.lookupAppVersion(project1, app1, 1, PLAN_CLASS)
-        JUnit5Asserter.assertEquals(PROJECT_MSG, project, foundAppVersion!!.project)
-        JUnit5Asserter.assertEquals("Expected app", app, foundAppVersion.app)
-        JUnit5Asserter.assertEquals("Expected plan class", PLAN_CLASS, foundAppVersion.planClass)
+        Assertions.assertEquals(project, foundAppVersion!!.project)
+        Assertions.assertEquals(app, foundAppVersion.app)
+        Assertions.assertEquals(PLAN_CLASS, foundAppVersion.planClass)
     }
 
     companion object {
@@ -185,8 +185,5 @@ class CcStateTest {
         private const val URL_1 = "URL 1"
         private const val URL_2 = "URL 2"
         private const val WORK_UNIT = "Work Unit"
-
-        private const val NULL_MSG = "Expected null"
-        private const val PROJECT_MSG = "Expected project"
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStatusTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/CcStatusTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import kotlin.test.junit5.JUnit5Asserter
 
 class CcStatusTest {
     @Test
@@ -47,6 +47,7 @@ class CcStatusTest {
     fun `Test serialization`() {
         val original = CcStatus()
         val copy = SerializationUtils.clone(original)
-        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
+
+        Assertions.assertEquals(original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import kotlin.test.junit5.JUnit5Asserter
 
 class MessageTest {
     @Test
@@ -39,6 +39,7 @@ class MessageTest {
     fun `Test serialization`() {
         val original = Message()
         val copy = SerializationUtils.clone(original)
-        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
+
+        Assertions.assertEquals(original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import kotlin.test.junit5.JUnit5Asserter
 
 class ProjectInfoTest {
     @Test
@@ -43,6 +43,6 @@ class ProjectInfoTest {
     fun `Test serialization`() {
         val original = ProjectInfo()
         val copy = SerializationUtils.clone(original)
-        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
+        Assertions.assertEquals(original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectTest.kt
@@ -18,19 +18,30 @@
  */
 package edu.berkeley.boinc.rpc
 
-import org.junit.jupiter.api.Test
-import kotlin.test.junit5.JUnit5Asserter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import org.junit.jupiter.params.provider.ArgumentsSource
+import java.util.stream.Stream
+
+private class ProjectArgumentsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> {
+        return Stream.of(
+                Arguments.of(Project(masterURL = "Master URL")),
+                Arguments.of(Project(masterURL = "Master URL", projectName = "Project"))
+        )
+    }
+}
 
 class ProjectTest {
-    @Test
-    fun `Expect getName() to return master URL when project name is empty`() {
-        val project = Project(masterURL = "Master URL")
-        JUnit5Asserter.assertEquals("Expected to be equal.","Master URL", project.name)
-    }
-
-    @Test
-    fun `Expect getName() to return project name when project name is not empty`() {
-        val project = Project(masterURL = "Master URL", projectName = "Project")
-        JUnit5Asserter.assertEquals("Expected to be equal.","Project", project.name)
+    @ParameterizedTest
+    @ArgumentsSource(ProjectArgumentsProvider::class)
+    fun `Test name property`(project: Project) {
+        if (project.projectName.isEmpty())
+            Assertions.assertEquals(project.masterURL, project.name)
+        else
+            Assertions.assertEquals(project.projectName, project.name)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransferTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransferTest.kt
@@ -20,8 +20,8 @@ package edu.berkeley.boinc.rpc
 
 import com.google.common.testing.EqualsTester
 import org.apache.commons.lang3.SerializationUtils
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
-import kotlin.test.junit5.JUnit5Asserter
 
 class TransferTest {
     @Test
@@ -46,6 +46,7 @@ class TransferTest {
     fun `Test serialization`() {
         val original = Transfer()
         val copy = SerializationUtils.clone(original)
-        JUnit5Asserter.assertEquals("Expected to be identical", original, copy)
+
+        Assertions.assertEquals(original, copy)
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsTest.kt
@@ -19,49 +19,42 @@
 package edu.berkeley.boinc.utils
 
 import org.apache.commons.io.input.CharSequenceReader
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.io.Reader
-import kotlin.test.junit5.JUnit5Asserter
 
 const val THIS = "This"
 const val STRING = "This is a string."
 
-internal class BOINCUtilsTest {
-    private lateinit var stringBuilder: StringBuilder
-    private lateinit var reader: Reader
-
-    @BeforeEach
-    fun setUp() {
-        stringBuilder = StringBuilder(STRING)
-        reader = CharSequenceReader(stringBuilder)
-    }
+class BOINCUtilsTest {
+    private var stringBuilder = StringBuilder(STRING)
+    private var reader: Reader = CharSequenceReader(stringBuilder)
 
     @Test
     fun testReadLineLimit_whenReaderHasEmptyStringAndLimitIs1_thenExpectNull() {
         stringBuilder.setLength(0)
-        JUnit5Asserter.assertNull("Expected null", reader.readLineLimit(1))
+        Assertions.assertNull(reader.readLineLimit(1))
     }
 
     @Test
     fun testReadLineLimit_whenReaderHasNonEmptyStringAndLimitIsLengthOfString_thenExpectReaderString() {
-        JUnit5Asserter.assertEquals("Expected $STRING", STRING, reader.readLineLimit(stringBuilder.length))
+        Assertions.assertEquals(STRING, reader.readLineLimit(stringBuilder.length))
     }
 
     @Test
     fun testReadLineLimit_whenReaderHasNonEmptyStringAndLimitIsLengthOfStringPlus1_thenExpectReaderString() {
-        JUnit5Asserter.assertEquals("Expected $STRING", STRING, reader.readLineLimit(stringBuilder.length + 1))
+        Assertions.assertEquals(STRING, reader.readLineLimit(stringBuilder.length + 1))
     }
 
     @Test
     fun testReadLineLimit_whenReaderHasStringWithNewlineAndLimitIsLengthOfString_thenExpectStringWithoutNewline() {
         stringBuilder.setCharAt(4, '\n')
-        JUnit5Asserter.assertEquals("Expected $THIS", THIS, reader.readLineLimit(stringBuilder.length))
+        Assertions.assertEquals(THIS, reader.readLineLimit(stringBuilder.length))
     }
 
     @Test
     fun testReadLineLimit_whenReaderHasStringWithCarriageReturnAndLimitIsLengthOfString_thenExpectStringWithoutCarriageReturn() {
         stringBuilder.setCharAt(4, '\r')
-        JUnit5Asserter.assertEquals("Expected $THIS", THIS, reader.readLineLimit(stringBuilder.length))
+        Assertions.assertEquals(THIS, reader.readLineLimit(stringBuilder.length))
     }
 }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/ErrorCodeDescriptionTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/ErrorCodeDescriptionTest.kt
@@ -16,11 +16,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
  */
-package edu.berkeley.boinc.rpc
+package edu.berkeley.boinc.utils
 
-import com.google.common.testing.EqualsTester
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -28,31 +26,23 @@ import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
 import java.util.stream.Stream
 
-private class AppArgumentsProvider : ArgumentsProvider {
+private class ErrorCodeDescriptionArgumentsProvider : ArgumentsProvider {
     override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> {
         return Stream.of(
-                Arguments.of(App("Name", null)),
-                Arguments.of(App("Name", "")),
-                Arguments.of(App("Name", "User-friendly name"))
+                Arguments.of(ErrorCodeDescription()),
+                Arguments.of(ErrorCodeDescription(code = 1)),
+                Arguments.of(ErrorCodeDescription(description = "Error"))
         )
     }
 }
 
-class AppTest {
+class ErrorCodeDescriptionTest {
     @ParameterizedTest
-    @ArgumentsSource(AppArgumentsProvider::class)
-    fun `Test displayName property`(app: App) {
-        if (app.userFriendlyName.isNullOrEmpty())
-            Assertions.assertEquals(app.displayName, app.name)
+    @ArgumentsSource(ErrorCodeDescriptionArgumentsProvider::class)
+    fun `Test isOK property`(errorCodeDescription: ErrorCodeDescription) {
+        if (errorCodeDescription.code == ERR_OK && errorCodeDescription.description.isNullOrEmpty())
+            Assertions.assertTrue(errorCodeDescription.isOK)
         else
-            Assertions.assertEquals(app.displayName, app.userFriendlyName)
-    }
-
-    @Test
-    fun `Test equals() and hashCode()`() {
-        EqualsTester().addEqualityGroup(App("Name"), App("NAME"))
-                .addEqualityGroup(App(userFriendlyName = "User-friendly name"),
-                        App(userFriendlyName = "USER-FRIENDLY NAME"))
-                .testEquals()
+            Assertions.assertFalse(errorCodeDescription.isOK)
     }
 }


### PR DESCRIPTION
**Description of the Change**
* Replace some ordinary tests with parameterized ones.
* Add parameterized test for `ErrorCodeDescription`.
* Remove the `kotlin-test-junit5` dependency, as calls to `JUnit5Asserter` have been replaced with calls to JUnit 5's `Assertions`.

**Release Notes**
N/A
