### PR TITLE
Mac fix gfx apps on xcode11

### DIFF
--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -1,6 +1,6 @@
 // Berkeley Open Infrastructure for Network Computing
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // This is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -394,6 +394,7 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
         [imageView removeFromSuperview];   // Releases imageView
         imageView = nil;
     }
+
     if (!myIsPreview) {
         closeBOINCSaver();
     }

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -207,9 +207,6 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
     gIsMojave = (compareOSVersionTo(10, 14) >= 0);
     gIsCatalina = (compareOSVersionTo(10, 15) >= 0);
 
-    // MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT is defined in mac_util.h
-    gUseLaunchAgent = (compareOSVersionTo(10, MIN_OS_TO_USE_SCREENSAVER_LAUNCH_AGENT) >= 0);
-
     if (gIsCatalina) {
         // Under OS 10.15, isPreview is often true even when it shouldn't be
         // so we use this hack instead

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -555,6 +555,11 @@
 		DDF5F85A10DD05DB006A50CD /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
 		DDF5F85B10DD05E4006A50CD /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDF93511176B0D0C00A2793C /* translate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF9350F176B0D0C00A2793C /* translate.cpp */; };
+		DDF9B767245C3A8000587EBE /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDF9B766245C3A7F00587EBE /* SystemConfiguration.framework */; };
+		DDF9B768245C3A8000587EBE /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDF9B766245C3A7F00587EBE /* SystemConfiguration.framework */; };
+		DDF9B769245C3A8000587EBE /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDF9B766245C3A7F00587EBE /* SystemConfiguration.framework */; };
+		DDF9B76A245C3C7900587EBE /* shmem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAA31C97042157A800A80164 /* shmem.cpp */; };
+		DDF9B76B245C3CC700587EBE /* shmem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAA31C97042157A800A80164 /* shmem.cpp */; };
 		DDF9EC0A144EB2BB005D6144 /* boinc_opencl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF9EC08144EB2BB005D6144 /* boinc_opencl.cpp */; };
 		DDF9EC0B144EB2BB005D6144 /* boinc_opencl.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF9EC09144EB2BB005D6144 /* boinc_opencl.h */; };
 		DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */ = {isa = PBXBuildFile; fileRef = DDFA60D40CB337D40037B88C /* gfx_switcher */; };
@@ -1307,6 +1312,7 @@
 		DDF93510176B0D0C00A2793C /* translate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = translate.h; path = ../lib/translate.h; sourceTree = "<group>"; };
 		DDF9385407E28906004DC076 /* checkin_notes */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = text; name = checkin_notes; path = ../checkin_notes; sourceTree = SOURCE_ROOT; };
 		DDF9B4D01F680006008BC9B7 /* x_opengl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = x_opengl.h; sourceTree = "<group>"; };
+		DDF9B766245C3A7F00587EBE /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = ../../../../../System/Library/Frameworks/SystemConfiguration.framework; sourceTree = "<group>"; };
 		DDF9EC03144EB14B005D6144 /* libboinc_opencl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboinc_opencl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF9EC08144EB2BB005D6144 /* boinc_opencl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = boinc_opencl.cpp; sourceTree = "<group>"; };
 		DDF9EC09144EB2BB005D6144 /* boinc_opencl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = boinc_opencl.h; sourceTree = "<group>"; };
@@ -1429,6 +1435,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDA70B4223632223007097BD /* AppKit.framework in Frameworks */,
+				DDF9B769245C3A8000587EBE /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1476,6 +1483,7 @@
 				DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */,
 				DDB74A6C0D74259E00E97A40 /* AppKit.framework in Frameworks */,
 				DDD93E7313E017B600B92D0F /* IOKit.framework in Frameworks */,
+				DDF9B767245C3A8000587EBE /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1532,6 +1540,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD26B52C237445DD00206557 /* AppKit.framework in Frameworks */,
+				DDF9B768245C3A8000587EBE /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1587,6 +1596,7 @@
 				DD81C79E144D8F97000BE61A /* jpeg */,
 				20286C2CFDCF999611CA2CEA /* Resources */,
 				20286C32FDCF999611CA2CEA /* External Frameworks and Libraries */,
+				DDF9B766245C3A7F00587EBE /* SystemConfiguration.framework */,
 				195DF8C9FE9D4F0611CA2CBB /* Products */,
 				DD96AFFA0811075100A06F22 /* ScreenSaver-Info.plist */,
 				DD1277B5081F3D67007B5DE1 /* PostInstall-Info.plist */,
@@ -3396,6 +3406,7 @@
 				DD262C871366D4D200C9A187 /* proxy_info.cpp in Sources */,
 				DDA165E513B49B0D00CB4DD5 /* url.cpp in Sources */,
 				DD76BF9A17CB46830075936D /* opencl_boinc.cpp in Sources */,
+				DDF9B76B245C3CC700587EBE /* shmem.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3570,12 +3581,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD69D09C23ACBD9E00304FD0 /* mac_spawn.cpp in Sources */,
 				DDFA60E40CB3396C0037B88C /* gfx_switcher.cpp in Sources */,
 				DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */,
 				DDF0776D236C4E420046EE44 /* coproc.cpp in Sources */,
 				DDC918FB236C2ABB009641C8 /* filesys.cpp in Sources */,
 				DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */,
-				DD69D09C23ACBD9E00304FD0 /* mac_spawn.cpp in Sources */,
 				DD26B52B237443BF00206557 /* mac_util.mm in Sources */,
 				DDFA61780CB348660037B88C /* mfile.cpp in Sources */,
 				DDFA617A0CB3486D0037B88C /* miofile.cpp in Sources */,
@@ -3583,6 +3594,7 @@
 				DDFA617E0CB3487F0037B88C /* parse.cpp in Sources */,
 				DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */,
 				DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */,
+				DDF9B76A245C3C7900587EBE /* shmem.cpp in Sources */,
 				DDFA61860CB3489E0037B88C /* str_util.cpp in Sources */,
 				DDF0776C236C4E1A0046EE44 /* url.cpp in Sources */,
 				DDC918FC236C2AE8009641C8 /* util.cpp in Sources */,

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -47,7 +47,6 @@
 		DD08648D19E0BE6D00994039 /* ProjectWelcomePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD08648B19E0BE6D00994039 /* ProjectWelcomePage.cpp */; };
 		DD0925B51FB05490000902DF /* project_list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD0925B31FB05490000902DF /* project_list.cpp */; };
 		DD0A06F50869A2D2007CD86E /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DD0BB7A21F62B105000151B2 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
 		DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD0C5A8A0816711400CEC5D7 /* boinc.jpg */; };
 		DD0D32DD1E0ABEEE00A0FBAB /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DD11E5B617D1A89700947975 /* MacAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = DD1907FA17D1A2F100596F03 /* MacAccessiblity.mm */; };
@@ -75,6 +74,8 @@
 		DD262C811366D35A00C9A187 /* cc_config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4AE04B13652BD700285859 /* cc_config.cpp */; };
 		DD262C821366D35D00C9A187 /* cc_config.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4AE04B13652BD700285859 /* cc_config.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DD262C871366D4D200C9A187 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DD26B52B237443BF00206557 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
+		DD26B52C237445DD00206557 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DD2B6C8013149177005D6F3E /* procinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2B6C7E13149177005D6F3E /* procinfo.cpp */; };
 		DD2B6C8113149177005D6F3E /* procinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2B6C7E13149177005D6F3E /* procinfo.cpp */; };
 		DD2B6C8D131491B7005D6F3E /* procinfo_mac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDB6934F0ABFE9C600689FD8 /* procinfo_mac.cpp */; };
@@ -90,10 +91,6 @@
 		DD35353607E1E13F00C4718D /* boinc_api.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5755AD302FE063A012012A7 /* boinc_api.cpp */; };
 		DD3741D610FC948C001257EB /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
 		DD3741D910FC94BA001257EB /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
-		DD39C56C244C681A00FBE22E /* boinc_ss_helper.sh in Resources */ = {isa = PBXBuildFile; fileRef = DD39C56B244C643F00FBE22E /* boinc_ss_helper.sh */; };
-		DD3A54E424519F96006A7249 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD22BD1C23A9029500829495 /* SystemConfiguration.framework */; };
-		DD3A54E524519FC9006A7249 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD22BD1C23A9029500829495 /* SystemConfiguration.framework */; };
-		DD3A54E62451A1A1006A7249 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD22BD1C23A9029500829495 /* SystemConfiguration.framework */; };
 		DD3E14DB0A774397007E0084 /* boinc in Resources */ = {isa = PBXBuildFile; fileRef = DDD74D8707CF482E0065AC9D /* boinc */; };
 		DD3E14DC0A774397007E0084 /* BOINCMgr.icns in Resources */ = {isa = PBXBuildFile; fileRef = DDF3028907CCCE2C00701169 /* BOINCMgr.icns */; };
 		DD3E14DF0A774397007E0084 /* AccountInfoPage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD58C41808F3343F00C1DF66 /* AccountInfoPage.cpp */; };
