### PR TITLE
hostinfo_unix: Enable FreeBSD CPU family/model/stepping detection.

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -718,9 +718,11 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
 #include <sys/types.h>
 #include <sys/cdefs.h>
 #include <machine/cpufunc.h>
+#include <machine/specialreg.h>
 
 void use_cpuid(HOST_INFO& host) {
     u_int p[4];
+    u_int cpu_id;
     int hasMMX, hasSSE, hasSSE2, hasSSE3, has3DNow, has3DNowExt, hasAVX;
     char capabilities[256];
 
@@ -731,6 +733,7 @@ void use_cpuid(HOST_INFO& host) {
 
         do_cpuid(0x1, p);
 
+        cpu_id = p[0];
         hasMMX  = (p[3] & (1 << 23 )) >> 23; // 0x0800000
         hasSSE  = (p[3] & (1 << 25 )) >> 25; // 0x2000000
         hasSSE2 = (p[3] & (1 << 26 )) >> 26; // 0x4000000
@@ -756,8 +759,8 @@ void use_cpuid(HOST_INFO& host) {
     if (hasAVX) safe_strcat(capabilities, "avx ");
     strip_whitespace(capabilities);
     char buf[1024];
-    snprintf(buf, sizeof(buf), "%s [] [%s]",
-        host.p_model, capabilities
+    snprintf(buf, sizeof(buf), "%s [Family %u Model %u Stepping %u] [%s]",
+        host.p_model, CPUID_TO_FAMILY(cpu_id), CPUID_TO_MODEL(cpu_id), cpu_id & CPUID_STEPPING, capabilities
     );
     strlcat(host.p_model, buf, sizeof(host.p_model));
 }


### PR DESCRIPTION
**Description of the Change**
Use native FreeBSD CPUID tools to derive family, model and stepping info. Tested on FreeBSD 12.1.

**Alternate Designs**
1. dmidecode: GNU tool creates unnecessary external dependency, and has trouble running in some VMs.
2. cpuinfo: FreeBSD has a kernel linux emulation capability, which allows a linprocfs to be mounted, containing cpuinfo. However, the implementation requires particular kernel knobs, and sometimes produces erroneous data (e.g., nonsense flags like 3dnow on Intel CPU).
3. dmesg: CPU data is visible and easily parsed from dmesg, but sane security settings generally prevent access to kernel message buffer from within FreeBSD jail.

**Release Notes**
FreeBSD now detects CPU family, model and stepping data.
