### PR TITLE
[Android] Add JUnit Vintage Engine dependency.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -85,6 +85,11 @@ android {
         exclude 'LICENSE-EDL-1.0.txt'
     }
 
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
+    }
     tasks.withType(Test) {
         testLogging {
             events "passed", "skipped", "failed"
@@ -112,6 +117,7 @@ dependencies {
     testImplementation "org.powermock:powermock-module-junit4:$powermock_version"
     testImplementation "org.powermock:powermock-api-mockito2:$powermock_version"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit5_version"
 }
 repositories {
     mavenCentral()


### PR DESCRIPTION
**Description of the Change**
Previously, only the JUnit 4 unit tests were run during the CI process. This change adds the JUnit Vintage Engine and configures the project to use the JUnit 5 runner by default to allow both the JUnit 4 and 5 tests to be run.

**Release Notes**
N/A