@@ -220,6 +217,7 @@
 		DD67F8140ADB9DD000B0015E /* wxPieCtrl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD40E75D0ADB87BC00214518 /* wxPieCtrl.cpp */; };
 		DD6802310E701ACD0067D009 /* cert_sig.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD68022E0E701ACD0067D009 /* cert_sig.cpp */; };
 		DD6803440E70A61D0067D009 /* diagnostics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BA207C5AE5A0043025C /* diagnostics.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DD69D09C23ACBD9E00304FD0 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD69FEF508416C6B00C01361 /* gui_rpc_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C5CC07C5D7D90098A04D /* gui_rpc_client.cpp */; };
 		DD69FEF708416C9A00C01361 /* boinc_cmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD69FEF608416C9A00C01361 /* boinc_cmd.cpp */; };
 		DD69FF0C084171CF00C01361 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6D0A8507E9A61B007F882B /* network.cpp */; };
@@ -353,9 +351,6 @@
 		DD8917E90F3B216000DE5B1C /* gutil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD40825507D3076400163EF5 /* gutil.cpp */; };
 		DD8917EE0F3B21CE00DE5B1C /* macglutfix.m in Sources */ = {isa = PBXBuildFile; fileRef = DD6D82DA08131AB1008F7200 /* macglutfix.m */; };
 		DD8917F00F3B21DA00DE5B1C /* mac_icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6381450870DB78007A2F8E /* mac_icon.cpp */; };
-		DD8A88F6244EF22700D9D64A /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD8A88F5244EF22600D9D64A /* AppKit.framework */; };
-		DD8A88F7244F0D7700D9D64A /* shmem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAA31C97042157A800A80164 /* shmem.cpp */; };
-		DD8A88F8244F0D9F00D9D64A /* shmem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAA31C97042157A800A80164 /* shmem.cpp */; };
 		DD93854520F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
 		DD93854620F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
 		DD93854720F609C8008EDE5A /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
@@ -369,7 +364,6 @@
 		DD957E5B181B908800ECA34E /* thumbnail.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E59181B908800ECA34E /* thumbnail.png */; };
 		DD957E5C181B908800ECA34E /* thumbnail@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = DD957E5A181B908800ECA34E /* thumbnail@2x.png */; };
 		DD9917251E69A4F100555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
-		DD9917261E69A8B300555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917271E69A8D100555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917281E69A90500555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
 		DD9917291E69A90800555337 /* mac_spawn.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2C5C3D1E66D83D00BF5511 /* mac_spawn.cpp */; };
@@ -450,9 +444,9 @@
 		DDC82FA31A35BB68005FA808 /* DlgHiddenColumns.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC82FA11A35BB68005FA808 /* DlgHiddenColumns.cpp */; };
 		DDC836E60EDEA5DB001C2EF9 /* TermsOfUsePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC836E50EDEA5DB001C2EF9 /* TermsOfUsePage.cpp */; };
 		DDC8FB2A1F6D393C00BE55B8 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
+		DDC918FB236C2ABB009641C8 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
+		DDC918FC236C2AE8009641C8 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
 		DDC988FE0F3BD44100EE8D0E /* gui_rpc_client_ops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD73E34E08A0694000656EB1 /* gui_rpc_client_ops.cpp */; };
-		DDC99C82244EEF6100D617D8 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
-		DDC99C83244EF03700D617D8 /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
 		DDCF84080E1B7C0A005EDC45 /* DlgItemProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDCF84060E1B7C0A005EDC45 /* DlgItemProperties.cpp */; };
 		DDD0697312D70C9400120920 /* sg_TaskPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD0697112D70C9400120920 /* sg_TaskPanel.cpp */; };
 		DDD095490A3EDF2D00C95BA4 /* switcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD095480A3EDF2D00C95BA4 /* switcher.cpp */; };
@@ -513,7 +507,6 @@
 		DDD8846418E17D7A00BE1E34 /* DlgDiagnosticLogFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD8846218E17D7A00BE1E34 /* DlgDiagnosticLogFlags.cpp */; };
 		DDD93E7313E017B600B92D0F /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDE2552B07C62F3E008E7D6E /* IOKit.framework */; };
 		DDD9C5A510CCF61F00A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
-		DDD9C5AA10CCF6A000A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
 		DDD9C5AB10CCF6A300A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
 		DDD9C5AC10CCF6AB00A1E4CD /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDDC2055183B560B00CB5845 /* mac_address.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDDC2053183B560B00CB5845 /* mac_address.cpp */; };
@@ -550,6 +543,13 @@
 		DDEEAA991F73D3D70051E8C5 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
 		DDEEAA9A1F73E8630051E8C5 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
 		DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
+		DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
+		DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
+		DDF0776B236C4DD60046EE44 /* opencl_boinc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD76BF9117CB45870075936D /* opencl_boinc.cpp */; };
+		DDF0776C236C4E1A0046EE44 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
+		DDF0776D236C4E420046EE44 /* coproc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7475500D86273300860636 /* coproc.cpp */; };
+		DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
+		DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
 		DDF5E23318B8673E005DEA6E /* uninstall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4688590C1661970089F500 /* uninstall.cpp */; };
 		DDF5E23418B86803005DEA6E /* AddRemoveUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD33709106224E800867C7D /* AddRemoveUser.cpp */; };
 		DDF5F85A10DD05DB006A50CD /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
@@ -559,18 +559,10 @@
 		DDF9EC0B144EB2BB005D6144 /* boinc_opencl.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF9EC09144EB2BB005D6144 /* boinc_opencl.h */; };
 		DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */ = {isa = PBXBuildFile; fileRef = DDFA60D40CB337D40037B88C /* gfx_switcher */; };
 		DDFA60E40CB3396C0037B88C /* gfx_switcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */; };
-		DDFA61520CB347500037B88C /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
-		DDFA61570CB347730037B88C /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
 		DDFA61780CB348660037B88C /* mfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD207C5B1150043025C /* mfile.cpp */; };
 		DDFA617A0CB3486D0037B88C /* miofile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BD507C5B1150043025C /* miofile.cpp */; };
 		DDFA617E0CB3487F0037B88C /* parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B901602AC0A2201FB7237 /* parse.cpp */; };
 		DDFA61860CB3489E0037B88C /* str_util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD7BF7D70B8E7A9800A009F7 /* str_util.cpp */; };
-		DDFA61890CB348A90037B88C /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; };
-		DDFA618C0CB348C50037B88C /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
-		DDFA618F0CB348E80037B88C /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159562029EB02001F5651B /* md5.cpp */; };
-		DDFA61900CB348E90037B88C /* md5_file.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159564029EB02001F5651B /* md5_file.cpp */; };
-		DDFA61920CB349020037B88C /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
-		DDFA61940CB349160037B88C /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
 		DDFD5F0F0818F2EE002B23D4 /* gui_rpc_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C5CC07C5D7D90098A04D /* gui_rpc_client.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F270818F329002B23D4 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F280818F33C002B23D4 /* md5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5159562029EB02001F5651B /* md5.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -580,11 +572,11 @@
 		DDFD5F2C0818F368002B23D4 /* network.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6D0A8507E9A61B007F882B /* network.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F2D0818F372002B23D4 /* parse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F54B901602AC0A2201FB7237 /* parse.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		DDFD5F2E0818F3A1002B23D4 /* util.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD479031AF001018E201A /* util.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		DDFE4E3D10AB778100919319 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
 		DDFE4E9110AB7C3A00919319 /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
 		DDFE84E50B60CD66009B43D9 /* DlgAdvPreferences.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFE84E10B60CD66009B43D9 /* DlgAdvPreferences.cpp */; };
 		DDFE84E70B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFE84E30B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp */; };
 		DDFF2AE90A53D599002BC19D /* setprojectgrp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFF2AE80A53D599002BC19D /* setprojectgrp.cpp */; };
