### PR TITLE
[Android] Fix build warnings.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
@@ -221,9 +221,10 @@ public class AcctMgrFragment extends DialogFragment {
                 for (AccountManager accountManager : accountManagers) {
                     adapterData.add(new AccountManagerSpinner(accountManager.getName(), accountManager.getUrl()));
                 }
-                final ArrayAdapter adapter = new ArrayAdapter(getActivity(),
-                                                              android.R.layout.simple_spinner_item,
-                                                              adapterData);
+                final ArrayAdapter<AccountManagerSpinner> adapter =
+                        new ArrayAdapter<>(getActivity(),
+                                           android.R.layout.simple_spinner_item,
+                                           adapterData);
                 adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
                 urlSpinner.setAdapter(adapter);
             }


### PR DESCRIPTION
**Description of the Change**
Fix build warnings by adding the generic parameter to the `ArrayAdapter` declaration in `AcctMgrFragment` and disabling R8 in `gradle.properties`.

**Release Notes**
N/A
