### PR TITLE
[Android] Fix: Set action menu text color to white.

### DIFF
--- a/android/BOINC/app/src/main/res/values/styles.xml
+++ b/android/BOINC/app/src/main/res/values/styles.xml
@@ -22,6 +22,7 @@
         <item name="colorPrimaryDark">#005b9f</item>
         <item name="colorAccent">#342871</item>
         <item name="colorControlNormal">@color/black</item>
+        <item name="actionMenuTextColor">@color/white</item>
         <item name="actionOverflowButtonStyle">@style/BoincActionOverflowButtonStyle</item>
         <item name="toolbarNavigationButtonStyle">@style/BoincActionButtonStyle</item>
         <item name="actionBarStyle">@style/myTheme.ActionBar</item>
@@ -29,7 +30,7 @@
 
     <style name="myTheme.ActionBar" parent="@style/Widget.AppCompat.ActionBar">
         <item name="background">@drawable/shape_light_primary_background</item>
-        <item name="titleTextStyle">@style/myTheme.ActionBar.Text</item>
+        <item name="titleTextStyle">@style/Boinc.ActionBar.Text</item>
     </style>
 
     <style name="BoincActionButtonStyle" parent="@style/Widget.AppCompat.Toolbar.Button.Navigation">
@@ -41,7 +42,7 @@
         <item name="android:tint">@color/white</item>
     </style>
 
-    <style name="myTheme.ActionBar.Text" parent="@style/TextAppearance.AppCompat">
+    <style name="Boinc.ActionBar.Text" parent="@style/TextAppearance.AppCompat">
         <item name="android:textColor">@color/white</item>
         <item name="android:textStyle">bold</item>
         <item name="android:textSize">20sp</item>


### PR DESCRIPTION
For Tablet and Android TV: (For landscape view). 
Set action menu text color to white.
Screenshot will be in the next posts.