### PR TITLE
Fix boinc platform strings for Android

### DIFF
--- a/m4/boinc_platform.m4
+++ b/m4/boinc_platform.m4
@@ -53,12 +53,14 @@ AC_DEFUN([BOINC_PLATFORM],[
         ;;
       aarch64*linux-android)
         boinc_platform="aarch64-android-linux-gnu"
+        boinc_alt_platform="arm-android-linux-gnu"
         ;;
       arm*linux-android*)
         boinc_platform="arm-android-linux-gnu"
         ;;
       x86_64*linux-android)
         boinc_platform="x86_64-android-linux-gnu"
+        boinc_alt_platform="x86-android-linux-gnu"
         ;;
       i686*linux-android)
         boinc_platform="x86-android-linux-gnu"

--- a/m4/boinc_platform.m4
+++ b/m4/boinc_platform.m4
@@ -51,6 +51,18 @@ AC_DEFUN([BOINC_PLATFORM],[
       ia64-hp-hpux*)
 	boinc_platform="ia64-hp-hpux"
         ;;
+      aarch64*linux-android)
+        boinc_platform="aarch64-android-linux-gnu"
+        ;;
+      arm*linux-android*)
+        boinc_platform="arm-android-linux-gnu"
+        ;;
+      x86_64*linux-android)
+        boinc_platform="x86_64-android-linux-gnu"
+        ;;
+      i686*linux-android)
+        boinc_platform="x86-android-linux-gnu"
+        ;;
     esac
     case "${target}" in
       i386-pc-os2)

--- a/m4/boinc_platform.m4
+++ b/m4/boinc_platform.m4
@@ -51,18 +51,18 @@ AC_DEFUN([BOINC_PLATFORM],[
       ia64-hp-hpux*)
 	boinc_platform="ia64-hp-hpux"
         ;;
-      aarch64*linux-android)
+      aarch64*linux-android*)
         boinc_platform="aarch64-android-linux-gnu"
         boinc_alt_platform="arm-android-linux-gnu"
         ;;
       arm*linux-android*)
         boinc_platform="arm-android-linux-gnu"
         ;;
-      x86_64*linux-android)
+      x86_64*linux-android*)
         boinc_platform="x86_64-android-linux-gnu"
         boinc_alt_platform="x86-android-linux-gnu"
         ;;
-      i686*linux-android)
+      i686*linux-android*)
         boinc_platform="x86-android-linux-gnu"
         ;;
     esac


### PR DESCRIPTION
**Description of the Change**
Some compiled clients may appear as `$ARCH-unknown-linux-android` instead of
`$ARCH-android-linux-gnu` to project servers
This is because of Android NDK specifies `$ARCH-linux-android` triplets and
users forget to specify `--with-boinc-platform`

Fix this in `boinc_platform.m4` so that Android boinc platform strings changes are not needed across all projects

boinc_alt_platform is excluded to prepare for 64bit only Android devices
Users can add back requesting 32bit tasks with `--with-boinc-alt-platform` during compile or `<alt_platform>` during runtime

**Alternate Designs**
Feedbacks are welcome.

**Release Notes**
N/A