+		DDFF2EAB245BA6A300347B89 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -901,7 +893,6 @@
 		DD1E4B7A14DCA83F0093C711 /* async_file.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = async_file.h; sourceTree = "<group>"; };
 		DD1F0ACD0822069E00AFC5FA /* MacGUI.pch */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = MacGUI.pch; path = ../clientgui/mac/MacGUI.pch; sourceTree = SOURCE_ROOT; };
 		DD2049DC0D862516009EEE7A /* coproc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = coproc.h; path = ../lib/coproc.h; sourceTree = SOURCE_ROOT; };
-		DD22BD1C23A9029500829495 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = ../../../../../System/Library/Frameworks/SystemConfiguration.framework; sourceTree = "<group>"; };
 		DD22DF5C1A235F58007FB597 /* DlgExclusiveApps.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DlgExclusiveApps.cpp; sourceTree = "<group>"; };
 		DD22DF5D1A235F58007FB597 /* DlgExclusiveApps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DlgExclusiveApps.h; sourceTree = "<group>"; };
 		DD247AF70AEA308A0034104A /* SkinManager.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = SkinManager.cpp; path = ../clientgui/SkinManager.cpp; sourceTree = SOURCE_ROOT; };
@@ -964,7 +955,6 @@
 		DD344BEE07C5B1770043025C /* proxy_info.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = proxy_info.h; path = ../lib/proxy_info.h; sourceTree = SOURCE_ROOT; };
 		DD344BEF07C5B1770043025C /* proxy_info.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_info.cpp; sourceTree = "<group>"; };
 		DD35353107E1E05C00C4718D /* libboinc_api.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboinc_api.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		DD39C56B244C643F00FBE22E /* boinc_ss_helper.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = boinc_ss_helper.sh; path = ../clientscr/boinc_ss_helper.sh; sourceTree = "<group>"; };
 		DD3E15420A774397007E0084 /* BOINCManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BOINCManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3EAAA6216A25AD00BC673C /* boinc_finish_install */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = boinc_finish_install; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3EAAAE216A268500BC673C /* finish_install.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = finish_install.cpp; path = ../mac_installer/finish_install.cpp; sourceTree = "<group>"; };
@@ -1182,7 +1172,6 @@
 		DD89163C0F3B182700DE5B1C /* ss_app.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ss_app.cpp; path = ../clientscr/ss_app.cpp; sourceTree = SOURCE_ROOT; };
 		DD89165D0F3B1BC200DE5B1C /* GLUT.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLUT.framework; path = /System/Library/Frameworks/GLUT.framework; sourceTree = "<absolute>"; };
 		DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
-		DD8A88F5244EF22600D9D64A /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		DD8DD4A509D9432F0043019E /* BOINCDialupManager.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = BOINCDialupManager.cpp; path = ../clientgui/BOINCDialupManager.cpp; sourceTree = SOURCE_ROOT; };
 		DD8DD4A609D9432F0043019E /* BOINCDialupManager.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = BOINCDialupManager.h; path = ../clientgui/BOINCDialupManager.h; sourceTree = SOURCE_ROOT; };
 		DD93854320F609C7008EDE5A /* mac_branding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = mac_branding.cpp; path = ../lib/mac/mac_branding.cpp; sourceTree = "<group>"; };
@@ -1440,7 +1429,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DDA70B4223632223007097BD /* AppKit.framework in Frameworks */,
-				DD3A54E524519FC9006A7249 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1471,7 +1459,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD0BB7A21F62B105000151B2 /* IOSurface.framework in Frameworks */,
+				DDFF2EAB245BA6A300347B89 /* IOSurface.framework in Frameworks */,
 				DD89165A0F3B1B9000DE5B1C /* AppKit.framework in Frameworks */,
 				DD89165F0F3B1BC200DE5B1C /* GLUT.framework in Frameworks */,
 				DD8916600F3B1BC200DE5B1C /* OpenGL.framework in Frameworks */,
@@ -1488,7 +1476,6 @@
 				DDEEAA9D1F73E9570051E8C5 /* OpenGL.framework in Frameworks */,
 				DDB74A6C0D74259E00E97A40 /* AppKit.framework in Frameworks */,
 				DDD93E7313E017B600B92D0F /* IOKit.framework in Frameworks */,
-				DD3A54E424519F96006A7249 /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1544,8 +1531,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD8A88F6244EF22700D9D64A /* AppKit.framework in Frameworks */,
-				DD3A54E62451A1A1006A7249 /* SystemConfiguration.framework in Frameworks */,
+				DD26B52C237445DD00206557 /* AppKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1607,7 +1593,6 @@
 				DD1AFE8F0A512D2600EE5B82 /* Installer-Info.plist */,
 				DD4688430C165F3C0089F500 /* Uninstaller-Info.plist */,
 				DDB219A610B3BB6200417AEF /* WaitPermissions-Info.plist */,
-				DD8A88F4244EF22600D9D64A /* Frameworks */,
 			);
 			name = "¬´PROJECTNAME¬ª";
 			sourceTree = "<group>";
@@ -1644,7 +1629,6 @@
 				DD89165D0F3B1BC200DE5B1C /* GLUT.framework */,
 				DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */,
 				DD0BB7A11F62B105000151B2 /* IOSurface.framework */,
-				DD22BD1C23A9029500829495 /* SystemConfiguration.framework */,
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = SOURCE_ROOT;
@@ -1891,14 +1875,6 @@
 			path = ../api;
 			sourceTree = "<group>";
 		};
-		DD8A88F4244EF22600D9D64A /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				DD8A88F5244EF22600D9D64A /* AppKit.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		DDA6BCED0BD4546D008F7921 /* mac */ = {
 			isa = PBXGroup;
 			children = (
@@ -1943,7 +1919,6 @@
 				DDE7A3B015C6739E002B3B96 /* ttfont.h */,
 				DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */,
 				DD5F654A23605C87009ED2A2 /* gfx_cleanup.mm */,
-				DD39C56B244C643F00FBE22E /* boinc_ss_helper.sh */,
 			);
 			name = clientscr;
 			sourceTree = SOURCE_ROOT;
@@ -2436,7 +2411,7 @@
 				DD96AFF60811075000A06F22 /* Sources */,
 				DD96AFF70811075000A06F22 /* Frameworks */,
 				DD5FD5990A0233D60093C19F /* ShellScript */,
-				DD39C56D244C6AF300FBE22E /* ShellScript */,
+				DDF9B764245C12AA00587EBE /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -2688,7 +2663,6 @@
 			files = (
 				DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */,
 				DD5F656623607472009ED2A2 /* gfx_cleanup in Resources */,
-				DD39C56C244C681A00FBE22E /* boinc_ss_helper.sh in Resources */,
 				DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */,
 				DD48091F081A66F100A174AA /* BOINCSaver.nib in Resources */,
 				DDBC6CA50D5D458700564C49 /* boinc_ss_logo.png in Resources */,
@@ -2753,24 +2727,6 @@
 			shellPath = /bin/sh;
 			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/Uninstall BOINC.app/Contents/Resources/English.lproj/\"\ncp -fpRv \"${SRCROOT}/English.lproj/Uninstaller-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/Uninstall BOINC.app/Contents/Resources/English.lproj/InfoPlist.strings\"";
 		};
-		DD39C56D244C6AF300FBE22E /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/boinc_sshelper.sh",
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "chmod u+x,g+x,o+x \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/boinc_ss_helper.sh\"\n";
-		};
 		DD3B67F6140CFFA20088683F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2809,7 +2765,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"CONFIGURATION = ${CONFIGURATION}\"\n# echo \"PRODUCT_NAME = ${PRODUCT_NAME}\"\nmkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" -nt \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n        strip -S \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    fi\nfi";
+			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"CONFIGURATION = ${CONFIGURATION}\"\n# echo \"PRODUCT_NAME = ${PRODUCT_NAME}\"\nmkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" -nt \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n        strip -S \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    fi\nfi\n";
 		};
 		DD5E20A8140CE842000FADAA /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2946,7 +2902,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" -nt \"${SRCROOT}/../api/MultiGPUMig.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" \"${SRCROOT}/../api/MultiGPUMig.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" \"${SRCROOT}/../api/MultiGPUMigServer.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" \"${SRCROOT}/../api/MultiGPUMigServer.c\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" -nt \"${SRCROOT}/../api/MultiGPUMigUser.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" \"${SRCROOT}/../api/MultiGPUMigUser.c\"\nfi\n";
+			shellScript = "if [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMig.h\" -nt \"${SRCROOT}/../api/MultiGPUMig.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMig.h\" \"${SRCROOT}/../api/MultiGPUMig.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.h\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.h\" \"${SRCROOT}/../api/MultiGPUMigServer.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.c\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.c\" \"${SRCROOT}/../api/MultiGPUMigServer.c\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigUser.c\" -nt \"${SRCROOT}/../api/MultiGPUMigUser.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigUser.c\" \"${SRCROOT}/../api/MultiGPUMigUser.c\"\nfi\n";
 		};
 		DDC8FB2C1F6D39B800BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2959,7 +2915,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" -nt \"${SRCROOT}/../api/MultiGPUMig.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMig.h\" \"${SRCROOT}/../api/MultiGPUMig.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.h\" \"${SRCROOT}/../api/MultiGPUMigServer.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigServer.c\" \"${SRCROOT}/../api/MultiGPUMigServer.c\"\nfi\nif [ \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" -nt \"${SRCROOT}/../api/MultiGPUMigUser.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/i386/MultiGPUMigUser.c\" \"${SRCROOT}/../api/MultiGPUMigUser.c\"\nfi\n";
