### PR TITLE
[Android] Fix notification preference.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SettingsFragment.kt
@@ -92,7 +92,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SharedPreferences.OnSharedP
         when (key) {
             // General
             "autostart" -> BOINCActivity.monitor!!.autostart = sharedPreferences.getBoolean(key, true)
-            "showNotification" -> BOINCActivity.monitor!!.showNotificationForNotices = sharedPreferences.getBoolean(key, true)
+            "showNotifications" -> BOINCActivity.monitor!!.showNotificationForNotices = sharedPreferences.getBoolean(key, true)
             "showAdvanced" -> {
                 BOINCActivity.monitor!!.showAdvanced = sharedPreferences.getBoolean(key, false)
                 setAdvancedPreferencesVisibility()

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.kt
@@ -31,7 +31,7 @@ class AppPreferences @Inject constructor(val context: Context) {
     private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
 
     var autostart = prefs.getBoolean("autostart", context.resources.getBoolean(R.bool.prefs_default_autostart))
-    var showNotificationForNotices = prefs.getBoolean("showNotification",
+    var showNotificationForNotices = prefs.getBoolean("showNotifications",
             context.resources.getBoolean(R.bool.prefs_default_notification_notices))
     var showAdvanced = prefs.getBoolean("showAdvanced", context.resources.getBoolean(R.bool.prefs_default_advanced))
     var logLevel = prefs.getInt("logLevel", context.resources.getInteger(R.integer.prefs_default_loglevel))


### PR DESCRIPTION
**Description of the Change**
Correct the key of the notification preference defined in `root_preference.xml` to match the one checked in `SettingsFragment`.

**Release Notes**
The notification setting should now work properly.
