### PR TITLE
client/manager, Win: remove references to _STDWX_H_; not used anymore

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -82,11 +82,8 @@
 // (not counting the part after the last checkpoint in an episode).
 
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
-#include "boinc_win.h"
-#endif
-
 #ifdef _WIN32
+#include "boinc_win.h"
 #include "version.h"
 #include "win_util.h"
 #else

--- a/api/boinc_opencl.cpp
+++ b/api/boinc_opencl.cpp
@@ -24,11 +24,8 @@
 // To use this function, link your application with libboinc_opencl.a
 //
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
-#include "boinc_win.h"
-#endif
-
 #ifdef _WIN32
+#include "boinc_win.h"
 #include "win_util.h"
 #else
 #include <string>

--- a/api/graphics2_win.cpp
+++ b/api/graphics2_win.cpp
@@ -20,7 +20,7 @@
 // Platform-independent code should NOT be here.
 //
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #else
 #include "config.h"

--- a/api/graphics_api.cpp
+++ b/api/graphics_api.cpp
@@ -17,7 +17,7 @@
 
 // DEPRECATED - DO NOT USE
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #else
 #include "config.h"

--- a/api/graphics_impl.cpp
+++ b/api/graphics_impl.cpp
@@ -23,17 +23,11 @@
 
 // DEPRECATED - use separate graphics app
 
-#ifndef _WIN32
-#include "config.h"
-#endif
-
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
-#include "boinc_win.h"
-#endif
-
 #ifdef _WIN32
+#include "boinc_win.h"
 extern void win_graphics_event_loop();
 #else
+#include "config.h"
 #include <cstring>
 #include <cstdarg>
 #include <pthread.h>

--- a/api/gutil.cpp
+++ b/api/gutil.cpp
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #else
 #include "config.h"

--- a/api/gutil_text.cpp
+++ b/api/gutil_text.cpp
@@ -17,7 +17,7 @@
 
 // The part of BOINC's graphics utilities that uses GLUT char-drawing
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #else
 #include "config.h"

--- a/api/reduce_lib.cpp
+++ b/api/reduce_lib.cpp
@@ -17,14 +17,11 @@
 
 // shared-library part of the implementation of REDUCE
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
+#include <GL/gl.h>
 #else
 #include "config.h"
-#endif
-
-#ifdef _WIN32
-#include <GL/gl.h>
 #endif
 
 #include <algorithm>

--- a/api/reduce_main.cpp
+++ b/api/reduce_main.cpp
@@ -20,7 +20,7 @@
 // This writes into a shared-memory structure
 // that's read by the graphics app
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #else
 #include "config.h"

--- a/api/ttfont.cpp
+++ b/api/ttfont.cpp
@@ -31,7 +31,7 @@
 
 // originally adapted by Carl Christensen
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_) 
+#ifdef _WIN32
 #include "boinc_win.h"
 #endif
 

--- a/api/windows_opengl.cpp
+++ b/api/windows_opengl.cpp
@@ -12,7 +12,7 @@
  * Visit My Site At nehe.gamedev.net
  * Adapted to BOINC by Eric Heien
  */
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #else
 #include "config.h"

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -20,11 +20,8 @@
 //
 // usage: boinccmd [--host hostname] [--passwd passwd] command
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
-#include "boinc_win.h"
-#endif
-
 #ifdef _WIN32
+#include "boinc_win.h"
 #include "win_util.h"
 #else
 #include "config.h"

--- a/client/boinc_log.cpp
+++ b/client/boinc_log.cpp
@@ -19,10 +19,6 @@
 //
 // usage: boinc_log [--host hostname] [--passwd passwd] 
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
-#include "boinc_win.h"
-#endif
-
 #if defined(_WIN32) && !defined(__CYGWIN32__)
 #define snprintf    _snprintf
 #define strdate     _strdate
@@ -31,6 +27,7 @@
 #endif
 
 #ifdef _WIN32
+#include "boinc_win.h"
 #include "win_util.h"
 #else
 #include "config.h"

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #endif
 

--- a/clientctrl/boincsvcctrl.cpp
+++ b/clientctrl/boincsvcctrl.cpp
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#ifdef _WIN32
 #include "boinc_win.h"
 #endif
 

--- a/clientgui/browser.cpp
+++ b/clientgui/browser.cpp
@@ -16,11 +16,8 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
-#include "boinc_win.h"
-#endif
-
 #ifdef _WIN32
+#include "boinc_win.h"
 #include "win_util.h"
 
 #ifndef InternetGetCookie

--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <cstring>

--- a/lib/base64.cpp
+++ b/lib/base64.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #endif

--- a/lib/cert_sig.cpp
+++ b/lib/cert_sig.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#ifdef _WIN32
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #ifdef _USING_FCGI_
@@ -32,10 +30,6 @@
 #include "error_numbers.h"
 
 #include "cert_sig.h"
