### PR TITLE
Mac: clean up gfx changes from PR #3667

### DIFF
--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -60,14 +60,15 @@ int compareOSVersionTo(int toMajor, int toMinor);
 #define SAVERDELAY 30
 
 void MacGLUTFix(bool isScreenSaver) {
-    static bool done = false;
+    static int count = 0;
     static NSMenu * emptyMenu;
     NSOpenGLContext * myContext = nil;
     NSView *myView = nil;
     NSWindow* myWindow = nil;
+    static int requestedWidth, requestedHeight;
 
-    if (done) return;
-    done = true;
+    if (count > 1) return;   // Do this only twice
+    count++;
     
     if (! boinc_is_standalone()) {
         if (emptyMenu == nil) {
@@ -79,38 +80,35 @@ void MacGLUTFix(bool isScreenSaver) {
     myContext = [ NSOpenGLContext currentContext ];
     if (myContext)
         myView = [ myContext view ];
-    if (myView) {
-#ifdef __MAC_10_15  // Do this only if built under OS 10.15 or later
-        // OpenGL apps built under Xcode 11 apparently use window dimensions based 
-        // on the number of backing store pixels. That is, they double the window 
-        // dimensions for Retina displays (which have 2X2 pixels per point.) But 
-        // OpenGL apps built under earlier versions of Xcode don't.
-        // Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
-        // older builds at half width and height, unless we compensate in our code.
-        // This code is part of my attempt to ensure that BOINC graphics apps built on 
-        // all versions of Xcode work properly on different versions of OS X. See also 
-        // [BOINC_Saver_ModuleView initWithFrame:] in clientscr/Mac_Saver_ModuleCiew.m
-        // and MacPassOffscreenBufferToScreenSaver() 
-        //
-        // NOTES:
-        //   * Graphics apps must be linked with the IOSurface framework
-        //   * The libboinc_graphics2.a library and the graphics app must be built 
-        //     with the same version of Xcode
-        //
-        if (compareOSVersionTo(10, 15) >= 0) {
-            int w = (int)[myView bounds].size.width;
-            int h = (int)[myView bounds].size.height;
-            NSArray *allScreens = [ NSScreen screens ];
-            int DPI_multiplier = [((NSScreen*)allScreens[0]) backingScaleFactor];
-            glViewport(0, 0, w*DPI_multiplier, h*DPI_multiplier);
-        }
-#endif
+    if (myView)
         myWindow = [ myView window ];
-    }
     if (myWindow == nil)
         return;
  
+    // Retina displays have 2X2 pixels per point. When OpenGL / GLUT apps built 
+    // using Xcode 11 are run on a Retina display under OS 10.15, they fail to 
+    // adjust their pixel dimesions to double the window size, and so fill only 
+    // 1/4 of the window (display at half width and height) until they are  
+    // resized by calls to glutReshapeWindow(), glutFullScreen(). etc. 
+    // However, they work correctly when run on earlier  versions of OS X.
+    //
+    // OpenGL / GLUT apps built using earlier versions of Xcode do not have this 
+    // problem on OS 10.15, but glutReshapeWindow(). 
+    //
+    // We work around this by calling glutReshapeWindow() twice, restoring the 
+    // window's original size. This transparently fixes the problem when necessary 
+    // without actually changing the window's size, and does no harm when not 
+    // necessary.
+
     if (!isScreenSaver) {
+        if (count == 1) {
+            requestedWidth = glutGet(GLUT_WINDOW_WIDTH);
+            requestedHeight = glutGet(GLUT_WINDOW_HEIGHT);
+            glutReshapeWindow(requestedWidth+1, requestedHeight);
+        } else {
+            glutReshapeWindow(requestedWidth, requestedHeight);
+        }
+        
         NSButton *closeButton = [myWindow standardWindowButton:NSWindowCloseButton ];
         [closeButton setEnabled:YES];
         [myWindow setDocumentEdited: NO];
@@ -324,21 +322,24 @@ kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, uin
 @end
 
 
-// OpenGL apps built under Xcode 11 apparently use window dimensions based 
-// on the number of backing store pixels. That is, they double the window 
-// dimensions for Retina displays (which have 2X2 pixels per point.) But 
-// OpenGL apps built under earlier versions of Xcode don't.
-// Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
-// older builds at half width and height, unless we compensate in our code.
-// This code is part of my attempt to ensure that BOINC graphics apps built on 
-// all versions of Xcode work properly on different versions of OS X. See also 
-// [BOINC_Saver_ModuleView initWithFrame:] in clientscr/Mac_Saver_ModuleCiew.m
-// and MacGLUTFix(bool isScreenSaver) above.
+// OpenGL / GLUT apps which call glutFullScreen() and are built using 
+// Xcode 11 apparently use window dimensions based on the number of 
+// backing store pixels. That is, they double the window dimensions 
+// for Retina displays (which have 2X2 pixels per point.) But OpenGL 
+// apps built under earlier versions of Xcode don't.
 //
-// NOTES:
-//   * Graphics apps must be linked with the IOSurface framework
-//   * The libboinc_graphics2.a library and the graphics app must be built 
-//     with the same version of Xcode
+// OS 10.15 Catalina assumes OpenGL / GLUT apps work as built under 
+// Xcode 11, so it displays older builds at half width and height, 
+// unless we compensate in our code. To ensure that BOINC graphics apps 
+// built on all versions of Xcode work properly on all versions of OS X, 
+// we set the IOSurface dimensions in this module to the viewportRect
+// dimensions.
+//
+// See also:
+// [BOINC_Saver_ModuleView initWithFrame:] in clientscr/Mac_Saver_ModuleView.m
+// clientscr/Mac_Saver_ModuleCiew.m and MacGLUTFix(bool isScreenSaver) above.
+//
+// NOTE: Graphics apps must now be linked with the IOSurface framework.
 //
 void MacPassOffscreenBufferToScreenSaver() {
     NSOpenGLContext * myContext = [ NSOpenGLContext currentContext ];

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -215,21 +215,24 @@ void launchedGfxApp(char * appPath, pid_t thePID, int slot) {
         myIsPreview = isPreview;
     }
     
-    // OpenGL apps built under Xcode 11 apparently use window dimensions based 
-    // on the number of backing store pixels. That is, they double the window 
-    // dimensions for Retina displays (which have 2X2 pixels per point.) But 
-    // OpenGL apps built under earlier versions of Xcode don't.
-    // Catalina assumes OpenGL apps work as built under Xcode 11, so it displays
-    // older builds at half width and height, unless we compensate in our code.
-    // This code is part of my attempt to ensure that BOINC graphics apps built on 
-    // all versions of Xcode work properly on different versions of OS X. See also 
-    // MacPassOffscreenBufferToScreenSaver() and MacGLUTFix(bool isScreenSaver) 
-    // in lib/macglutfix.m and for more info.
+    // OpenGL / GLUT apps which call glutFullScreen() and are built using 
+    // Xcode 11 apparently use window dimensions based on the number of 
+    // backing store pixels. That is, they double the window dimensions 
+    // for Retina displays (which have 2X2 pixels per point.) But OpenGL 
+    // apps built under earlier versions of Xcode don't.
     //
-    // NOTES:
-    //   * Graphics apps must be linked with the IOSurface framework
-    //   * The libboinc_graphics2.a library and the graphics app must be built 
-    //     with the same version of Xcode
+    // OS 10.15 Catalina assumes OpenGL / GLUT apps work as built under 
+    // Xcode 11, so it displays older builds at half width and height, 
+    // unless we compensate in our code. 
+    //
+    // To ensure that BOINC graphics apps built on all versions of Xcode work 
+    // properly on different versions of OS X, we set the IOSurface dimensions 
+    // in this module to double the screen dimensions when running under 
+    // OS 10.15 or later. 
+    //
+    // See also MacGLUTFix(bool isScreenSaver) in api/macglutfix.m for more info.
+    //
+    // NOTE: Graphics apps must now be linked with the IOSurface framework.
     //
     if (gIsCatalina) {
         NSArray *allScreens = [ NSScreen screens ];
@@ -1337,6 +1340,25 @@ kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, mac
 
 }
 
+// OpenGL / GLUT apps which call glutFullScreen() and are built using 
+// Xcode 11 apparently use window dimensions based on the number of 
+// backing store pixels. That is, they double the window dimensions 
+// for Retina displays (which have 2X2 pixels per point.) But OpenGL 
+// apps built under earlier versions of Xcode don't.
+//
+// OS 10.15 Catalina assumes OpenGL / GLUT apps work as built under 
+// Xcode 11, so it displays older builds at half width and height, 
+// unless we compensate in our code. 
+//
+// To ensure that BOINC graphics apps built on all versions of Xcode work 
+// properly on different versions of OS X, we set the IOSurface dimensions 
+// in this module to double the screen dimensions when running under 
+// OS 10.15 or later. 
+//
+// See also MacGLUTFix(bool isScreenSaver) in api/macglutfix.m for more info.
+//
+// NOTE: Graphics apps must now be linked with the IOSurface framework.
+//
 - (void)drawRect:(NSRect)theRect
 {
     glViewport(0, 0, (GLint)[[self window]frame].size.width*DPI_multiplier, (GLint)[[self window] frame].size.height*DPI_multiplier);

--- a/clientscr/ss_app.cpp
+++ b/clientscr/ss_app.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -498,7 +498,9 @@ int main(int argc, char** argv) {
         BOINC_DIAG_MEMORYLEAKCHECKENABLED |
 #endif
         BOINC_DIAG_DUMPCALLSTACKENABLED | 
+#ifndef __APPLE__   // Can't access user's directories under sandbox security
         BOINC_DIAG_PERUSERLOGFILES |
+#endif
         BOINC_DIAG_REDIRECTSTDERR |
         BOINC_DIAG_REDIRECTSTDOUT |
         BOINC_DIAG_TRACETOSTDOUT;

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 		DD80632D131FAA4100DC8971 /* sg_BoincSimpleFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDAFA7AC12D4834D00997329 /* sg_BoincSimpleFrame.cpp */; };
 		DD806336131FAD9A00DC8971 /* sg_CustomControls.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD1C822F0AF372D900F709AC /* sg_CustomControls.cpp */; };
 		DD806339131FADE700DC8971 /* sg_DlgMessages.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4C560C0AD389A2009E23C6 /* sg_DlgMessages.cpp */; };
+		DD818295245ED4110076E5D0 /* boinc_ss_helper.sh in Resources */ = {isa = PBXBuildFile; fileRef = DD818294245ED4010076E5D0 /* boinc_ss_helper.sh */; };
 		DD81C7E3144D900B000BE61A /* jcapimin.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7A1144D900B000BE61A /* jcapimin.c */; };
 		DD81C7E4144D900B000BE61A /* jcapistd.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7A2144D900B000BE61A /* jcapistd.c */; };
 		DD81C7E5144D900B000BE61A /* jccoefct.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7A3144D900B000BE61A /* jccoefct.c */; };
@@ -1072,6 +1073,7 @@
 		DD7C5E7508110AE3002FCE1E /* ScreenSaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScreenSaver.framework; path = /System/Library/Frameworks/ScreenSaver.framework; sourceTree = "<absolute>"; };
 		DD80C83D0CBAEB4F00F1121D /* sandbox.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = sandbox.cpp; sourceTree = "<group>"; };
 		DD80C83E0CBAEB4F00F1121D /* sandbox.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = sandbox.h; path = ../client/sandbox.h; sourceTree = SOURCE_ROOT; };
+		DD818294245ED4010076E5D0 /* boinc_ss_helper.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = boinc_ss_helper.sh; path = ../clientscr/boinc_ss_helper.sh; sourceTree = "<group>"; };
 		DD81C3D507C5CEB50098A04D /* cpp.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = cpp.h; path = ../client/cpp.h; sourceTree = SOURCE_ROOT; };
 		DD81C3FE07C5D1020098A04D /* BOINCBaseView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BOINCBaseView.cpp; path = ../clientgui/BOINCBaseView.cpp; sourceTree = SOURCE_ROOT; };
 		DD81C3FF07C5D1020098A04D /* DlgOptions.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = DlgOptions.cpp; path = ../clientgui/DlgOptions.cpp; sourceTree = SOURCE_ROOT; };
@@ -1929,6 +1931,7 @@
 				DDE7A3B015C6739E002B3B96 /* ttfont.h */,
 				DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */,
 				DD5F654A23605C87009ED2A2 /* gfx_cleanup.mm */,
+				DD818294245ED4010076E5D0 /* boinc_ss_helper.sh */,
 			);
 			name = clientscr;
 			sourceTree = SOURCE_ROOT;
@@ -2421,6 +2424,7 @@
 				DD96AFF60811075000A06F22 /* Sources */,
 				DD96AFF70811075000A06F22 /* Frameworks */,
 				DD5FD5990A0233D60093C19F /* ShellScript */,
+				DD818296245EDA220076E5D0 /* ShellScript */,
 				DDF9B764245C12AA00587EBE /* ShellScript */,
 			);
 			buildRules = (
@@ -2673,6 +2677,7 @@
 			files = (
 				DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */,
 				DD5F656623607472009ED2A2 /* gfx_cleanup in Resources */,
+				DD818295245ED4110076E5D0 /* boinc_ss_helper.sh in Resources */,
 				DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */,
 				DD48091F081A66F100A174AA /* BOINCSaver.nib in Resources */,
 				DDBC6CA50D5D458700564C49 /* boinc_ss_logo.png in Resources */,
@@ -2863,6 +2868,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n  touch \"${BUILT_PRODUCTS_DIR}/SymbolTables/${PRODUCT_NAME}.dSYM\"\nfi\n";
+		};
+		DD818296245EDA220076E5D0 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "chmod u+x,g+x,o+x \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/boinc_ss_helper.sh\"\n";
 		};
 		DD81C827144D90FC000BE61A /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -1283,6 +1283,7 @@
 		DDDC2054183B560B00CB5845 /* mac_address.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mac_address.h; sourceTree = "<group>"; };
 		DDDD6D7E12E4611300C258A0 /* sg_ProjectPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = sg_ProjectPanel.cpp; path = ../clientgui/sg_ProjectPanel.cpp; sourceTree = SOURCE_ROOT; };
 		DDDD6D7F12E4611300C258A0 /* sg_ProjectPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sg_ProjectPanel.h; path = ../clientgui/sg_ProjectPanel.h; sourceTree = SOURCE_ROOT; };
+		DDDE391224600D05005FCEFA /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SystemConfiguration.framework; sourceTree = "<group>"; };
 		DDDE43B00EC04C1800083520 /* DlgExitMessage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DlgExitMessage.cpp; path = ../clientgui/DlgExitMessage.cpp; sourceTree = SOURCE_ROOT; };
 		DDDE43B80EC04C3C00083520 /* DlgExitMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DlgExitMessage.h; path = ../clientgui/DlgExitMessage.h; sourceTree = SOURCE_ROOT; };
 		DDE1372810DC5E5300161D6B /* cs_notice.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cs_notice.cpp; path = ../client/cs_notice.cpp; sourceTree = SOURCE_ROOT; };
@@ -1641,6 +1642,7 @@
 				DD89165D0F3B1BC200DE5B1C /* GLUT.framework */,
 				DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */,
 				DD0BB7A11F62B105000151B2 /* IOSurface.framework */,
