### PR TITLE
[Android] Use try-with resources in Monitor's installFile().

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -722,22 +722,23 @@ public class Monitor extends Service {
 
         // If file is executable, cpu architecture has to be evaluated
         // and assets directory select accordingly
-        String source;
+        final String source;
         if (executable)
             source = getAssetsDirForCpuArchitecture() + file;
         else
             source = file;
 
-        try {
+        final File target;
+        if (!targetFile.isEmpty()) {
+            target = new File(boincWorkingDir + targetFile);
+        } else {
+            target = new File(boincWorkingDir + file);
+        }
+
+        try (InputStream asset = getApplicationContext().getAssets().open(source);
+             OutputStream targetData = new FileOutputStream(target)) {
             if (Logging.ERROR)
                 Log.d(Logging.TAG, "installing: " + source);
-
-            File target;
-            if (!targetFile.isEmpty()) {
-                target = new File(boincWorkingDir + targetFile);
-            } else {
-                target = new File(boincWorkingDir + file);
-            }
 
             // Check path and create it
             File installDir = new File(boincWorkingDir);
@@ -771,13 +772,9 @@ public class Monitor extends Service {
             }
 
             // Copy file from the asset manager to clientPath
-            InputStream asset = getApplicationContext().getAssets().open(source);
-            OutputStream targetData = new FileOutputStream(target);
             while ((count = asset.read(b)) != -1) {
                 targetData.write(b, 0, count);
             }
-            asset.close();
-            targetData.close();
 
             success = true; //copy succeeded without exception
 


### PR DESCRIPTION
**Description of the Change**
Use the try-with resources language feature in the `installFile()` method of `Monitor`, as this eliminates the need to close the resources separately and ensures that they will be closed even if an exception is thrown.

**Release Notes**
N/A
