### PR TITLE
[Android] Add Robolectric tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,10 @@ jobs:
             - android-29
             - extra-google-m2repository
             - extra-android-m2repository
+      dist: xenial
       env: BOINC_TYPE=manager-android
+      jdk:
+        - openjdk9
 
 before_install:
    - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( sudo apt-get -qq update ) fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
     - master
     - coverity_scan
 
-dist: trusty
+dist: xenial
 
 cache:
   timeout: 600
@@ -58,7 +58,6 @@ jobs:
             - android-29
             - extra-google-m2repository
             - extra-android-m2repository
-      dist: xenial
       env: BOINC_TYPE=manager-android
       jdk:
         - openjdk9
@@ -66,7 +65,7 @@ jobs:
 before_install:
    - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( sudo apt-get -qq update ) fi
    - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( sudo apt-get install -y freeglut3-dev libxmu-dev libxi-dev libfcgi-dev libxss-dev libnotify-dev libxcb-util0-dev libsqlite3-dev libgtk2.0-dev libwebkitgtk-dev mingw-w64 binutils-mingw-w64-i686 binutils-mingw-w64-x86-64 gcc-mingw-w64 gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 g++-mingw-w64 g++-mingw-w64-i686 g++-mingw-w64-x86-64 realpath p7zip-full ) fi
-   - if [[ "${BOINC_TYPE}" == "integration-test" ]]; then ( sudo apt-get install ansible/trusty-backports; sudo service mysql stop; ) fi
+   - if [[ "${BOINC_TYPE}" == "integration-test" ]]; then ( sudo apt-get install ansible/xenial-backports; sudo service mysql stop; ) fi
 
 before_script:
 - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ( ./_autosetup ) fi

--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -87,8 +87,11 @@ android {
     }
 
     testOptions {
-        unitTests.all {
-            useJUnitPlatform()
+        unitTests {
+            includeAndroidResources = true
+            all {
+                useJUnitPlatform()
+            }
         }
     }
     tasks.withType(Test) {
@@ -110,6 +113,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.eclipse.collections:eclipse-collections:10.2.0'
 
+    testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'com.google.guava:guava-testlib:28.2-jre'
     testImplementation 'commons-io:commons-io:2.6'
     testImplementation 'junit:junit:4.13'
@@ -117,6 +121,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5_version"
     testImplementation "org.powermock:powermock-module-junit4:$powermock_version"
     testImplementation "org.powermock:powermock-api-mockito2:$powermock_version"
+    testImplementation 'org.robolectric:robolectric:4.3.1'
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit5_version"
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountClasses.kt
@@ -27,7 +27,7 @@ import androidx.core.os.ParcelCompat.writeBoolean
  * Account credentials, consisting of a [url], [emailAddress], [userName], [password], [teamName]
  * and [usesName] (if true, ID represents a user name, otherwise the user's email address).
  */
-class AccountIn(
+data class AccountIn(
         var url: String? = null,
         var emailAddress: String? = null,
         var userName: String? = null,

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/ErrorCodeDescription.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/ErrorCodeDescription.kt
@@ -21,7 +21,8 @@ package edu.berkeley.boinc.utils
 import android.os.Parcel
 import android.os.Parcelable
 
-class ErrorCodeDescription @JvmOverloads constructor(val code: Int = 0, val description: String? = "") : Parcelable {
+data class ErrorCodeDescription @JvmOverloads constructor(val code: Int = 0, val description: String? = "")
+    : Parcelable {
     private constructor(parcel: Parcel) : this(parcel.readInt(), parcel.readString())
 
     val isOK: Boolean

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountInParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountInParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AccountInParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = AccountIn()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = AccountIn.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = AccountIn.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountManagerParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountManagerParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AccountManagerParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = AccountManager()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = AccountManager.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = AccountManager.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountOutParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AccountOutParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AccountOutParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = AccountOut()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = AccountOut.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = AccountOut.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrInfoParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AcctMgrInfoParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AcctMgrInfoParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = AcctMgrInfo()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = AcctMgrInfo.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = AcctMgrInfo.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AppParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = App()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = App.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = App.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppVersionParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/AppVersionParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AppVersionParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = AppVersion()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = AppVersion.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = AppVersion.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GlobalPreferencesParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GlobalPreferencesParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GlobalPreferencesParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = GlobalPreferences()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = GlobalPreferences.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = GlobalPreferences.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GuiUrlParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/GuiUrlParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GuiUrlParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = GuiUrl()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = GuiUrl.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = GuiUrl.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/HostInfoParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/HostInfoParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class HostInfoParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = HostInfo()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = HostInfo.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = HostInfo.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/MessageParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MessageParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = Message()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = Message.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = Message.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/NoticeParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/NoticeParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NoticeParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = Notice()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = Notice.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = Notice.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/PlatformInfoParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/PlatformInfoParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PlatformInfoParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = PlatformInfo()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = PlatformInfo.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = PlatformInfo.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectConfigParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectConfigParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ProjectConfigParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = ProjectConfig()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = ProjectConfig.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = ProjectConfig.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectInfoParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ProjectInfoParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = ProjectInfo()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = ProjectInfo.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = ProjectInfo.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ProjectParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ProjectParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = Project()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = Project.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = Project.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ResultParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/ResultParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ResultParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = Result()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = Result.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = Result.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TimePreferencesParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TimePreferencesParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TimePreferencesParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = TimePreferences()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = TimePreferences.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = TimePreferences.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransferParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/TransferParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TransferParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = Transfer()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = Transfer.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = Transfer.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/WorkUnitParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/rpc/WorkUnitParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.rpc
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WorkUnitParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = WorkUnit()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = WorkUnit.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = WorkUnit.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/ErrorCodeDescriptionParcelableTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/ErrorCodeDescriptionParcelableTest.kt
@@ -1,0 +1,47 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.utils
+
+import android.os.Parcel
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ErrorCodeDescriptionParcelableTest {
+    @Test
+    fun `Test Creator createFromParcel()`() {
+        val expected = ErrorCodeDescription()
+        val parcel = Parcel.obtain()
+        expected.writeToParcel(parcel, expected.describeContents())
+
+        // Reset parcel for reading.
+        parcel.setDataPosition(0)
+        val actual = ErrorCodeDescription.CREATOR.createFromParcel(parcel)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `Test Creator newArray()`() {
+        val array = ErrorCodeDescription.CREATOR.newArray(2)
+        Assert.assertNotNull(array)
+        Assert.assertEquals(2, array.size)
+    }
+}


### PR DESCRIPTION
**Description of the Change**
Add tests that use the Robolectric framework, to eliminate the need to set up an Android emulator for testing certain functionality.

**Release Notes**
N/A

**Note**
JaCoCo code coverage does not currently work for Robolectric tests: https://github.com/robolectric/robolectric/issues/3023
