### PR TITLE
[Android] Remove neon optimization from arm.

### DIFF
--- a/android/build_boinc_arm.sh
+++ b/android/build_boinc_arm.sh
@@ -25,8 +25,8 @@ export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
 export CC=arm-linux-androideabi-clang
 export CXX=arm-linux-androideabi-clang++
 export LD=arm-linux-androideabi-ld
-export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -D__ANDROID_API__=19"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -D__ANDROID_API__=19"
+export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=19"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=19"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -march=armv7-a -Wl,--fix-cortex-a8"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 export PKG_CONFIG_SYSROOT_DIR="$TCSYSROOT"

--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -1,6 +1,9 @@
 ## -*- mode: makefile; tab-width: 4 -*-
 ## $Id$
-CXXFLAGS := $(filter-out -mfpu=vfpv3-d16,$(CXXFLAGS))
+
+if OS_ARM_LINUX
+    CXXFLAGS := $(filter-out -mfpu=vfpv3-d16,$(CXXFLAGS))
+endif
 
 include $(top_srcdir)/Makefile.incl
 
@@ -30,7 +33,10 @@ endif
 
 boinccmd_SOURCES = boinc_cmd.cpp
 boinccmd_DEPENDENCIES = $(LIBBOINC)
-boinccmd_CPPFLAGS = $(AM_CPPFLAGS)  -mfpu=vfpv3-d16
+boinccmd_CPPFLAGS = $(AM_CPPFLAGS)
+if OS_ARM_LINUX
+    boinccmd_CPPFLAGS += -mfpu=vfpv3-d16
+endif
 boinccmd_LDFLAGS = $(AM_LDFLAGS) -L$(top_srcdir)/lib
 boinccmd_LDADD = $(LIBBOINC) $(BOINC_EXTRA_LIBS) $(PTHREAD_LIBS)
 
@@ -93,8 +99,14 @@ boinc_client_SOURCES = \
     work_fetch.cpp
 
 boinc_client_DEPENDENCIES = $(LIBBOINC)
-boinc_client_CPPFLAGS = $(AM_CPPFLAGS)  -mfpu=vfpv3-d16
-boinc_client_CXXFLAGS = $(AM_CXXFLAGS) $(SSL_CXXFLAGS) -mfpu=vfpv3-d16
+boinc_client_CPPFLAGS = $(AM_CPPFLAGS)
+if OS_ARM_LINUX
+    boinc_client_CPPFLAGS += -mfpu=vfpv3-d16
+endif
+boinc_client_CXXFLAGS = $(AM_CXXFLAGS) $(SSL_CXXFLAGS)
+if OS_ARM_LINUX
+    boinc_client_CPPFLAGS += -mfpu=vfpv3-d16
+endif
 boinc_client_LDFLAGS = $(AM_LDFLAGS) $(SSL_LDFLAGS) -L$(top_srcdir)/lib
 if OS_WIN32
 boinc_client_CXXFLAGS += -I$(top_srcdir)/coprocs/NVIDIA/include

--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -1,5 +1,6 @@
 ## -*- mode: makefile; tab-width: 4 -*-
 ## $Id$
+CXXFLAGS := $(filter-out -mfpu=vfpv3-d16,$(CXXFLAGS))
 
 include $(top_srcdir)/Makefile.incl
 
@@ -29,7 +30,7 @@ endif
 
 boinccmd_SOURCES = boinc_cmd.cpp
 boinccmd_DEPENDENCIES = $(LIBBOINC)
-boinccmd_CPPFLAGS = $(AM_CPPFLAGS)
+boinccmd_CPPFLAGS = $(AM_CPPFLAGS)  -mfpu=vfpv3-d16
 boinccmd_LDFLAGS = $(AM_LDFLAGS) -L$(top_srcdir)/lib
 boinccmd_LDADD = $(LIBBOINC) $(BOINC_EXTRA_LIBS) $(PTHREAD_LIBS)
 
@@ -92,8 +93,8 @@ boinc_client_SOURCES = \
     work_fetch.cpp
 
 boinc_client_DEPENDENCIES = $(LIBBOINC)
-boinc_client_CPPFLAGS = $(AM_CPPFLAGS)
-boinc_client_CXXFLAGS = $(AM_CXXFLAGS) $(SSL_CXXFLAGS)
+boinc_client_CPPFLAGS = $(AM_CPPFLAGS)  -mfpu=vfpv3-d16
+boinc_client_CXXFLAGS = $(AM_CXXFLAGS) $(SSL_CXXFLAGS) -mfpu=vfpv3-d16
 boinc_client_LDFLAGS = $(AM_LDFLAGS) $(SSL_LDFLAGS) -L$(top_srcdir)/lib
 if OS_WIN32
 boinc_client_CXXFLAGS += -I$(top_srcdir)/coprocs/NVIDIA/include
