### PR TITLE
[Android] Disable obfuscation in release builds.

### DIFF
--- a/android/BOINC/app/proguard-rules-debug.txt
+++ b/android/BOINC/app/proguard-rules-debug.txt
@@ -10,7 +10,7 @@
 -keepattributes SourceFile,LineNumberTable
 
 # Useful for debugging
--printusage build/usage.txt     # Prints unused APIs removed by ProGuard
--printmapping build/mapping.txt # Prints mappings of class names to their obfuscated names
+#-printusage build/usage.txt     # Prints unused APIs removed by ProGuard
+#-printmapping build/mapping.txt # Prints mappings of class names to their obfuscated names
 
 -dontobfuscate

--- a/android/BOINC/app/proguard-rules.txt
+++ b/android/BOINC/app/proguard-rules.txt
@@ -13,4 +13,4 @@
 #-printusage build/usage.txt     # Prints unused APIs removed by ProGuard
 #-printmapping build/mapping.txt # Prints mappings of class names to their obfuscated names
 
-#-dontobfuscate
+-dontobfuscate


### PR DESCRIPTION
**Description of the Change**
Disable code obfuscation in release builds for better compliance with open source ideals.

**Release Notes**
N/A