### PR TITLE
[Android] Initialize more variables using dependency injection.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientInterfaceImplementation.java
@@ -40,9 +40,12 @@ import edu.berkeley.boinc.utils.Logging;
 public class ClientInterfaceImplementation extends RpcClient {
     // interval between polling retries in ms
     private final int minRetryInterval = 1000;
+    private ClientStatus clientStatus;
 
     @Inject
-    public ClientInterfaceImplementation() {}
+    public ClientInterfaceImplementation(ClientStatus clientStatus) {
+        this.clientStatus = clientStatus;
+    }
 
     /**
      * Reads authentication key from specified file path and authenticates GUI for advanced RPCs with the client
@@ -81,27 +84,15 @@ public class ClientInterfaceImplementation extends RpcClient {
      * @param prefs new target preferences for the client
      * @return success
      */
-    public Boolean setGlobalPreferences(GlobalPreferences prefs) {
-
-        // try to get current client status from monitor
-        ClientStatus status;
-        try {
-            status = Monitor.getClientStatus();
-        } catch (Exception e) {
-            if (Logging.WARNING) {
-                Log.w(Logging.TAG, "Monitor.setGlobalPreferences: Could not load data, clientStatus not initialized.");
-            }
-            return false;
-        }
-
-        Boolean retval1 = setGlobalPrefsOverrideStruct(prefs); //set new override settings
-        Boolean retval2 = readGlobalPrefsOverride(); //trigger reload of override settings
+    public boolean setGlobalPreferences(GlobalPreferences prefs) {
+        boolean retval1 = setGlobalPrefsOverrideStruct(prefs); //set new override settings
+        boolean retval2 = readGlobalPrefsOverride(); //trigger reload of override settings
         if (!retval1 || !retval2) {
             return false;
         }
         GlobalPreferences workingPrefs = getGlobalPrefsWorkingStruct();
         if (workingPrefs != null) {
-            status.setPrefs(workingPrefs);
+            clientStatus.setPrefs(workingPrefs);
             return true;
         }
         return false;

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -49,6 +49,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import edu.berkeley.boinc.R;
 import edu.berkeley.boinc.rpc.AcctMgrInfo;
 import edu.berkeley.boinc.rpc.CcStatus;
@@ -67,6 +70,7 @@ import edu.berkeley.boinc.utils.Logging;
  * Singleton that holds the client status data, as determined by the Monitor.
  * To get instance call Monitor.getClientStatus()
  */
+@Singleton
 public class ClientStatus {
     private Context context; // application context in order to fire broadcast events
     private AppPreferences appPreferences;
@@ -123,9 +127,13 @@ public class ClientStatus {
     private List<Notice> serverNotices = new ArrayList<>();
     private int mostRecentNoticeSeqNo = 0;
 
-    public ClientStatus(Context context, AppPreferences appPreferences) {
+    private DeviceStatus deviceStatus;
+
+    @Inject
+    public ClientStatus(Context context, AppPreferences appPreferences, DeviceStatus deviceStatus) {
         this.context = context;
         this.appPreferences = appPreferences;
+        this.deviceStatus = deviceStatus;
 
         // set up CPU wakelock
         // see documentation at http://developer.android.com/reference/android/os/PowerManager.html
@@ -595,7 +603,7 @@ public class ClientStatus {
                             statusString = context.getString(R.string.suspend_battery_charging);
                             try {
                                 double minCharge = prefs.getBatteryChargeMinPct();
-                                int currentCharge = Monitor.getDeviceStatus().getStatus().getBatteryChargePct();
+                                int currentCharge = deviceStatus.getStatus().getBatteryChargePct();
                                 statusString = context.getString(R.string.suspend_battery_charging_long) + " " +
                                                (int) minCharge
                                                + "% (" + context.getString(R.string.suspend_battery_charging_current) +

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
@@ -33,9 +33,13 @@ import android.util.Log;
 import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import edu.berkeley.boinc.rpc.DeviceStatusData;
 import edu.berkeley.boinc.utils.Logging;
 
+@Singleton
 public class DeviceStatus {
     // variables describing device status in RPC
     private DeviceStatusData status = new DeviceStatusData();
@@ -49,7 +53,7 @@ public class DeviceStatus {
 
     // android specifics
     // context required for reading device status
-    private Context ctx;
+    private Context context;
     // connManager contains current wifi status
     private ConnectivityManager connManager;
     // telManager to retrieve call state
@@ -62,13 +66,14 @@ public class DeviceStatus {
     /**
      * Constructor. Needs to be called before calling update.
      *
-     * @param ctx Application Context
+     * @param context Application Context
      */
-    DeviceStatus(Context ctx, AppPreferences appPrefs) {
-        this.ctx = ctx;
-        this.connManager = ContextCompat.getSystemService(ctx, ConnectivityManager.class);
-        this.telManager = ContextCompat.getSystemService(ctx, TelephonyManager.class);
-        this.batteryStatus = ctx.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+    @Inject
+    DeviceStatus(Context context, AppPreferences appPrefs) {
+        this.context = context;
+        this.connManager = ContextCompat.getSystemService(context, ConnectivityManager.class);
+        this.telManager = ContextCompat.getSystemService(context, TelephonyManager.class);
+        this.batteryStatus = context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
         this.appPrefs = appPrefs;
     }
 
@@ -80,7 +85,7 @@ public class DeviceStatus {
      * @throws Exception if error occurs
      */
     public DeviceStatusData update(Boolean screenOn) throws Exception {
-        if(ctx == null) {
+        if(context == null) {
             throw new Exception("DeviceStatus: can not update, Context not set.");
         }
         this.screenOn = screenOn;
@@ -216,7 +221,7 @@ public class DeviceStatus {
     private boolean determineBatteryStatus() throws Exception {
         // check battery
         boolean change = false;
-        batteryStatus = ctx.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        batteryStatus = context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
         if(batteryStatus != null) {
             stationaryDeviceSuspected =
                     !batteryStatus.getBooleanExtra(BatteryManager.EXTRA_PRESENT, true); // if no battery present, suspect stationary device

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/DeviceStatus.java
@@ -42,7 +42,7 @@ import edu.berkeley.boinc.utils.Logging;
 @Singleton
 public class DeviceStatus {
     // variables describing device status in RPC
-    private DeviceStatusData status = new DeviceStatusData();
+    private DeviceStatusData status;
 
     // additional device status
     // true, if operating in stationary device mode
@@ -69,12 +69,14 @@ public class DeviceStatus {
      * @param context Application Context
      */
     @Inject
-    DeviceStatus(Context context, AppPreferences appPrefs) {
+    DeviceStatus(Context context, AppPreferences appPrefs, DeviceStatusData status) {
         this.context = context;
-        this.connManager = ContextCompat.getSystemService(context, ConnectivityManager.class);
-        this.telManager = ContextCompat.getSystemService(context, TelephonyManager.class);
-        this.batteryStatus = context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        this.status = status;
         this.appPrefs = appPrefs;
+
+        connManager = ContextCompat.getSystemService(context, ConnectivityManager.class);
+        telManager = ContextCompat.getSystemService(context, TelephonyManager.class);
+        batteryStatus = context.registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
     }
 
     /**

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/PersistentStorage.kt
@@ -21,13 +21,14 @@ package edu.berkeley.boinc.client
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
+import javax.inject.Inject
 
 /**
  * This class wraps persistent key value pairs.
  * Similar technique to AppPrefs, but with a non-preference incentive.
  */
-class PersistentStorage(ctx: Context) {
-    private val store: SharedPreferences = ctx.getSharedPreferences("Store", 0)
+class PersistentStorage @Inject constructor(context: Context) {
+    private val store: SharedPreferences = context.getSharedPreferences("Store", 0)
 
     var lastNotifiedNoticeArrivalTime: Double
         get() {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/di/AppComponent.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/di/AppComponent.kt
@@ -21,6 +21,7 @@ package edu.berkeley.boinc.di
 import android.content.Context
 import dagger.BindsInstance
 import dagger.Component
+import edu.berkeley.boinc.attach.ProjectAttachService
 import edu.berkeley.boinc.client.Monitor
 import edu.berkeley.boinc.mutex.MutexModule
 import javax.inject.Singleton
@@ -34,4 +35,5 @@ interface AppComponent {
     }
 
     fun inject(monitor: Monitor)
+    fun inject(projectAttachService: ProjectAttachService)
 }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/DeviceStatusData.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/DeviceStatusData.kt
@@ -18,7 +18,9 @@
  */
 package edu.berkeley.boinc.rpc
 
-class DeviceStatusData {
+import javax.inject.Inject
+
+class DeviceStatusData @Inject constructor() {
     var isOnACPower = false
     var isOnUSBPower = false // not used
     var batteryChargePct = 0

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/MonitorTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/MonitorTest.kt
@@ -24,18 +24,20 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.*
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mockito
-import org.mockito.MockitoAnnotations
-import org.mockito.Spy
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.android.controller.ServiceController
 
 @RunWith(RobolectricTestRunner::class)
 class MonitorTest {
+    @Mock
+    private lateinit var clientStatus: ClientStatus
+
     @Spy
-    private val clientInterface = ClientInterfaceImplementation()
+    @InjectMocks
+    private lateinit var clientInterface: ClientInterfaceImplementation
 
     private lateinit var monitor: Monitor
     private lateinit var controller: ServiceController<Monitor>


### PR DESCRIPTION
**Description of the Change**
Initialize more class variables, such as `Monitor`'s `clientStatus`, `deviceStatus` and `noticeNotification` variables, using dependency injection, as this removes the need to implement the singleton pattern for these variables separately.

**Release Notes**
N/A
