### PR TITLE
[Android] Add XML attributes that provide RTL layout support.

### DIFF
--- a/android/BOINC/app/src/main/res/layout/attach_project_acct_mgr_dialog.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_acct_mgr_dialog.xml
@@ -81,7 +81,7 @@
         android:id="@+id/continue_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="right"
+        android:layout_gravity="end"
         android:layout_margin="10dp"
         android:background="@drawable/shape_button_blue"
         android:minWidth="150dp"
@@ -102,12 +102,13 @@
         android:visibility="gone">
 
         <ProgressBar
-            style="?android:attr/progressBarStyleSmall"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginRight="10dp"
-            android:background="@android:color/transparent" />
+                style="?android:attr/progressBarStyleSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_marginEnd="10dp"
+                android:layout_marginRight="10dp"
+                android:background="@android:color/transparent" />
 
         <TextView
             android:id="@+id/ongoing_desc"

--- a/android/BOINC/app/src/main/res/layout/attach_project_batch_conflicts_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_batch_conflicts_layout.xml
@@ -46,7 +46,7 @@
             android:textColor="@android:color/white"
             android:layout_below="@+id/logo"
             android:padding="5dp"
-            android:background="@drawable/shape_dark_blue_background"/>/>
+            android:background="@drawable/shape_dark_blue_background"/>
     <ListView
             android:id="@+id/list_view"
             android:layout_width="fill_parent"
@@ -58,15 +58,16 @@
             android:id="@+id/finish_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
             android:layout_alignParentBottom="true"
-            android:text="@string/generic_button_finish"
-            android:textColor="@android:color/white"
-            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_margin="10dp"
             android:background="@drawable/shape_button_blue"
             android:minWidth="150dp"
+            android:onClick="finishClicked"
             android:padding="5dp"
-            android:layout_margin="10dp"
-            android:onClick="finishClicked"/>
+            android:text="@string/generic_button_finish"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@android:color/white" />
 
 </RelativeLayout>

--- a/android/BOINC/app/src/main/res/layout/attach_project_batch_conflicts_listitem.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_batch_conflicts_listitem.xml
@@ -33,20 +33,22 @@
 
         <ImageView
                 android:id="@+id/status_image"
-                android:tint="?attr/colorControlNormal"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
+                android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
-                android:visibility="gone"/>
+                android:tint="?attr/colorControlNormal"
+                android:visibility="gone" />
 
         <ProgressBar
                 android:id="@+id/status_pb"
+                style="?android:attr/progressBarStyleSmall"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="?android:attr/progressBarStyleSmall"
-                android:background="@android:color/transparent"
+                android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
-                android:visibility="gone"/>
+                android:background="@android:color/transparent"
+                android:visibility="gone" />
 
     </LinearLayout>
 
@@ -54,10 +56,12 @@
             android:id="@+id/text_wrapper"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
             android:layout_centerVertical="true"
+            android:layout_toStartOf="@+id/resolve_button_image"
+            android:layout_toLeftOf="@+id/resolve_button_image"
+            android:layout_toEndOf="@+id/visual_status_wrapper"
             android:layout_toRightOf="@+id/visual_status_wrapper"
-            android:layout_toLeftOf="@+id/resolve_button_image">
+            android:orientation="vertical">
 
         <TextView
                 android:textAppearance="?android:attr/textAppearanceMedium"
@@ -77,8 +81,9 @@
             android:id="@+id/resolve_button_image"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:srcCompat="@drawable/ic_baseline_arrow_forward"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
             android:layout_centerVertical="true"
-            android:layout_alignParentRight="true"/>
+            app:srcCompat="@drawable/ic_baseline_arrow_forward" />
 
 </RelativeLayout>

--- a/android/BOINC/app/src/main/res/layout/attach_project_batch_processing_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_batch_processing_layout.xml
@@ -49,11 +49,13 @@
                 android:id="@+id/hint_header_image_left"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                app:srcCompat="@drawable/ic_baseline_arrow_back"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
