### PR TITLE
[Android] Replace StringReader with CharSequenceReader in RpcClient.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -106,12 +106,12 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.core:core-ktx:1.2.0'
+    implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'org.eclipse.collections:eclipse-collections:10.2.0'
 
     testImplementation 'com.google.guava:guava-testlib:28.2-jre'
-    testImplementation 'commons-io:commons-io:2.6'
     testImplementation 'junit:junit:4.13'
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junit5_version"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junit5_version"

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -24,6 +24,7 @@ import android.net.LocalSocketAddress;
 import android.util.Log;
 import android.util.Xml;
 
+import org.apache.commons.io.input.CharSequenceReader;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.collections.api.list.ImmutableList;
 import org.xml.sax.SAXException;
@@ -33,7 +34,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -368,7 +368,7 @@ public class RpcClient {
             Log.d(Logging.TAG, "mResult.capacity() = " + mResult.capacity());
 
         if (Logging.RPC_DATA) {
-            BufferedReader dbr = new BufferedReader(new StringReader(mResult.toString()));
+            BufferedReader dbr = new BufferedReader(new CharSequenceReader(mResult));
             String dl;
             int ln = 0;
             try {


### PR DESCRIPTION
**Description of the Change**
Use Apache Commons IO's `CharSequenceReader` instead of `StringReader`, as the former supports all classes that implement the `CharSequence` interface.

**Release Notes**
N/A