+				DDDE391224600D05005FCEFA /* SystemConfiguration.framework */,
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = SOURCE_ROOT;
@@ -3831,6 +3833,7 @@
 					"-framework",
 					Carbon,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.Installer;
 				PRODUCT_NAME = "BOINC Installer";
 			};
 			name = Development;
@@ -3843,6 +3846,7 @@
 					"-framework",
 					Carbon,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.Installer;
 				PRODUCT_NAME = "BOINC Installer";
 				STRIP_INSTALLED_PRODUCT = YES;
 			};
@@ -3891,6 +3895,7 @@
 					"-lpthread",
 					"-lm",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc;
 				PRODUCT_NAME = BOINCManager;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -3949,6 +3954,7 @@
 					"-lpthread",
 					"-lm",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc;
 				PRODUCT_NAME = BOINCManager;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
@@ -4081,6 +4087,7 @@
 					"-framework",
 					Carbon,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.Uninstaller;
 				PRODUCT_NAME = "Uninstall BOINC";
 				WRAPPER_EXTENSION = app;
 			};
@@ -4094,6 +4101,7 @@
 					"-framework",
 					Carbon,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.Uninstaller;
 				PRODUCT_NAME = "Uninstall BOINC";
 				WRAPPER_EXTENSION = app;
 			};