+			shellScript = "if [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMig.h\" -nt \"${SRCROOT}/../api/MultiGPUMig.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMig.h\" \"${SRCROOT}/../api/MultiGPUMig.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.h\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.h\" \"${SRCROOT}/../api/MultiGPUMigServer.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.c\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.c\" \"${SRCROOT}/../api/MultiGPUMigServer.c\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigUser.c\" -nt \"${SRCROOT}/../api/MultiGPUMigUser.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigUser.c\" \"${SRCROOT}/../api/MultiGPUMigUser.c\"\nfi\n";
 		};
 		DDEE5E8E0D9112AF0056A99E /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -2975,6 +2931,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n    touch \"${BUILT_PRODUCTS_DIR}/SymbolTables/BOINCManager.app.dSYM\"\nfi\n";
+		};
+		DDF9B764245C12AA00587EBE /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMig.h\" -nt \"${SRCROOT}/../api/MultiGPUMig.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMig.h\" \"${SRCROOT}/../api/MultiGPUMig.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.h\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.h\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.h\" \"${SRCROOT}/../api/MultiGPUMigServer.h\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.c\" -nt \"${SRCROOT}/../api/MultiGPUMigServer.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigServer.c\" \"${SRCROOT}/../api/MultiGPUMigServer.c\"\nfi\nif [ \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigUser.c\" -nt \"${SRCROOT}/../api/MultiGPUMigUser.c\" ]; then\n    cp -fp \"${DERIVED_FILES_DIR}/x86_64/MultiGPUMigUser.c\" \"${SRCROOT}/../api/MultiGPUMigUser.c\"\nfi\n";
 		};
 		DDF9EC07144EB255005D6144 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3423,7 +3396,6 @@
 				DD262C871366D4D200C9A187 /* proxy_info.cpp in Sources */,
 				DDA165E513B49B0D00CB4DD5 /* url.cpp in Sources */,
 				DD76BF9A17CB46830075936D /* opencl_boinc.cpp in Sources */,
-				DD8A88F8244F0D9F00D9D64A /* shmem.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3598,25 +3570,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD9917261E69A8B300555337 /* mac_spawn.cpp in Sources */,
 				DDFA60E40CB3396C0037B88C /* gfx_switcher.cpp in Sources */,
-				DDFA61520CB347500037B88C /* app_ipc.cpp in Sources */,
-				DDFA61570CB347730037B88C /* filesys.cpp in Sources */,
+				DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */,
+				DDF0776D236C4E420046EE44 /* coproc.cpp in Sources */,
+				DDC918FB236C2ABB009641C8 /* filesys.cpp in Sources */,
+				DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */,
+				DD69D09C23ACBD9E00304FD0 /* mac_spawn.cpp in Sources */,
+				DD26B52B237443BF00206557 /* mac_util.mm in Sources */,
 				DDFA61780CB348660037B88C /* mfile.cpp in Sources */,
 				DDFA617A0CB3486D0037B88C /* miofile.cpp in Sources */,
+				DDF0776B236C4DD60046EE44 /* opencl_boinc.cpp in Sources */,
 				DDFA617E0CB3487F0037B88C /* parse.cpp in Sources */,
+				DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */,
+				DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */,
 				DDFA61860CB3489E0037B88C /* str_util.cpp in Sources */,
