### PR TITLE
ClientGui: Fix potential buffer overflow in lstrcpyn

### DIFF
--- a/clientgui/msw/taskbarex.cpp
+++ b/clientgui/msw/taskbarex.cpp
@@ -131,7 +131,7 @@ bool wxTaskBarIconEx::SetIcon(const wxIcon& icon, const wxString& message)
 
     if (!message.empty()) {
         notifyData.uFlags       |= NIF_TIP;
-        lstrcpyn(notifyData.szTip, message.c_str(), sizeof(notifyData.szTip));
+        lstrcpyn(notifyData.szTip, message.c_str(), ARRAYSIZE(notifyData.szTip));
     }
 
     UpdateIcon();
@@ -156,8 +156,8 @@ bool wxTaskBarIconEx::SetBalloon(const wxIcon& icon, const wxString title, const
     notifyData.uVersion         = NOTIFYICON_VERSION;
     notifyData.hIcon            = (HICON) icon.GetHICON();
 
-    lstrcpyn(notifyData.szInfoTitle, title.c_str(), sizeof(notifyData.szInfoTitle));
-    lstrcpyn(notifyData.szInfo, message.c_str(), sizeof(notifyData.szInfo));
+    lstrcpyn(notifyData.szInfoTitle, title.c_str(), ARRAYSIZE(notifyData.szInfoTitle));
+    lstrcpyn(notifyData.szInfo, message.c_str(), ARRAYSIZE(notifyData.szInfo));
 
     UpdateIcon();
     return m_iconAdded;
@@ -181,8 +181,8 @@ bool wxTaskBarIconEx::QueueBalloon(const wxIcon& icon, const wxString title, con
     notifyData.uVersion         = NOTIFYICON_VERSION;
     notifyData.hIcon            = (HICON) icon.GetHICON();
 
-    lstrcpyn(notifyData.szInfoTitle, title.c_str(), sizeof(notifyData.szInfoTitle));
-    lstrcpyn(notifyData.szInfo, message.c_str(), sizeof(notifyData.szInfo));
+    lstrcpyn(notifyData.szInfoTitle, title.c_str(), ARRAYSIZE(notifyData.szInfoTitle));
+    lstrcpyn(notifyData.szInfo, message.c_str(), ARRAYSIZE(notifyData.szInfo));
 
     UpdateIcon();
     return m_iconAdded;


### PR DESCRIPTION
**Description of the Change**
lstrcpyn takes size of buffer in *characters*, not in bytes as last argument. If Unicode version of the function is used, `sizeof(buffer)` returns twice as much buffer size than expected by the function. And it may lead to out of buffer write.

See https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-lstrcpynw#security-warning: 
"If the buffer pointed to by lpString1 is not large enough to contain the copied string, a buffer overrun can occur. When copying an entire string, note that sizeof returns the number of bytes. For example, if lpString1 points to a buffer szString1 which is declared as TCHAR szString[100], then sizeof(szString1) gives the size of the buffer in bytes rather than WCHAR, which could lead to a buffer overflow for the Unicode version of the function.
...
Using sizeof(szString1)/sizeof(szString1[0]) gives the proper size of the buffer."

Even more, "If the function fails, the return value is `NULL` and lpString1 may not be null-terminated.".

**Release Notes**
Fixed potential buffer overflow in Taskbar icon tip and balloons.