### PR TITLE
Client: don't allow empty GUI RPC password

### DIFF
--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -174,6 +174,7 @@ int main(int argc, char** argv) {
     char passwd_buf[256], hostname_buf[256], *hostname=0;
     char* passwd = passwd_buf, *p, *q;
     bool unix_domain = false;
+    string msg;
 
 #ifdef _WIN32
     chdir_to_data_dir();
@@ -181,7 +182,11 @@ int main(int argc, char** argv) {
     chdir("/Library/Application Support/BOINC Data");
 #endif
     safe_strcpy(passwd_buf, "");
-    read_gui_rpc_password(passwd_buf);
+    retval = read_gui_rpc_password(passwd_buf, msg);
+    if (retval) {
+        fprintf(stderr, "Can't get RPC password: %s\n", msg.c_str());
+        fprintf(stderr, "Only operations not requiring authorization will be allowed.\n");
+    }
 
 #if defined(_WIN32) && defined(USE_WINSOCK)
     WSADATA wsdata;

--- a/client/boinc_log.cpp
+++ b/client/boinc_log.cpp
@@ -15,10 +15,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// boinclog: command-line interface to a BOINC client,
-// using GUI RPCs.
+// boinc_log: show stream of event-log messages from a client
 //
-// usage: boinccmd [--host hostname] [--passwd passwd] command
+// usage: boinc_log [--host hostname] [--passwd passwd] 
 
 #if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
 #include "boinc_win.h"
@@ -176,7 +175,8 @@ int main(int argc, char** argv) {
 #endif
     }
 
-    read_gui_rpc_password(passwd_buf);
+    std::string msg;
+    read_gui_rpc_password(passwd_buf, msg);
 
     retval = rpc.init(hostname, port);
     if (retval) {

--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -500,19 +500,10 @@ void CBOINCBaseFrame::ShowConnectionBadPasswordAlert(
         if (password_msg.empty()) {
             password_msg = "Invalid client RPC password.  Try reinstalling BOINC.";
         }
-        ShowAlert(
-            strDialogTitle,
-            password_msg,
-            wxOK | wxICON_ERROR
-        );
     } else {
-        ShowAlert(
-            strDialogTitle,
-            _("The password you have provided is incorrect, please try again."),
-            wxOK | wxICON_ERROR
-        );
+        password_msg = "Invalid client RPC password.  Try reinstalling BOINC.";
     }
-
+    wxMessageBox(wxString(password_msg), strDialogTitle, wxOK | wxICON_ERROR);
     wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::ShowConnectionBadPasswordAlert - Function End"));
 }
 
@@ -623,12 +614,7 @@ void CBOINCBaseFrame::ShowDaemonStartFailedAlert() {
     );
 #endif
 
-    ShowAlert(
-        strDialogTitle,
-        strDialogMessage,
-        wxOK | wxICON_ERROR
-    );
-
+    wxMessageBox(strDialogMessage, strDialogTitle, wxOK | wxICON_ERROR);
     wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::ShowDaemonStartFailedAlert - Function End"));
 }
 
@@ -684,12 +670,7 @@ void CBOINCBaseFrame::ShowNotCurrentlyConnectedAlert() {
         pSkinAdvanced->GetApplicationShortName().c_str(),
         pSkinAdvanced->GetApplicationShortName().c_str()
     );
-    ShowAlert(
-        strDialogTitle,
-        strDialogMessage,
-        wxOK | wxICON_ERROR
-    );
-
+    wxMessageBox(strDialogMessage, strDialogTitle, wxOK | wxICON_ERROR);
     wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::ShowNotCurrentlyConnectedAlert - Function End"));
 }
 

--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -476,7 +476,9 @@ bool CBOINCBaseFrame::SelectComputer(wxString& hostName, int& portNum, wxString&
 }
 
 