-				DDFA61890CB348A90037B88C /* util.cpp in Sources */,
-				DDFA618C0CB348C50037B88C /* hostinfo.cpp in Sources */,
-				DDFA618F0CB348E80037B88C /* md5.cpp in Sources */,
-				DDFA61900CB348E90037B88C /* md5_file.cpp in Sources */,
-				DDFA61920CB349020037B88C /* proxy_info.cpp in Sources */,
-				DDFA61940CB349160037B88C /* prefs.cpp in Sources */,
-				DDFE4E3D10AB778100919319 /* url.cpp in Sources */,
-				DDD9C5AA10CCF6A000A1E4CD /* coproc.cpp in Sources */,
-				DDC99C83244EF03700D617D8 /* opencl_boinc.cpp in Sources */,
-				DDC99C82244EEF6100D617D8 /* mac_util.mm in Sources */,
-				DD8A88F7244F0D7700D9D64A /* shmem.cpp in Sources */,
+				DDF0776C236C4E1A0046EE44 /* url.cpp in Sources */,
+				DDC918FC236C2AE8009641C8 /* util.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/samples/example_app/MakeMacExample.sh
+++ b/samples/example_app/MakeMacExample.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # http://boinc.berkeley.edu
-# Copyright (C) 2008 University of California
+# Copyright (C) 2020 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License

--- a/samples/example_app/MakeMacExample.sh
+++ b/samples/example_app/MakeMacExample.sh
@@ -26,8 +26,9 @@
 # Updated 8/3/12 for TrueType fonts
 # Updated 11/8/12 to add slide_show
 # Updated 4/14/15 to fix build instructions
+# Updated 4/30/20 for Xcode 11
 #
-## This script requires OS 10.6 or later
+## This script requires OS 10.7 or later
 #
 ## If you drag-install Xcode 4.3 or later, you must have opened Xcode 
 ## and clicked the Install button on the dialog which appears to 
@@ -76,29 +77,7 @@ export PATH="${TOOLSPATH1}":"${TOOLSPATH2}":/usr/local/bin:$PATH
 
 SDKPATH=`xcodebuild -version -sdk macosx Path`
 
-rm -fR i386 x86_64
-
-echo
-echo "***************************************************"
-echo "******* Building 32-bit Intel Application *********"
-echo "***************************************************"
-echo
-
-export CC="${GCCPATH}";export CXX="${GPPPATH}"
-export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,i386"
-export VARIANTFLAGS="-isysroot ${SDKPATH} -arch i386 -DMAC_OS_X_VERSION_MAX_ALLOWED=1040 -DMAC_OS_X_VERSION_MIN_REQUIRED=1040 -fvisibility=hidden -fvisibility-inlines-hidden"
-export SDKROOT="${SDKPATH}"
-export MACOSX_DEPLOYMENT_TARGET=10.4
-
-make -f Makefile_mac clean
-make -f Makefile_mac all
-
-if [  $? -ne 0 ]; then exit 1; fi
-
-mkdir i386
-mv uc2 i386/
-mv uc2_graphics i386/
-mv slide_show i386/
+rm -fR x86_64
 
 echo
 echo "***************************************************"
@@ -108,9 +87,9 @@ echo
 
 export CC="${GCCPATH}";export CXX="${GPPPATH}"
 export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64"
-export VARIANTFLAGS="-isysroot ${SDKPATH} -arch x86_64 -DMAC_OS_X_VERSION_MAX_ALLOWED=1050 -DMAC_OS_X_VERSION_MIN_REQUIRED=1050 -fvisibility=hidden -fvisibility-inlines-hidden"
+export VARIANTFLAGS="-isysroot ${SDKPATH} -arch x86_64 -DMAC_OS_X_VERSION_MAX_ALLOWED=1070 -DMAC_OS_X_VERSION_MIN_REQUIRED=1070 -fvisibility=hidden -fvisibility-inlines-hidden"
 export SDKROOT="${SDKPATH}"
-export MACOSX_DEPLOYMENT_TARGET=10.5
+export MACOSX_DEPLOYMENT_TARGET=10.7
 
 make -f Makefile_mac clean
 make -f Makefile_mac all

--- a/samples/example_app/Makefile_mac
+++ b/samples/example_app/Makefile_mac
@@ -5,6 +5,7 @@
 # Updated 8/3/12 for TrueType fonts
 # Updated 11/8/12 to add slide_show
 # Updated 4/14/15 for compatibility with Xcode 6
+# Updated 4/30/20 for compatibility with Xcode 11 and OS 10.13
 #
 ## First, build the BOINC libraries using boinc/mac_build/BuildMacBOINC.sh
 ## This file assumes the locations of the needed libraries are those 

--- a/samples/example_app/Makefile_mac
+++ b/samples/example_app/Makefile_mac
@@ -24,7 +24,7 @@ FRAMEWORKS_DIR = /System/Library/Frameworks
 
 CXXFLAGS = $(VARIANTFLAGS) \
     -g \
-    -stdlib=libstdc++ \
+    -stdlib=libc++ \
     -DAPP_GRAPHICS \
     -I$(BOINC_CONFIG_DIR) \
     -I$(BOINC_DIR) \
@@ -70,11 +70,11 @@ uc2_graphics: uc2_graphics.o ttfont.o $(BOINC_BUILD_DIR)/libboinc.a\
     $(BOINC_BUILD_DIR)/libboinc_graphics2.a
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o uc2_graphics uc2_graphics.o ttfont.o\
     -lboinc_graphics2 -lboinc_api -lboinc -ljpeg -lfreetype -lftgl -lz -lbz2\
-    -framework AppKit -framework GLUT -framework OpenGL
+    -framework AppKit -framework GLUT -framework OpenGL -framework IOSurface
 
 slide_show: slide_show.o $(BOINC_BUILD_DIR)/libboinc.a\
     $(BOINC_BUILD_DIR)/libboinc_graphics2.a
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o slide_show slide_show.o\
     -lboinc_graphics2 -lboinc_api -lboinc -ljpeg -lboinc_zip\
-    -framework AppKit -framework GLUT -framework OpenGL
+    -framework AppKit -framework GLUT -framework OpenGL -framework IOSurface
     

--- a/samples/example_app/Makefile_mac2
+++ b/samples/example_app/Makefile_mac2
@@ -26,7 +26,7 @@ FRAMEWORKS_DIR = /System/Library/Frameworks
 
 CXXFLAGS_ALL = \
     -g \
-    -stdlib=libstdc++ \
+     -stdlib=libc++ \
     -DAPP_GRAPHICS \
     -I$(BOINC_CONFIG_DIR) \
     -I$(BOINC_DIR) \
@@ -43,20 +43,12 @@ LDFLAGS_ALL = \
     -Wl,-L/usr/lib \
     -Wl,-L.
 
-CXXFLAGS_i386 = -arch i386 -DMAC_OS_X_VERSION_MAX_ALLOWED=1040 -DMAC_OS_X_VERSION_MIN_REQUIRED=1040 \
-    $(CXXFLAGS_ALL) -fvisibility=hidden -fvisibility-inlines-hidden
-LDFLAGS_i386 = -Wl,-arch,i386 $(LDFLAGS_ALL)
-
-CXXFLAGS_x86_64 = -arch x86_64 -DMAC_OS_X_VERSION_MAX_ALLOWED=1050 -DMAC_OS_X_VERSION_MIN_REQUIRED=1050 \
+CXXFLAGS_x86_64 = -arch x86_64 -DMAC_OS_X_VERSION_MAX_ALLOWED=1070 -DMAC_OS_X_VERSION_MIN_REQUIRED=1070 \
     $(CXXFLAGS_ALL) -fvisibility=hidden -fvisibility-inlines-hidden
 LDFLAGS_x86_64 = -Wl,-arch,x86_64 $(LDFLAGS_ALL)
 
 
 OBJ = \
-    uc2_i386.o \
-    ttfont_i386.o \
-    uc2_graphics_i386.o \
-    slide_show_i386.o \
     uc2_x86_64.o \
     ttfont_x86_64.o \
     uc2_graphics_x86_64.o \
@@ -64,7 +56,6 @@ OBJ = \
 
 
 PROGS = \
-    uc2_i386 uc2_graphics_i386 slide_show_i386 \
     uc2_x86_64 uc2_graphics_x86_64 slide_show_x86_64
 
 all: $(PROGS)
@@ -72,27 +63,11 @@ all: $(PROGS)
 clean:
 	/bin/rm -f $(PROGS) $(OBJ)
 
-uc2_i386: export MACOSX_DEPLOYMENT_TARGET=10.4
-uc2_graphics_i386: export MACOSX_DEPLOYMENT_TARGET=10.4
-slide_show_i386: export MACOSX_DEPLOYMENT_TARGET=10.4
 uc2_x86_64: export MACOSX_DEPLOYMENT_TARGET=10.5
-uc2_graphics_x86_64: export MACOSX_DEPLOYMENT_TARGET=10.5
-slide_show_x86_64: export MACOSX_DEPLOYMENT_TARGET=10.5
+uc2_graphics_x86_64: export MACOSX_DEPLOYMENT_TARGET=10.7
+slide_show_x86_64: export MACOSX_DEPLOYMENT_TARGET=10.7
 
-target uc2_i386: MACOSX_DEPLOYMENT_TARGET=10.4
-uc2_i386.o: uc2.cpp
-	$(CXX) -c $(CXXFLAGS_i386) uc2.cpp -o uc2_i386.o
-
-ttfont_i386.o: $(BOINC_API_DIR)/ttfont.cpp
-	$(CXX) -c $(CXXFLAGS_i386) $(BOINC_API_DIR)/ttfont.cpp -o ttfont_i386.o
-
-uc2_graphics_i386.o: uc2_graphics.cpp
-	$(CXX) -c $(CXXFLAGS_i386) uc2_graphics.cpp -o uc2_graphics_i386.o
-
-slide_show_i386.o: slide_show.cpp
-	$(CXX) $(CXXFLAGS_i386) -c slide_show.cpp -o slide_show_i386.o
-
-target uc2_x86_64: MACOSX_DEPLOYMENT_TARGET=10.5
+target uc2_x86_64: MACOSX_DEPLOYMENT_TARGET=10.7
 uc2_x86_64.o: uc2.cpp
 	$(CXX) -c $(CXXFLAGS_x86_64) uc2.cpp -o uc2_x86_64.o
 
@@ -105,22 +80,6 @@ uc2_graphics_x86_64.o: uc2_graphics.cpp
 slide_show_x86_64.o: slide_show.cpp
 	$(CXX) $(CXXFLAGS_x86_64) -c slide_show.cpp -o slide_show_x86_64.o
 
-uc2_i386: uc2_i386.o $(BOINC_BUILD_DIR)/libboinc_api.a $(BOINC_BUILD_DIR)/libboinc.a
-	$(CXX) $(CXXFLAGS_i386) $(LDFLAGS_i386) -o uc2_i386 uc2_i386.o -lboinc_api -lboinc
-
-uc2_graphics_i386: uc2_graphics_i386.o ttfont_i386.o $(BOINC_BUILD_DIR)/libboinc.a\
-    $(BOINC_BUILD_DIR)/libboinc_graphics2.a $(FREETYPE_DIR/objs/.libs/libfreetype.a\
-    $(FTGL_DIR)/src/.libs/libftgl.a
-	$(CXX) $(CXXFLAGS_i386) $(LDFLAGS_i386) -o uc2_graphics_i386 uc2_graphics_i386.o\
-    ttfont_i386.o -lboinc_graphics2 -lboinc_api -lboinc -ljpeg -lfreetype -lftgl -lz\
-    -lbz2 -framework AppKit -framework GLUT -framework OpenGL
-
-slide_show_i386: slide_show_i386.o $(BOINC_BUILD_DIR)/libboinc.a\
-    $(BOINC_BUILD_DIR)/libboinc_graphics2.a
-	$(CXX) $(CXXFLAGS_x86_64) $(LDFLAGS_i386) -o slide_show_i386 slide_show_i386.o\
-    -lboinc_graphics2 -lboinc_api -lboinc -ljpeg -lboinc_zip\
-    -framework AppKit -framework GLUT -framework OpenGL
-
 uc2_x86_64: uc2_x86_64.o $(BOINC_BUILD_DIR)/libboinc_api.a $(BOINC_BUILD_DIR)/libboinc.a
 	$(CXX) $(CXXFLAGS_x86_64) $(LDFLAGS_x86_64) -o uc2_x86_64 uc2_x86_64.o -lboinc_api -lboinc
 
@@ -129,10 +88,11 @@ uc2_graphics_x86_64: uc2_graphics_x86_64.o ttfont_x86_64.o $(BOINC_BUILD_DIR)/li
     $(FTGL_DIR)/src/.libs/libftgl.a
 	$(CXX) $(CXXFLAGS_x86_64) $(LDFLAGS_x86_64) -o uc2_graphics_x86_64\
     uc2_graphics_x86_64.o ttfont_x86_64.o -lboinc_graphics2 -lboinc_api -lboinc -ljpeg\
-    -lfreetype -lftgl -lz -lbz2 -framework AppKit -framework GLUT -framework OpenGL
+    -lfreetype -lftgl -lz -lbz2 -framework AppKit -framework GLUT -framework OpenGL\
+     -framework IOSurface
 
 slide_show_x86_64: slide_show_x86_64.o $(BOINC_BUILD_DIR)/libboinc.a\
     $(BOINC_BUILD_DIR)/libboinc_graphics2.a
 	$(CXX) $(CXXFLAGS_x86_64) $(LDFLAGS_x86_64) -o slide_show_x86_64 slide_show_x86_64.o\
     -lboinc_graphics2 -lboinc_api -lboinc -ljpeg -lboinc_zip\
-    -framework AppKit -framework GLUT -framework OpenGL
+    -framework AppKit -framework GLUT -framework OpenGL -framework IOSurface

--- a/samples/example_app/Makefile_mac2
+++ b/samples/example_app/Makefile_mac2
@@ -3,6 +3,7 @@
 # Updated 8/3/12 for TrueType fonts
 # Updated 11/8/12 to add slide_show
 # Updated 4/14/15 for compatibility with Xcode 6
+# Updated 4/30/20 for compatibility with Xcode 11 and OS 10.13
 #
 ## First, build the BOINC libraries using boinc/mac_build/BuildMacBOINC.sh 
 ## This file assumes the locations of the needed libraries are those

--- a/samples/example_app/ReadMe.txt
+++ b/samples/example_app/ReadMe.txt
@@ -4,6 +4,8 @@ First build the BOINC libraries:
 cd [path]/mac_build
 source BuildMacBOINC.sh -lib
 
+NOTE: The libboinc_graphics2.a library and the graphics app must be built with the same version of Xcode
+
 For more details, see the instructions in that script's comments or at:
 [path]/mac_build/HowToBuildBOINC_XCode.rtf
 

--- a/samples/mac_build/UpperCase2.xcodeproj/project.pbxproj
+++ b/samples/mac_build/UpperCase2.xcodeproj/project.pbxproj
@@ -15,9 +15,6 @@
 			dependencies = (
 				DDC479C015AC57C40022401F /* PBXTargetDependency */,
 				DDC479BE15AC57BC0022401F /* PBXTargetDependency */,
