### PR TITLE
[Android] Correct string unit to GB.

### DIFF
--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -186,7 +186,7 @@
         is not recommended to change this value.
     </string>
     <string name="prefs_disk_max_pct_header">Max. used storage space (%)</string>
-    <string name="prefs_disk_min_free_gb_header">Min. spare storage (MB)</string>
+    <string name="prefs_disk_min_free_gb_header">Min. spare storage (GB)</string>
     <string name="prefs_disk_access_interval_header">Access interval (seconds)</string>
     <string name="prefs_disk_access_interval_description">Suggests an interval between disk accesses</string>
     <string name="prefs_network_daily_xfer_limit_mb_header">Daily transfer limit (days)</string>


### PR DESCRIPTION
**Description of the Change**
Correct the unit in `prefs_disk_min_free_gb_header` to GB from MB.

**Release Notes**
Display the unit of the minimum storage setting as GB instead of MB.
