### PR TITLE
[Android] Update Android Gradle plugin to 4.1 beta 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,7 +81,7 @@ script:
 - if [[ "${BOINC_TYPE}" == "libs-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw ) fi
 - if [[ "${BOINC_TYPE}" == "apps-mingw" ]]; then ( cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw wrapper ) fi
 - if [[ "${BOINC_TYPE}" == "manager-osx" ]]; then ( ./3rdParty/buildMacDependencies.sh -q && ./mac_build/buildMacBOINC-CI.sh --no_shared_headers ) fi
-- if [[ "${BOINC_TYPE}" == "manager-android" ]]; then ( cd android && ./travis_build_all.sh && cd BOINC && ./gradlew clean assemble combinedTestReportDebug && bash <(curl -s https://codecov.io/bash) && cd ../../ ) fi
+- if [[ "${BOINC_TYPE}" == "manager-android" ]]; then ( cd android && ./travis_build_all.sh && cd BOINC && ./gradlew clean assemble jacocoTestReportDebug && bash <(curl -s https://codecov.io/bash) && cd ../../ ) fi
 - if [[ "${BOINC_TYPE}" == "unit-test" ]]; then ( ./3rdParty/buildLinuxDependencies.sh --gtest-only && ./configure --disable-client --disable-manager --enable-unit-tests CFLAGS="-g -O0" CXXFLAGS="-g -O0" && make && ./tests/executeUnitTests.sh --report-coverage ) fi
 - if [[ "${BOINC_TYPE}" == "integration-test" ]]; then ( ./integration_test/executeTestSuite.sh ) fi
 

--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.1.0-beta02'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0'
     }

--- a/android/BOINC/gradle/wrapper/gradle-wrapper.properties
+++ b/android/BOINC/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 03 17:44:56 UTC 2019
+#Thu Jul 09 06:48:51 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-rc-1-all.zip


### PR DESCRIPTION
**Description of the Change**
Update the Android Gradle plugin to 4.1 beta 2, which includes a fix for the Java 8 API desugar warnings: https://issuetracker.google.com/issues/155423440

**Release Notes**
N/A
