### PR TITLE
[Android] Use Glide to handle image loading in ProjectInfoFragment.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -135,6 +135,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.core:core-ktx:1.2.0'
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
     implementation 'commons-io:commons-io:2.6'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/glide/ScaleBitmapBy2.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/glide/ScaleBitmapBy2.kt
@@ -1,0 +1,41 @@
+/*
+ * This file is part of BOINC.
+ * http://boinc.berkeley.edu
+ * Copyright (C) 2020 University of California
+ *
+ * BOINC is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * BOINC is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package edu.berkeley.boinc.attach.glide
+
+import android.graphics.Bitmap
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool
+import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
+import java.security.MessageDigest
+
+class ScaleBitmapBy2 : BitmapTransformation() {
+    override fun transform(pool: BitmapPool, toTransform: Bitmap, outWidth: Int, outHeight: Int): Bitmap {
+        return Bitmap.createScaledBitmap(toTransform, toTransform.width * 2, toTransform.height * 2, false)
+    }
+
+    override fun equals(other: Any?) = other is ScaleBitmapBy2
+
+    override fun hashCode() = ID.hashCode()
+
+    override fun updateDiskCacheKey(messageDigest: MessageDigest) = messageDigest.update(ID_BYTES)
+
+    companion object {
+        private const val ID = "edu.berkeley.boinc.attach.glide.ScaleBitmapBy2"
+        private val ID_BYTES = ID.toByteArray(Charsets.UTF_8)
+    }
+}

--- a/android/BOINC/app/src/main/res/layout/attach_project_info_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_info_layout.xml
@@ -17,9 +17,8 @@
   along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="wrap_content"
-            android:layout_height="wrap_content">
+        android:layout_height="wrap_content">
 
     <LinearLayout
             android:layout_width="wrap_content"
@@ -50,32 +49,15 @@
                     android:background="@android:color/transparent"/>
         </LinearLayout>
 
-        <LinearLayout
-                android:id="@+id/project_logo_wrapper"
+        <ImageView
+                android:id="@+id/project_logo"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_margin="10dp"
-                android:layout_gravity="center_horizontal">
-
-            <ProgressBar
-                    android:id="@+id/project_logo_loading_pb"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:padding="20dp"
-                    style="?android:attr/progressBarStyleSmall"
-                    android:background="@android:color/transparent"/>
-
-            <ImageView
-                    android:id="@+id/project_logo"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:maxWidth="400dp"
-                    android:adjustViewBounds="true"
-                    app:srcCompat="@drawable/ic_boinc_logo"
-                    android:contentDescription="@string/app_name"
-                    android:visibility="gone"/>
-        </LinearLayout>
+                android:layout_gravity="center_horizontal"
+                android:maxWidth="400dp"
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/app_name"
+                android:visibility="visible"/>
 
         <TextView
                 android:id="@+id/project_summary"


### PR DESCRIPTION
**Description of the Change**
Make use of [Glide](https://github.com/bumptech/glide) to handle loading the project logos in `ProjectInfoFragment` instead of handling it manually, as the library supports caching and requires much less code.

**Release Notes**
* The project logos displayed in the dialog shown when a project is selected in the selection screen are now cached locally to reduce network bandwidth usage.
* A placeholder image (the BOINC logo) is displayed for projects that do not have a logo or until the actual project logo has been downloaded.

**Screenshots**
![Screenshot_20200526-094459_BOINC](https://user-images.githubusercontent.com/31027858/82860653-f0314580-9f37-11ea-9b97-eb1a4ae5d227.png)

![Screenshot_20200526-094507_BOINC](https://user-images.githubusercontent.com/31027858/82860675-02ab7f00-9f38-11ea-9f35-494c1f3679b5.png)
