### PR TITLE
GUI RPC: bind to INADDR_ANY if a remote host is actually configured

### DIFF
--- a/client/gui_rpc_server.cpp
+++ b/client/gui_rpc_server.cpp
@@ -98,7 +98,7 @@ GUI_RPC_CONN::~GUI_RPC_CONN() {
 }
 
 GUI_RPC_CONN_SET::GUI_RPC_CONN_SET() {
-    remote_hosts_file_exists = false;
+    remote_hosts_configured = false;
     lsock = -1;
     time_of_last_rpc_needing_network = 0;
     safe_strcpy(password,"");
@@ -196,13 +196,11 @@ int GUI_RPC_CONN_SET::get_allowed_hosts() {
     char buf[256];
 
     allowed_remote_ip_addresses.clear();
-    remote_hosts_file_exists = false;
 
     // scan remote_hosts.cfg, convert names to IP addresses
     //
     FILE* f = fopen(REMOTEHOST_FILE_NAME, "r");
     if (f) {
-        remote_hosts_file_exists = true;
         if (log_flags.gui_rpc_debug) {
             msg_printf(0, MSG_INFO,
                 "[gui_rpc] found allowed hosts list"
@@ -228,6 +226,9 @@ int GUI_RPC_CONN_SET::get_allowed_hosts() {
         }
         fclose(f);
     }
+
+    remote_hosts_configured = !allowed_remote_ip_addresses.empty();
+
     return 0;
 }
 
@@ -323,7 +324,7 @@ int GUI_RPC_CONN_SET::init_tcp(bool last_time) {
 #ifdef __APPLE__
     addr.sin_addr.s_addr = htonl(INADDR_ANY);
 #else
-    if (cc_config.allow_remote_gui_rpc || remote_hosts_file_exists) {
+    if (cc_config.allow_remote_gui_rpc || remote_hosts_configured) {
         addr.sin_addr.s_addr = htonl(INADDR_ANY);
         if (log_flags.gui_rpc_debug) {
             msg_printf(NULL, MSG_INFO, "[gui_rpc] Remote control allowed");

--- a/client/gui_rpc_server.h
+++ b/client/gui_rpc_server.h
@@ -103,7 +103,7 @@ class GUI_RPC_CONN_SET {
     void get_password();
     int insert(GUI_RPC_CONN*);
     bool check_allowed_list(sockaddr_storage& ip_addr);
-    bool remote_hosts_file_exists;
+    bool remote_hosts_configured;
 public:
     int lsock;
     double time_of_last_rpc_needing_network;


### PR DESCRIPTION
Instead of binding to INADDR_ANY as soon as remote_hosts.cfg exists,
only do so if the file actually contains at least one host. Prior to
this change, boinc client would bind to INADDR_ANY even if
--allow_remote_gui_rpc was *not* given and the remote_hosts.cfg
does *not* contain any hosts (but exists). This behavior is not
sensible, because in that case no client would be allowed to connect
eventually.

Furthermore, many distributions ship an example remote_hosts.cfg as
part of their boinc client package. And the previous behavior caused
boinc client to bind on INADDR_ANY, opening a remotely accessible port
per default.

To tighten security further, boinc client will now only
bind to localhost even if remote-hosts.cfg exists, but there are no
remote hosts configured witin that file.

**Release Notes**
Only listen on INADDR_ANY if either --allow_remote_gui_rpc is given, or if there is a least one host configured in remote_hosts.cfg. Otherwise, listen only on localhost. Previously, boinc would listen on INADDR_ANY as soon as remote_hosts.cfg exists, even if it does not contain any hosts.