### PR TITLE
fix some gcc warnings

### DIFF
--- a/api/reduce_lib.cpp
+++ b/api/reduce_lib.cpp
@@ -185,7 +185,7 @@ void REDUCED_ARRAY_RENDER::draw_row_rect_x(int row)  {
 		for (i=0; i<rdimx; i++) {
 			x0 = draw_pos[0] + (draw_size[0]*i)/rdimx;
 			x1 = x0 + draw_deltax*.8f;
-			float h = (row0[i]-rdata_min)/(rdata_max-rdata_min);
+			h = (row0[i]-rdata_min)/(rdata_max-rdata_min);
 
 			y1 = draw_pos[1] + draw_size[1]*h;
 #ifdef DRAW_ROW_WITH_LINES

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -431,7 +431,6 @@ int main(int argc, char** argv) {
         }
     } else if (!strcmp(cmd, "--set_host_info")) {
         HOST_INFO h;
-        memset(static_cast<void*>(&h), 0, sizeof(h));
         char* pn = next_arg(argc, argv, i);
         safe_strcpy(h.product_name, pn);
         retval = rpc.set_host_info(h);

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -431,7 +431,7 @@ int main(int argc, char** argv) {
         }
     } else if (!strcmp(cmd, "--set_host_info")) {
         HOST_INFO h;
-        memset(&h, 0, sizeof(h));
+        memset(static_cast<void*>(&h), 0, sizeof(h));
         char* pn = next_arg(argc, argv, i);
         safe_strcpy(h.product_name, pn);
         retval = rpc.set_host_info(h);

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1476,7 +1476,7 @@ int RPC_CLIENT::exchange_versions(string client_name, VERSION_INFO& server) {
 
     retval = rpc.do_rpc(buf);
     if (!retval) {
-        memset(&server, 0, sizeof(server));
+        memset(static_cast<void*>(&server), 0, sizeof(server));
         while (rpc.fin.fgets(buf, 256)) {
             if (match_tag(buf, "</server_version>")) break;
             else if (parse_int(buf, "<major>", server.major)) continue;

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1476,7 +1476,6 @@ int RPC_CLIENT::exchange_versions(string client_name, VERSION_INFO& server) {
 
     retval = rpc.do_rpc(buf);
     if (!retval) {
-        memset(static_cast<void*>(&server), 0, sizeof(server));
         while (rpc.fin.fgets(buf, 256)) {
             if (match_tag(buf, "</server_version>")) break;
             else if (parse_int(buf, "<major>", server.major)) continue;


### PR DESCRIPTION
list of changes:
* api/reduce_lib.cpp:188:10: warning: declaration of 'h' shadows a previous local
* lib/gui_rpc_client_ops.cpp:1479:42: warning: clearing an object of non-trivial type 'struct VERSION_INFO'
* client/boinc_cmd.cpp:434:32: warning: clearing an object of non-trivial type 'class HOST_INFO'
