### PR TITLE
[Android] Fix crash when switching between themes.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
@@ -38,6 +38,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
     private val hostInfo = BOINCActivity.monitor!!.hostInfo // Get the hostinfo from client via RPC
     private val prefs = BOINCActivity.monitor!!.prefs
 
+    private lateinit var light: String
+    private lateinit var dark: String
+    private lateinit var battery: String
+    private lateinit var system: String
+
     override fun onResume() {
         super.onResume()
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
@@ -54,6 +59,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        light = getString(R.string.prefs_theme_light)
+        dark = getString(R.string.prefs_theme_dark)
+        battery = getString(R.string.prefs_theme_battery_saver)
+        system = getString(R.string.prefs_theme_system)
+
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
         if ("usedCpuCores" !in sharedPreferences) {
             sharedPreferences.edit { putInt("usedCpuCores", pctCpuCoresToNumber(hostInfo, prefs.maxNoOfCPUsPct)) }
@@ -224,15 +234,9 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
     private fun getThemeString(string: String): String {
         return when (string) {
-            "light" -> getString(R.string.prefs_theme_light)
-            "dark" -> getString(R.string.prefs_theme_dark)
-            else -> {
-                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                    getString(R.string.prefs_theme_battery_saver)
-                } else {
-                    getString(R.string.prefs_theme_system)
-                }
-            }
+            "light" -> light
+            "dark" -> dark
+            else -> if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) battery else system
         }
     }
 


### PR DESCRIPTION
**Description of the Change**
Locally store the theme values to prevent a crash when switching between themes.

**Release Notes**
Fix crash when switching between themes more than once.
