### PR TITLE
[Android] Fix crash on API levels < 21.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCApplication.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCApplication.kt
@@ -18,6 +18,7 @@
  */
 package edu.berkeley.boinc
 
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.multidex.MultiDexApplication
 import androidx.preference.PreferenceManager
 import edu.berkeley.boinc.di.AppComponent
@@ -27,6 +28,8 @@ import edu.berkeley.boinc.utils.setAppTheme
 open class BOINCApplication : MultiDexApplication() {
     override fun onCreate() {
         super.onCreate()
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
+
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
         setAppTheme(sharedPreferences.getString("theme", "default")!!)
     }


### PR DESCRIPTION
**Description of the Change**
Fix a crash that occurs on API levels lower than 21 (Lollipop) due to the use of vector drawables in the app.

**Release Notes**
Fix the app crashing on Android versions older than Lollipop.
