### PR TITLE
[Android] Fix bug that status image always black.

### DIFF
--- a/android/BOINC/app/src/main/res/layout/attach_project_batch_conflicts_listitem.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_batch_conflicts_listitem.xml
@@ -33,6 +33,7 @@
 
         <ImageView
                 android:id="@+id/status_image"
+                android:tint="?attr/colorControlNormal"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 android:layout_marginRight="10dp"


### PR DESCRIPTION
Fix bug that status image always black.
Now the image is black / white according to theme.
