### PR TITLE
LIB: Fix UB when printf-like format specifiers don't match argument types

### DIFF
--- a/lib/boinc_win.h
+++ b/lib/boinc_win.h
@@ -277,6 +277,7 @@ typedef LPCSTR PCTSTR, LPCTSTR, PCUTSTR, LPCUTSTR;
 #include <cassert>
 #include <cctype>
 #include <cerrno>
+#include <cinttypes>
 #include <cmath>
 #include <csetjmp>
 #include <csignal>
@@ -291,6 +292,7 @@ typedef LPCSTR PCTSTR, LPCTSTR, PCUTSTR, LPCUTSTR;
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <math.h>
 #include <setjmp.h>
 #include <signal.h>

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -122,7 +122,7 @@ void boinc_catch_signal_invalid_parameter(
 ) {
 	fprintf(
 		stderr,
-        "ERROR: Invalid parameter detected in function %ls. File: %ls Line: %d\n",
+        "ERROR: Invalid parameter detected in function %ls. File: %ls Line: %u\n",
 		function,
 		file,
 		line

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -122,14 +122,14 @@ void boinc_catch_signal_invalid_parameter(
 ) {
 	fprintf(
 		stderr,
-        "ERROR: Invalid parameter detected in function %s. File: %s Line: %d\n",
+        "ERROR: Invalid parameter detected in function %ls. File: %ls Line: %d\n",
 		function,
 		file,
 		line
 	);
 	fprintf(
 		stderr,
-		"ERROR: Expression: %s\n",
+		"ERROR: Expression: %ls\n",
 		expression
 	);
 

--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -1298,29 +1298,29 @@ int diagnostics_dump_process_information() {
     fprintf(
         stderr, 
         "- Paged Pool Usage -\n"
-        "QuotaPagedPoolUsage: %d, QuotaPeakPagedPoolUsage: %d\n"
-        "QuotaNonPagedPoolUsage: %d, QuotaPeakNonPagedPoolUsage: %d\n"
+        "QuotaPagedPoolUsage: %" PRIuMAX ", QuotaPeakPagedPoolUsage: %" PRIuMAX "\n"
+        "QuotaNonPagedPoolUsage: %" PRIuMAX ", QuotaPeakNonPagedPoolUsage: %" PRIuMAX "\n"
         "\n"
         "- Virtual Memory Usage -\n"
-        "VirtualSize: %d, PeakVirtualSize: %d\n"
+        "VirtualSize: %" PRIuMAX ", PeakVirtualSize: %" PRIuMAX "\n"
         "\n"
         "- Pagefile Usage -\n"
-        "PagefileUsage: %d, PeakPagefileUsage: %d\n"
+        "PagefileUsage: %" PRIuMAX ", PeakPagefileUsage: %" PRIuMAX "\n"
         "\n"
         "- Working Set Size -\n"
-        "WorkingSetSize: %d, PeakWorkingSetSize: %d, PageFaultCount: %d\n"
+        "WorkingSetSize: %" PRIuMAX ", PeakWorkingSetSize: %" PRIuMAX ", PageFaultCount: %" PRIuMAX "\n"
         "\n",
-        diagnostics_process.vm_counters.QuotaPagedPoolUsage,
-        diagnostics_process.vm_counters.QuotaPeakPagedPoolUsage,
-        diagnostics_process.vm_counters.QuotaNonPagedPoolUsage,
-        diagnostics_process.vm_counters.QuotaPeakNonPagedPoolUsage,
-        diagnostics_process.vm_counters.VirtualSize,
-        diagnostics_process.vm_counters.PeakVirtualSize,
-        diagnostics_process.vm_counters.PagefileUsage,
-        diagnostics_process.vm_counters.PeakPagefileUsage,
-        diagnostics_process.vm_counters.WorkingSetSize,
-        diagnostics_process.vm_counters.PeakWorkingSetSize,
-        diagnostics_process.vm_counters.PageFaultCount
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.QuotaPagedPoolUsage),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.QuotaPeakPagedPoolUsage),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.QuotaNonPagedPoolUsage),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.QuotaPeakNonPagedPoolUsage),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.VirtualSize),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.PeakVirtualSize),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.PagefileUsage),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.PeakPagefileUsage),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.WorkingSetSize),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.PeakWorkingSetSize),
+        static_cast<uintmax_t>(diagnostics_process.vm_counters.PageFaultCount)
     );
 
     return 0;

