### PR TITLE
[Android] Fix DigestUtils usage to prevent a blank MD5 hash being returned.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.java
@@ -740,12 +740,12 @@ public class Monitor extends Service {
         try {
             final byte[] md5Bytes;
             if (inAssets) {
-                md5Bytes = DigestUtils.digest(DigestUtils.getMd5Digest(), new File(fileName));
-            } else {
                 final InputStream inputStream = getApplicationContext().getAssets().open(
                         getAssetsDirForCpuArchitecture() + fileName);
                 md5Bytes = DigestUtils.digest(DigestUtils.getMd5Digest(), inputStream);
                 inputStream.close();
+            } else {
+                md5Bytes = DigestUtils.digest(DigestUtils.getMd5Digest(), new File(fileName));
             }
             return DigestUtils.md5Hex(md5Bytes);
         } catch (IOException e) {


### PR DESCRIPTION
**Description of the Change**
Correct the if condition in `computeMd5` to prevent a blank MD5 hash string from being returned, which causes the app to be unable to start.

**Release Notes**
N/A
