### PR TITLE
[Android] Use AppCompat theme for BoincNotExclusiveDialog.

### DIFF
--- a/android/BOINC/app/src/main/AndroidManifest.xml
+++ b/android/BOINC/app/src/main/AndroidManifest.xml
@@ -127,6 +127,6 @@
 
         <activity
                 android:name=".BoincNotExclusiveDialog"
-                android:theme="@android:style/Theme.Dialog"/>
+                android:theme="@style/Theme.AppCompat.DayNight.Dialog"/>
     </application>
 </manifest>


### PR DESCRIPTION
**Description of the Change**
Fix a crash by using the `AppCompat.Dialog` theme for `BoincNotExclusiveDialog`.

**Release Notes**
Fix a crash that occurs when displaying the "Volunteer computing app detected" dialog.