### PR TITLE
[Android] Use asynchronous edit() extension function for SharedPreferences.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.kt
@@ -45,8 +45,7 @@ class AppPreferences {
         }
     var logLevel = 0
         set(value) {
-            // Commit a new value synchronously
-            prefs?.edit(commit = true) { putInt("logLevel", value) }
+            prefs?.edit { putInt("logLevel", value) }
             field = value
             Logging.setLogLevel(value)
         }
@@ -77,7 +76,7 @@ class AppPreferences {
         }
 
     private fun putBooleanToPrefs(key: String, value: Boolean) {
-        prefs?.edit(commit = true) { putBoolean(key, value) }
+        prefs?.edit { putBoolean(key, value) }
     }
 
     fun readPrefs(ctx: Context) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.kt
@@ -20,6 +20,7 @@ package edu.berkeley.boinc.client
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 
 /**
  * This class wraps persistent key value pairs.
@@ -35,24 +36,18 @@ class PersistentStorage(ctx: Context) {
                     defaultValue.toDouble().toRawBits()))
         }
         set(arrivalTime) {
-            val editor = store.edit()
-            editor.putLong("lastNotifiedNoticeArrivalTime", arrivalTime.toRawBits())
-            editor.apply()
+            store.edit { putLong("lastNotifiedNoticeArrivalTime", arrivalTime.toRawBits()) }
         }
 
     var lastEmailAddress: String?
         get() = store.getString("lastEmailAddress", "")
         set(email) {
-            val editor = store.edit()
-            editor.putString("lastEmailAddress", email)
-            editor.apply()
+            store.edit { putString("lastEmailAddress", email) }
         }
 
     var lastUserName: String?
         get() = store.getString("lastUserName", "")
         set(name) {
-            val editor = store.edit()
-            editor.putString("lastUserName", name)
-            editor.apply()
+            store.edit { putString("lastUserName", name) }
         }
 }


### PR DESCRIPTION
**Description of the Change**
Make use of the edit() extension function for `SharedPreferences` in `PersistentStorage` and remove the `commit = true` parameter from its usages in `AppPreferences`.

**Release Notes**
N/A