--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -1430,13 +1430,21 @@ int diagnostics_dump_exception_record(PEXCEPTION_POINTERS pExPtrs) {
                 switch(pExPtrs->ExceptionRecord->ExceptionInformation[0]) {
                 case 0: // read attempt
                     snprintf(substatus, sizeof(substatus),
-                        "read attempt to address 0x%8.8X",
+#ifdef _WIN64
+                        "read attempt to address 0x%16.16" PRIxPTR,
+#else
+                        "read attempt to address 0x%8.8" PRIxPTR,
+#endif
                         pExPtrs->ExceptionRecord->ExceptionInformation[1]
                     );
                     break;
                 case 1: // write attempt
                     snprintf(substatus, sizeof(substatus),
-                        "write attempt to address 0x%8.8X",
+#ifdef _WIN64
+                        "write attempt to address 0x%16.16" PRIxPTR,
+#else
+                        "write attempt to address 0x%8.8" PRIxPTR,
+#endif
                         pExPtrs->ExceptionRecord->ExceptionInformation[1]
                     );
                     break;

--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -1281,10 +1281,10 @@ int diagnostics_dump_process_information() {
     fprintf(
         stderr, 
         "- I/O Operations Counters -\n"
-        "Read: %d, Write: %d, Other %d\n"
+        "Read: %" PRIu64 ", Write: %" PRIu64 ", Other %" PRIu64 "\n"
         "\n"
         "- I/O Transfers Counters -\n"
-        "Read: %d, Write: %d, Other %d\n"
+        "Read: %" PRIu64 ", Write: %" PRIu64 ", Other %" PRIu64 "\n"
         "\n",
         diagnostics_process.io_counters.ReadOperationCount,
         diagnostics_process.io_counters.WriteOperationCount,

--- a/lib/mfile.cpp
+++ b/lib/mfile.cpp
@@ -108,8 +108,8 @@ size_t MFILE::write(const void *ptr, size_t size, size_t nitems) {
     buf = (char *)realloc_aux( buf, len+(size*nitems)+1 );
     if (!buf) {
         fprintf(stderr,
-            "ERROR: realloc() failed in MFILE::write(); len %d size %lu nitems %lu\n",
-            len, size, nitems
+            "ERROR: realloc() failed in MFILE::write(); len %d size %" PRIuMAX " nitems %" PRIuMAX "\n",
+            len, static_cast<uintmax_t>(size), static_cast<uintmax_t>(nitems)
         );
         exit(1);
     }

--- a/lib/mfile.cpp
+++ b/lib/mfile.cpp
@@ -21,12 +21,13 @@
 #include "stdwx.h"
 #else
 #include "config.h"
+#include <cerrno>
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <cstdarg>
 #include <cstring>
 #include <string>
-#include <cerrno>
 #include <unistd.h>
 #endif
 

--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -297,7 +297,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                     lpTranslate[0].wCodePage
                 );
                 if (pVQV(lpData, szQuery, &lpVar, &uiVarSize)) {
-                    uiVarSize = snprintf(szCompanyName, sizeof(szCompanyName), "%s", lpVar);
+                    uiVarSize = snprintf(szCompanyName, sizeof(szCompanyName), "%s", static_cast<const char*>(lpVar));
                     if ((sizeof(szCompanyName) == uiVarSize) || (-1 == uiVarSize)) {
                         szCompanyName[255] = '\0';
                     }
@@ -311,7 +311,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                     lpTranslate[0].wCodePage
                 );
                 if (pVQV(lpData, szQuery, &lpVar, &uiVarSize)) {
-                    uiVarSize = snprintf(szProductName, sizeof(szProductName), "%s", lpVar);
+                    uiVarSize = snprintf(szProductName, sizeof(szProductName), "%s", static_cast<const char*>(lpVar));
                     if ((sizeof(szProductName) == uiVarSize) || (-1 == uiVarSize)) {
                         szProductName[255] = '\0';
                     }
@@ -325,7 +325,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                     lpTranslate[0].wCodePage
                 );
                 if (pVQV(lpData, szQuery, &lpVar, &uiVarSize)) {
-                    uiVarSize = snprintf(szFileVersion, sizeof(szFileVersion), "%s", lpVar);
+                    uiVarSize = snprintf(szFileVersion, sizeof(szFileVersion), "%s", static_cast<const char*>(lpVar));
                     if ((sizeof(szFileVersion) == uiVarSize) || (-1 == uiVarSize)) {
                         szFileVersion[255] = '\0';
                     }
@@ -337,7 +337,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                     lpTranslate[0].wCodePage
                 );
                 if (pVQV(lpData, szQuery, &lpVar, &uiVarSize)) {
-                    uiVarSize = snprintf(szProductVersion, sizeof(szProductVersion), "%s", lpVar);
+                    uiVarSize = snprintf(szProductVersion, sizeof(szProductVersion), "%s", static_cast<const char*>(lpVar));
                     if ((sizeof(szProductVersion) == uiVarSize) || (-1 == uiVarSize)) {
                         szProductVersion[255] = '\0';
                     }

--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -878,12 +878,12 @@ static void ShowStackRM(HANDLE hThread, CONTEXT& Context)
         } // we seem to have a valid PC
 
 
-        fprintf(stderr, "%.8x ", StackFrame.AddrFrame.Offset);
-        fprintf(stderr, "%.8x ", StackFrame.AddrReturn.Offset);
-        fprintf(stderr, "%.8x ", StackFrame.Params[0]);
-        fprintf(stderr, "%.8x ", StackFrame.Params[1]);
-        fprintf(stderr, "%.8x ", StackFrame.Params[2]);
-        fprintf(stderr, "%.8x ", StackFrame.Params[3]);
+        fprintf(stderr, "%.16" PRIx64 " ", StackFrame.AddrFrame.Offset);
+        fprintf(stderr, "%.16" PRIx64 " ", StackFrame.AddrReturn.Offset);
+        fprintf(stderr, "%.16" PRIx64 " ", StackFrame.Params[0]);
+        fprintf(stderr, "%.16" PRIx64 " ", StackFrame.Params[1]);
+        fprintf(stderr, "%.16" PRIx64 " ", StackFrame.Params[2]);
+        fprintf(stderr, "%.16" PRIx64 " ", StackFrame.Params[3]);
         fprintf(stderr, "%s",    Module.ModuleName);
         fprintf(stderr, "!%s+",  undName);
         fprintf(stderr, "0x%x ", offsetFromLine);
@@ -911,7 +911,7 @@ static void ShowStackRM(HANDLE hThread, CONTEXT& Context)
         if (strlen(szMsgSymFromAddr) || strlen(szMsgSymGetLineFromAddr) || strlen(szMsgSymGetModuleInfo)) {
             fprintf(
                 stderr,
-                "%s %s %s Address = '%.8x'",
+                "%s %s %s Address = '%.16" PRIx64 "'",
                 szMsgSymFromAddr,
                 szMsgSymGetLineFromAddr,
                 szMsgSymGetModuleInfo,

--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -349,7 +349,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
     }
 
     fprintf(stderr, "ModLoad: ");
-    fprintf(stderr, "%.16x "                                , Module.BaseOfImage);
+    fprintf(stderr, "%.16" PRIx64 " "                       , Module.BaseOfImage);
     fprintf(stderr, "%.16x "                                , Module.ImageSize);
     fprintf(stderr, "%s "                                   , Module.LoadedImageName);
     if (bFileVersionSupported && bFileVersionRetrieved) {
@@ -729,15 +729,15 @@ static void ShowStackRM(HANDLE hThread, CONTEXT& Context)
     // Dump the Context data
 #if defined(_WIN64) && defined(_M_X64)
     fprintf(stderr, 
-        "rax=%.16x rbx=%.16x rcx=%.16x rdx=%.16x rsi=%.16x rdi=%.16x\n",
+        "rax=%.16" PRIx64 " rbx=%.16" PRIx64 " rcx=%.16" PRIx64 " rdx=%.16" PRIx64 " rsi=%.16" PRIx64 " rdi=%.16" PRIx64 "\n",
         Context.Rax, Context.Rbx, Context.Rcx, Context.Rdx, Context.Rsi, Context.Rdi
     );
     fprintf(stderr, 
-        "r8=%.16x r9=%.16x r10=%.16x r11=%.16x r12=%.16x r13=%.16x\n",
+        "r8=%.16" PRIx64 " r9=%.16" PRIx64 " r10=%.16" PRIx64 " r11=%.16" PRIx64 " r12=%.16" PRIx64 " r13=%.16" PRIx64 "\n",
         Context.R8, Context.R9, Context.R10, Context.R11, Context.R12, Context.R13
     );
     fprintf(stderr, 
-        "r14=%.16x r15=%.16x rip=%.16x rsp=%.16x rbp=%.16x\n",
+        "r14=%.16" PRIx64 " r15=%.16" PRIx64 " rip=%.16" PRIx64 " rsp=%.16" PRIx64 " rbp=%.16" PRIx64 "\n",
         Context.R14, Context.R15, Context.Rip, Context.Rsp, Context.Rbp
     );
     fprintf(stderr, 


### PR DESCRIPTION
**Description of the Change**
Using format specifier that doesn't match argument type in `printf` functions family is undefined behavior (UB). 
* Change format specifiers to the correct ones for passed into `printf` family arguments.
* Extend printed 64 bit values to 16 hex digits width with leading zeros.
* Print correct, not truncated to 4 bytes values of crash info params and process dumps on x86-64.

**Release Notes**
* Windows crash info's now contain correct values of cpu registries, stack params and addresses involved for x86-64.
* Windows process information dumps now contain correct values of I/O and memory usage counters for x86-64.

