### PR TITLE
samples/worker: added install target, $(CXX)

### DIFF
--- a/samples/worker/Makefile
+++ b/samples/worker/Makefile
@@ -14,6 +14,5 @@ worker: worker.o
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o worker worker.o
 
 install: all
-	@echo "--- The example app $(PROGS) is not installed ---"
 
 .PHONY: install all distclean clean

--- a/samples/worker/Makefile
+++ b/samples/worker/Makefile
@@ -1,4 +1,5 @@
 CXXFLAGS += -g
+CXX ?= g++
 
 PROGS = worker
 
@@ -10,4 +11,9 @@ distclean:
 	rm -f $(PROGS) *.o
 
 worker: worker.o
-	g++ $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o worker worker.o
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o worker worker.o
+
+install: all
+	@echo "--- The example app $(PROGS) is not installed ---"
+
+.PHONY: install all distclean clean


### PR DESCRIPTION
Without the $(CXX) the cross-compilation failed for OpenWrt ... in a very subtle manner that did cost me some time. I know, the worker is not needed for anything, but this should nonetheless just work.