### PR TITLE
[linux][cuda] Fix CUDA version number truncated

### DIFF
--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -99,6 +99,26 @@ static void get_available_nvidia_ram(COPROC_NVIDIA &cc, vector<string>& warnings
 #ifndef SIM
 #if !(defined(_WIN32) || defined(__APPLE__))
 
+#include <cmath>
+
+static int fix_nvidia_driver_version(string driver_string) {
+  float fVersion = atof(driver_string.c_str());
+  std::size_t pos = driver_string.find('.');
+  if (pos == string::npos) {
+    pos = driver_string.find(',');
+    if (pos == string::npos) {
+      return (int)(fVersion * 100.);
+    }
+  }
+
+  std::size_t size = driver_string.size() - pos - 1;
+  if (size > 2) {
+    return (int)((floor(fVersion) + 0.99) * 100.);
+  } else {
+    return (int)(fVersion * 100.);
+  }
+}
+
 static int nvidia_driver_version() {
     int (*nvml_init)()  = NULL;
     int (*nvml_finish)()  = NULL;
@@ -122,7 +142,7 @@ static int nvidia_driver_version() {
 
     if (nvml_init()) goto end;
     if (nvml_driver(driver_string, 80)) goto end;
-    dri_ver = (int) (100. * atof(driver_string));
+    dri_ver = fix_nvidia_driver_version(driver_string);
 
 end:
     if (nvml_finish) nvml_finish();

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -315,7 +315,7 @@ void COPROC_NVIDIA::description(char* buf, int buflen) {
 #else
         int maj = display_driver_version/100;
         int min = display_driver_version%100;
-        snprintf(vers, sizeof(vers), "%d.%02d", maj, min);
+        snprintf(vers, sizeof(vers), "%d", display_driver_version);
 #endif
     } else {
         safe_strcpy(vers, "unknown");


### PR DESCRIPTION
Change minor version to 99 if actual minor version is > 99

This fixes #3893

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
