### PR TITLE
[Android] Display task progress in a percentage of upto 3 decimal places.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/TasksListAdapter.java
@@ -71,7 +71,7 @@ public class TasksListAdapter extends ArrayAdapter<TaskData> {
         this.activity = activity;
         this.elapsedTimeStringBuilder = new StringBuilder();
         percentNumberFormat = NumberFormat.getPercentInstance();
-        percentNumberFormat.setMinimumFractionDigits(1);
+        percentNumberFormat.setMinimumFractionDigits(3);
     }
 
     @NonNull


### PR DESCRIPTION
**Description of the Change**
This alters the display of the task progress percentage to use upto 3 decimal places instead of just 1, to match the desktop client.

**Release Notes**
Task progress is displayed up to 3 decimal places instead of 1.
