### PR TITLE
[Android] Add extension property to determine if the device is online.

### DIFF
--- a/android/BOINC/.idea/misc.xml
+++ b/android/BOINC/.idea/misc.xml
@@ -39,5 +39,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="9" project-jdk-type="JavaSDK" />
 </project>

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/AcctMgrFragment.java
@@ -26,9 +26,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.util.Log;
@@ -61,6 +59,7 @@ import edu.berkeley.boinc.client.IMonitor;
 import edu.berkeley.boinc.client.Monitor;
 import edu.berkeley.boinc.rpc.AccountManager;
 import edu.berkeley.boinc.utils.BOINCErrors;
+import edu.berkeley.boinc.utils.BOINCUtils;
 import edu.berkeley.boinc.utils.ErrorCodeDescription;
 import edu.berkeley.boinc.utils.Logging;
 
@@ -192,13 +191,8 @@ public class AcctMgrFragment extends DialogFragment {
         final ConnectivityManager connectivityManager =
                 ContextCompat.getSystemService(activity, ConnectivityManager.class);
         assert connectivityManager != null;
-        final boolean online;
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            final NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-            online = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
-        } else {
-            online = connectivityManager.getActiveNetwork() != null;
-        }
+
+        final boolean online = BOINCUtils.isOnline(connectivityManager);
         if (!online) {
             Toast toast = Toast.makeText(getActivity(), R.string.attachproject_list_no_internet, Toast.LENGTH_SHORT);
             toast.show();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ManualUrlInputFragment.java
@@ -23,8 +23,6 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
 import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.os.Build;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -40,6 +38,7 @@ import androidx.core.content.ContextCompat;
 import androidx.fragment.app.DialogFragment;
 
 import edu.berkeley.boinc.R;
+import edu.berkeley.boinc.utils.BOINCUtils;
 import edu.berkeley.boinc.utils.Logging;
 
 public class ManualUrlInputFragment extends DialogFragment {
@@ -92,14 +91,7 @@ public class ManualUrlInputFragment extends DialogFragment {
         final ConnectivityManager connectivityManager = ContextCompat.getSystemService(activity, ConnectivityManager.class);
         assert connectivityManager != null;
 
-        final boolean online;
-        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            final NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-            online = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
-        }
-        else {
-            online = connectivityManager.getActiveNetwork() != null;
-        }
+        final boolean online = BOINCUtils.isOnline(connectivityManager);
         if(!online) {
             Toast toast = Toast.makeText(getActivity(), R.string.attachproject_list_no_internet, Toast.LENGTH_SHORT);
             toast.show();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.java
@@ -24,9 +24,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.RemoteException;
@@ -49,6 +47,7 @@ import edu.berkeley.boinc.client.IMonitor;
 import edu.berkeley.boinc.client.Monitor;
 import edu.berkeley.boinc.rpc.AcctMgrInfo;
 import edu.berkeley.boinc.rpc.ProjectInfo;
+import edu.berkeley.boinc.utils.BOINCUtils;
 import edu.berkeley.boinc.utils.Logging;
 
 public class SelectionListActivity extends FragmentActivity {
@@ -111,14 +110,7 @@ public class SelectionListActivity extends FragmentActivity {
                 ContextCompat.getSystemService(this, ConnectivityManager.class);
         assert connectivityManager != null;
 
-        final boolean online;
-        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-            final NetworkInfo activeNetworkInfo = connectivityManager.getActiveNetworkInfo();
-            online = activeNetworkInfo != null && activeNetworkInfo.isConnectedOrConnecting();
-        }
-        else {
-            online = connectivityManager.getActiveNetwork() != null;
-        }
+        final boolean online = BOINCUtils.isOnline(connectivityManager);
         if(!online) {
             Toast toast =
                     Toast.makeText(getApplicationContext(), R.string.attachproject_list_no_internet, Toast.LENGTH_SHORT);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
@@ -21,9 +21,20 @@
 package edu.berkeley.boinc.utils
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.os.Build
 import edu.berkeley.boinc.R
 import java.io.IOException
 import java.io.Reader
+
+val ConnectivityManager.isOnline: Boolean
+    get() {
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            activeNetworkInfo?.isConnectedOrConnecting == true
+        } else {
+            activeNetwork != null
+        }
+    }
 
 @Throws(IOException::class)
 fun Reader.readLineLimit(limit: Int): String? {

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsIsOnlineTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsIsOnlineTest.kt
@@ -1,0 +1,42 @@
+package edu.berkeley.boinc.utils
+
+import android.net.ConnectivityManager
+import android.os.Build
+import androidx.core.content.getSystemService
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.Spy
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class BOINCUtilsIsOnlineTest {
+    @Spy
+    private val connectivityManager = InstrumentationRegistry.getInstrumentation().context
+            .getSystemService<ConnectivityManager>()
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+    }
+
+    @Config(minSdk = Build.VERSION_CODES.KITKAT, maxSdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+    @Test
+    fun `Expect isOnline property to call getActiveNetworkInfo() when API level is below 23`() {
+        connectivityManager!!.isOnline
+
+        Mockito.verify(connectivityManager)!!.activeNetworkInfo
+    }
+
+    @Config(minSdk = Build.VERSION_CODES.M, maxSdk = Build.VERSION_CODES.P)
+    @Test
+    fun `Expect isOnline property to call getActiveNetwork() when API level is 23 or higher`() {
+        connectivityManager!!.isOnline
+
+        Mockito.verify(connectivityManager)!!.activeNetwork
+    }
+}


### PR DESCRIPTION
**Description of the Change**
Add an extension property for `ConnectivityManager` to determine if the device is currently online and alter the existing code to make use of this. This is so that the mechanism to determine if the device is online can also be used in any future code.

**Release Notes**
N/A
