### PR TITLE
Prefer curl-config from --with-libcurl

### DIFF
--- a/m4/libcurl.m4
+++ b/m4/libcurl.m4
@@ -67,6 +67,7 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
      if test -d "$_libcurl_with" ; then
         CPPFLAGS="${CPPFLAGS} -I$withval/include"
         LDFLAGS="${LDFLAGS} -L$withval/lib"
+        PATH="$withval/bin:${PATH}"
      fi
 
      AC_PATH_PROG([_libcurl_config],[curl-config])

--- a/m4/libcurl.m4
+++ b/m4/libcurl.m4
@@ -67,7 +67,7 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
      if test -d "$_libcurl_with" ; then
         CPPFLAGS="${CPPFLAGS} -I$withval/include"
         LDFLAGS="${LDFLAGS} -L$withval/lib"
-        PATH="$withval/bin:${PATH}"
+        PATH="${withval%/}/bin:$PATH"
      fi
 
      AC_PATH_PROG([_libcurl_config],[curl-config])


### PR DESCRIPTION
**Description of the Change**
If "--with-libcurl" is passed, prefer using "curl-config" from directory instead of system provided

**Alternate Designs**
Really makes no sense not to do this

**Release Notes**
N/A