### PR TITLE
[Android] Remove warnings in compilation time.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.kt
@@ -134,7 +134,14 @@ class BatchProcessingActivity : AppCompatActivity() {
         }
         val intent = Intent(Intent.ACTION_SEND).apply {
             type = "text/plain"
-            addFlags(Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET)
+            
+            val flag = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+                @Suppress("DEPRECATION")
+                Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET
+            } else {
+                Intent.FLAG_ACTIVITY_NEW_DOCUMENT
+            }
+            addFlags(flag)
 
             // Add data to the intent, the receiving app will decide what to do with it.
             putExtra(Intent.EXTRA_SUBJECT, getString(R.string.social_invite_content_title))

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
@@ -331,17 +331,17 @@ class Monitor : LifecycleService() {
                 val transfers = clientInterface.fileTransfers
                 val acctMgrInfo = clientInterface.acctMgrInfo
                 val newNotices = clientInterface.getNotices(clientStatus.mostRecentNoticeSeqNo)
+                var nullValues = ""
+                if (state == null) {
+                    nullValues += "state "
+                    Log.e(Logging.TAG, "readClientStatus(): connection problem, null: " + nullValues);
+                }
                 if (allNotNull(status, state, state!!.hostInfo, acctMgrInfo)) {
                     clientStatus.setClientStatus(status, state.results, state.projects,
                             transfers, state.hostInfo, acctMgrInfo,
                             newNotices)
                 } else {
-                    var nullValues = ""
-                    if (state == null) {
-                        nullValues += "state "
-                    } else {
-                        if (state.hostInfo == null) nullValues += "state.host_info "
-                    }
+                    if (state.hostInfo == null) nullValues += "state.host_info "
                     if (transfers == null) nullValues += "transfers "
                     if (acctMgrInfo == null) nullValues += "acctMgrInfo "
                     if (Logging.ERROR) Log.e(Logging.TAG, "readClientStatus(): connection problem, null: $nullValues")


### PR DESCRIPTION
Remove:
* `w: boinc\android\BOINC\app\src\main\java\edu\berkeley\boinc\attach\BatchProcessingActivity.kt: (137, 29): 'FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET: Int' is deprecated. Deprecated in Java`
Solution from:
https://stackoverflow.com/questions/33179042/i-tried-using-this-flag-in-setflags-from-tutorial-but-its-deprecated-what-do-i
* `w: boinc\android\BOINC\app\src\main\java\edu\berkeley\boinc\client\Monitor.kt: (340, 25): Condition 'state == null' is always 'false'` warning.
Add check to state if it null. if yes, write to log. and continue as before this change.