### PR TITLE
configure.ac: Fix have_xss test to respect --without-x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -626,10 +626,14 @@ AM_CONDITIONAL(BUILD_GRAPHICS_API, [ test "$have_glut" = yes -a "$have_jpeg" = 1
 
 dnl check for X screen saver lib (X-based idle detection on Linux)
 if test "$enable_xss" = yes; then
-    AC_CHECK_LIB([Xss], [XScreenSaverAllocInfo], [have_Xss="yes"], [have_Xss="no"])
-    AC_CHECK_HEADER([X11/extensions/scrnsaver.h], [have_Xss="yes"], [have_Xss="no"])
-    if test "$have_Xss" = no; then
-        AC_MSG_WARN([libxss missing, disabling X ScreenSaver user idle detection])
+    if test "X${no_x}" = "Xyes" ; then
+        AC_MSG_WARN([X Window include files/libs excluded or location unknown, disabling X ScreenSaver user idle detection])
+    else
+        AC_CHECK_LIB([Xss], [XScreenSaverAllocInfo], [have_Xss="yes"], [have_Xss="no"])
+        AC_CHECK_HEADER([X11/extensions/scrnsaver.h], [have_Xss="yes"], [have_Xss="no"])
+        if test "$have_Xss" = no; then
+            AC_MSG_WARN([libxss missing, disabling X ScreenSaver user idle detection])
+        fi
     fi
 fi
 


### PR DESCRIPTION
Fixes: unreported issue

**Description of the Change**
Add test to check value of `no_x` to prevent undesired inclusion of libXss, even if present. The **AC_PATH_X** macro sets the shell variable `no_x` to 'yes' if the user gave the command line option `--without-x`, so this must be respected for the screensaver idle detection. However, since the macro sets `no_x` to the same value if the X Window System include files and libraries cannot be located, provide build warning to assist with debugging.

**Alternate Designs**
- Place test for value of `no_x` at line 628 (`if test "X${no_x}" != "Xyes" -a "$enable_xss" = yes; then`) . This would silently disable the X ScreenSaver user idle detection, whether or not that is what the user desired (i.e., didn't supply `--without-x`, but X libraries couldn't be found). 
- Add additional configure option to disable X ScreenSaver idle detection. This would be a larger change, because` --without-x` would need to imply `--without-xss`, and user would need to be alerted if conflicting options were supplied.
- Add additional test(s) for values of `x_includes` and `x_libraries` variable to resolve ambiguity of whether X libraries are missing or simply undesired (and thus further clarify the message to user). This is unnecessary, as the user who chose to ignore them (by passing `--without-x`) will properly interpret the warning to mean nothing is actually wrong.

**Release Notes**
N/A