### PR TITLE
Add Error On Sqlite3 Check Fail

### DIFF
--- a/m4/sqlite3.m4
+++ b/m4/sqlite3.m4
@@ -47,6 +47,12 @@ if test "x$have_sqlite3" = "xyes"; then
     AC_DEFINE([HAVE_SQLITE3], [1], [Define to 1 if you have sqlite3.])
     AC_SUBST(SQLITE3_LIBS)
     AC_SUBST(SQLITE3_CPPFLAGS)
+else
+  AC_MSG_ERROR([
+================================================================================
+ERROR: could not find sqlite3
+================================================================================
+  ])
 fi
 
 LIBS=$LIBS_save


### PR DESCRIPTION
**Description of the Change**
Currently if configure.ac doesn't find sqlite and needs it, it doesn't do anything. Then when you build BOINC it fails several minutes in. This makes it so that it errors while configuring after failing to find sqlite.

**Alternate Designs**
I don't know automake well enough to know of alternative ways to implement this

**Release Notes**
N/A