@@ -118,10 +119,10 @@ EXTRA_boinc_client_DEPENDENCIES = libwhetneon.a libwhetvfp.a
 boinc_client_LDADD += libwhetneon.a libwhetvfp.a
 noinst_LIBRARIES = libwhetneon.a libwhetvfp.a
 libwhetneon_a_SOURCES = whetstone.cpp
-libwhetneon_a_CXXFLAGS = $(boinc_client_CXXFLAGS) -DANDROID_NEON -mfloat-abi=softfp -mfpu=neon
+libwhetneon_a_CXXFLAGS = $(filter-out -mfpu=vfpv3-d16,$(boinc_client_CXXFLAGS)) -DANDROID_NEON -mfloat-abi=softfp -mfpu=neon
 
 libwhetvfp_a_SOURCES = whetstone.cpp
-libwhetvfp_a_CXXFLAGS = $(boinc_client_CXXFLAGS) -DANDROID_VFP -mfloat-abi=softfp -mfpu=vfp
+libwhetvfp_a_CXXFLAGS = $(boinc_client_CXXFLAGS) -DANDROID_VFP -mfloat-abi=softfp -mfpu=vfpv3-d16
 endif
 
 switcher_SOURCES = switcher.cpp

--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -1,9 +1,7 @@
 ## -*- mode: makefile; tab-width: 4 -*-
 ## $Id$
 
-if OS_ARM_LINUX
-    CXXFLAGS := $(filter-out -mfpu=vfpv3-d16,$(CXXFLAGS))
-endif
+CXXFLAGS := $(filter-out -mfpu=vfpv3-d16,$(CXXFLAGS))
 
 include $(top_srcdir)/Makefile.incl
 
@@ -34,9 +32,6 @@ endif
 boinccmd_SOURCES = boinc_cmd.cpp
 boinccmd_DEPENDENCIES = $(LIBBOINC)
 boinccmd_CPPFLAGS = $(AM_CPPFLAGS)
-if OS_ARM_LINUX
-    boinccmd_CPPFLAGS += -mfpu=vfpv3-d16
-endif
 boinccmd_LDFLAGS = $(AM_LDFLAGS) -L$(top_srcdir)/lib
 boinccmd_LDADD = $(LIBBOINC) $(BOINC_EXTRA_LIBS) $(PTHREAD_LIBS)
 
@@ -100,13 +95,7 @@ boinc_client_SOURCES = \
 
 boinc_client_DEPENDENCIES = $(LIBBOINC)
 boinc_client_CPPFLAGS = $(AM_CPPFLAGS)
-if OS_ARM_LINUX
-    boinc_client_CPPFLAGS += -mfpu=vfpv3-d16
-endif
 boinc_client_CXXFLAGS = $(AM_CXXFLAGS) $(SSL_CXXFLAGS)
-if OS_ARM_LINUX
-    boinc_client_CPPFLAGS += -mfpu=vfpv3-d16
-endif
 boinc_client_LDFLAGS = $(AM_LDFLAGS) $(SSL_LDFLAGS) -L$(top_srcdir)/lib
 if OS_WIN32
 boinc_client_CXXFLAGS += -I$(top_srcdir)/coprocs/NVIDIA/include
@@ -127,6 +116,9 @@ boinc_client_LDADD = $(LIBBOINC) $(LIBBOINC_CRYPT) $(BOINC_EXTRA_LIBS) $(PTHREAD
 boinc_clientdir = $(bindir)
 
 if OS_ARM_LINUX
+boinccmd_CPPFLAGS += -mfpu=vfpv3-d16
+boinc_client_CPPFLAGS += -mfpu=vfpv3-d16
+boinc_client_CXXFLAGS += -mfpu=vfpv3-d16
 EXTRA_boinc_client_DEPENDENCIES = libwhetneon.a libwhetvfp.a
 boinc_client_LDADD += libwhetneon.a libwhetvfp.a
 noinst_LIBRARIES = libwhetneon.a libwhetvfp.a


### PR DESCRIPTION
Remove neon optimization from arm, to support old devices (android 4.4 Kitkat, api 19)
Our arm compiler compile the code with neon optimization by default:
```bash
./boinc/3rdParty/buildCache/android-tc/arm/bin/arm-linux-androideabi-clang -E -dM - < /dev/null | grep -i neon
```
```c++
#define ARM_NEON 1
#define ARM_NEON_FP 0x4
#define ARM_NEON 1
```
This information brought to me by @truboxl.
I also verify it in different way.
The global flag: ` -mfpu=vfpv3-d16` disable neon optimization.
There was conflict with neon benchmark module that I solve.

Running on AVD 4.4:
![running](https://user-images.githubusercontent.com/7043539/84143627-92384e00-aa5f-11ea-91b1-f5dac76b8f84.png)

