### PR TITLE
[Android] Fix white text on yellow warning in dark mode.

### DIFF
--- a/android/BOINC/app/src/main/res/layout/projects_layout_listitem.xml
+++ b/android/BOINC/app/src/main/res/layout/projects_layout_listitem.xml
@@ -67,7 +67,7 @@
                 android:layout_height="wrap_content"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:background="@drawable/shape_yellow_background"
-                android:textColor="?android:attr/textColorPrimary"
+                android:textColor="@color/black"
                 android:textStyle="bold"
                 android:padding="3dip"
                 android:layout_marginBottom="5dip"


### PR DESCRIPTION
Make the text black.
No change in light mode.
Before the fix in Android TV:
![crop](https://user-images.githubusercontent.com/7043539/85946858-f9a33880-b94f-11ea-812c-2d310df88233.png)
![Screenshot_20200628-082915](https://user-images.githubusercontent.com/7043539/85946859-fa3bcf00-b94f-11ea-9b9b-77bfe394b60c.png)
