### PR TITLE
client: don't show "no work" messages as notices

### DIFF
--- a/client/client_state.h
+++ b/client/client_state.h
@@ -675,6 +675,5 @@ extern THREAD throttle_thread;
 #endif
 
 #define NEED_NETWORK_MSG _("BOINC can't access Internet - check network connection or proxy configuration.")
-#define NO_WORK_MSG _("Your settings do not allow fetching tasks for")
 
 #endif

--- a/client/cs_notice.cpp
+++ b/client/cs_notice.cpp
@@ -544,9 +544,6 @@ void NOTICES::remove_notices(PROJECT* p, int which) {
         case REMOVE_SCHEDULER_MSG:
             remove = !strcmp(n.category, "scheduler");
             break;
-        case REMOVE_NO_WORK_MSG:
-            remove = !strstr(n.description.c_str(), NO_WORK_MSG);
-            break;
         case REMOVE_CONFIG_MSG:
             remove = (strstr(n.description.c_str(), "cc_config.xml") != NULL);
             break;

--- a/client/cs_notice.h
+++ b/client/cs_notice.h
@@ -88,8 +88,6 @@ struct NOTICES {
     // "need network access" notice
 #define REMOVE_SCHEDULER_MSG    1
     // msgs from scheduler
-#define REMOVE_NO_WORK_MSG      2
-    // msgs about no work due to settings
 #define REMOVE_CONFIG_MSG       3
     // notices about cc_config.xml
 #define REMOVE_APP_INFO_MSG     4

--- a/client/project.cpp
+++ b/client/project.cpp
@@ -984,51 +984,31 @@ void PROJECT::check_no_apps() {
     }
 }
 
-// show a notice if we can't get work from this project,
-// and there's something the user could do about it.
+// show devices this project is not allowed to compute for
+// because of a user setting
 //
 void PROJECT::show_no_work_notice() {
-    bool some_banned = false;
     for (int i=0; i<coprocs.n_rsc; i++) {
         if (no_rsc_apps[i]) continue;
-        bool banned_by_user = no_rsc_pref[i] || no_rsc_config[i];
-        if (!gstate.acct_mgr_info.dynamic) {
-            // dynamic account managers manage rsc usage themselves, not user
-            //
-            banned_by_user = banned_by_user || no_rsc_ams[i];
-            // note to self: ||= doesn't exist
-        }
-        if (!banned_by_user) {
-            continue;
-        }
-        string x;
-        x = NO_WORK_MSG;
-        x += " ";
-        x += rsc_name_long(i);
-        x += ".  ";
-        x += _("To fix this, you can ");
+            // project can't use resource anyway
 
-        bool first = true;
         if (no_rsc_pref[i]) {
-            x += _("change Project Preferences on the project's web site");
-            first = false;
+            msg_printf(this, MSG_INFO,
+                "Not using %s: project preferences",
+                rsc_name_long(i)
+            );
         }
         if (no_rsc_config[i]) {
-            if (!first) x += ", or ";
-            x += _("remove GPU exclusions in your cc_config.xml file");
-            first = false;
+            msg_printf(this, MSG_INFO,
+                "Not using %s: GPU exclusions in cc_config.xml",
+                rsc_name_long(i)
+            );
         }
         if (no_rsc_ams[i] && !gstate.acct_mgr_info.dynamic) {
-            if (!first) x += ", or ";
-            x += _("change your settings at your account manager web site");
+            msg_printf(this, MSG_INFO,
+                "Not using %s: account manager settings",
+                rsc_name_long(i)
+            );
         }
-        x += ".";
-        msg_printf(this, MSG_USER_ALERT, "%s", x.c_str());
-        some_banned = true;
     }
-    if (!some_banned) {
-        notices.remove_notices(this, REMOVE_NO_WORK_MSG);
-        return;
-    }
-
 }


### PR DESCRIPTION
On startup the client sees, for each project,
whether it's barred from using particular resources (CPU, GPU).
It was showing these situations as notices.
I think the idea was to make sure the user hadn't changed
a setting and forgotten about it.

But this was annoying overkill.
Instead, just show startup messages (not notices)
saying what (project, resource) pairs are disallowed, and wy.

Fixes #3590 (subject to review - RH 28 May)

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