-void CBOINCBaseFrame::ShowConnectionBadPasswordAlert( bool bUsedDefaultPassword, int iReadGUIRPCAuthFailure ) {
+void CBOINCBaseFrame::ShowConnectionBadPasswordAlert(
+    bool bUsedDefaultPassword, int iReadGUIRPCAuthFailure, std::string password_msg
+) {
     CSkinAdvanced*      pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     wxString            strDialogTitle = wxEmptyString;
 
@@ -495,26 +497,14 @@ void CBOINCBaseFrame::ShowConnectionBadPasswordAlert( bool bUsedDefaultPassword,
     );
 
     if ( bUsedDefaultPassword ) {
-#ifdef __WXMSW__
-        if ( EACCES == iReadGUIRPCAuthFailure || ENOENT == iReadGUIRPCAuthFailure ) {
-            ShowAlert(
-                strDialogTitle,
-                _("You currently are not authorized to manage the client.\nPlease contact your administrator to add you to the 'boinc_users' local user group."),
-                wxOK | wxICON_ERROR
-            );
-        } else 
-#endif
-        {
-            ShowAlert(
-                strDialogTitle,
-#ifndef __WXMAC__
-                _("Authorization failed connecting to running client.\nMake sure you start this program in the same directory as the client."),
-#else
-                _("Authorization failed connecting to running client."),
-#endif
-                wxOK | wxICON_ERROR
-            );
+        if (password_msg.empty()) {
+            password_msg = "Invalid client RPC password.  Try reinstalling BOINC.";
         }
+        ShowAlert(
+            strDialogTitle,
+            password_msg,
+            wxOK | wxICON_ERROR
+        );
     } else {
         ShowAlert(
             strDialogTitle,

--- a/clientgui/BOINCBaseFrame.h
+++ b/clientgui/BOINCBaseFrame.h
@@ -83,7 +83,7 @@ public:
     void                FireNotification();
 
     bool                SelectComputer(wxString& hostName, int& portNum, wxString& password, bool required = false);
-    void                ShowConnectionBadPasswordAlert( bool bUsedDefaultPassword, int iReadGUIRPCAuthFailure );
+    void                ShowConnectionBadPasswordAlert( bool bUsedDefaultPassword, int iReadGUIRPCAuthFailure, std::string);
     void                ShowConnectionFailedAlert();
     void                ShowDaemonStartFailedAlert();
     void                ShowNotCurrentlyConnectedAlert();

--- a/clientgui/BOINCClientManager.cpp
+++ b/clientgui/BOINCClientManager.cpp
@@ -329,11 +329,13 @@ bool CBOINCClientManager::StartupBOINCCore() {
 
     if (0 != m_lBOINCCoreProcessId) {
         m_bBOINCStartedByManager = true;
-        bReturnValue = true;
         // Allow time for daemon to start up so we don't keep relaunching it
         for (int i=0; i<100; i++) {     // Wait up to 1 seccond in 10 ms increments
             boinc_sleep(0.01);
-            if (IsBOINCCoreRunning()) break;
+            if (IsBOINCCoreRunning()) {
+                bReturnValue = true;
+                break;
+            }
         }
     }
 

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -126,22 +126,10 @@ CNetworkConnection::~CNetworkConnection() {
 
 int CNetworkConnection::GetLocalPassword(wxString& strPassword){
     char buf[256];
-    safe_strcpy(buf, "");
-
-    FILE* f = fopen("gui_rpc_auth.cfg", "r");
-    if (!f) return errno;
-    fgets(buf, 256, f);
-    fclose(f);
-    int n = (int)strlen(buf);
-    if (n) {
-        n--;
-        if (buf[n]=='\n') {
-            buf[n] = 0;
-        }
-    }
-
+ 
+    int retval = read_gui_rpc_password(buf, password_msg);
     strPassword = wxString(buf, wxConvUTF8);
-    return 0;
+    return retval;
 }
 
 
@@ -317,7 +305,7 @@ void CNetworkConnection::SetStateErrorAuthentication() {
 
         m_bConnectEvent = false;
 
-        pFrame->ShowConnectionBadPasswordAlert(m_bUsedDefaultPassword, m_iReadGUIRPCAuthFailure);
+        pFrame->ShowConnectionBadPasswordAlert(m_bUsedDefaultPassword, m_iReadGUIRPCAuthFailure, password_msg);
     }
 }
 

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -59,6 +59,8 @@ extern bool g_use_sandbox;
 class CMainDocument;
 class CBOINCClientManager;
 
+// GUI RPC connection to a client (should change the name)
+//
 class CNetworkConnection : public wxObject {
 public:
     CNetworkConnection(CMainDocument* pDocument);
@@ -85,6 +87,7 @@ public:
     bool           IsConnectEventSignaled() { return m_bConnectEvent; };
     bool           IsConnected() { return m_bConnected; };
     bool           IsReconnecting() { return m_bReconnecting; };
+    std::string    password_msg;
 
 private:
     CMainDocument* m_pDocument;

--- a/clientscr/gfx_cleanup.mm
+++ b/clientscr/gfx_cleanup.mm
@@ -65,10 +65,11 @@ void killGfxApp(pid_t thePID) {
     char userName[64];
     RPC_CLIENT *rpc;
     int retval;
+    string msg;
     
     chdir("/Library/Application Support/BOINC Data");
     safe_strcpy(buf, "");
-    read_gui_rpc_password(buf);
+    read_gui_rpc_password(buf, msg);
     
     rpc = new RPC_CLIENT;
     if (rpc->init(NULL)) {     // Initialize communications with Core Client

--- a/clientscr/gfx_cleanup.mm
+++ b/clientscr/gfx_cleanup.mm
@@ -65,7 +65,7 @@ void killGfxApp(pid_t thePID) {
     char userName[64];
     RPC_CLIENT *rpc;
     int retval;
-    string msg;
+    std::string msg;
     
     chdir("/Library/Application Support/BOINC Data");
     safe_strcpy(buf, "");

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -308,7 +308,7 @@ void doBoinc_Sleep(double seconds) {
 CScreensaver::CScreensaver() {
     struct ss_periods periods;
     char saved_dir[MAXPATHLEN];
-    string msg;
+    std::string msg;
     
     m_dwBlankScreen = 0;
     m_dwBlankTime = 0;

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -308,6 +308,7 @@ void doBoinc_Sleep(double seconds) {
 CScreensaver::CScreensaver() {
     struct ss_periods periods;
     char saved_dir[MAXPATHLEN];
+    string msg;
     
     m_dwBlankScreen = 0;
     m_dwBlankTime = 0;
@@ -334,7 +335,7 @@ CScreensaver::CScreensaver() {
     if (gIsCatalina) {
         getcwd(saved_dir, sizeof(saved_dir));
         chdir("/Library/Application Support/BOINC Data");
-        read_gui_rpc_password(passwd_buf);
+        read_gui_rpc_password(passwd_buf, msg);
         chdir(saved_dir);
         
         CFStringRef cf_gUserName = SCDynamicStoreCopyConsoleUser(NULL, NULL, NULL);

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -362,5 +362,6 @@ struct DEVICE_STATUS {
 #else
 #define DEFAULT_SS_EXECUTABLE       "boincscr"
 #endif
+#define LINUX_CONFIG_FILE           "/etc/boinc-client/config.properties"
 
 #endif

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -404,11 +404,85 @@ int RPC::parse_reply() {
     return -1;
 }
 
-// If there's a password file, read it
+// Look for a GUI RPC password file and read it.
+// If fail, return a prescriptive message.
+// Win/Mac: look in current dir.
+// Linux: also look in a directory specified in
+// /etc/boinc-client/config.properties
 //
-int read_gui_rpc_password(char* buf) {
+int read_gui_rpc_password(char* buf, string& msg) {
+    char msg_buf[1024];
     FILE* f = fopen(GUI_RPC_PASSWD_FILE, "r");
-    if (!f) return ERR_FOPEN;
+    if (!f) {
+#if defined(__linux__)
+        if (errno == EACCES) {
+            sprintf(msg_buf,
+                "%s exists but can't be read.  Check the file permissions.",
+                GUI_RPC_PASSWD_FILE
+            );
+            msg = msg_buf;
+            return ERR_FOPEN;
+        }
+        FILE* g = fopen(LINUX_CONFIG_FILE, "r");
+        if (g) {
+            char buf2[MAXPATHLEN], path[MAXPATHLEN];
+            char *p = 0;
+            while (fgets(buf2, MAXPATHLEN, g)) {
+                strip_whitespace(buf2);
+                p = strstr(buf2, "data_dir=");
+                if (p) break;
+            }
+            fclose(g);
+            if (p) {
+                p += strlen("data_dir=");
+                sprintf(path, "%s/%s", p, GUI_RPC_PASSWD_FILE);
+                f = fopen(path, "r");
+                if (!f) {
+                    if (errno == EACCES) {
+                        sprintf(msg_buf,
+                            "%s exists but can't be read.  Check the file permissions.",
+                            path
+                        );
+                    } else {
+                        sprintf(msg_buf, "%s not found.  Try reinstalling BOINC.",
+                            path
+                        );
+                    }
+                    msg = msg_buf;
+                    return ERR_FOPEN;
+                }
+            } else {
+                sprintf(msg_buf,
+                    "No data_dir= found in %s.  Try reinstalling BOINC.",
+                    LINUX_CONFIG_FILE
+                );
+                msg = msg_buf;
+                return ERR_FOPEN;
+            }
+        } else {
+            sprintf(msg_buf, "%s not found.  Try reinstalling BOINC.",
+                GUI_RPC_PASSWD_FILE
+            );
+            msg = msg_buf;
+            return ERR_FOPEN;
+        }
+#else
+        // non-Linux
+
+        if (errno == EACCES) {
+            sprintf(msg_buf,
+                "%s exists but can't be read.  Make sure your account is in the 'boinc_users' group",
+                GUI_RPC_PASSWD_FILE
+            );
+        } else {
+            sprintf(msg_buf, "%s not found.  Try reinstalling BOINC.",
+                GUI_RPC_PASSWD_FILE
+            );
+        }
+        msg = msg_buf;
+        return ERR_FOPEN;
+#endif
+    }
     char* p = fgets(buf, 256, f);
     if (p) {
         // trim CR

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -804,6 +804,6 @@ struct SET_LOCALE {
 };
 #endif
 
-extern int read_gui_rpc_password(char*);
+extern int read_gui_rpc_password(char*, std::string&);
 
 #endif // BOINC_GUI_RPC_CLIENT_H


### PR DESCRIPTION
If the GUI RPC file exists and is empty,
create a random password and write it to the file.

Running with an empty password is a security risk.
It means anyone on the same machine can control the client,
e.g. attach it to an arbitrary project.
