### PR TITLE
[Android][Scripts] Upgrade android scripts to ndk r-21d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ locale/*/*.flag
 3rdParty/linux/
 3rdParty/mac/
 3rdParty/buildCache/
+3rdParty/android/
 
 .libs/
 svn_version.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
 - if [[ "${BOINC_TYPE}" == "libs-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw ) fi
 - if [[ "${BOINC_TYPE}" == "apps-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw wrapper ) fi
 - if [[ "${BOINC_TYPE}" == "manager-osx" ]]; then ( ./3rdParty/buildMacDependencies.sh -q && ./mac_build/buildMacBOINC-CI.sh --no_shared_headers ) fi
-- if [[ "${BOINC_TYPE}" == "manager-android" ]]; then ( cd android && ./buildAndroidBOINC-CI.sh --arch arm --silent && ./buildAndroidBOINC-CI.sh --arch arm64 --silent && ./buildAndroidBOINC-CI.sh --arch x86 --silent && ./buildAndroidBOINC-CI.sh --arch x86_64 --silent && cd BOINC && ./gradlew clean assemble combinedTestReportDebug && bash <(curl -s https://codecov.io/bash) && cd ../../ ) fi
+- if [[ "${BOINC_TYPE}" == "manager-android" ]]; then ( cd android && ./travis_build_all.sh && cd BOINC && ./gradlew clean assemble combinedTestReportDebug && bash <(curl -s https://codecov.io/bash) && cd ../../ ) fi
 - if [[ "${BOINC_TYPE}" == "unit-test" ]]; then ( ./3rdParty/buildLinuxDependencies.sh --gtest-only && ./configure --disable-client --disable-manager --enable-unit-tests CFLAGS="-g -O0" CXXFLAGS="-g -O0" && make && ./tests/executeUnitTests.sh --report-coverage ) fi
 - if [[ "${BOINC_TYPE}" == "integration-test" ]]; then ( ./integration_test/executeTestSuite.sh ) fi
 

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -134,29 +134,21 @@ fi
 
 export COMPILEOPENSSL="no"
 export COMPILECURL="no"
-export NDK_FLAGFILE="$PREFIX/NDK-${NDK_VERSION}_done"
+export NDK_FLAGFILE="$PREFIX/NDK-${NDK_VERSION}-${arch}_done"
 export CURL_FLAGFILE="$PREFIX/curl-${CURL_VERSION}-${arch}_done"
 export OPENSSL_FLAGFILE="$PREFIX/openssl-${OPENSSL_VERSION}-${arch}_done"
 export CREATE_NDK_FOLDER=${CREATE_NDK_FOLDER:-"no"}
 
-createNDKFolder()
-{
+if [ ! -e "${NDK_FLAGFILE}" ]; then
+    rm -rf $OPENSSL_FLAGFILE
+    rm -rf $CURL_FLAGFILE
     if [ $CREATE_NDK_FOLDER = "no" ]; then
         rm -rf "$BUILD_DIR/android-ndk-r${NDK_VERSION}"
         wget -c --no-verbose -O /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip
-        unzip -qq /tmp/ndk.zip -d $BUILD_DIR
+        unzip -qq /tmp/ndk_${NDK_VERSION}.zip -d $BUILD_DIR
         export CREATE_NDK_FOLDER="yes"
     fi
-}
-
-if [ ci = "yes" ]; then
-    createNDKFolder
-else
-    if [ ! -e "${NDK_FLAGFILE}" ]; then
-        export CREATE_NDK_FOLDER="no"
-        createNDKFolder
-        touch "${NDK_FLAGFILE}"
-    fi
+    touch "${NDK_FLAGFILE}"
 fi
 
 export NDK_ROOT=$BUILD_DIR/android-ndk-r${NDK_VERSION}

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -153,6 +153,7 @@ if [ $ci = "yes" ]; then
     createNDKFolder
 else
     if [ ! -e "${NDK_FLAGFILE}" ]; then
+        export CREATED_NDK_FOLDER="no"
         createNDKFolder
         touch "${NDK_FLAGFILE}"
     fi

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -27,7 +27,6 @@ export ANDROID_HOME=$HOME/Android/Sdk
 export NDK_ROOT=$HOME/Android/Ndk
 export ANDROID_TC=$HOME/Android/Toolchains
 
-
 # checks if a given path is canonical (absolute and does not contain relative links)
 # from http://unix.stackexchange.com/a/256437
 isPathCanonical() {
@@ -114,7 +113,7 @@ fi
 
 mkdir -p "${PREFIX}"
 mkdir -p "${BUILD_DIR}"
-
+echo $PREFIX
 if [ "${doclean}" = "yes" ]; then
     echo "cleaning cache"
     rm -rf "${PREFIX}"

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -146,7 +146,6 @@ createNDKFolder()
         wget -c --no-verbose -O /tmp/ndk_${NDK_VERSION}.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip
         unzip -qq /tmp/ndk_${NDK_VERSION}.zip -d $BUILD_DIR
         export CREATED_NDK_FOLDER="yes"
-        touch "${NDK_FLAGFILE}"
     fi
 }
 
@@ -154,13 +153,14 @@ if [ ci = "yes" ]; then
     if [ ! -e "${NDK_FLAGFILE}" ]; then
         rm -rf $OPENSSL_FLAGFILE
         rm -rf $CURL_FLAGFILE
+        touch "${NDK_FLAGFILE}"
     fi
     createNDKFolder
 else
     if [ ! -e "${NDK_FLAGFILE}" ]; then
         rm -rf $OPENSSL_FLAGFILE
         rm -rf $CURL_FLAGFILE
-        export CREATED_NDK_FOLDER="no"
+        touch "${NDK_FLAGFILE}"
         createNDKFolder
     fi
 fi

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -123,9 +123,9 @@ if [ "${doclean}" = "yes" ]; then
     rm -rf "${BUILD_DIR}"
     mkdir -p "${BUILD_DIR}"
     echo "cleaning downloaded cache files"
-    rm -f /tmp/ndk.zip
-    rm -f /tmp/openssl.tgz
-    rm -f /tmp/curl.tgz
+    rm -f /tmp/ndk_${NDK_VERSION}.zip
+    rm -f /tmp/openssl_${OPENSSL_VERSION}.tgz
+    rm -f /tmp/curl_${CURL_VERSION}.tgz
 fi
 
 if [ "${silent}" = "yes" ]; then
@@ -143,8 +143,8 @@ createNDKFolder()
 {
     if [ $CREATED_NDK_FOLDER = "no" ]; then
         rm -rf "$BUILD_DIR/android-ndk-r${NDK_VERSION}"
-        wget -c --no-verbose -O /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip
-        unzip -qq /tmp/ndk.zip -d $BUILD_DIR
+        wget -c --no-verbose -O /tmp/ndk_${NDK_VERSION}.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip
+        unzip -qq /tmp/ndk_${NDK_VERSION}.zip -d $BUILD_DIR
         export CREATED_NDK_FOLDER="yes"
         touch "${NDK_FLAGFILE}"
     fi
@@ -170,16 +170,16 @@ export NDK_ROOT=$BUILD_DIR/android-ndk-r${NDK_VERSION}
 
 if [ ! -e "${OPENSSL_FLAGFILE}" ]; then
     rm -rf "$BUILD_DIR/openssl-${OPENSSL_VERSION}"
-    wget -c --no-verbose -O /tmp/openssl.tgz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
-    tar xzf /tmp/openssl.tgz --directory=$BUILD_DIR
+    wget -c --no-verbose -O /tmp/openssl_${OPENSSL_VERSION}.tgz https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz
+    tar xzf /tmp/openssl_${OPENSSL_VERSION}.tgz --directory=$BUILD_DIR
     export COMPILEOPENSSL="yes"
 fi
 export OPENSSL_SRC=$BUILD_DIR/openssl-${OPENSSL_VERSION}
 
 if [ ! -e "${CURL_FLAGFILE}" ]; then
     rm -rf "$BUILD_DIR/curl-${CURL_VERSION}"
-    wget -c --no-verbose -O /tmp/curl.tgz https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
-    tar xzf /tmp/curl.tgz --directory=$BUILD_DIR
+    wget -c --no-verbose -O /tmp/curl_${CURL_VERSION}.tgz https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.gz
+    tar xzf /tmp/curl_${CURL_VERSION}.tgz --directory=$BUILD_DIR
     export COMPILECURL="yes"
 fi
 export CURL_SRC=$BUILD_DIR/curl-${CURL_VERSION}

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -137,18 +137,33 @@ export COMPILECURL="no"
 export NDK_FLAGFILE="$PREFIX/NDK-${NDK_VERSION}-${arch}_done"
 export CURL_FLAGFILE="$PREFIX/curl-${CURL_VERSION}-${arch}_done"
 export OPENSSL_FLAGFILE="$PREFIX/openssl-${OPENSSL_VERSION}-${arch}_done"
-export CREATE_NDK_FOLDER=${CREATE_NDK_FOLDER:-"no"}
+export CREATED_NDK_FOLDER=${CREATED_NDK_FOLDER:-"no"}
 
-if [ ! -e "${NDK_FLAGFILE}" ]; then
-    rm -rf $OPENSSL_FLAGFILE
-    rm -rf $CURL_FLAGFILE
-    if [ $CREATE_NDK_FOLDER = "no" ]; then
+createNDKFolder()
+{
+    if [ $CREATED_NDK_FOLDER = "no" ]; then
         rm -rf "$BUILD_DIR/android-ndk-r${NDK_VERSION}"
         wget -c --no-verbose -O /tmp/ndk.zip https://dl.google.com/android/repository/android-ndk-r${NDK_VERSION}-linux-x86_64.zip
-        unzip -qq /tmp/ndk_${NDK_VERSION}.zip -d $BUILD_DIR
-        export CREATE_NDK_FOLDER="yes"
+        unzip -qq /tmp/ndk.zip -d $BUILD_DIR
+        export CREATED_NDK_FOLDER="yes"
+        touch "${NDK_FLAGFILE}"
     fi
-    touch "${NDK_FLAGFILE}"
+}
+
+if [ ci = "yes" ]; then
+    if [ ! -e "${NDK_FLAGFILE}" ]; then
+        rm -rf $OPENSSL_FLAGFILE
+        rm -rf $CURL_FLAGFILE
+        export CREATED_NDK_FOLDER="no"
+    fi
+    createNDKFolder
+else
+    if [ ! -e "${NDK_FLAGFILE}" ]; then
+        rm -rf $OPENSSL_FLAGFILE
+        rm -rf $CURL_FLAGFILE
+        export CREATED_NDK_FOLDER="no"
+        createNDKFolder
+    fi
 fi
 
 export NDK_ROOT=$BUILD_DIR/android-ndk-r${NDK_VERSION}

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -134,9 +134,9 @@ fi
 
 export COMPILEOPENSSL="no"
 export COMPILECURL="no"
-export NDK_FLAGFILE="$PREFIX/NDK-${NDK_VERSION}-${arch}_done"
-export CURL_FLAGFILE="$PREFIX/curl-${CURL_VERSION}-${arch}_done"
-export OPENSSL_FLAGFILE="$PREFIX/openssl-${OPENSSL_VERSION}-${arch}_done"
+export NDK_FLAGFILE="$PREFIX/NDK-${NDK_VERSION}_done"
+export CURL_FLAGFILE="$PREFIX/curl-${CURL_VERSION}-${NDK_VERSION}-${arch}_done"
+export OPENSSL_FLAGFILE="$PREFIX/openssl-${OPENSSL_VERSION}-${NDK_VERSION}-${arch}_done"
 export CREATED_NDK_FOLDER=${CREATED_NDK_FOLDER:-"no"}
 
 createNDKFolder()
@@ -150,18 +150,11 @@ createNDKFolder()
 }
 
 if [ $ci = "yes" ]; then
-    if [ ! -e "${NDK_FLAGFILE}" ]; then
-        rm -rf $OPENSSL_FLAGFILE
-        rm -rf $CURL_FLAGFILE
-        touch "${NDK_FLAGFILE}"
-    fi
     createNDKFolder
 else
     if [ ! -e "${NDK_FLAGFILE}" ]; then
-        rm -rf $OPENSSL_FLAGFILE
-        rm -rf $CURL_FLAGFILE
-        touch "${NDK_FLAGFILE}"
         createNDKFolder
+        touch "${NDK_FLAGFILE}"
     fi
 fi
 

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -154,7 +154,6 @@ if [ ci = "yes" ]; then
     if [ ! -e "${NDK_FLAGFILE}" ]; then
         rm -rf $OPENSSL_FLAGFILE
         rm -rf $CURL_FLAGFILE
-        export CREATED_NDK_FOLDER="no"
     fi
     createNDKFolder
 else

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -149,7 +149,7 @@ createNDKFolder()
     fi
 }
 
-if [ ci = "yes" ]; then
+if [ $ci = "yes" ]; then
     if [ ! -e "${NDK_FLAGFILE}" ]; then
         rm -rf $OPENSSL_FLAGFILE
         rm -rf $CURL_FLAGFILE

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -113,7 +113,7 @@ fi
 
 mkdir -p "${PREFIX}"
 mkdir -p "${BUILD_DIR}"
-echo $PREFIX
+
 if [ "${doclean}" = "yes" ]; then
     echo "cleaning cache"
     rm -rf "${PREFIX}"

--- a/android/build_boinc_arm.sh
+++ b/android/build_boinc_arm.sh
@@ -15,25 +15,23 @@ VERBOSE="${VERBOSE:-no}"
 
 export BOINC=".." #BOINC source code
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_ARM:-$ANDROID_TC/arm}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/arm-linux-androideabi"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/armv7-a/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=arm-linux-androideabi-clang
-export CXX=arm-linux-androideabi-clang++
+export CC=armv7a-linux-androideabi16-clang
+export CXX=armv7a-linux-androideabi16-clang++
 export LD=arm-linux-androideabi-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -march=armv7-a -Wl,--fix-cortex-a8"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-export PKG_CONFIG_SYSROOT_DIR="$TCSYSROOT"
-
-# Prepare android toolchain and environment
-./build_androidtc_arm.sh
+export PKG_CONFIG_SYSROOT_DIR="$TCSYSROOT" 
 
 if [ -n "$COMPILEBOINC" ]; then
     cd "$BOINC"
@@ -48,8 +46,6 @@ if [ -n "$COMPILEBOINC" ]; then
     if [ -n "$CONFIGURE" ]; then
         ./_autosetup
         ./configure --host=arm-linux --with-boinc-platform="arm-android-linux-gnu" --with-ssl="$TCINCLUDES" --disable-server --disable-manager --disable-shared --enable-static --disable-largefile
-        sed -e "s%^CLIENTLIBS *= *.*$%CLIENTLIBS = -lm $STDCPPTC%g" client/Makefile > client/Makefile.out
-        mv client/Makefile.out client/Makefile
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent

--- a/android/build_boinc_arm64.sh
+++ b/android/build_boinc_arm64.sh
@@ -15,25 +15,23 @@ VERBOSE="${VERBOSE:-no}"
 
 export BOINC=".." #BOINC source code
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
-export ANDROIDTC="${ANDROID_TC_ARM64-$ANDROID_TC/arm64}"
-export TCBINARIES="$ANDROIDTC/bin"
+export ANDROIDTC="${ANDROID_TC_ARM64:-$ANDROID_TC/arm64}"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/aarch64-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=aarch64-linux-android-clang
-export CXX=aarch64-linux-android-clang++
+export CC=aarch64-linux-android21-clang
+export CXX=aarch64-linux-android21-clang++
 export LD=aarch64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 export PKG_CONFIG_SYSROOT_DIR="$TCSYSROOT"
-
-# Prepare android toolchain and environment
-./build_androidtc_arm64.sh
 
 if [ -n "$COMPILEBOINC" ]; then
     cd "$BOINC"
@@ -48,8 +46,6 @@ if [ -n "$COMPILEBOINC" ]; then
     if [ -n "$CONFIGURE" ]; then
         ./_autosetup
         ./configure --host=aarch64-linux --with-boinc-platform="aarch64-android-linux-gnu" --with-boinc-alt-platform="arm-android-linux-gnu" --with-ssl="$TCINCLUDES" --disable-server --disable-manager --disable-shared --enable-static
-        sed -e "s%^CLIENTLIBS *= *.*$%CLIENTLIBS = -lm $STDCPPTC%g" client/Makefile > client/Makefile.out
-        mv client/Makefile.out client/Makefile
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent

--- a/android/build_boinc_x86.sh
+++ b/android/build_boinc_x86.sh
@@ -15,25 +15,23 @@ VERBOSE="${VERBOSE:-no}"
 
 export BOINC=".." #BOINC source code
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
-export ANDROIDTC="${ANDROID_TC_X86-$ANDROID_TC/x86}"
-export TCBINARIES="$ANDROIDTC/bin"
+export ANDROIDTC="${ANDROID_TC_X86:-$ANDROID_TC/x86}"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/i686-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=i686-linux-android-clang
-export CXX=i686-linux-android-clang++
+export CC=i686-linux-android16-clang
+export CXX=i686-linux-android16-clang++
 export LD=i686-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=16"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=16"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 export PKG_CONFIG_SYSROOT_DIR="$TCSYSROOT"
-
-# Prepare android toolchain and environment
-./build_androidtc_x86.sh
 
 if [ -n "$COMPILEBOINC" ]; then
     cd "$BOINC"
@@ -48,8 +46,6 @@ if [ -n "$COMPILEBOINC" ]; then
     if [ -n "$CONFIGURE" ]; then
         ./_autosetup
         ./configure --host=i686-linux --with-boinc-platform="x86-android-linux-gnu" --with-ssl="$TCINCLUDES" --disable-server --disable-manager --disable-shared --enable-static --disable-largefile
-        sed -e "s%^CLIENTLIBS *= *.*$%CLIENTLIBS = -lm $STDCPPTC%g" client/Makefile > client/Makefile.out
-        mv client/Makefile.out client/Makefile
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent

--- a/android/build_boinc_x86_64.sh
+++ b/android/build_boinc_x86_64.sh
@@ -15,16 +15,17 @@ VERBOSE="${VERBOSE:-no}"
 
 export BOINC=".." #BOINC source code
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
-export ANDROIDTC="${ANDROID_TC_X86_64-$ANDROID_TC/x86_64}"
-export TCBINARIES="$ANDROIDTC/bin"
+export ANDROIDTC="${ANDROID_TC_X86_64:-$ANDROID_TC/x86_64}"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/x86_64-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib64/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=x86_64-linux-android-clang
-export CXX=x86_64-linux-android-clang++
+export CC=x86_64-linux-android21-clang
+export CXX=x86_64-linux-android21-clang++
 export LD=x86_64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
@@ -48,8 +49,6 @@ if [ -n "$COMPILEBOINC" ]; then
     if [ -n "$CONFIGURE" ]; then
         ./_autosetup
         ./configure --host=x86_64-linux --with-boinc-platform="x86_64-android-linux-gnu" --with-boinc-alt-platform="x86-android-linux-gnu" --with-ssl="$TCINCLUDES" --disable-server --disable-manager --disable-shared --enable-static
-        sed -e "s%^CLIENTLIBS *= *.*$%CLIENTLIBS = -lm $STDCPPTC%g" client/Makefile > client/Makefile.out
-        mv client/Makefile.out client/Makefile
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent

--- a/android/build_curl_arm.sh
+++ b/android/build_curl_arm.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 CURL="${CURL_SRC:-$HOME/src/curl-7.61.0}" #CURL sources, required by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_ARM:-$ANDROID_TC/arm}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/arm-linux-androideabi"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=arm-linux-androideabi-clang
-export CXX=arm-linux-androideabi-clang++
+export CC=armv7a-linux-androideabi16-clang
+export CXX=armv7a-linux-androideabi16-clang++
 export LD=arm-linux-androideabi-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -march=armv7-a -Wl,--fix-cortex-a8"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_arm.sh
 
 if [ "$COMPILECURL" = "yes" ]; then
     cd "$CURL"

--- a/android/build_curl_arm64.sh
+++ b/android/build_curl_arm64.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 CURL="${CURL_SRC:-$HOME/src/curl-7.61.0}" #CURL sources, required by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_ARM64:-$ANDROID_TC/arm64}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/aarch64-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=aarch64-linux-android-clang
-export CXX=aarch64-linux-android-clang++
+export CC=aarch64-linux-android21-clang
+export CXX=aarch64-linux-android21-clang++
 export LD=aarch64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall  -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_arm64.sh
 
 if [ "$COMPILECURL" = "yes" ]; then
     cd "$CURL"

--- a/android/build_curl_x86.sh
+++ b/android/build_curl_x86.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 CURL="${CURL_SRC:-$HOME/src/curl-7.61.0}" #CURL sources, required by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_X86:-$ANDROID_TC/x86}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/i686-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=i686-linux-android-clang
-export CXX=i686-linux-android-clang++
+export CC=i686-linux-android16-clang
+export CXX=i686-linux-android16-clang++
 export LD=i686-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=16"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=16"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_x86.sh
 
 if [ "$COMPILECURL" = "yes" ]; then
     cd "$CURL"

--- a/android/build_curl_x86_64.sh
+++ b/android/build_curl_x86_64.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 CURL="${CURL_SRC:-$HOME/src/curl-7.61.0}" #CURL sources, required by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_X86_64:-$ANDROID_TC/x86_64}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/x86_64-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=x86_64-linux-android-clang
-export CXX=x86_64-linux-android-clang++
+export CC=x86_64-linux-android21-clang
+export CXX=x86_64-linux-android21-clang++
 export LD=x86_64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_x86_64.sh
 
 if [ "$COMPILECURL" = "yes" ]; then
     cd "$CURL"

--- a/android/build_openssl_arm.sh
+++ b/android/build_openssl_arm.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_ARM:-$ANDROID_TC/arm}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/arm-linux-androideabi"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=arm-linux-androideabi-clang
-export CXX=arm-linux-androideabi-clang++
+export CC=armv7a-linux-androideabi16-clang
+export CXX=armv7a-linux-androideabi16-clang++
 export LD=arm-linux-androideabi-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -march=armv7-a -Wl,--fix-cortex-a8"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_arm.sh
 
 if [ "$COMPILEOPENSSL" = "yes" ]; then
     cd "$OPENSSL"
@@ -45,11 +43,7 @@ if [ "$COMPILEOPENSSL" = "yes" ]; then
         fi
     fi
     if [ -n "$CONFIGURE" ]; then
-        ./Configure linux-generic32 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES/ssl" 1>$STDOUT_TARGET
-        #override flags in Makefile
-        sed -e "s/^CFLAG=.*$/`grep -e \^CFLAG= Makefile` \$(CFLAGS)/g
-s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
-        mv Makefile.out Makefile
+        ./Configure linux-generic32 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES" 1>$STDOUT_TARGET
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent 1>$STDOUT_TARGET

--- a/android/build_openssl_arm64.sh
+++ b/android/build_openssl_arm64.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_ARM64:-$ANDROID_TC/arm64}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/aarch64-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=aarch64-linux-android-clang
-export CXX=aarch64-linux-android-clang++
+export CC=aarch64-linux-android21-clang
+export CXX=aarch64-linux-android21-clang++
 export LD=aarch64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_arm64.sh
 
 if [ "$COMPILEOPENSSL" = "yes" ]; then
     cd "$OPENSSL"    
@@ -45,11 +43,7 @@ if [ "$COMPILEOPENSSL" = "yes" ]; then
         fi
     fi
     if [ -n "$CONFIGURE" ]; then
-        ./Configure linux-generic32 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES/ssl" 1>$STDOUT_TARGET
-        #override flags in Makefile
-        sed -e "s/^CFLAG=.*$/`grep -e \^CFLAG= Makefile` \$(CFLAGS)/g
-s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
-        mv Makefile.out Makefile
+        ./Configure linux-generic32 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES" 1>$STDOUT_TARGET
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent 1>$STDOUT_TARGET

--- a/android/build_openssl_x86.sh
+++ b/android/build_openssl_x86.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_X86:-$ANDROID_TC/x86}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/i686-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=i686-linux-android-clang
-export CXX=i686-linux-android-clang++
+export CC=i686-linux-android16-clang
+export CXX=i686-linux-android16-clang++
 export LD=i686-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=16"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=16"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=16"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_x86.sh
 
 if [ "$COMPILEOPENSSL" = "yes" ]; then
     cd "$OPENSSL"
@@ -45,11 +43,7 @@ if [ "$COMPILEOPENSSL" = "yes" ]; then
         fi
     fi
     if [ -n "$CONFIGURE" ]; then
-        ./Configure linux-generic32 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES/ssl" 1>$STDOUT_TARGET
-        #override flags in Makefile
-        sed -e "s/^CFLAG=.*$/`grep -e \^CFLAG= Makefile` \$(CFLAGS)/g
-s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
-        mv Makefile.out Makefile
+        ./Configure linux-generic32 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES" 1>$STDOUT_TARGET
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent 1>$STDOUT_TARGET

--- a/android/build_openssl_x86_64.sh
+++ b/android/build_openssl_x86_64.sh
@@ -15,24 +15,22 @@ VERBOSE="${VERBOSE:-no}"
 
 OPENSSL="${OPENSSL_SRC:-$HOME/src/openssl-1.0.2p}" #openSSL sources, requiered by BOINC
 
+export NDK_ROOT=${NDK_ROOT:-$HOME/Android/Ndk}
 export ANDROID_TC="${ANDROID_TC:-$HOME/android-tc}"
 export ANDROIDTC="${ANDROID_TC_X86_64:-$ANDROID_TC/x86_64}"
-export TCBINARIES="$ANDROIDTC/bin"
+export TOOLCHAINROOT="$NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/"
+export TCBINARIES="$TOOLCHAINROOT/bin"
 export TCINCLUDES="$ANDROIDTC/x86_64-linux-android"
-export TCSYSROOT="$ANDROIDTC/sysroot"
-export STDCPPTC="$TCINCLUDES/lib/libstdc++.a"
+export TCSYSROOT="$TOOLCHAINROOT/sysroot"
 
 export PATH="$TCBINARIES:$TCINCLUDES/bin:$PATH"
-export CC=x86_64-linux-android-clang
-export CXX=x86_64-linux-android-clang++
+export CC=x86_64-linux-android21-clang
+export CXX=x86_64-linux-android21-clang++
 export LD=x86_64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
+export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
-
-# Prepare android toolchain and environment
-./build_androidtc_x86_64.sh
 
 if [ "$COMPILEOPENSSL" = "yes" ]; then
     cd "$OPENSSL"
@@ -45,11 +43,7 @@ if [ "$COMPILEOPENSSL" = "yes" ]; then
         fi
     fi
     if [ -n "$CONFIGURE" ]; then
-        ./Configure linux-x86_64 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES/ssl" 1>$STDOUT_TARGET
-        #override flags in Makefile
-        sed -e "s/^CFLAG=.*$/`grep -e \^CFLAG= Makefile` \$(CFLAGS)/g
-s%^INSTALLTOP=.*%INSTALLTOP=$TCINCLUDES%g" Makefile > Makefile.out
-        mv Makefile.out Makefile
+        ./Configure linux-x86_64 no-shared no-dso -DL_ENDIAN --openssldir="$TCINCLUDES" 1>$STDOUT_TARGET
     fi
     if [ "$VERBOSE" = "no" ]; then
         make --silent 1>$STDOUT_TARGET

--- a/android/travis_build_all.sh
+++ b/android/travis_build_all.sh
@@ -6,7 +6,7 @@ set -e
 #
 
 # Script to compile everything BOINC needs for Android
-
+echo ANDROID_TC=$ANDROID_TC
 ./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch arm
 ./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch arm64
 ./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch x86

--- a/android/travis_build_all.sh
+++ b/android/travis_build_all.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+#
+# See: https://boinc.berkeley.edu/trac/wiki/AndroidBuildClient
+#
+
+# Script to compile everything BOINC needs for Android
+
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch arm
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch arm64
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch x86
+./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch x86_64
+
+echo '===== BOINC for all platforms build done ====='

--- a/android/travis_build_all.sh
+++ b/android/travis_build_all.sh
@@ -6,7 +6,7 @@ set -e
 #
 
 # Script to compile everything BOINC needs for Android
-echo ANDROID_TC=$ANDROID_TC
+
 ./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch arm
 ./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch arm64
 ./buildAndroidBOINC-CI.sh --cache_dir "$ANDROID_TC" --build_dir "$BUILD_DIR" --silent --ci --arch x86


### PR DESCRIPTION
Important: Please delete the old ndk zip in tmp folder before you try local:
`rm -rf /tmp/ndk.zip`

Upgrade android scripts to ndk r-21d.
Remove toolchain. deprecated in ndk21.