### PR TITLE
Pass user priority config items to wrappers

### DIFF
--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -113,6 +113,9 @@ void APP_INIT_DATA::copy(const APP_INIT_DATA& a) {
         project_preferences = NULL;
     }
     vbox_window                 = a.vbox_window;
+    no_priority_change          = a.no_priority_change;
+    process_priority            = a.process_priority;
+    process_priority_special    = a.process_priority_special;
     app_files                   = a.app_files;
 }
 
@@ -202,7 +205,10 @@ int write_init_data_file(FILE* f, APP_INIT_DATA& ai) {
         "<rsc_memory_bound>%f</rsc_memory_bound>\n"
         "<rsc_disk_bound>%f</rsc_disk_bound>\n"
         "<computation_deadline>%f</computation_deadline>\n"
-        "<vbox_window>%d</vbox_window>\n",
+        "<vbox_window>%d</vbox_window>\n"
+        "<no_priority_change>%d</no_priority_change>\n"
+        "<process_priority>%d</process_priority>\n"
+        "<process_priority_special>%d</process_priority_special>\n",
         ai.slot,
         ai.client_pid,
         ai.wu_cpu_time,
@@ -227,7 +233,10 @@ int write_init_data_file(FILE* f, APP_INIT_DATA& ai) {
         ai.rsc_memory_bound,
         ai.rsc_disk_bound,
         ai.computation_deadline,
-        ai.vbox_window
+        ai.vbox_window,
+        ai.no_priority_change?1:0,
+        ai.process_priority,
+        ai.process_priority_special
     );
     MIOFILE mf;
     mf.init_file(f);
@@ -295,6 +304,9 @@ void APP_INIT_DATA::clear() {
     memset(&shmem_seg_name, 0, sizeof(shmem_seg_name));
     wu_cpu_time = 0;
     vbox_window = false;
+    no_priority_change = false;
+    process_priority = -1;
+    process_priority_special = -1;
 }
 
 int parse_init_data_file(FILE* f, APP_INIT_DATA& ai) {
@@ -401,6 +413,9 @@ int parse_init_data_file(FILE* f, APP_INIT_DATA& ai) {
         if (xp.parse_double("fraction_done_start", ai.fraction_done_start)) continue;
         if (xp.parse_double("fraction_done_end", ai.fraction_done_end)) continue;
         if (xp.parse_bool("vbox_window", ai.vbox_window)) continue;
+        if (xp.parse_bool("no_priority_change", ai.no_priority_change)) continue;
+        if (xp.parse_int("process_priority", ai.process_priority)) continue;
+        if (xp.parse_int("process_priority_special", ai.process_priority_special)) continue;
         xp.skip_unexpected(false, "parse_init_data_file");
     }
     fprintf(stderr, "%s: parse_init_data_file: no end tag\n",

--- a/lib/app_ipc.h
+++ b/lib/app_ipc.h
@@ -199,9 +199,15 @@ struct APP_INIT_DATA {
     //
     double ncpus;
 
-    // client configuration info
+    // client configuration info, from cc_config.h
     //
     bool vbox_window;       // whether to open a console window for VM apps
+
+    // the following for wrappers
+    //
+    bool no_priority_change;
+    int process_priority;
+    int process_priority_special;
 
     // list of files in the app version (for wrappers)
     //

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -740,6 +740,19 @@ int TASK::run(int argct, char** argvt) {
         boinc_msg_prefix(buf, sizeof(buf)), app_path, command_line.c_str()
     );
 
+    // decide on subprocess priority.  User prefs trump job.xml
+    //
+    int priority_val = 0;
+    if (aid.no_priority_change) {
+        priority_val = 0;
+    } else {
+        if (aid.process_priority > 0) {
+            priority_val = process_priority_value(aid.process_priority);
+        } else {
+            priority_val = process_priority_value(priority);
+        }
+    }
+
 #ifdef _WIN32
     PROCESS_INFORMATION process_info;
     STARTUPINFO startup_info;
@@ -800,7 +813,7 @@ int TASK::run(int argct, char** argvt) {
         NULL,
         NULL,
         TRUE,        // bInheritHandles
-        CREATE_NO_WINDOW|process_priority_value(priority),
+        CREATE_NO_WINDOW|priority_val,
         (LPVOID) env_vars,
         exec_dir.empty()?NULL:exec_dir.c_str(),
         &startup_info,
@@ -875,7 +888,9 @@ int TASK::run(int argct, char** argvt) {
         argv[0] = app_path;
         strlcpy(arglist, command_line.c_str(), sizeof(arglist));
         parse_command_line(arglist, argv+1);
-        setpriority(PRIO_PROCESS, 0, process_priority_value(priority));
+        if (priority_val) {
+            setpriority(PRIO_PROCESS, 0, priority_val);
+        }
         if (!exec_dir.empty()) {
             retval = chdir(exec_dir.c_str());
             if (retval) {


### PR DESCRIPTION
The user can specify 3 priority-related prefs in cc_config.h:
bool no_priority_change
int process_priority
int process_priority_special

Wrappers should honor these prefs,
but currently they don't have access to them.
Pass them in the APP_INIT_DATA structure.

Modify wrapper.cpp to use these prefs if they exist;
this overrides the priority specified in the job file, if any.

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