@@ -4153,6 +4161,7 @@
 					"-Wno-unknown-pragmas",
 					"-Wno-write-strings",
 					"-Wno-main",
+					"-Wno-shift-negative-value",
 				);
 			};
 			name = Development;
@@ -4168,6 +4177,7 @@
 					"-Wno-unknown-pragmas",
 					"-Wno-write-strings",
 					"-Wno-main",
+					"-Wno-shift-negative-value",
 				);
 			};
 			name = Deployment;
@@ -4299,6 +4309,7 @@
 					"-framework",
 					AppKit,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boincsaver;
 				PRODUCT_NAME = BOINCSaver;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = saver;
@@ -4359,6 +4370,7 @@
 					"-framework",
 					Carbon,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.PostInstall;
 				PRODUCT_NAME = PostInstall;
 			};
 			name = Deployment;
@@ -4465,6 +4477,7 @@
 					"-framework",
 					AppKit,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boincsaver;
 				PRODUCT_NAME = BOINCSaver;
 				SDKROOT = macosx;
 				WRAPPER_EXTENSION = saver;
@@ -4524,6 +4537,7 @@
 					"-framework",
 					Carbon,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.PostInstall;
 				PRODUCT_NAME = PostInstall;
 			};
 			name = Development;

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -481,7 +481,7 @@ int main(int argc, char *argv[])
 
     if (compareOSVersionTo(10, 13) >= 0) {
         getPathToThisApp(path, sizeof(path));
-        strncat(path, "/Contents/Resources/boinc_Finish_Install", sizeof(s)-1);
+        strncat(path, "/Contents/Resources/boinc_Finish_Install", sizeof(path)-1);
         snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC Data/%s_Finish_Install\"", path, appName[brandID]);
         err = callPosixSpawn(s);
         REPORT_ERROR(err);

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -976,7 +976,7 @@ Boolean DeleteLoginItemLaunchAgent(long brandID, passwd *pw)
    
     if (!alreadyCopied) {
         getPathToThisApp(path, sizeof(path));
-        strncat(path, "/Contents/Resources/boinc_finish_install", sizeof(s)-1);
+        strncat(path, "/Contents/Resources/boinc_finish_install", sizeof(path)-1);
         snprintf(s, sizeof(s), "cp -f \"%s\" \"/Library/Application Support/BOINC Data/%s_Finish_Uninstall\"", path, appName[brandID]);
         err = callPosixSpawn(s);
          if (err) {

--- a/samples/mac_build/UpperCase2.xcodeproj/project.pbxproj
+++ b/samples/mac_build/UpperCase2.xcodeproj/project.pbxproj
@@ -23,8 +23,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		DD0FAC13245ADFB60015D684 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD69ED6F2459A5840012014C /* IOSurface.framework */; };
-		DD0FAC14245ADFF10015D684 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD69ED6F2459A5840012014C /* IOSurface.framework */; };
 		DD59379F164D16CE001D94A5 /* slide_show.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD08CB6F164CAC1A005B47DD /* slide_show.cpp */; };
 		DD5937A1164D16CE001D94A5 /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
 		DD5937A2164D16CE001D94A5 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E67094E56DB002CACC4 /* OpenGL.framework */; };
