### PR TITLE
[Android] Remove unused packagingOptions configuration.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -102,10 +102,6 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
-    packagingOptions {
-        exclude 'LICENSE-EPL-1.0.txt'
-        exclude 'LICENSE-EDL-1.0.txt'
-    }
 
     testOptions {
         unitTests {


### PR DESCRIPTION
**Description of the Change**
Remove the unused `packagingOptions` configuration from `app/build.gradle`.

**Release Notes**
N/A