+                android:onClick="previousHintClicked"
+                android:paddingStart="10dp"
                 android:paddingLeft="10dp"
                 android:visibility="gone"
-                android:onClick="previousHintClicked"/>
+                app:srcCompat="@drawable/ic_baseline_arrow_back" />
 
         <TextView
                 android:id="@+id/hint_header_text"
@@ -68,10 +70,12 @@
                 android:id="@+id/hint_header_image_right"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                app:srcCompat="@drawable/ic_baseline_arrow_forward"
+                android:layout_alignParentEnd="true"
                 android:layout_alignParentRight="true"
+                android:onClick="nextHintClicked"
+                android:paddingEnd="10dp"
                 android:paddingRight="10dp"
-                android:onClick="nextHintClicked"/>
+                app:srcCompat="@drawable/ic_baseline_arrow_forward" />
     </RelativeLayout>
 
     <androidx.viewpager.widget.ViewPager
@@ -91,21 +95,23 @@
             android:gravity="center">
 
         <LinearLayout
-                style="@style/BackgroundDayNight"
                 android:id="@+id/attach_status_ongoing_wrapper"
+                style="@style/BackgroundDayNight"
                 android:layout_width="fill_parent"
                 android:layout_height="fill_parent"
-                android:orientation="horizontal"
                 android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingStart="20dp"
                 android:paddingLeft="20dp">
 
             <ProgressBar
                     android:id="@+id/attach_status_pb"
+                    style="?android:attr/progressBarStyleSmall"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    style="?android:attr/progressBarStyleSmall"
-                    android:background="@android:color/transparent"
-                    android:layout_marginRight="10dp"/>
+                    android:layout_marginEnd="10dp"
+                    android:layout_marginRight="10dp"
+                    android:background="@android:color/transparent" />
 
             <TextView
                     android:id="@+id/attach_status_text"

--- a/android/BOINC/app/src/main/res/layout/attach_project_credential_input_dialog.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_credential_input_dialog.xml
@@ -83,25 +83,27 @@
                 android:id="@+id/show_pwd_cb"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/attachproject_credential_input_show_pwd"
-                android:textColor="?android:attr/textColorPrimary"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
-                android:layout_centerVertical="true"/>
+                android:layout_centerVertical="true"
+                android:text="@string/attachproject_credential_input_show_pwd"
+                android:textColor="?android:attr/textColorPrimary" />
 
         <TextView
                 android:id="@+id/forgot_pwd_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:padding="5dp"
-                android:text="@string/attachproject_login_button_forgotpw"
-                android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textStyle="bold"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_centerVertical="true"
                 android:layout_gravity="center"
                 android:background="@drawable/shape_button_grey"
                 android:clickable="true"
                 android:focusable="true"
-                android:layout_alignParentRight="true"
-                android:layout_centerVertical="true"/>
+                android:padding="5dp"
+                android:text="@string/attachproject_login_button_forgotpw"
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                android:textStyle="bold" />
 
     </RelativeLayout>
 
@@ -115,23 +117,25 @@
                 android:id="@+id/register_button"
                 android:layout_width="110dp"
                 android:layout_height="wrap_content"
-                android:text="@string/attachproject_login_button_registration"
-                android:textColor="@android:color/white"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentLeft="true"
                 android:background="@drawable/shape_button_blue"
                 android:padding="5dp"
-                android:layout_alignParentLeft="true"/>
+                android:text="@string/attachproject_login_button_registration"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@android:color/white" />
 
         <Button
                 android:id="@+id/login_button"
                 android:layout_width="110dp"
                 android:layout_height="wrap_content"
-                android:text="@string/attachproject_login_button_login"
-                android:textColor="@android:color/white"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
                 android:background="@drawable/shape_button_blue"
                 android:padding="5dp"
-                android:layout_alignParentRight="true"/>
+                android:text="@string/attachproject_login_button_login"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="@android:color/white" />
 
     </RelativeLayout>
 

