### PR TITLE
[Android] [Scripts] Remove exit from script

### DIFF
--- a/android/build_all.sh
+++ b/android/build_all.sh
@@ -16,4 +16,3 @@ cd android/
 ./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --arch x86_64
 
 echo '===== BOINC for all platforms build done ====='
-exit


### PR DESCRIPTION
Remove exit from script:
I think it not good thing that there is an `exit` in the end of the script. It never has, and also it will be exit if you in another window.