-				DD84C7200C856DA6000EBEC4 /* PBXTargetDependency */,
-				DD84C7220C856DA6000EBEC4 /* PBXTargetDependency */,
-				DD84B698164D0151008E1369 /* PBXTargetDependency */,
 				DD5937AB164D1759001D94A5 /* PBXTargetDependency */,
 			);
 			name = Build_All;
@@ -26,22 +23,12 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		DD08CB70164CAC1A005B47DD /* slide_show.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD08CB6F164CAC1A005B47DD /* slide_show.cpp */; };
-		DD1194B00F42CB4900C2BC25 /* uc2_graphics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD1194AF0F42CB4900C2BC25 /* uc2_graphics.cpp */; };
-		DD1194B20F42CB5400C2BC25 /* uc2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD1194B10F42CB5400C2BC25 /* uc2.cpp */; };
+		DD0FAC13245ADFB60015D684 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD69ED6F2459A5840012014C /* IOSurface.framework */; };
+		DD0FAC14245ADFF10015D684 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD69ED6F2459A5840012014C /* IOSurface.framework */; };
 		DD59379F164D16CE001D94A5 /* slide_show.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD08CB6F164CAC1A005B47DD /* slide_show.cpp */; };
 		DD5937A1164D16CE001D94A5 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
 		DD5937A2164D16CE001D94A5 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E67094E56DB002CACC4 /* OpenGL.framework */; };
 		DD5937A3164D16CE001D94A5 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E65094E56DB002CACC4 /* AppKit.framework */; };
-		DD760E68094E56DB002CACC4 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E65094E56DB002CACC4 /* AppKit.framework */; };
-		DD760E69094E56DB002CACC4 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
-		DD760E6A094E56DB002CACC4 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E67094E56DB002CACC4 /* OpenGL.framework */; };
-		DD84B667164CEA83008E1369 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
-		DD84B669164CEA87008E1369 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E67094E56DB002CACC4 /* OpenGL.framework */; };
-		DD84B66A164CEB78008E1369 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E65094E56DB002CACC4 /* AppKit.framework */; };
-		DD84C6DF0C856B36000EBEC4 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E65094E56DB002CACC4 /* AppKit.framework */; };
-		DD84C6E00C856B36000EBEC4 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
-		DD84C6E10C856B36000EBEC4 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E67094E56DB002CACC4 /* OpenGL.framework */; };
 		DDC4796715AC56CA0022401F /* uc2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD1194B10F42CB5400C2BC25 /* uc2.cpp */; };
 		DDC4796915AC56CA0022401F /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E65094E56DB002CACC4 /* AppKit.framework */; };
 		DDC4796A15AC56CA0022401F /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
@@ -50,63 +37,16 @@
 		DDC479B015AC56EB0022401F /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E65094E56DB002CACC4 /* AppKit.framework */; };
 		DDC479B115AC56EB0022401F /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
 		DDC479B215AC56EB0022401F /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E67094E56DB002CACC4 /* OpenGL.framework */; };
-		DDF8050515CB9C75005473CC /* ttfont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF8050315CB9C75005473CC /* ttfont.cpp */; };
 		DDF8050615CB9C75005473CC /* ttfont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF8050315CB9C75005473CC /* ttfont.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
-		DD760E3C094E540C002CACC4 /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.gcc.4_0;
-			fileType = sourcecode.asm;
-			isEditable = 1;
-			outputFiles = (
-			);
-		};
-		DD760E3D094E540D002CACC4 /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.gcc.4_0;
-			fileType = sourcecode.cpp;
-			isEditable = 1;
-			outputFiles = (
-			);
-		};
-		DD760E3E094E540D002CACC4 /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.gcc.4_0;
-			fileType = sourcecode.c;
-			isEditable = 1;
-			outputFiles = (
-			);
-		};
-		DD84C6E30C856B36000EBEC4 /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.gcc.4_0;
-			fileType = sourcecode.c;
-			isEditable = 1;
-			outputFiles = (
-			);
-		};
-		DD84C6E40C856B36000EBEC4 /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.gcc.4_0;
-			fileType = sourcecode.cpp;
-			isEditable = 1;
-			outputFiles = (
-			);
-		};
-		DD84C6E50C856B36000EBEC4 /* PBXBuildRule */ = {
-			isa = PBXBuildRule;
-			compilerSpec = com.apple.compilers.gcc.4_0;
-			fileType = sourcecode.asm;
-			isEditable = 1;
-			outputFiles = (
-			);
-		};
 		DDC4796E15AC56CA0022401F /* PBXBuildRule */ = {
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.c;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -115,6 +55,8 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.cpp;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -123,6 +65,8 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.asm;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -131,6 +75,8 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.c;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -139,6 +85,8 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.cpp;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -147,6 +95,8 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.asm;
+			inputFiles = (
+			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -160,27 +110,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = DD59379D164D16CE001D94A5;
 			remoteInfo = "slide_show-x86_64";
-		};
-		DD84B697164D0151008E1369 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DD08CB63164CAAFF005B47DD;
-			remoteInfo = slide_show;
-		};
-		DD84C71F0C856DA6000EBEC4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8DD76FA90486AB0100D96B5E;
-			remoteInfo = UC2;
-		};
-		DD84C7210C856DA6000EBEC4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DD84C6A70C856B36000EBEC4;
-			remoteInfo = UC2Gfx;
 		};
 		DDC479BD15AC57BC0022401F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -199,17 +128,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		8DD76FB20486AB0100D96B5E /* uc2_i686-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "uc2_i686-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DD08CB64164CAAFF005B47DD /* slide_show_i686-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "slide_show_i686-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD08CB6F164CAC1A005B47DD /* slide_show.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = slide_show.cpp; path = ../example_app/slide_show.cpp; sourceTree = "<group>"; };
 		DD1194AE0F42CAF400C2BC25 /* checkin_notes_samples */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = checkin_notes_samples; path = ../../checkin_notes_samples; sourceTree = SOURCE_ROOT; };
 		DD1194AF0F42CB4900C2BC25 /* uc2_graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = uc2_graphics.cpp; path = ../example_app/uc2_graphics.cpp; sourceTree = SOURCE_ROOT; };
 		DD1194B10F42CB5400C2BC25 /* uc2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = uc2.cpp; path = ../example_app/uc2.cpp; sourceTree = SOURCE_ROOT; };
 		DD5937A8164D16CE001D94A5 /* slide_show_x86_64-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "slide_show_x86_64-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD69ED6F2459A5840012014C /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = IOSurface.framework; sourceTree = "<group>"; };
 		DD760E65094E56DB002CACC4 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		DD760E66094E56DB002CACC4 /* GLUT.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLUT.framework; path = /System/Library/Frameworks/GLUT.framework; sourceTree = "<absolute>"; };
 		DD760E67094E56DB002CACC4 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
-		DD84C6EA0C856B36000EBEC4 /* uc2_graphics_i686-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "uc2_graphics_i686-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD84C6F90C856C0E000EBEC4 /* uc2.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = uc2.h; path = ../example_app/uc2.h; sourceTree = SOURCE_ROOT; };
 		DDC4797515AC56CA0022401F /* UC2_x86_64-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "UC2_x86_64-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDC479BB15AC56EB0022401F /* UC2_graphics_x86_64-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "UC2_graphics_x86_64-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -218,43 +145,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		8DD76FAD0486AB0100D96B5E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD760E68094E56DB002CACC4 /* AppKit.framework in Frameworks */,
-				DD760E69094E56DB002CACC4 /* GLUT.framework in Frameworks */,
-				DD760E6A094E56DB002CACC4 /* OpenGL.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DD08CB61164CAAFF005B47DD /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD84B667164CEA83008E1369 /* GLUT.framework in Frameworks */,
-				DD84B669164CEA87008E1369 /* OpenGL.framework in Frameworks */,
-				DD84B66A164CEB78008E1369 /* AppKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DD5937A0164D16CE001D94A5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD0FAC14245ADFF10015D684 /* IOSurface.framework in Frameworks */,
 				DD5937A1164D16CE001D94A5 /* GLUT.framework in Frameworks */,
 				DD5937A2164D16CE001D94A5 /* OpenGL.framework in Frameworks */,
 				DD5937A3164D16CE001D94A5 /* AppKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DD84C6DE0C856B36000EBEC4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD84C6DF0C856B36000EBEC4 /* AppKit.framework in Frameworks */,