--- a/android/BOINC/app/src/main/res/layout/attach_project_credential_input_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_credential_input_layout.xml
@@ -115,14 +115,16 @@
             android:id="@+id/continue_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
             android:layout_alignParentBottom="true"
-            android:text="@string/generic_button_continue"
-            android:textColor="@android:color/white"
-            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_marginEnd="10dp"
+            android:layout_marginRight="10dp"
             android:background="@drawable/shape_button_blue"
             android:minWidth="150dp"
+            android:onClick="continueClicked"
             android:padding="5dp"
-            android:layout_marginRight="10dp"
-            android:onClick="continueClicked"/>
+            android:text="@string/generic_button_continue"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@android:color/white" />
 </RelativeLayout>

--- a/android/BOINC/app/src/main/res/layout/attach_project_hint_contribution_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_hint_contribution_layout.xml
@@ -33,10 +33,11 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
-                android:text="@string/attachproject_hint_contribtion_header"/>
+                android:text="@string/attachproject_hint_contribtion_header"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
     </RelativeLayout>
 
     <RelativeLayout
@@ -48,20 +49,23 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/hint_contribution_image_1"
                 android:layout_toLeftOf="@+id/hint_contribution_image_1"
-                android:text="@string/attachproject_hint_contribtion_wifi"/>
+                android:text="@string/attachproject_hint_contribtion_wifi"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
         <ImageView
                 android:id="@+id/hint_contribution_image_1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                app:srcCompat="@drawable/ic_baseline_wifi"
-                android:contentDescription="@string/attachproject_hint_contribtion_wifi"/>
+                android:contentDescription="@string/attachproject_hint_contribtion_wifi"
+                app:srcCompat="@drawable/ic_baseline_wifi" />
     </RelativeLayout>
 
     <RelativeLayout
@@ -73,20 +77,23 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/hint_contribution_image_2"
                 android:layout_toLeftOf="@+id/hint_contribution_image_2"
-                android:text="@string/attachproject_hint_contribtion_charger"/>
+                android:text="@string/attachproject_hint_contribtion_charger"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
         <ImageView
                 android:id="@+id/hint_contribution_image_2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                app:srcCompat="@drawable/ic_baseline_power"
-                android:contentDescription="@string/attachproject_hint_contribtion_charger"/>
+                android:contentDescription="@string/attachproject_hint_contribtion_charger"
+                app:srcCompat="@drawable/ic_baseline_power" />
     </RelativeLayout>
 
     <RelativeLayout
@@ -98,19 +105,22 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/hint_contribution_image_3"
                 android:layout_toLeftOf="@+id/hint_contribution_image_3"
-                android:text="@string/attachproject_hint_contribtion_screen"/>
+                android:text="@string/attachproject_hint_contribtion_screen"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
         <ImageView
                 android:id="@+id/hint_contribution_image_3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                app:srcCompat="@drawable/ic_baseline_stay_current_portrait"
-                android:contentDescription="@string/attachproject_hint_contribtion_screen"/>
+                android:contentDescription="@string/attachproject_hint_contribtion_screen"
+                app:srcCompat="@drawable/ic_baseline_stay_current_portrait" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/BOINC/app/src/main/res/layout/attach_project_hint_projectwebsite_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_hint_projectwebsite_layout.xml
@@ -32,10 +32,11 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
-                android:text="@string/attachproject_hint_projectwebsite_header"/>
+                android:text="@string/attachproject_hint_projectwebsite_header"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
     </RelativeLayout>
 
     <RelativeLayout
@@ -47,20 +48,23 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/hint_contribution_image_1"
                 android:layout_toLeftOf="@+id/hint_contribution_image_1"
-                android:text="@string/attachproject_hint_projectwebsite_science"/>
+                android:text="@string/attachproject_hint_projectwebsite_science"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
         <ImageView
                 android:id="@+id/hint_contribution_image_1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                app:srcCompat="@drawable/ic_baseline_search"
