### PR TITLE
[Android] Fix image download issue in ProjectInfoFragment.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
@@ -155,7 +155,7 @@ data class ProjectInfo(
         const val SPECIFIC_AREA = "specific_area"
         const val HOME = "home"
         const val PLATFORMS = "platforms"
-        const val IMAGE_URL = "image_url"
+        const val IMAGE_URL = "image"
         const val SUMMARY = "summary"
     }
 


### PR DESCRIPTION
**Description of the Change**
This fixes an issue that resulted in `ProjectInfoParser` not parsing the project image URL.

**Release Notes**
The project logo now shows up in the project info dialog.
