### PR TITLE
[Android][Compile][Scripts] Compile with `vfpv3-d16` flag

### DIFF
--- a/android/build_boinc_arm.sh
+++ b/android/build_boinc_arm.sh
@@ -25,8 +25,8 @@ export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=arm-linux-androideabi-clang
 export CXX=arm-linux-androideabi-clang++
 export LD=arm-linux-androideabi-ld
-export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -D__ANDROID_API__=19"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -D__ANDROID_API__=19"
+export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=19"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=19"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -march=armv7-a -Wl,--fix-cortex-a8"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 export PKG_CONFIG_SYSROOT_DIR="$TCSYSROOT"

--- a/client/cpu_benchmark.h
+++ b/client/cpu_benchmark.h
@@ -32,9 +32,9 @@ extern bool benchmark_time_to_stop(int which);
 // separate different compilations of whetstone.cpp which will utilize
 // various ARM fp features ie neon, vfp, or "normal"
 #ifdef ANDROID
-#ifdef ANDROID_NEON
+#ifdef ANDROID_NEON1
 // add CXXFLAGS/CFLAGS for gcc:  -DANDROID_NEON -mfloat-abi=softfp -mfpu=neon
-#include <arm_neon.h>
+    #include <arm_neon.h>
 #endif // ANDROID_NEON
 
 namespace android_neon {

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -183,12 +183,18 @@ int cpu_benchmarks(BENCHMARK_DESC* bdp) {
     //
     if (strstr(gstate.host_info.p_features, " neon ")) { 
         // have ARM neon FP capabilities
-        retval = android_neon::whetstone(host_info.p_fpops, fp_time, MIN_CPU_TIME);
+        #if defined(ANDROID_NEON1)
+            retval = android_neon::whetstone(host_info.p_fpops, fp_time, MIN_CPU_TIME);
+        #endif
     } else if (strstr(gstate.host_info.p_features, " vfp ")) { 
         // have ARM vfp FP capabilities
-        retval = android_vfp::whetstone(host_info.p_fpops, fp_time, MIN_CPU_TIME);
+        #if defined(ANDROID_VFP)
+            retval = android_vfp::whetstone(host_info.p_fpops, fp_time, MIN_CPU_TIME);
+        #endif
     } else { // just run normal test
-        retval = whetstone(host_info.p_fpops, fp_time, MIN_CPU_TIME);
+        #if !defined(ANDROID_NEON1) && !defined(ANDROID_VFP)
+            retval = whetstone(host_info.p_fpops, fp_time, MIN_CPU_TIME);
+        #endif
     }
 #else
     retval = whetstone(host_info.p_fpops, fp_time, MIN_CPU_TIME);

--- a/client/whetstone.cpp
+++ b/client/whetstone.cpp
@@ -41,7 +41,7 @@
 #endif
 
 #ifdef ANDROID
-#ifdef ANDROID_NEON
+#ifdef ANDROID_NEON1
     namespace android_neon {
 #else
   #ifdef ANDROID_VFP
@@ -290,6 +290,6 @@ int whetstone(double& flops, double& cpu_time, double min_cpu_time) {
     return 0;
 }
 
-#if defined(ANDROID_NEON) || defined(ANDROID_VFP)
+#if defined(ANDROID_NEON1) || defined(ANDROID_VFP)
   }
 #endif // namespace closure


### PR DESCRIPTION
Compile with `vfpv3-d16` flag.
To support running boinc cpp running on old devices with android api 19. (Android 4.4 Kitkat) 