-                android:contentDescription="@string/attachproject_hint_projectwebsite_science"/>
+                android:contentDescription="@string/attachproject_hint_projectwebsite_science"
+                app:srcCompat="@drawable/ic_baseline_search" />
     </RelativeLayout>
 
     <RelativeLayout
@@ -72,20 +76,23 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/hint_contribution_image_2"
                 android:layout_toLeftOf="@+id/hint_contribution_image_2"
-                android:text="@string/attachproject_hint_projectwebsite_stats"/>
+                android:text="@string/attachproject_hint_projectwebsite_stats"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
         <ImageView
                 android:id="@+id/hint_contribution_image_2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                app:srcCompat="@drawable/ic_baseline_show_chart"
-                android:contentDescription="@string/attachproject_hint_projectwebsite_stats"/>
+                android:contentDescription="@string/attachproject_hint_projectwebsite_stats"
+                app:srcCompat="@drawable/ic_baseline_show_chart" />
     </RelativeLayout>
 
     <RelativeLayout
@@ -97,19 +104,22 @@
         <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentLeft="true"
                 android:layout_centerVertical="true"
+                android:layout_toStartOf="@+id/hint_contribution_image_3"
                 android:layout_toLeftOf="@+id/hint_contribution_image_3"
-                android:text="@string/attachproject_hint_projectwebsite_community"/>
+                android:text="@string/attachproject_hint_projectwebsite_community"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
 
         <ImageView
                 android:id="@+id/hint_contribution_image_3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
-                app:srcCompat="@drawable/ic_baseline_chat"
-                android:contentDescription="@string/attachproject_hint_projectwebsite_community"/>
+                android:contentDescription="@string/attachproject_hint_projectwebsite_community"
+                app:srcCompat="@drawable/ic_baseline_chat" />
     </RelativeLayout>
 </LinearLayout>

--- a/android/BOINC/app/src/main/res/layout/attach_project_info_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_info_layout.xml
@@ -84,7 +84,7 @@
                 android:id="@+id/continue_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
+                android:layout_gravity="end"
                 android:text="@string/generic_button_continue"
                 android:textColor="@android:color/white"
                 android:textAppearance="?android:attr/textAppearanceMedium"

--- a/android/BOINC/app/src/main/res/layout/attach_project_manual_url_input_dialog.xml
+++ b/android/BOINC/app/src/main/res/layout/attach_project_manual_url_input_dialog.xml
@@ -47,14 +47,15 @@
             android:id="@+id/continue_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/generic_button_continue"
-            android:textColor="@android:color/white"
-            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_below="@+id/url_input"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_margin="10dp"
             android:background="@drawable/shape_button_blue"
             android:minWidth="150dp"
             android:padding="5dp"
-            android:layout_below="@+id/url_input"
-            android:layout_alignParentRight="true"
-            android:layout_margin="10dp"/>
+            android:text="@string/generic_button_continue"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@android:color/white" />
 
 </RelativeLayout>

--- a/android/BOINC/app/src/main/res/layout/dialog_about.xml
+++ b/android/BOINC/app/src/main/res/layout/dialog_about.xml
@@ -42,14 +42,15 @@
                 android:id="@+id/title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
                 android:layout_marginLeft="10dp"
+                android:background="@android:color/transparent"
                 android:singleLine="true"
+                android:text="@string/about_title"
+                android:textAppearance="?android:attr/textAppearanceMedium"
                 android:textColor="@android:color/white"
                 android:textSize="20sp"
-                android:textStyle="bold"
-                android:textAppearance="?android:attr/textAppearanceMedium"
-                android:background="@android:color/transparent"
-                android:text="@string/about_title" />
+                android:textStyle="bold" />
 
     </LinearLayout>
 

--- a/android/BOINC/app/src/main/res/layout/dialog_confirm.xml
+++ b/android/BOINC/app/src/main/res/layout/dialog_confirm.xml
@@ -42,11 +42,12 @@
                 android:id="@+id/title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
                 android:layout_marginLeft="10dp"