@@ -37,6 +35,8 @@
 		DDC479B015AC56EB0022401F /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E65094E56DB002CACC4 /* AppKit.framework */; };
 		DDC479B115AC56EB0022401F /* GLUT.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E66094E56DB002CACC4 /* GLUT.framework */; };
 		DDC479B215AC56EB0022401F /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD760E67094E56DB002CACC4 /* OpenGL.framework */; };
+		DDDE391624600EAF005FCEFA /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDE391524600EAF005FCEFA /* IOSurface.framework */; };
+		DDDE391724600EE9005FCEFA /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDE391524600EAF005FCEFA /* IOSurface.framework */; };
 		DDF8050615CB9C75005473CC /* ttfont.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF8050315CB9C75005473CC /* ttfont.cpp */; };
 /* End PBXBuildFile section */
 
@@ -45,8 +45,6 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.c;
-			inputFiles = (
-			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -55,8 +53,6 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.cpp;
-			inputFiles = (
-			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -65,8 +61,6 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.asm;
-			inputFiles = (
-			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -75,8 +69,6 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.c;
-			inputFiles = (
-			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -85,8 +77,6 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.cpp;
-			inputFiles = (
-			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -95,8 +85,6 @@
 			isa = PBXBuildRule;
 			compilerSpec = com.apple.compilers.gcc.4_0;
 			fileType = sourcecode.asm;
-			inputFiles = (
-			);
 			isEditable = 1;
 			outputFiles = (
 			);
@@ -133,13 +121,13 @@
 		DD1194AF0F42CB4900C2BC25 /* uc2_graphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = uc2_graphics.cpp; path = ../example_app/uc2_graphics.cpp; sourceTree = SOURCE_ROOT; };
 		DD1194B10F42CB5400C2BC25 /* uc2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = uc2.cpp; path = ../example_app/uc2.cpp; sourceTree = SOURCE_ROOT; };
 		DD5937A8164D16CE001D94A5 /* slide_show_x86_64-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "slide_show_x86_64-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DD69ED6F2459A5840012014C /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = IOSurface.framework; sourceTree = "<group>"; };
 		DD760E65094E56DB002CACC4 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		DD760E66094E56DB002CACC4 /* GLUT.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLUT.framework; path = /System/Library/Frameworks/GLUT.framework; sourceTree = "<absolute>"; };
 		DD760E67094E56DB002CACC4 /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
 		DD84C6F90C856C0E000EBEC4 /* uc2.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = uc2.h; path = ../example_app/uc2.h; sourceTree = SOURCE_ROOT; };
 		DDC4797515AC56CA0022401F /* UC2_x86_64-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "UC2_x86_64-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDC479BB15AC56EB0022401F /* UC2_graphics_x86_64-apple-darwin */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "UC2_graphics_x86_64-apple-darwin"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DDDE391524600EAF005FCEFA /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = ../../../../../../System/Library/Frameworks/IOSurface.framework; sourceTree = "<group>"; };
 		DDF8050315CB9C75005473CC /* ttfont.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ttfont.cpp; path = ../../api/ttfont.cpp; sourceTree = "<group>"; };
 		DDF8050415CB9C75005473CC /* ttfont.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ttfont.h; path = ../../api/ttfont.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -149,7 +137,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD0FAC14245ADFF10015D684 /* IOSurface.framework in Frameworks */,
+				DDDE391624600EAF005FCEFA /* IOSurface.framework in Frameworks */,
 				DD5937A1164D16CE001D94A5 /* GLUT.framework in Frameworks */,
 				DD5937A2164D16CE001D94A5 /* OpenGL.framework in Frameworks */,
 				DD5937A3164D16CE001D94A5 /* AppKit.framework in Frameworks */,
@@ -170,7 +158,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DD0FAC13245ADFB60015D684 /* IOSurface.framework in Frameworks */,
+				DDDE391724600EE9005FCEFA /* IOSurface.framework in Frameworks */,
 				DDC479B015AC56EB0022401F /* AppKit.framework in Frameworks */,
 				DDC479B115AC56EB0022401F /* GLUT.framework in Frameworks */,
 				DDC479B215AC56EB0022401F /* OpenGL.framework in Frameworks */,
@@ -227,7 +215,7 @@
 				DD760E65094E56DB002CACC4 /* AppKit.framework */,
 				DD760E66094E56DB002CACC4 /* GLUT.framework */,
 				DD760E67094E56DB002CACC4 /* OpenGL.framework */,
-				DD69ED6F2459A5840012014C /* IOSurface.framework */,
+				DDDE391524600EAF005FCEFA /* IOSurface.framework */,
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = "<group>";


### PR DESCRIPTION
* Restores Xcode project settings lost in commit _e091b98d07_ PR #3667
* Optimizes handling of graphics applications on Retina displays when built on Xcode 11 and run on OS 10.15 Catalina.
