### PR TITLE
[WIP] [Android] Use RxJava instead of AsyncTask for background processing.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -109,6 +109,8 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'commons-io:commons-io:2.6'
+    implementation 'io.reactivex.rxjava3:rxandroid:3.0.0'
+    implementation 'io.reactivex.rxjava3:rxjava:3.0.3'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
@@ -125,4 +127,5 @@ dependencies {
 }
 repositories {
     mavenCentral()
+    maven { url "https://oss.jfrog.org/libs-snapshot" }
 }


### PR DESCRIPTION
**Description of the Change**
Alter the background processing tasks to be implemented using RxJava instead of `AsyncTask`, as the latter approach can easily lead to memory leaks with inner classes extending `AsyncTask` and makes chaining operations complex.

**Release Notes**
N/A
