### PR TITLE
Client and manager, Win: fix crashes and runtime warnings with VS2019

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -556,5 +556,6 @@ int main(int argc, char** argv) {
     retval = boinc_main_loop();
 
 #endif
+    main_exited = true;
     return retval;
 }

--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -207,11 +207,11 @@ void CAccountInfoPage::CreateControls()
 
     m_pAccountManagerLinkLabelStaticCtrl = new wxStaticText;
     m_pAccountManagerLinkLabelStaticCtrl->Create( itemWizardPage56, ID_ACCOUNTLINKLABELSTATICCTRL, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    itemBoxSizer57->Add(m_pAccountManagerLinkLabelStaticCtrl, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    itemBoxSizer57->Add(m_pAccountManagerLinkLabelStaticCtrl, 0, wxGROW|wxALL, 5);
 
     m_pAccountForgotPasswordCtrl = new wxHyperlinkCtrl;
     m_pAccountForgotPasswordCtrl->Create( itemWizardPage56, ID_ACCOUNTFORGOTPASSWORDCTRL, wxT(" "), wxT(" "), wxDefaultPosition, wxDefaultSize, wxNO_BORDER | wxHL_ALIGN_LEFT | wxHL_CONTEXTMENU );
-    itemBoxSizer57->Add(m_pAccountForgotPasswordCtrl, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    itemBoxSizer57->Add(m_pAccountForgotPasswordCtrl, 0, wxGROW|wxALL, 5);
     ////@end CAccountInfoPage content construction
 
 }

--- a/clientgui/AccountManagerInfoPage.cpp
+++ b/clientgui/AccountManagerInfoPage.cpp
@@ -169,7 +169,7 @@ void CAccountManagerInfoPage::CreateControls()
 
     wxFlexGridSizer* itemFlexGridSizer14 = new wxFlexGridSizer(1, 2, 0, 0);
     itemFlexGridSizer14->AddGrowableCol(1);
-    itemBoxSizer24->Add(itemFlexGridSizer14, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxRIGHT, 10);
+    itemBoxSizer24->Add(itemFlexGridSizer14, 0, wxGROW|wxRIGHT, 10);
 
     m_pProjectUrlStaticCtrl = new wxStaticText;
     m_pProjectUrlStaticCtrl->Create( itemWizardPage23, ID_PROJECTURLSTATICCTRL, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -25,6 +25,7 @@
 #include "error_numbers.h"
 #include "str_replace.h"
 #include "util.h"
+
 #ifdef __WXMAC__
 #include "mac_util.h"
 #endif

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -61,6 +61,8 @@
 
 #include "diagnostics.h"
 
+bool main_exited;   // set at end of main()
+
 #ifdef ANDROID_VOODOO
 // for signal handler backtrace
 unwind_backtrace_signal_arch_t unwind_backtrace_signal_arch;
@@ -153,6 +155,14 @@ void boinc_term_func() {
 int __cdecl boinc_message_reporting(int reportType, char *szMsg, int *retVal){
     int n;
     (*retVal) = 0;
+
+    // can't call CRT functions after main returns
+    //
+    if (main_exited) return 0;
+#if defined(wxUSE_GUI)
+    return 0;
+#endif
+
 
     switch(reportType){
 

--- a/lib/diagnostics.h
+++ b/lib/diagnostics.h
@@ -34,6 +34,8 @@
 #include <dlfcn.h>
 #endif
 
+extern bool main_exited;
+
 // some of the Android stuff below causes seg faults on some devices.
 // Disable by default.
 // Set this to enable it.


### PR DESCRIPTION
In VS2019, making CRT calls like printf after main.cpp() has returned
raises and exception.  Don't do this.

Also, there were some runtime warnings from WxWidgets about bad flags
for vertical spacers.  Fix these.