### PR TITLE
[Android] Correct the way in which the value of ramMaxUsedIdleFrac is assigned.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
@@ -176,7 +176,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
 
             // Memory
             "maxRamUsedIdle" -> {
-                prefs.ramMaxUsedIdleFrac = sharedPreferences.getInt(key, 90).toDouble()
+                prefs.ramMaxUsedIdleFrac = sharedPreferences.getInt(key, 50).toDouble() / 100.0
 
                 lifecycleScope.launch { writeClientPrefs(prefs) }
             }

--- a/android/BOINC/app/src/main/res/xml/root_preferences.xml
+++ b/android/BOINC/app/src/main/res/xml/root_preferences.xml
@@ -207,7 +207,7 @@
 
         <SeekBarPreference
                 android:max="100"
-                app:defaultValue="90"
+                app:defaultValue="50"
                 app:iconSpaceReserved="false"
                 app:key="maxRamUsedIdle"
                 app:min="0"


### PR DESCRIPTION
Fixes #

**Description of the Change**
Set the default value of the `maxRamUsedIdleFrac` shared property to 50 and divide it by 100 when assigning it to `ramMaxUsedIdleFrac`.

**Release Notes**
The "RAM limit" setting should now work as expected.
