### PR TITLE
[Android] Update isOnline test for Android versions below Marshmallow.

### DIFF
--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsIsOnlineTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/utils/BOINCUtilsIsOnlineTest.kt
@@ -17,26 +17,26 @@ import org.robolectric.annotation.Config
 class BOINCUtilsIsOnlineTest {
     @Spy
     private val connectivityManager = InstrumentationRegistry.getInstrumentation().context
-            .getSystemService<ConnectivityManager>()
+            .getSystemService<ConnectivityManager>()!!
 
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
     }
 
-    @Config(minSdk = Build.VERSION_CODES.KITKAT, maxSdk = Build.VERSION_CODES.LOLLIPOP_MR1)
+    @Config(minSdk = Build.VERSION_CODES.JELLY_BEAN, maxSdk = Build.VERSION_CODES.LOLLIPOP_MR1)
     @Test
     fun `Expect isOnline property to call getActiveNetworkInfo() when API level is below 23`() {
-        connectivityManager!!.isOnline
+        connectivityManager.isOnline
 
-        Mockito.verify(connectivityManager)!!.activeNetworkInfo
+        Mockito.verify(connectivityManager).activeNetworkInfo
     }
 
     @Config(minSdk = Build.VERSION_CODES.M, maxSdk = Build.VERSION_CODES.P)
     @Test
     fun `Expect isOnline property to call getActiveNetwork() when API level is 23 or higher`() {
-        connectivityManager!!.isOnline
+        connectivityManager.isOnline
 
-        Mockito.verify(connectivityManager)!!.activeNetwork
+        Mockito.verify(connectivityManager).activeNetwork
     }
 }


### PR DESCRIPTION
**Description of the Change**
Update the test for the `isOnline` extension property for Android versions below Marshmallow to run on Android 4.1 (Jelly Bean) and above.

**Release Notes**
N/A