### PR TITLE
[Android] Simplify installFile() using FileUtils.copyInputStreamToFile().

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -133,7 +133,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.core:core-ktx:1.2.0'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
-    implementation 'commons-io:commons-io:2.6'
+    implementation 'commons-io:commons-io:2.7'
     implementation 'org.apache.commons:commons-lang3:3.10'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 


### PR DESCRIPTION
**Description of the Change**
Use `FileUtils`' `copyInputStreamToFile` method to simplify `installFile`, as it handles the directory creation, overwrites the destination file if it already exists and closes the `InputStream` afterwards.

**Release Notes**
N/A
