### PR TITLE
[Android] Use ContextCompat to retrieve system services.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/EventLogActivity.java
@@ -36,6 +36,7 @@ import android.widget.Toast;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBar.Tab;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -199,7 +200,7 @@ public class EventLogActivity extends AppCompatActivity {
 
     private void onCopy() {
         try {
-            ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+            ClipboardManager clipboard = ContextCompat.getSystemService(this, ClipboardManager.class);
             ClipData clipData = ClipData.newPlainText("log", getLogDataAsString());
             clipboard.setPrimaryClip(clipData);
             Toast.makeText(getApplicationContext(), R.string.eventlog_copy_toast, Toast.LENGTH_SHORT).show();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ClientLogListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ClientLogListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -28,6 +27,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -99,7 +99,7 @@ public class ClientLogListAdapter extends ArrayAdapter<Message> {
 
         // Only inflate a new view if the ListView does not already have a view assigned.
         if(convertView == null) {
-            vi = ((LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE))
+            vi = ContextCompat.getSystemService(activity, LayoutInflater.class)
                     .inflate(R.layout.eventlog_client_listitem_layout, null);
 
             viewEventLog = new ViewEventLog();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -18,7 +18,6 @@
  */
 package edu.berkeley.boinc.adapter;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.util.Log;
@@ -29,6 +28,8 @@ import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+
+import androidx.core.content.ContextCompat;
 
 import java.text.NumberFormat;
 import java.util.ArrayList;
@@ -103,8 +104,7 @@ public class NavDrawerListAdapter extends BaseAdapter {
             if(navDrawerItems.get(position).isSubItem()) {
                 layoutId = R.layout.navlist_listitem_subitem;
             }
-            LayoutInflater mInflater =
-                    (LayoutInflater) context.getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
+            LayoutInflater mInflater = ContextCompat.getSystemService(context, LayoutInflater.class);
             convertView = mInflater.inflate(layoutId, null);
         }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NoticesListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NoticesListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.net.Uri;
@@ -33,6 +32,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import java.text.DateFormat;
 import java.util.Date;
@@ -58,7 +58,7 @@ public class NoticesListAdapter extends ArrayAdapter<Notice> {
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         final Notice listItem = entries.get(position);
 
-        LayoutInflater vi = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        LayoutInflater vi = ContextCompat.getSystemService(activity, LayoutInflater.class);
         assert vi != null;
         View v = vi.inflate(R.layout.notices_layout_listitem, null);
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;
-import android.content.Context;
 import android.text.format.Formatter;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,6 +30,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -57,7 +57,7 @@ public class PrefsListAdapter extends ArrayAdapter<PrefsListItemWrapper> {
     @Override
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         View v;
-        LayoutInflater vi = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        LayoutInflater vi = ContextCompat.getSystemService(activity, LayoutInflater.class);
 
         PrefsListItemWrapper listItem = entries.get(position);
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsSelectionDialogListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/PrefsSelectionDialogListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;
-import android.content.Context;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -32,6 +31,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import java.util.List;
 import java.util.Objects;
@@ -75,7 +75,7 @@ public class PrefsSelectionDialogListAdapter extends ArrayAdapter<SelectionDialo
         SelectionDialogOption listItem = entries.get(position);
 
         if(v == null) {
-            LayoutInflater li = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            LayoutInflater li = ContextCompat.getSystemService(activity, LayoutInflater.class);
             assert li != null;
             v = li.inflate(R.layout.prefs_layout_listitem_bool, null);
             CheckBox cb = v.findViewById(R.id.checkbox);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectControlsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectControlsListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;
-import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -28,6 +27,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import java.util.List;
 
@@ -67,8 +67,8 @@ public class ProjectControlsListAdapter extends ArrayAdapter<ProjectControl> {
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         ProjectControl data = entries.get(position);
 
-        View vi =
-                ((LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE)).inflate(R.layout.projects_controls_listitem_layout, null);
+        View vi = ContextCompat.getSystemService(activity, LayoutInflater.class)
+                               .inflate(R.layout.projects_controls_listitem_layout, null);
 
         TextView tvText = vi.findViewById(R.id.text);
         String text = "";

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/ProjectsListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.text.format.DateUtils;
 import android.util.Log;
@@ -33,6 +32,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -124,7 +124,7 @@ public class ProjectsListAdapter extends ArrayAdapter<ProjectsListData> {
         }
 
         if(setup) {
-            final LayoutInflater layoutInflater = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            final LayoutInflater layoutInflater = ContextCompat.getSystemService(activity, LayoutInflater.class);
             assert layoutInflater != null;
             // first time getView is called for this element
             if(isAcctMgr) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.adapter;
 
 import android.app.Activity;
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.text.format.DateUtils;
 import android.util.Log;
@@ -34,6 +33,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -96,7 +96,8 @@ public class TasksListAdapter extends ArrayAdapter<TaskData> {
         }
 
         if(setup) {
-            LayoutInflater vi = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            LayoutInflater vi = ContextCompat.getSystemService(activity, LayoutInflater.class);
+            assert vi != null;
             v = vi.inflate(R.layout.tasks_layout_listitem, null);
             v.setTag(listItem.id);
         }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
@@ -23,7 +23,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.app.Service;
 import android.content.ComponentName;
-import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.net.ConnectivityManager;
@@ -47,6 +46,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 
 import org.apache.commons.lang3.StringUtils;
@@ -190,7 +190,7 @@ public class AcctMgrFragment extends DialogFragment {
         final Activity activity = getActivity();
         assert activity != null;
         final ConnectivityManager connectivityManager =
-                (ConnectivityManager) activity.getSystemService(Context.CONNECTIVITY_SERVICE);
+                ContextCompat.getSystemService(activity, ConnectivityManager.class);
         assert connectivityManager != null;
         final boolean online;
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchConflictListAdapter.java
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc.attach;
 
 import android.app.Activity;
-import android.content.Context;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,6 +30,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentManager;
 
 import java.util.List;
@@ -61,7 +61,7 @@ public class BatchConflictListAdapter extends ArrayAdapter<ProjectAttachWrapper>
                                " with result: " + listItem.result);
         }
 
-        LayoutInflater vi = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        LayoutInflater vi = ContextCompat.getSystemService(activity, LayoutInflater.class);
         assert vi != null;
         View v = vi.inflate(R.layout.attach_project_batch_conflicts_listitem, null);
         TextView name = v.findViewById(R.id.name);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
@@ -21,7 +21,6 @@ package edu.berkeley.boinc.attach;
 
 import android.app.Activity;
 import android.app.Dialog;
-import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -37,6 +36,7 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 
 import edu.berkeley.boinc.R;
@@ -89,8 +89,7 @@ public class ManualUrlInputFragment extends DialogFragment {
     private boolean checkDeviceOnline() {
         final Activity activity = getActivity();
         assert activity != null;
-        final ConnectivityManager connectivityManager =
-                (ConnectivityManager) activity.getSystemService(Context.CONNECTIVITY_SERVICE);
+        final ConnectivityManager connectivityManager = ContextCompat.getSystemService(activity, ConnectivityManager.class);
         assert connectivityManager != null;
 
         final boolean online;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
@@ -21,7 +21,6 @@ package edu.berkeley.boinc.attach;
 
 import android.app.Service;
 import android.content.ComponentName;
-import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.net.ConnectivityManager;
@@ -36,6 +35,7 @@ import android.view.View;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 
 import java.text.Collator;
@@ -108,7 +108,7 @@ public class SelectionListActivity extends FragmentActivity {
     // is possible!
     private boolean checkDeviceOnline() {
         final ConnectivityManager connectivityManager =
-                (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+                ContextCompat.getSystemService(this, ConnectivityManager.class);
         assert connectivityManager != null;
 
         final boolean online;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListAdapter.java
@@ -18,7 +18,6 @@
  */
 package edu.berkeley.boinc.attach;
 
-import android.content.Context;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -31,6 +30,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 
 import java.util.List;
@@ -53,7 +53,7 @@ public class SelectionListAdapter extends ArrayAdapter<ProjectListEntry> {
     @Override
     public View getView(int position, View convertView, @NonNull ViewGroup parent) {
         View v;
-        LayoutInflater vi = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        LayoutInflater vi = ContextCompat.getSystemService(activity, LayoutInflater.class);
         final ProjectListEntry listItem = entries.get(position);
 
         assert vi != null;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientNotification.java
@@ -1,13 +1,5 @@
 package edu.berkeley.boinc.client;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import edu.berkeley.boinc.BOINCActivity;
-import edu.berkeley.boinc.R;
-import edu.berkeley.boinc.rpc.Result;
-import edu.berkeley.boinc.utils.Logging;
-
 import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationManager;
@@ -15,8 +7,18 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.BitmapFactory;
-import androidx.core.app.NotificationCompat;
 import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.berkeley.boinc.BOINCActivity;
+import edu.berkeley.boinc.R;
+import edu.berkeley.boinc.rpc.Result;
+import edu.berkeley.boinc.utils.Logging;
 
 public class ClientNotification {
 
@@ -51,7 +53,7 @@ public class ClientNotification {
 
     private ClientNotification(Context ctx) {
         this.context = ctx;
-        this.nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        this.nm = ContextCompat.getSystemService(context, NotificationManager.class);
         notificationId = context.getResources().getInteger(R.integer.autostart_notification_id);
         Intent intent = new Intent(context, BOINCActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -29,6 +29,8 @@ import android.os.PowerManager.WakeLock;
 import android.text.format.DateUtils;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -120,7 +122,7 @@ public class ClientStatus {
 
         // set up CPU wakelock
         // see documentation at http://developer.android.com/reference/android/os/PowerManager.html
-        PowerManager pm = (PowerManager) ctx.getSystemService(Context.POWER_SERVICE);
+        PowerManager pm = ContextCompat.getSystemService(ctx, PowerManager.class);
         wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, Logging.WAKELOCK);
         // "one call to release() is sufficient to undo the effect of all previous calls to acquire()"
         wakeLock.setReferenceCounted(false);
@@ -130,7 +132,7 @@ public class ClientStatus {
         // can cause a memory leak if the context is not the application context.
         // You should consider using context.getApplicationContext().getSystemService() rather than
         // context.getSystemService()
-        WifiManager wm = (WifiManager) ctx.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
+        WifiManager wm = ContextCompat.getSystemService(ctx.getApplicationContext(), WifiManager.class);
         wifiLock = wm.createWifiLock(WifiManager.WIFI_MODE_FULL, "MyWifiLock");
         wifiLock.setReferenceCounted(false);
     }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
@@ -18,9 +18,6 @@
  */
 package edu.berkeley.boinc.client;
 
-import edu.berkeley.boinc.rpc.DeviceStatusData;
-import edu.berkeley.boinc.utils.*;
-
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -34,6 +31,10 @@ import android.telephony.TelephonyManager;
 import android.util.Log;
 
 import androidx.annotation.RequiresApi;
+import androidx.core.content.ContextCompat;
+
+import edu.berkeley.boinc.rpc.DeviceStatusData;
+import edu.berkeley.boinc.utils.Logging;
 
 public class DeviceStatus {
     // variables describing device status in RPC
@@ -65,8 +66,8 @@ public class DeviceStatus {
      */
     DeviceStatus(Context ctx, AppPreferences appPrefs) {
         this.ctx = ctx;
-        this.connManager = (ConnectivityManager) ctx.getSystemService(Context.CONNECTIVITY_SERVICE);
-        this.telManager = (TelephonyManager) ctx.getSystemService(Context.TELEPHONY_SERVICE);
+        this.connManager = ContextCompat.getSystemService(ctx, ConnectivityManager.class);
+        this.telManager = ContextCompat.getSystemService(ctx, TelephonyManager.class);
         this.batteryStatus = ctx.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
         this.appPrefs = appPrefs;
     }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -31,6 +31,8 @@ import android.os.PowerManager;
 import android.os.RemoteException;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -140,8 +142,7 @@ public class Monitor extends Service {
         if (Logging.ERROR) Log.d(Logging.TAG, "Monitor onCreate(): singletons initialized");
 
         // set current screen on/off status
-        PowerManager pm = (PowerManager)
-                getSystemService(Context.POWER_SERVICE);
+        PowerManager pm = ContextCompat.getSystemService(this, PowerManager.class);
         screenOn = pm.isScreenOn();
 
         // initialize DeviceStatus wrapper

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
@@ -26,16 +26,18 @@ import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import androidx.core.app.NotificationCompat;
 import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import edu.berkeley.boinc.BOINCActivity;
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.rpc.Notice;
 import edu.berkeley.boinc.utils.Logging;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class NoticeNotification {
     private static NoticeNotification noticeNotification = null;
@@ -65,7 +67,7 @@ public class NoticeNotification {
     public NoticeNotification(Context ctx) {
         this.context = ctx;
         this.store = new PersistentStorage(ctx);
-        this.nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        this.nm = ContextCompat.getSystemService(context, NotificationManager.class);
         notificationId = context.getResources().getInteger(R.integer.notice_notification_id);
         Intent intent = new Intent(context, BOINCActivity.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);


### PR DESCRIPTION
**Description of the Change**
Make use of `ContextCompat`'s `getSystemService` method instead of directly calling `Context`'s `getSystemService` method, as the former calls `Context`'s `getSystemService(Class)` on Android Marshmallow and later and `getSystemService(String)` on versions of Android older than Marshmallow.

**Release Notes**
N/A
