### PR TITLE
[Android] Fix issue preventing an account manager being displayed.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountManagerClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountManagerClasses.kt
@@ -96,11 +96,11 @@ data class AcctMgrInfo internal constructor(
     }
 
     object Fields {
-        const val ACCT_MGR_NAME = "acctMgrName"
-        const val ACCT_MGR_URL = "acctMgrUrl"
-        const val COOKIE_FAILURE_URL = "cookieFailureUrl"
-        const val HAVING_CREDENTIALS = "havingCredentials"
-        const val COOKIE_REQUIRED = "cookieRequired"
+        const val ACCT_MGR_NAME = "acct_mgr_name"
+        const val ACCT_MGR_URL = "acct_mgr_url"
+        const val COOKIE_FAILURE_URL = "cookie_failure_url"
+        const val HAVING_CREDENTIALS = "having_credentials"
+        const val COOKIE_REQUIRED = "cookie_required"
     }
 
     companion object {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountManagerClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/AccountManagerClasses.kt
@@ -99,7 +99,7 @@ data class AcctMgrInfo internal constructor(
         const val ACCT_MGR_NAME = "acct_mgr_name"
         const val ACCT_MGR_URL = "acct_mgr_url"
         const val COOKIE_FAILURE_URL = "cookie_failure_url"
-        const val HAVING_CREDENTIALS = "having_credentials"
+        const val HAVING_CREDENTIALS = "have_credentials"
         const val COOKIE_REQUIRED = "cookie_required"
     }
 


### PR DESCRIPTION
**Description of the Change**
This changes the constant values in the `Fields` class of `AcctMgrInfo` to those of the tags in the XML returned by the BOINC client, so that the XML can be parsed correctly.

**Release Notes**
If an account manager is used, it will be displayed properly.
