### PR TITLE
[Client] Add Elapsed Time

### DIFF
--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -174,6 +174,7 @@ void RESULT::print() {
             printf("   suspended via GUI: yes\n");
         }
         printf("   estimated CPU time remaining: %f\n", estimated_cpu_time_remaining);
+        printf("   elapsed task time: %f\n", elapsed_time);
     }
 
     // stuff for jobs that are running or have run


### PR DESCRIPTION
Add elapsed time to task info for boinccmd.

Fixes #3463 

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
Prints the current elapsed time of a task (RESULT), if it is still running. The property was already available to the RESULT struct.

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
Added elapsed time to boinc-cmd task information.