### PR TITLE
switcher: build only for macOS

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -25,7 +25,7 @@ if OS_DARWIN
 endif
 
 bin_PROGRAMS = boinc_client boinccmd
-if !OS_WIN32
+if OS_DARWIN
 bin_PROGRAMS += switcher
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -1049,12 +1049,15 @@ if echo $host_os | grep '^darwin' >/dev/null ; then
   AS_IF([test "${enable_client}" = "yes" || test "${enable_manager}" = "yes"],
         [AC_MSG_WARN([
 ===============================================================================
-WARNING: Building BOINC for macOS through Autotools may not be secure.
+WARNING: Building BOINC client and manager for macOS through Autotools is
+         deprecated. See PR#3804.
 
-    Please refer boinc/mac_build/HowToBuildBOINC_XCode.rtf on how to build
-    BOINC for macOS.
+    Please refer to the docs below on how to build BOINC for macOS.
 
-    To continue building other BOINC components, please run with the option:
+    boinc/mac_build/HowToBuildBOINC_XCode.rtf
+    boinc/mac_build/HowToBuildBOINC_XCode.pdf
+
+    To disable this warning, please run with the option:
 
     ./configure --disable-client --disable-manager
 

--- a/configure.ac
+++ b/configure.ac
@@ -1046,6 +1046,21 @@ if echo $host_os | grep '^darwin' >/dev/null ; then
   if test `uname -r | sed 's/\.//g'` -lt 800 ; then
     AC_DEFINE_UNQUOTED(DARWIN_10_3, [1],[Define to 1 if compiling under OS X 10.3 or earlier])
   fi
+  AS_IF([test "${enable_client}" = "yes" || test "${enable_manager}" = "yes"],
+        [AC_MSG_WARN([
+===============================================================================
+WARNING: Building BOINC for macOS through Autotools may not be secure.
+
+    Please refer boinc/mac_build/HowToBuildBOINC_XCode.rtf on how to build
+    BOINC for macOS.
+
+    To continue building other BOINC components, please run with the option:
+
+    ./configure --disable-client --disable-manager
+
+===============================================================================
+        ])
+  ])
 fi
 
 AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep '^linux' > /dev/null])


### PR DESCRIPTION
Fixes #3751

**Description of the Change**
Clean up build files.

**Alternate Designs**
N/A

**Release Notes**
switcher executable is removed for all OS except macOS as it is only used on macOS.
Details on switcher usage on macOS can be found at https://boinc.berkeley.edu/sandbox_design.php