### PR TITLE
[Android] Add some tests for Monitor.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -63,6 +63,7 @@ import edu.berkeley.boinc.rpc.CcStatus;
 import edu.berkeley.boinc.rpc.GlobalPreferences;
 import edu.berkeley.boinc.rpc.HostInfo;
 import edu.berkeley.boinc.rpc.ImageWrapper;
+import edu.berkeley.boinc.rpc.Message;
 import edu.berkeley.boinc.rpc.Notice;
 import edu.berkeley.boinc.rpc.Project;
 import edu.berkeley.boinc.rpc.ProjectConfig;
@@ -1046,8 +1047,7 @@ public class Monitor extends Service {
 // --end -- async tasks
 
     // remote service
-    private final IMonitor.Stub mBinder = new IMonitor.Stub() {
-
+    final IMonitor.Stub mBinder = new IMonitor.Stub() {
         @Override
         public boolean transferOperation(List<Transfer> list, int op) throws RemoteException {
             return clientInterface.transferOperation(list, op);
@@ -1138,13 +1138,12 @@ public class Monitor extends Service {
         }
 
         @Override
-        public List<edu.berkeley.boinc.rpc.Message> getMessages(int seq) throws RemoteException {
+        public List<Message> getMessages(int seq) throws RemoteException {
             return clientInterface.getMessages(seq);
         }
 
         @Override
-        public List<edu.berkeley.boinc.rpc.Message> getEventLogMessages(int seq, int num)
-                throws RemoteException {
+        public List<Message> getEventLogMessages(int seq, int num) throws RemoteException {
             return clientInterface.getEventLogMessages(seq, num);
         }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -672,7 +672,7 @@ public class RpcClient {
                     opTag = "project_reset";
                     break;
                 default:
-                    if (edu.berkeley.boinc.utils.Logging.LOGLEVEL <= 4)
+                    if (Logging.LOGLEVEL <= 4)
                         Log.e(Logging.TAG, "projectOp() - unsupported operation: " + operation);
                     return false;
             }

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/MonitorTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/MonitorTest.kt
@@ -1,0 +1,113 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.client
+
+import edu.berkeley.boinc.rpc.Transfer
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+import org.mockito.Spy
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.android.controller.ServiceController
+
+@RunWith(RobolectricTestRunner::class)
+class MonitorTest {
+    @Spy
+    private val clientInterface = ClientInterfaceImplementation()
+
+    private lateinit var monitor: Monitor
+    private lateinit var controller: ServiceController<Monitor>
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+
+        controller = Robolectric.buildService(Monitor::class.java).create()
+        monitor = controller.get()
+        monitor.clientInterface = clientInterface
+    }
+
+    @Test
+    fun `Expect default config location when getAuthFilePath() is called`() {
+        Assert.assertEquals("/data/data/edu.berkeley.boinc/client/gui_rpc_auth.cfg", monitor.authFilePath)
+    }
+
+    @Test
+    fun `Expect arm-android-linux-gnu when getBoincPlatform() is called`() {
+        Assert.assertEquals("arm-android-linux-gnu", monitor.getString(monitor.boincPlatform))
+    }
+
+    @Test
+    fun `Expect blank string when getBoincAltPlatform() is called`() {
+        Assert.assertTrue(monitor.boincAltPlatform.isEmpty())
+    }
+
+    @Test
+    fun `Expect ClientInterfaceImplementation's transferOperation() to be called when mBinding's transferOperation() is called`() {
+        monitor.mBinder.transferOperation(emptyList(), 1)
+
+        Mockito.verify(clientInterface).transferOperation(eq(emptyList<Transfer>()), eq(1))
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun `Expect NullPointerException to be thrown when mBinder's setGlobalPreferences() is called with a null parameter`() {
+        monitor.mBinder.setGlobalPreferences(null)
+    }
+
+    @Test(expected = NullPointerException::class)
+    fun `Expect NullPointerException to be thrown when mBinder's readAuthToken() is called with a null parameter`() {
+        monitor.mBinder.readAuthToken(null)
+    }
+
+    @Test
+    fun `Expect empty string when mBinder's readAuthToken() is called with a non-existent path`() {
+        Assert.assertTrue(monitor.mBinder.readAuthToken("somefile.txt").isEmpty())
+    }
+
+    @Test
+    fun `Expect false when mBinder's projectOp() is called with an unsupported operation`() {
+        Assert.assertFalse(monitor.mBinder.projectOp(0, ""))
+    }
+
+    @Test
+    fun `Expect empty list when mBinder's getServerNotices() is called`() {
+        Assert.assertTrue(monitor.mBinder.serverNotices.isEmpty())
+    }
+
+    @Test
+    fun `Expect battery charge to be 0 when mBinder's getBatteryChargeStatus() is called`() {
+        Assert.assertEquals(0, monitor.mBinder.batteryChargeStatus)
+    }
+
+    @Test
+    fun `Expect BOINC mutex to not be acquired when mBinder's boincMutexAcquired() is called`() {
+        Assert.assertFalse(monitor.mBinder.boincMutexAcquired())
+    }
+
+    @After
+    fun tearDown() {
+        controller.destroy()
+    }
+}


### PR DESCRIPTION
**Description of the Change**
Adds Robolectric tests for the Monitor class.

Note: Tests for methods that call the RPC XML parsers could not be added as Robolectric does not support them.

**Release Notes**
N/A
