### PR TITLE
[Android] Set light theme as default and remove "Set by Battery Saver" option.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCApplication.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCApplication.kt
@@ -31,7 +31,7 @@ open class BOINCApplication : MultiDexApplication() {
         AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
 
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
-        setAppTheme(sharedPreferences.getString("theme", "default")!!)
+        setAppTheme(sharedPreferences.getString("theme", "light")!!)
     }
 
     val appComponent: AppComponent by lazy {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
@@ -19,7 +19,6 @@
 package edu.berkeley.boinc
 
 import android.content.SharedPreferences
-import android.os.Build
 import android.os.Bundle
 import android.os.RemoteException
 import android.util.Log
@@ -40,17 +39,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
     private lateinit var light: String
     private lateinit var dark: String
-    private lateinit var battery: String
     private lateinit var system: String
 
     override fun onResume() {
         super.onResume()
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this)
-
-        val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-
-        val theme = sharedPreferences.getString("theme", "default")!!
-        findPreference<ListPreference>("theme")?.summary = getThemeString(theme)
     }
 
     override fun onPause() {
@@ -61,7 +54,6 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         light = getString(R.string.prefs_theme_light)
         dark = getString(R.string.prefs_theme_dark)
-        battery = getString(R.string.prefs_theme_battery_saver)
         system = getString(R.string.prefs_theme_system)
 
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -107,11 +99,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
             }
             "suspendWhenScreenOn" -> BOINCActivity.monitor!!.suspendWhenScreenOn = sharedPreferences.getBoolean(key, true)
             "deviceName" -> BOINCActivity.monitor!!.setDomainName(sharedPreferences.getString(key, ""))
-            "theme" -> {
-                val theme = sharedPreferences.getString(key, "default")!!
-                findPreference<ListPreference>(key)?.summary = getThemeString(theme)
-                setAppTheme(theme)
-            }
+            "theme" -> setAppTheme(sharedPreferences.getString(key, "light")!!)
 
             // Network
             "networkWiFiOnly" -> {
@@ -216,14 +204,6 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
                 BOINCActivity.monitor!!.logLevel = sharedPreferences.getInt(key,
                         resources.getInteger(R.integer.prefs_default_loglevel))
             }
-        }
-    }
-
-    private fun getThemeString(string: String): String {
-        return when (string) {
-            "light" -> light
-            "dark" -> dark
-            else -> if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) battery else system
         }
     }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
@@ -50,13 +50,7 @@ fun setAppTheme(theme: String) {
     when (theme) {
         "light" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         "dark" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-        "default" -> {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY)
-            } else {
-                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-            }
-        }
+        "system" -> AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
     }
 }
 

--- a/android/BOINC/app/src/main/res/values-v29/arrays.xml
+++ b/android/BOINC/app/src/main/res/values-v29/arrays.xml
@@ -16,10 +16,16 @@
   You should have received a copy of the GNU Lesser General Public License
   along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources>
-    <string-array name="theme_entries">
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string-array name="theme_entries" tools:ignore="InconsistentArrays">
         <item>@string/prefs_theme_system</item>
         <item>@string/prefs_theme_light</item>
         <item>@string/prefs_theme_dark</item>
+    </string-array>
+
+    <string-array name="theme_values" translatable="false" tools:ignore="InconsistentArrays">
+        <item>system</item>
+        <item>light</item>
+        <item>dark</item>
     </string-array>
 </resources>

--- a/android/BOINC/app/src/main/res/values/arrays.xml
+++ b/android/BOINC/app/src/main/res/values/arrays.xml
@@ -16,15 +16,13 @@
   You should have received a copy of the GNU Lesser General Public License
   along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources>
-    <string-array name="theme_entries">
-        <item>@string/prefs_theme_battery_saver</item>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string-array name="theme_entries" tools:ignore="InconsistentArrays">
         <item>@string/prefs_theme_light</item>
         <item>@string/prefs_theme_dark</item>
     </string-array>
 
-    <string-array name="theme_values" translatable="false">
-        <item>default</item>
+    <string-array name="theme_values" translatable="false" tools:ignore="InconsistentArrays">
         <item>light</item>
         <item>dark</item>
     </string-array>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -241,7 +241,6 @@
     <string name="prefs_theme_light">Light</string>
     <string name="prefs_theme_dark">Dark</string>
     <string name="prefs_theme_system">System default</string>
-    <string name="prefs_theme_battery_saver">Set by Battery saver</string>
 
     <!-- projects tab strings -->
     <string name="projects_loading">Reading projects&#8230;</string>

--- a/android/BOINC/app/src/main/res/xml/root_preferences.xml
+++ b/android/BOINC/app/src/main/res/xml/root_preferences.xml
@@ -55,12 +55,13 @@
                 app:useSimpleSummaryProvider="true" />
 
         <ListPreference
-                app:defaultValue="default"
+                app:defaultValue="light"
                 app:entries="@array/theme_entries"
                 app:entryValues="@array/theme_values"
                 app:iconSpaceReserved="false"
                 app:key="theme"
-                app:title="@string/prefs_theme_header" />
+                app:title="@string/prefs_theme_header"
+                app:useSimpleSummaryProvider="true" />
 
     </PreferenceCategory>
 


### PR DESCRIPTION
**Description of the Change**
* Remove the "Set by Battery Saver" option on Android versions < Q.
* Set the light theme as default for consistency between Android Q and Android versions < Q.

**Release Notes**
* Remove the "Set by Battery Saver" option on Android versions < Q.
* Set the light theme as default.

**Screenshots**
![Screenshot_20200612-103605](https://user-images.githubusercontent.com/31027858/84467581-39a0c500-ac9a-11ea-864d-92e1c6fb409c.jpg)
![Screenshot_2020-06-12-10-34-26-643_edu berkeley boinc](https://user-images.githubusercontent.com/31027858/84467583-3b6a8880-ac9a-11ea-8f64-dce5e40b588e.jpg)