-
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
 
 CERT_SIG::CERT_SIG() {
     this->clear();

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #ifdef _USING_FCGI_
 #include "boinc_fcgi.h"

--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <cctype>

--- a/lib/daemonmgt_win.cpp
+++ b/lib/daemonmgt_win.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 
 /**

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -18,10 +18,8 @@
 // Stuff related to stderr/stdout direction and exception handling;
 // used by both core client and by apps
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 
 #ifdef __EMX__

--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -18,14 +18,8 @@
 // Stuff related to catching SEH exceptions, monitoring threads, and trapping
 // debugger messages; used by both core client and by apps.
 
-#ifdef  _WIN32
-#ifndef __STDWX_H__
 #include "boinc_win.h"
-#else
-#include "stdwx.h"
-#endif
 #include "win_util.h"
-#endif
 
 #ifndef __CYGWIN32__
 #include "stackwalker_win.h"

--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #define MAXPATHLEN 4096
 #endif
 

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -18,12 +18,8 @@
 // This file is the underlying mechanism of GUI RPC client
 // (not the actual RPCs)
 
-
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_) 
-#include "boinc_win.h"
-#endif
-
 #ifdef _WIN32
+#include "boinc_win.h"
 #include "../version.h"
 #ifdef _MSC_VER
 #define snprintf _snprintf

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -41,16 +41,12 @@
 //   formatting failures for any software that has been localized or
 //   displays localized data.
 
-
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
-#include "boinc_win.h"
-#endif
-
 #ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 
 #ifdef _WIN32
+#include "boinc_win.h"
 #include "../version.h"
 #else
 #include "config.h"

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -18,11 +18,8 @@
 // This file is code to print (in ASCII) the stuff returned by GUI RPC.
 // Used only by boinccmd.
 
-#if defined(_WIN32) && !defined(__STDWX_H__) && !defined(_BOINC_WIN_) && !defined(_AFX_STDAFX_H_)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#endif
-
-#ifdef _WIN32
 #include "../version.h"
 #else
 #include "config.h"

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -18,10 +18,8 @@
 // Write and parse HOST_INFO structures.
 // Used by client and GUI
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <cstdio>

--- a/lib/idlemon_win.cpp
+++ b/lib/idlemon_win.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 
 #include "win_util.h"

--- a/lib/md5_file.cpp
+++ b/lib/md5_file.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #ifdef _USING_FCGI_

--- a/lib/mem_usage.cpp
+++ b/lib/mem_usage.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #if HAVE_PROCFS_H

--- a/lib/mfile.cpp
+++ b/lib/mfile.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <cstdio>

--- a/lib/miofile.cpp
+++ b/lib/miofile.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <string>

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -15,11 +15,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
 #include <fcntl.h>
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #if HAVE_UNISTD_H

--- a/lib/notice.cpp
+++ b/lib/notice.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 
 #include "error_numbers.h"

--- a/lib/opencl_boinc.cpp
+++ b/lib/opencl_boinc.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #ifdef _USING_FCGI_
 #include "boinc_fcgi.h"

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -24,10 +24,8 @@
 //
 // 2) a better one (class XML_PARSER) which parses arbitrary XML
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <cstring>

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <cstdio>

--- a/lib/proc_control.cpp
+++ b/lib/proc_control.cpp
@@ -18,12 +18,8 @@
 #include <vector>
 #ifdef _WIN32
 #include "diagnostics.h"
-#ifdef __STDWX_H__
-#include "stdwx.h"
-#else
 #include "boinc_win.h"
 #include "win_util.h"
-#endif
 #else
 #include "config.h"
 #include <sys/types.h>

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -17,11 +17,9 @@
 
 // platform-independent process-enumeration functions
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
 #include "win_util.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <sys/types.h>

--- a/lib/project_init.cpp
+++ b/lib/project_init.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <cstdio>

--- a/lib/run_app_windows.cpp
+++ b/lib/run_app_windows.cpp
@@ -18,11 +18,7 @@
 // Code to run a BOINC application (main or graphics) under Windows
 // Don't include this in applications
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
-#endif
 
 #include "win_util.h"
 #include "filesys.h"

--- a/lib/shmem.cpp
+++ b/lib/shmem.cpp
@@ -17,10 +17,8 @@
 
 // interfaces for accessing shared memory segments
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 
 #ifdef _MSC_VER

--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -42,10 +42,8 @@
  *//////////////////////////////////////////////////////////////////////////////
 
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 
 #include "diagnostics.h"

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 #ifdef _WIN32
 #include "win_util.h"

--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32) 
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #else
 #include "config.h"
 #include <string>

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -15,12 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifdef  _WIN32
-#ifndef __STDWX_H__
+#if defined(_WIN32)
 #include "boinc_win.h"
-#else
-#include "stdwx.h"
-#endif
 #include "str_replace.h"
 #include "win_util.h"
 #endif

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#if   defined(_WIN32) && !defined(__STDWX_H__)
+#if defined(_WIN32)
 #include "boinc_win.h"
-#elif defined(_WIN32) && defined(__STDWX_H__)
-#include "stdwx.h"
 #endif
 
 #include "diagnostics.h"


### PR DESCRIPTION
Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
