### PR TITLE
[Android][Scripts] Fix touch files.

### DIFF
--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -130,8 +130,8 @@ fi
 export COMPILEOPENSSL="no"
 export COMPILECURL="no"
 export NDK_FLAGFILE="$PREFIX/NDK-${NDK_VERSION}-${arch}_done"
-CURL_FLAGFILE="$PREFIX/curl-${CURL_VERSION}-${arch}_done"
-OPENSSL_FLAGFILE="$PREFIX/openssl-${OPENSSL_VERSION}-${arch}_done"
+export CURL_FLAGFILE="$PREFIX/curl-${CURL_VERSION}-${arch}_done"
+export OPENSSL_FLAGFILE="$PREFIX/openssl-${OPENSSL_VERSION}-${arch}_done"
 
 if [ ! -e "${NDK_FLAGFILE}" ]; then
     rm -rf "$BUILD_DIR/android-ndk-r${NDK_VERSION}"
@@ -148,7 +148,6 @@ if [ ! -e "${OPENSSL_FLAGFILE}" ]; then
     wget -c --no-verbose -O /tmp/openssl.tgz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
     tar xzf /tmp/openssl.tgz --directory=$BUILD_DIR
     export COMPILEOPENSSL="yes"
-    touch "${OPENSSL_FLAGFILE}"
 fi
 export OPENSSL_SRC=$BUILD_DIR/openssl-${OPENSSL_VERSION}
 
@@ -157,7 +156,6 @@ if [ ! -e "${CURL_FLAGFILE}" ]; then
     wget -c --no-verbose -O /tmp/curl.tgz https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
     tar xzf /tmp/curl.tgz --directory=$BUILD_DIR
     export COMPILECURL="yes"
-    touch "${CURL_FLAGFILE}"
 fi
 export CURL_SRC=$BUILD_DIR/curl-${CURL_VERSION}
 

--- a/android/build_curl_arm.sh
+++ b/android/build_curl_arm.sh
@@ -54,5 +54,8 @@ if [ "$COMPILECURL" = "yes" ]; then
         make SHELL="/bin/bash -x"
         make install SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${CURL_FLAGFILE} ]; then
+        touch "${CURL_FLAGFILE}"
+    fi
     echo "===== curl for arm build done ====="
 fi

--- a/android/build_curl_arm64.sh
+++ b/android/build_curl_arm64.sh
@@ -54,5 +54,8 @@ if [ "$COMPILECURL" = "yes" ]; then
         make SHELL="/bin/bash -x"
         make install SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${CURL_FLAGFILE} ]; then
+        touch "${CURL_FLAGFILE}"
+    fi
     echo "===== curl for arm64 build done ====="
 fi

--- a/android/build_curl_x86.sh
+++ b/android/build_curl_x86.sh
@@ -54,5 +54,8 @@ if [ "$COMPILECURL" = "yes" ]; then
         make SHELL="/bin/bash -x"
         make install SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${CURL_FLAGFILE} ]; then
+        touch "${CURL_FLAGFILE}"
+    fi
     echo "===== curl for x86 build done ====="
 fi

--- a/android/build_curl_x86_64.sh
+++ b/android/build_curl_x86_64.sh
@@ -54,5 +54,8 @@ if [ "$COMPILECURL" = "yes" ]; then
         make SHELL="/bin/bash -x"
         make install SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${CURL_FLAGFILE} ]; then
+        touch "${CURL_FLAGFILE}"
+    fi
     echo "===== curl for x86-64 build done ====="
 fi

--- a/android/build_openssl_arm.sh
+++ b/android/build_openssl_arm.sh
@@ -58,5 +58,8 @@ s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
         make SHELL="/bin/bash -x"
         make install_sw SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${OPENSSL_FLAGFILE} ]; then
+        touch "${OPENSSL_FLAGFILE}"
+    fi
     echo "===== openssl for arm build done ====="
 fi

--- a/android/build_openssl_arm64.sh
+++ b/android/build_openssl_arm64.sh
@@ -58,5 +58,8 @@ s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
         make SHELL="/bin/bash -x"
         make install_sw SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${OPENSSL_FLAGFILE} ]; then
+        touch "${OPENSSL_FLAGFILE}"
+    fi
     echo "===== openssl for arm64 build done ====="
 fi

--- a/android/build_openssl_x86.sh
+++ b/android/build_openssl_x86.sh
@@ -58,5 +58,8 @@ s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
         make SHELL="/bin/bash -x"
         make install_sw SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${OPENSSL_FLAGFILE} ]; then
+        touch "${OPENSSL_FLAGFILE}"
+    fi
     echo "===== openssl for x86 build done ====="
 fi

--- a/android/build_openssl_x86_64.sh
+++ b/android/build_openssl_x86_64.sh
@@ -58,5 +58,8 @@ s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
         make SHELL="/bin/bash -x"
         make install_sw SHELL="/bin/bash -x"
     fi
+    if  [ ! -z ${OPENSSL_FLAGFILE} ]; then
+        touch "${OPENSSL_FLAGFILE}"
+    fi
     echo "===== openssl for x86-64 build done ====="
 fi


### PR DESCRIPTION
Before the fix: 
If you stop the compilation process in middle of curl or openssl, when next time you compile, it will think you already
compile curl or openssl, and skip it, and try to compile boinc without the libs.

This fix: 
Create the touch files after it finish all compilation process of curl or openssl.