-				DD84C6E00C856B36000EBEC4 /* GLUT.framework in Frameworks */,
-				DD84C6E10C856B36000EBEC4 /* OpenGL.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -272,6 +170,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD0FAC13245ADFB60015D684 /* IOSurface.framework in Frameworks */,
 				DDC479B015AC56EB0022401F /* AppKit.framework in Frameworks */,
 				DDC479B115AC56EB0022401F /* GLUT.framework in Frameworks */,
 				DDC479B215AC56EB0022401F /* OpenGL.framework in Frameworks */,
@@ -307,11 +206,8 @@
 		1AB674ADFE9D54B511CA2CBB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				8DD76FB20486AB0100D96B5E /* uc2_i686-apple-darwin */,
-				DD84C6EA0C856B36000EBEC4 /* uc2_graphics_i686-apple-darwin */,
 				DDC4797515AC56CA0022401F /* UC2_x86_64-apple-darwin */,
 				DDC479BB15AC56EB0022401F /* UC2_graphics_x86_64-apple-darwin */,
-				DD08CB64164CAAFF005B47DD /* slide_show_i686-apple-darwin */,
 				DD5937A8164D16CE001D94A5 /* slide_show_x86_64-apple-darwin */,
 			);
 			name = Products;
@@ -331,6 +227,7 @@
 				DD760E65094E56DB002CACC4 /* AppKit.framework */,
 				DD760E66094E56DB002CACC4 /* GLUT.framework */,
 				DD760E67094E56DB002CACC4 /* OpenGL.framework */,
+				DD69ED6F2459A5840012014C /* IOSurface.framework */,
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = "<group>";
@@ -347,44 +244,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		8DD76FA90486AB0100D96B5E /* UC2-i386 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DD6341000973C81800B1057F /* Build configuration list for PBXNativeTarget "UC2-i386" */;
-			buildPhases = (
-				8DD76FAB0486AB0100D96B5E /* Sources */,
-				8DD76FAD0486AB0100D96B5E /* Frameworks */,
-				DD7A737915AD66AB004F2841 /* ShellScript */,
-			);
-			buildRules = (
-				DD760E3E094E540D002CACC4 /* PBXBuildRule */,
-				DD760E3D094E540D002CACC4 /* PBXBuildRule */,
-				DD760E3C094E540C002CACC4 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = "UC2-i386";
-			productInstallPath = "$(HOME)/bin";
-			productName = UpperCase;
-			productReference = 8DD76FB20486AB0100D96B5E /* uc2_i686-apple-darwin */;
-			productType = "com.apple.product-type.tool";
-		};
-		DD08CB63164CAAFF005B47DD /* slide_show-i386 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DD08CB6D164CAAFF005B47DD /* Build configuration list for PBXNativeTarget "slide_show-i386" */;
-			buildPhases = (
-				DD08CB60164CAAFF005B47DD /* Sources */,
-				DD08CB61164CAAFF005B47DD /* Frameworks */,
-				DD59379C164D1657001D94A5 /* ShellScript */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "slide_show-i386";
-			productName = slide_show;
-			productReference = DD08CB64164CAAFF005B47DD /* slide_show_i686-apple-darwin */;
-			productType = "com.apple.product-type.tool";
-		};
 		DD59379D164D16CE001D94A5 /* slide_show-x86_64 */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD5937A5164D16CE001D94A5 /* Build configuration list for PBXNativeTarget "slide_show-x86_64" */;
@@ -400,27 +259,6 @@
 			name = "slide_show-x86_64";
 			productName = slide_show;
 			productReference = DD5937A8164D16CE001D94A5 /* slide_show_x86_64-apple-darwin */;
-			productType = "com.apple.product-type.tool";
-		};
-		DD84C6A70C856B36000EBEC4 /* UC2Gfx-i386 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = DD84C6E60C856B36000EBEC4 /* Build configuration list for PBXNativeTarget "UC2Gfx-i386" */;
-			buildPhases = (
-				DD84C6A80C856B36000EBEC4 /* Sources */,
-				DD84C6DE0C856B36000EBEC4 /* Frameworks */,
-				DD7A737A15AD66CA004F2841 /* ShellScript */,
-			);
-			buildRules = (
-				DD84C6E30C856B36000EBEC4 /* PBXBuildRule */,
-				DD84C6E40C856B36000EBEC4 /* PBXBuildRule */,
-				DD84C6E50C856B36000EBEC4 /* PBXBuildRule */,
-			);
-			dependencies = (
-			);
-			name = "UC2Gfx-i386";
-			productInstallPath = "$(HOME)/bin";
-			productName = UpperCase;
-			productReference = DD84C6EA0C856B36000EBEC4 /* uc2_graphics_i686-apple-darwin */;
 			productType = "com.apple.product-type.tool";
 		};
 		DDC4796515AC56CA0022401F /* UC2-x86_64 */ = {
@@ -487,57 +325,15 @@
 			projectRoot = "";
 			targets = (
 				DD84C71E0C856D9E000EBEC4 /* Build_All */,
-				8DD76FA90486AB0100D96B5E /* UC2-i386 */,
-				DD84C6A70C856B36000EBEC4 /* UC2Gfx-i386 */,
 				DDC4796515AC56CA0022401F /* UC2-x86_64 */,
 				DDC4797715AC56EB0022401F /* UC2Gfx-x86_64 */,
-				DD08CB63164CAAFF005B47DD /* slide_show-i386 */,
 				DD59379D164D16CE001D94A5 /* slide_show-x86_64 */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		DD59379C164D1657001D94A5 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" -nt \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}\"\n    if [ \"$CONFIGURATION\" = \"Release\" ]; then\n        rm -fR \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}.dSYM\"\n        cp -fpR \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.dSYM\" \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}.dSYM\"\n    fi\nfi\n";
-		};
 		DD5937A4164D16CE001D94A5 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" -nt \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}\"\n    if [ \"$CONFIGURATION\" = \"Release\" ]; then\n        rm -fR \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}.dSYM\"\n        cp -fpR \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.dSYM\" \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}.dSYM\"\n    fi\nfi\n";
-		};
-		DD7A737915AD66AB004F2841 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" -nt \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\" \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}\"\n    if [ \"$CONFIGURATION\" = \"Release\" ]; then\n        rm -fR \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}.dSYM\"\n        cp -fpR \"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.dSYM\" \"${SRCROOT}/build/${CONFIGURATION}/${PRODUCT_NAME}.dSYM\"\n    fi\nfi\n";
-		};
-		DD7A737A15AD66CA004F2841 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -579,36 +375,11 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		8DD76FAB0486AB0100D96B5E /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD1194B20F42CB5400C2BC25 /* uc2.cpp in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DD08CB60164CAAFF005B47DD /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD08CB70164CAC1A005B47DD /* slide_show.cpp in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DD59379E164D16CE001D94A5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				DD59379F164D16CE001D94A5 /* slide_show.cpp in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		DD84C6A80C856B36000EBEC4 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DD1194B00F42CB4900C2BC25 /* uc2_graphics.cpp in Sources */,
-				DDF8050515CB9C75005473CC /* ttfont.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -637,21 +408,6 @@
 			target = DD59379D164D16CE001D94A5 /* slide_show-x86_64 */;
 			targetProxy = DD5937AA164D1759001D94A5 /* PBXContainerItemProxy */;
 		};
-		DD84B698164D0151008E1369 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DD08CB63164CAAFF005B47DD /* slide_show-i386 */;
-			targetProxy = DD84B697164D0151008E1369 /* PBXContainerItemProxy */;
-		};
-		DD84C7200C856DA6000EBEC4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 8DD76FA90486AB0100D96B5E /* UC2-i386 */;
-			targetProxy = DD84C71F0C856DA6000EBEC4 /* PBXContainerItemProxy */;
-		};
-		DD84C7220C856DA6000EBEC4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DD84C6A70C856B36000EBEC4 /* UC2Gfx-i386 */;
-			targetProxy = DD84C7210C856DA6000EBEC4 /* PBXContainerItemProxy */;
-		};
 		DDC479BE15AC57BC0022401F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDC4796515AC56CA0022401F /* UC2-x86_64 */;
@@ -665,87 +421,18 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		DD08CB6B164CAAFF005B47DD /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				GCC_CHAR_IS_UNSIGNED_CHAR = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					../..,
-					../../lib,
-					../../api,
-					../../zip,
-				);
-				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Development/;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_LDFLAGS = (
-					"-lboinc_api",
-					"-lboinc_graphics2",
-					"-lboinc",
-					"-ljpeg",
-					"-lboinc_zip",
-				);
-				PRODUCT_NAME = "slide_show_i686-apple-darwin";
-			};
-			name = Debug;
-		};
-		DD08CB6C164CAAFF005B47DD /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = YES;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				GCC_CHAR_IS_UNSIGNED_CHAR = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					../..,
-					../../lib,
-					../../api,
-					../../zip,
-				);
-				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Deployment/;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
-				OTHER_LDFLAGS = (
-					"-lboinc_api",
-					"-lboinc_graphics2",
-					"-lboinc",
-					"-ljpeg",
-					"-lboinc_zip",
-				);
-				PRODUCT_NAME = "slide_show_i686-apple-darwin";
-			};
-			name = Release;
-		};
 		DD5937A6164D16CE001D94A5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				GCC_CHAR_IS_UNSIGNED_CHAR = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -764,10 +451,14 @@
 					../../lib,
 					../../api,
 					../../zip,
