### PR TITLE
Fix 32bit ARM Android build in Automake 1.16.1

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -114,6 +114,7 @@ boinc_client_LDADD = $(LIBBOINC) $(LIBBOINC_CRYPT) $(BOINC_EXTRA_LIBS) $(PTHREAD
 boinc_clientdir = $(bindir)
 
 if OS_ARM_LINUX
+EXTRA_boinc_client_DEPENDENCIES = libwhetneon.a libwhetvfp.a
 boinc_client_LDADD += libwhetneon.a libwhetvfp.a
 noinst_LIBRARIES = libwhetneon.a libwhetvfp.a
 libwhetneon_a_SOURCES = whetstone.cpp


### PR DESCRIPTION
Split off from #3665
That one is getting too big and is more a feature change PR now
Will remove this change in that PR

**Description of the Change**
Add `EXTRA_boinc_client_DEPENDENCIES =` to ensure `libwhet*.a` are built before linking with boinc_client
This fixes the issue when building with Automake 1.16.1 where generated `boinc/client/Makefile` yields:
`all-am: Makefile $(PROGRAMS) $(LIBRARIES) all-local`
instead of the output from Automake 1.15.1 and earlier:
`all-am: Makefile $(LIBRARIES) $(PROGRAMS) all-local`

**Alternate Designs**
This is only a bug fix for building 32bit ARM Android client and does not change BOINC workings

**Release Notes**
N/A