+                android:background="@android:color/transparent"
                 android:singleLine="true"
-                android:textColor="?android:attr/textColorPrimary"
                 android:textAppearance="?android:attr/textAppearanceMedium"
-                android:background="@android:color/transparent"/>
+                android:textColor="?android:attr/textColorPrimary" />
 
     </LinearLayout>
 

--- a/android/BOINC/app/src/main/res/layout/event_log_client_list_item_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/event_log_client_list_item_layout.xml
@@ -30,21 +30,23 @@
             android:background="@android:color/transparent"/>
 
     <TextView
-            android:textAppearance="?android:attr/textAppearanceSmall"
             android:id="@+id/msgs_project"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="2dp"
             android:layout_below="@+id/msgs_date"
+            android:layout_alignStart="@+id/msgs_date"
             android:layout_alignLeft="@+id/msgs_date"
-            android:background="@android:color/transparent"/>
+            android:layout_margin="2dp"
+            android:background="@android:color/transparent"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <TextView
             android:id="@+id/msgs_message"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:layout_below="@+id/msgs_project"
+            android:layout_alignStart="@+id/msgs_project"
             android:layout_alignLeft="@+id/msgs_project"
-            android:background="@android:color/transparent"/>
+            android:background="@android:color/transparent" />
 
 </RelativeLayout>

--- a/android/BOINC/app/src/main/res/layout/project_details_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/project_details_layout.xml
@@ -37,11 +37,12 @@
             <TextView
                     android:id="@+id/header_status"
                     android:layout_width="100dp"
-                    android:singleLine="true"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:text="@string/tab_status"/>
+                    android:singleLine="true"
+                    android:text="@string/tab_status"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
             <TextView
                     android:id="@+id/status_text"
@@ -60,11 +61,12 @@
             <TextView
                     android:id="@+id/header_general_area"
                     android:layout_width="100dp"
-                    android:singleLine="true"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:text="@string/attachproject_login_header_general_area"/>
+                    android:singleLine="true"
+                    android:text="@string/attachproject_login_header_general_area"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
             <TextView
                     android:id="@+id/general_area"
@@ -83,11 +85,12 @@
             <TextView
                     android:id="@+id/header_specific_area"
                     android:layout_width="100dp"
-                    android:singleLine="true"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:text="@string/attachproject_login_header_specific_area"/>
+                    android:singleLine="true"
+                    android:text="@string/attachproject_login_header_specific_area"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
             <TextView
                     android:id="@+id/specific_area"
@@ -106,11 +109,12 @@
             <TextView
                     android:id="@+id/header_description"
                     android:layout_width="100dp"
-                    android:singleLine="true"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:text="@string/attachproject_login_header_description"/>
+                    android:singleLine="true"
+                    android:text="@string/attachproject_login_header_description"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
             <TextView
                     android:id="@+id/description"
@@ -129,11 +133,12 @@
             <TextView
                     android:id="@+id/header_based_at"
                     android:layout_width="100dp"
-                    android:singleLine="true"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:text="@string/attachproject_login_header_home"/>
+                    android:singleLine="true"
+                    android:text="@string/attachproject_login_header_home"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
             <TextView
                     android:id="@+id/based_at"
@@ -151,11 +156,12 @@
             <TextView
                     android:id="@+id/header_url"
                     android:layout_width="100dp"
-                    android:singleLine="true"
                     android:layout_height="wrap_content"
+                    android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:text="@string/attachproject_login_header_url"/>
+                    android:singleLine="true"
+                    android:text="@string/attachproject_login_header_url"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
 
             <TextView
                     android:id="@+id/project_url"

--- a/android/BOINC/app/src/main/res/layout/projects_layout_listitem.xml
+++ b/android/BOINC/app/src/main/res/layout/projects_layout_listitem.xml
@@ -97,10 +97,11 @@
                     android:id="@+id/project_credits_label"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:paddingEnd="5dp"
                     android:paddingRight="5dp"
                     android:text="@string/projects_credits"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textStyle="bold"/>
