### PR TITLE
[Android] Suppress warnings displayed during compilation.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.kt
@@ -123,7 +123,7 @@ class BOINCActivity : AppCompatActivity() {
             override fun onDrawerClosed(view: View) {
                 supportActionBar!!.title = mTitle
                 // calling onPrepareOptionsMenu() to show action bar icons
-                supportInvalidateOptionsMenu()
+                invalidateOptionsMenu()
             }
 
             override fun onDrawerOpened(drawerView: View) {
@@ -131,7 +131,7 @@ class BOINCActivity : AppCompatActivity() {
                 // force redraw of all items (adapter.getView()) in order to adapt changing icons or number of tasks/notices
                 mDrawerListAdapter.notifyDataSetChanged()
                 // calling onPrepareOptionsMenu() to hide action bar icons
-                supportInvalidateOptionsMenu()
+                invalidateOptionsMenu()
             }
         }
         binding.drawerLayout.addDrawerListener(mDrawerToggle)
@@ -322,7 +322,7 @@ class BOINCActivity : AppCompatActivity() {
                 if (newComputingStatus != clientComputingStatus) {
                     // computing status has changed, update and invalidate to force adaption of action items
                     clientComputingStatus = newComputingStatus
-                    supportInvalidateOptionsMenu()
+                    invalidateOptionsMenu()
                 }
                 if (numberProjectsInNavList != monitor!!.projects.size) {
                     numberProjectsInNavList = mDrawerListAdapter.compareAndAddProjects(monitor!!.projects)

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.kt
@@ -102,7 +102,7 @@ class BatchProcessingActivity : AppCompatActivity() {
     }
 
     // triggered by continue button
-    fun continueClicked(v: View?) {
+    fun continueClicked(@Suppress("UNUSED_PARAMETER") v: View) {
         val conflicts = attachService!!.anyUnresolvedConflicts()
         if (Logging.DEBUG) {
             Log.d(Logging.TAG, "BatchProcessingActivity.continueClicked: conflicts? $conflicts")
@@ -128,7 +128,7 @@ class BatchProcessingActivity : AppCompatActivity() {
     }
 
     // triggered by share button
-    fun shareClicked(v: View?) {
+    fun shareClicked(@Suppress("UNUSED_PARAMETER") v: View) {
         if (Logging.DEBUG) {
             Log.d(Logging.TAG, "BatchProcessingActivity.shareClicked.")
         }
@@ -171,7 +171,7 @@ class BatchProcessingActivity : AppCompatActivity() {
     }
 
     // previous image in hint header clicked
-    fun previousHintClicked(view: View?) {
+    fun previousHintClicked(@Suppress("UNUSED_PARAMETER") view: View) {
         if (Logging.DEBUG) {
             Log.d(Logging.TAG, "BatchProcessingActivity.previousHintClicked.")
         }
@@ -179,7 +179,7 @@ class BatchProcessingActivity : AppCompatActivity() {
     }
 
     // previous image in hint header clicked
-    fun nextHintClicked(view: View?) {
+    fun nextHintClicked(@Suppress("UNUSED_PARAMETER") view: View) {
         if (Logging.DEBUG) {
             Log.d(Logging.TAG, "BatchProcessingActivity.nextHintClicked.")
         }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/SelectionListActivity.kt
@@ -110,7 +110,7 @@ class SelectionListActivity : AppCompatActivity() {
     }
 
     // triggered by continue button
-    fun continueClicked(v: View?) {
+    fun continueClicked(@Suppress("UNUSED_PARAMETER") v: View) {
         if (!checkProjectChecked() || !checkDeviceOnline()) {
             return
         }
@@ -147,7 +147,7 @@ class SelectionListActivity : AppCompatActivity() {
     }
 
     // triggered by cancel button
-    fun cancelClicked(v: View?) {
+    fun cancelClicked(@Suppress("UNUSED_PARAMETER") v: View) {
         onCancel()
     }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
@@ -53,6 +53,13 @@ import kotlin.properties.Delegates
  * - holds singleton of client status data model and applications persistent preferences
  */
 class Monitor : LifecycleService() {
+    private val abi = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        @Suppress("DEPRECATION")
+        Build.CPU_ABI
+    } else {
+        Build.SUPPORTED_ABIS[0]
+    }
+
     //hold the status of the app, controlled by AppPreferences
     @Inject
     lateinit var appPreferences: AppPreferences
@@ -468,8 +475,7 @@ class Monitor : LifecycleService() {
 
                 // set Android model as hostinfo
                 // should output something like "Samsung Galaxy SII - SDK:15 ABI:armeabi-v7a"
-                val model = "${Build.MANUFACTURER} ${Build.MODEL} - SDK: ${Build.VERSION.SDK_INT}" +
-                        " ABI: ${Build.CPU_ABI}"
+                val model = "${Build.MANUFACTURER} ${Build.MODEL} - SDK: ${Build.VERSION.SDK_INT} ABI: $abi"
                 val version = Build.VERSION.RELEASE
                 if (Logging.ERROR) {
                     Log.d(Logging.TAG, "reporting hostinfo model name: $model")

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/MonitorExtensions.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/MonitorExtensions.kt
@@ -44,8 +44,15 @@ internal fun MessageDigest.digest(inputStream: InputStream): ByteArray {
     return digest
 }
 
-internal val PowerManager.isScreenOnCompat
-    get() = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT_WATCH) isScreenOn else isInteractive
+internal val PowerManager.isScreenOnCompat: Boolean
+    get() {
+        return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT_WATCH) {
+            @Suppress("DEPRECATION")
+            isScreenOn
+        } else {
+            isInteractive
+        }
+    }
 
 internal fun md5Digest() = DigestUtils.getMd5Digest()
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
@@ -41,6 +41,7 @@ import java.io.Reader
 val ConnectivityManager.isOnline: Boolean
     get() {
         return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            @Suppress("DEPRECATION")
             activeNetworkInfo?.isConnectedOrConnecting == true
         } else {
             activeNetwork != null


### PR DESCRIPTION
**Description of the Change**
* Replace `supportInvalidateOptionsMenu()` with `invalidateOptionsMenu()`.
* Suppress deprecation warnings for methods needed on older versions of Android, such as `getActiveNetworkInfo()`.
* Suppress unused variable warnings for methods that are assigned via the `onClick` XML attribute.

**Release Notes**
N/A
