### PR TITLE
[Android] Change downloading string from 'waiting for download' to 'downloading'.

### DIFF
--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -290,7 +290,7 @@
     <string name="tasks_header_project_paused">(suspended)</string>
     <string name="tasks_header_deadline">Deadline:</string>
     <string name="tasks_result_new">new</string>
-    <string name="tasks_result_files_downloading">waiting for download</string>
+    <string name="tasks_result_files_downloading">downloading</string>
     <string name="tasks_result_files_downloaded">download complete</string>
     <string name="tasks_result_compute_error">computation error</string>
     <string name="tasks_result_files_uploading">uploading</string>


### PR DESCRIPTION
**Description of the Change**
Change the tasks_result_files_downloading string from 'waiting for download' to 'downloading' for a more accurate message.

**Release Notes**
Display 'downloading' instead of 'waiting for download'.