+                    android:textStyle="bold" />
 
             <TextView
                     android:id="@+id/project_credits"

--- a/android/BOINC/app/src/main/res/layout/status_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/status_layout.xml
@@ -80,11 +80,12 @@
 
         <ProgressBar
                 android:id="@+id/restarting_progressBar"
+                style="?android:attr/progressBarStyleSmall"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                style="?android:attr/progressBarStyleSmall"
+                android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
-                android:background="@android:color/transparent"/>
+                android:background="@android:color/transparent" />
 
         <TextView
                 android:id="@+id/restarting_text"

--- a/android/BOINC/app/src/main/res/layout/tasks_layout_list_item.xml
+++ b/android/BOINC/app/src/main/res/layout/tasks_layout_list_item.xml
@@ -45,11 +45,14 @@
             android:id="@+id/centerColumnWrapper"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
+            android:layout_marginStart="3dp"
             android:layout_marginLeft="3dp"
-            android:orientation="vertical"
-            android:layout_toRightOf="@+id/icon_background"
+            android:layout_toStartOf="@+id/rightColumnWrapper"
             android:layout_toLeftOf="@+id/rightColumnWrapper"
-            android:layout_alignParentTop="true">
+            android:layout_toEndOf="@+id/icon_background"
+            android:layout_toRightOf="@+id/icon_background"
+            android:orientation="vertical">
 
         <TextView
                 android:id="@+id/task_header"
@@ -86,11 +89,12 @@
                     android:id="@+id/task_status_percentage"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="10dip"
                     android:layout_marginLeft="10dip"
                     android:singleLine="true"
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textStyle="bold"/>
+                    android:textStyle="bold" />
         </LinearLayout>
 
         <ProgressBar
@@ -120,18 +124,20 @@
                         android:id="@+id/taskTimeLabel"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:paddingEnd="5dp"
                         android:paddingRight="5dp"
                         android:text="@string/tasks_header_elapsed_time"
                         android:textColor="?android:attr/textColorPrimary"
-                        android:textStyle="bold"/>
+                        android:textStyle="bold" />
 
                 <TextView
                         android:id="@+id/task_time"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:paddingEnd="10dp"
                         android:paddingRight="10dp"
                         android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary"/>
+                        android:textColor="?android:attr/textColorPrimary" />
             </LinearLayout>
 
             <LinearLayout
@@ -143,10 +149,11 @@
                         android:id="@+id/taskNameLabel"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:paddingEnd="5dp"
                         android:paddingRight="5dp"
                         android:text="@string/tasks_header_name"
                         android:textColor="?android:attr/textColorPrimary"
-                        android:textStyle="bold"/>
+                        android:textStyle="bold" />
 
                 <TextView
                         android:id="@+id/taskName"
@@ -165,10 +172,11 @@
                         android:id="@+id/deadlineLabel"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:paddingEnd="5dp"
                         android:paddingRight="5dp"
                         android:text="@string/tasks_header_deadline"
                         android:textColor="?android:attr/textColorPrimary"
-                        android:textStyle="bold"/>
+                        android:textStyle="bold" />
 
                 <TextView
                         android:id="@+id/deadline"
@@ -187,9 +195,10 @@
             android:id="@+id/rightColumnWrapper"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
-            android:orientation="vertical"
+            android:layout_alignParentTop="true"
+            android:layout_alignParentEnd="true"
             android:layout_alignParentRight="true"
-            android:layout_alignParentTop="true">
+            android:orientation="vertical">
 
         <ImageView
                 android:id="@+id/expand_collapse"


### PR DESCRIPTION
**Description of the Change**
Make use of XML attributes that provide RTL support, such as `layout_marginEnd`.

Also add missing XML attributes that support API level 16 (Android 4.1), such as `layout_alignParentLeft`.

**Release Notes**
RTL layouts should now be improved.