### PR TITLE
[Android] Use SwipeRefreshLayout in event log fragments.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -139,6 +139,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-service:$lifecycle_version"
     implementation 'androidx.preference:preference-ktx:1.1.1'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
     implementation 'com.google.android.material:material:1.1.0'

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ui/eventlog/EventLogClientFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ui/eventlog/EventLogClientFragment.kt
@@ -39,17 +39,26 @@ import kotlinx.coroutines.withContext
 class EventLogClientFragment : Fragment() {
     private lateinit var activity: EventLogActivity
 
+    private var _binding: EventLogClientLayoutBinding? = null
+    private val binding get() = _binding!!
+
     private var mostRecentSeqNo = 0
     private var pastSeqNo = -1 // oldest (lowest) seqNo currently loaded to GUI
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         activity = getActivity() as EventLogActivity
-        val binding = EventLogClientLayoutBinding.inflate(inflater, container, false)
+        _binding = EventLogClientLayoutBinding.inflate(inflater, container, false)
         activity.clientLogList = binding.clientLogList
         activity.clientLogRecyclerViewAdapter = ClientLogRecyclerViewAdapter(activity.clientLogData)
         activity.clientLogList.layoutManager = LinearLayoutManager(context)
         activity.clientLogList.adapter = activity.clientLogRecyclerViewAdapter
+        binding.root.setOnRefreshListener { update() }
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     fun init() {
@@ -89,6 +98,7 @@ class EventLogClientFragment : Fragment() {
                 }
             } //IndexOutOfBoundException
             activity.clientLogRecyclerViewAdapter.notifyDataSetChanged()
+            withContext(Dispatchers.Main) { binding.root.isRefreshing = false }
         }
     }
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/ui/eventlog/EventLogGuiFragment.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/ui/eventlog/EventLogGuiFragment.java
@@ -40,22 +40,30 @@ import edu.berkeley.boinc.utils.Logging;
 
 public class EventLogGuiFragment extends Fragment {
     private EventLogActivity a;
+    private EventLogGuiLayoutBinding binding;
     private GuiLogRecyclerViewAdapter adapter;
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         a = ((EventLogActivity) getActivity());
 
-        final EventLogGuiLayoutBinding binding = EventLogGuiLayoutBinding.inflate(inflater, container, false);
+        binding = EventLogGuiLayoutBinding.inflate(inflater, container, false);
 
         adapter = new GuiLogRecyclerViewAdapter(a.getGuiLogData());
         binding.guiLogList.setLayoutManager(new LinearLayoutManager(getContext()));
         binding.guiLogList.setAdapter(adapter);
+        binding.getRoot().setOnRefreshListener(this::readLogcat);
 
         // read messages
         readLogcat();
 
         return binding.getRoot();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
     }
 
     public void update() {
@@ -104,6 +112,7 @@ public class EventLogGuiFragment extends Fragment {
                 Log.v(Logging.TAG, "readLogcat read " + a.getGuiLogData().size() + " lines.");
             }
             adapter.notifyDataSetChanged();
+            binding.getRoot().setRefreshing(false);
         }
         catch(IOException e) {
             if(Logging.WARNING) {

--- a/android/BOINC/app/src/main/res/layout/event_log_client_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/event_log_client_layout.xml
@@ -16,14 +16,14 @@
   You should have received a copy of the GNU Lesser General Public License
   along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical">
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/client_log_list"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content" />
 
-</LinearLayout>
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/android/BOINC/app/src/main/res/layout/event_log_gui_layout.xml
+++ b/android/BOINC/app/src/main/res/layout/event_log_gui_layout.xml
@@ -16,14 +16,14 @@
   You should have received a copy of the GNU Lesser General Public License
   along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical">
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
     <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/gui_log_list"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"/>
+            android:layout_height="wrap_content" />
 
-</LinearLayout>
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>


### PR DESCRIPTION
**Description of the Change**
Use `SwipeRefreshLayout` instead of `LinearLayout` as the parent layout in the event log fragments and implement the corresponding refresh functionality.

**Release Notes**
The event log can now be refreshed using a swipe gesture.

**Video**
![Screenrecorder-2020-07-16-20-24-58-606](https://user-images.githubusercontent.com/31027858/87688353-81889f80-c7a4-11ea-842a-e967f9b2ca1f.gif)