+					../../clientgui/mac,
 				);
 				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Deployment/;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
+					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
+				);
 				OTHER_LDFLAGS = (
 					"-lboinc_api",
 					"-lboinc_graphics2",
@@ -785,8 +476,13 @@
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				GCC_CHAR_IS_UNSIGNED_CHAR = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -799,9 +495,13 @@
 					../../lib,
 					../../api,
 					../../zip,
+					../../clientgui/mac,
 				);
 				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Deployment/;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				OTHER_CFLAGS = (
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
+					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
+				);
 				OTHER_LDFLAGS = (
 					"-lboinc_api",
 					"-lboinc_graphics2",
@@ -813,37 +513,13 @@
 			};
 			name = Release;
 		};
-		DD6341010973C81800B1057F /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
-				GCC_MODEL_TUNING = G5;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					../..,
-					../../lib,
-					../../api,
-					../../clientgui/mac,
-				);
-				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Development/;
-				PREBINDING = NO;
-				PRODUCT_NAME = "uc2_i686-apple-darwin";
-				ZERO_LINK = NO;
-			};
-			name = Debug;
-		};
 		DD6341050973C81800B1057F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = (
 					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
 					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
@@ -854,30 +530,9 @@
 				);
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = NO;
+				VALID_ARCHS = x86_64;
 			};
 			name = Debug;
-		};
-		DD63410B0973C84A00B1057F /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
-				GCC_MODEL_TUNING = G5;
-				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					../..,
-					../../lib,
-					../../api,
-					../../clientgui/mac,
-				);
-				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Deployment/;
-				PREBINDING = NO;
-				PRODUCT_NAME = "uc2_i686-apple-darwin";
-				ZERO_LINK = NO;
-			};
-			name = Release;
 		};
 		DD63410C0973C84A00B1057F /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -885,7 +540,7 @@
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_CFLAGS = (
 					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
 					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
@@ -896,102 +551,7 @@
 				);
 				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		DD84C6E70C856B36000EBEC4 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
-				GCC_MODEL_TUNING = G5;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"../../../freetype-2.4.10/include",
-					"../../../ftgl-2.1.3~rc5/src",
-					../..,
-					../../lib,
-					../../api,
-				);
-				INSTALL_PATH = "$(HOME)/bin";
-				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Development/;
-				OTHER_CFLAGS = (
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
-					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
-					"-DHAVE_STDLIB_H",
-				);
-				OTHER_LDFLAGS = (
-					"-lboinc_api",
-					"-lboinc_graphics2",
-					"-lboinc",
-					"-ljpeg",
-					"../../../freetype-2.4.10/objs/.libs/libfreetype.a",
-					"../../../ftgl-2.1.3~rc5/src/.libs/libftgl.a",
-					"-lz",
-					"-lbz2",
-				);
-				PREBINDING = NO;
-				PRODUCT_NAME = "uc2_graphics_i686-apple-darwin";
-				WARNING_LDFLAGS = (
-					"-lboinc_api",
-					"-lboinc_graphics2",
-					"-lboinc",
-					"../../../freetype-2.4.10/objs/.libs/libfreetype.a",
-					"../../../ftgl-2.1.3~rc5/src/.libs/libftgl.a",
-					"-lbz2",
-				);
-				ZERO_LINK = NO;
-			};
-			name = Debug;
-		};
-		DD84C6E90C856B36000EBEC4 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
-				GCC_MODEL_TUNING = G5;
-				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = (
-					"../../../freetype-2.4.10/include",
-					"../../../ftgl-2.1.3~rc5/src",
-					../..,
-					../../lib,
-					../../api,
-				);
-				INSTALL_PATH = "$(HOME)/bin";
-				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Deployment/;
-				OTHER_CFLAGS = (
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
-					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
-					"-DHAVE_STDLIB_H",
-				);
-				OTHER_LDFLAGS = (
-					"-lboinc_api",
-					"-lboinc_graphics2",
-					"-lboinc",
-					"-ljpeg",
-					"../../../freetype-2.4.10/objs/.libs/libfreetype.a",
-					"../../../ftgl-2.1.3~rc5/src/.libs/libftgl.a",
-					"-lz",
-					"-lbz2",
-				);
-				PREBINDING = NO;
-				PRODUCT_NAME = "uc2_graphics_i686-apple-darwin";
-				WARNING_LDFLAGS = (
-					"-lboinc_api",
-					"-lboinc_graphics2",
-					"-lboinc",
-					"../../../freetype-2.4.10/objs/.libs/libfreetype.a",
-					"../../../ftgl-2.1.3~rc5/src/.libs/libftgl.a",
-					"-lbz2",
-				);
-				ZERO_LINK = NO;
+				VALID_ARCHS = x86_64;
 			};
 			name = Release;
 		};
@@ -1017,6 +577,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
@@ -1032,6 +593,10 @@
 					../../clientgui/mac,
 				);
 				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Development/;
+				OTHER_CFLAGS = (
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
+					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
+				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "UC2_x86_64-apple-darwin";
 				ZERO_LINK = NO;
@@ -1042,6 +607,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_MODEL_TUNING = G5;
@@ -1055,6 +621,10 @@
 					../../clientgui/mac,
 				);
 				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Deployment/;
+				OTHER_CFLAGS = (
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=1040",
+					"-DMAC_OS_X_VERSION_MIN_REQUIRED=1040",
+				);
 				PREBINDING = NO;
 				PRODUCT_NAME = "UC2_x86_64-apple-darwin";
 				ZERO_LINK = NO;
@@ -1065,6 +635,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LIBRARY = "libc++";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
@@ -1079,6 +654,7 @@
 					../..,
 					../../lib,
 					../../api,
+					../../clientgui/mac,
 				);
 				INSTALL_PATH = "$(HOME)/bin";
 				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Development/;
@@ -1107,6 +683,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LIBRARY = "libc++";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
 				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_MODEL_TUNING = G5;
@@ -1119,6 +700,7 @@
 					../..,
 					../../lib,
 					../../api,
+					../../clientgui/mac,
 				);
 				INSTALL_PATH = "$(HOME)/bin";
 				LIBRARY_SEARCH_PATHS = ../../mac_build/build/Deployment/;
@@ -1146,15 +728,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		DD08CB6D164CAAFF005B47DD /* Build configuration list for PBXNativeTarget "slide_show-i386" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DD08CB6B164CAAFF005B47DD /* Debug */,
-				DD08CB6C164CAAFF005B47DD /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		DD5937A5164D16CE001D94A5 /* Build configuration list for PBXNativeTarget "slide_show-x86_64" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1164,29 +737,11 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		DD6341000973C81800B1057F /* Build configuration list for PBXNativeTarget "UC2-i386" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DD6341010973C81800B1057F /* Debug */,
-				DD63410B0973C84A00B1057F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
 		DD6341040973C81800B1057F /* Build configuration list for PBXProject "UpperCase2" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DD6341050973C81800B1057F /* Debug */,
 				DD63410C0973C84A00B1057F /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Debug;
-		};
-		DD84C6E60C856B36000EBEC4 /* Build configuration list for PBXNativeTarget "UC2Gfx-i386" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				DD84C6E70C856B36000EBEC4 /* Debug */,
-				DD84C6E90C856B36000EBEC4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;


### PR DESCRIPTION
his adds to my previous fixes (PR #3369) for the Macintosh BOINC screensaver running under OS 10.15 Catalina when built using Xcode 11. That PR solved problems with displaying graphics applications in the screensaver on Retina displays, but overlooked the same problem displaying project graphics apps in a window when invoked by the "Show graphics" button in the BOINC Manager.

This PR adds a fix for that issue. It also updates the graphics sample code in samples/example_app.

None of these problems occurred when building with earlier versions of Xcode or on versions of MacOS before OS 10.15 Catalina. These changes, along with my earlier ones, preserve proper operation when built with earlier Xcode or run on earlier versions of MacOS.

OpenGL / GLUT apps built under Xcode 11 apparently use window dimensions based on the number of backing store pixels. That is, they double the window dimensions for Retina displays (which have 2X2 pixels per point.) But OpenGL apps built under earlier versions of Xcode don't. Catalina assumes OpenGL apps work as built under Xcode 11, so it displays older builds at half width and height, unless we compensate in our code.

This PR is part of my attempt to ensure that BOINC graphics apps built on all versions of Xcode work properly on different versions of OS X.