### PR TITLE
[Android] Use Okio to handle RPC.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/RpcClient.java
@@ -31,8 +31,6 @@ import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -44,7 +42,10 @@ import edu.berkeley.boinc.utils.BOINCDefs;
 import edu.berkeley.boinc.utils.BOINCUtils;
 import edu.berkeley.boinc.utils.Logging;
 import kotlin.text.Charsets;
+import okio.BufferedSink;
+import okio.BufferedSource;
 import okio.ByteString;
+import okio.Okio;
 
 import static org.apache.commons.lang3.BooleanUtils.toInteger;
 
@@ -84,9 +85,9 @@ public class RpcClient {
     public static final int MGR_SYNC = 31;
 
     private LocalSocket mSocket;
-    private OutputStreamWriter mOutput;
-    private InputStream mInput;
-    private byte[] mReadBuffer = new byte[READ_BUF_SIZE];
+    private BufferedSource socketSource;
+    private BufferedSink socketSink;
+    private final byte[] mReadBuffer = new byte[READ_BUF_SIZE];
     protected StringBuilder mResult = new StringBuilder(RESULT_BUILDER_INIT_SIZE);
     protected StringBuilder mRequest = new StringBuilder(REQUEST_BUILDER_INIT_SIZE);
 
@@ -179,10 +180,10 @@ public class RpcClient {
             mSocket = new LocalSocket();
             mSocket.connect(new LocalSocketAddress(socketAddress));
             mSocket.setSoTimeout(READ_TIMEOUT);
-            mInput = mSocket.getInputStream();
-            mOutput = new OutputStreamWriter(mSocket.getOutputStream(), Charsets.ISO_8859_1);
+            socketSource = Okio.buffer(Okio.source(mSocket.getInputStream()));
+            socketSink = Okio.buffer(Okio.sink(mSocket.getOutputStream()));
         } catch (IllegalArgumentException e) {
-            if (edu.berkeley.boinc.utils.Logging.LOGLEVEL <= 4)
+            if (Logging.LOGLEVEL <= 4)
                 Log.e(Logging.TAG, "connect failure: illegal argument", e);
             mSocket = null;
             return false;
@@ -208,12 +209,12 @@ public class RpcClient {
             return;
         }
         try {
-            mInput.close();
+            socketSource.close();
         } catch (IOException e) {
             if (Logging.WARNING) Log.w(Logging.TAG, "input close failure", e);
         }
         try {
-            mOutput.close();
+            socketSink.close();
         } catch (IOException e) {
             if (Logging.WARNING) Log.w(Logging.TAG, "output close failure", e);
         }
@@ -316,12 +317,11 @@ public class RpcClient {
             Log.d(Logging.TAG, "mRequest.capacity() = " + mRequest.capacity());
         if (Logging.RPC_DATA && Logging.DEBUG)
             Log.d(Logging.TAG, "Sending request: \n" + request);
-        if (mOutput == null)
+        if (socketSink == null)
             return;
-        mOutput.write("<boinc_gui_rpc_request>\n");
-        mOutput.write(request);
-        mOutput.write("</boinc_gui_rpc_request>\n\003");
-        mOutput.flush();
+        final String requestBody = "<boinc_gui_rpc_request>\n" + request + "</boinc_gui_rpc_request>\n\003";
+        socketSink.writeString(requestBody, Charsets.ISO_8859_1);
+        socketSink.flush();
     }
 
     /**
@@ -342,10 +342,10 @@ public class RpcClient {
         //                             ~ 95 KB/s for buffer size 4096
         // The chosen buffer size is 2048
         int bytesRead;
-        if (mInput == null)
+        if (socketSource == null)
             return mResult.toString();    // empty string
         do {
-            bytesRead = mInput.read(mReadBuffer);
+            bytesRead = socketSource.read(mReadBuffer);
             if (bytesRead == -1) break;
             mResult.append(new String(mReadBuffer, 0, bytesRead));
             if (mReadBuffer[bytesRead - 1] == '\003') {


### PR DESCRIPTION
**Description of the Change**
Use Okio's `BufferedSource` and `BufferedSink` classes to handle RPC communication instead of using the raw `InputStream` and `OutputStreamWriter`, due to providing many advantages over the standard Java IO APIs: https://jakewharton.com/a-few-ok-libraries/.

**Release Notes**
N/A
