### PR TITLE
Added EVT_MENU_OPEN to the event table for Windows - Fixes #3934

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1111,6 +1111,17 @@ void CAdvancedFrame::OnMenuOpening( wxMenuEvent &event) {
     if (exitItem) {
         exitItem->Enable(true);
     }
+
+    // Specific menu items to keep enabled always (Switch to simple view and "other options")
+    wxMenuItem* simpleViewItem = menu->FindChildItem(ID_CHANGEGUI, NULL);
+    if (simpleViewItem) {
+        simpleViewItem->Enable(true);
+    }
+
+    wxMenuItem* otherOptionsItem = menu->FindChildItem(ID_OPTIONS, NULL);
+    if (otherOptionsItem) {
+        otherOptionsItem->Enable(true);
+    }
     
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnMenuOpening - Function End"));
 }

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -163,9 +163,7 @@ void CStatusBar::OnSize(wxSizeEvent& event) {
 IMPLEMENT_DYNAMIC_CLASS(CAdvancedFrame, CBOINCBaseFrame)
 
 BEGIN_EVENT_TABLE (CAdvancedFrame, CBOINCBaseFrame)
-#ifndef __WXMSW__
     EVT_MENU_OPEN(CAdvancedFrame::OnMenuOpening)
-#endif
     // View
     EVT_MENU_RANGE(ID_ADVNOTICESVIEW, ID_ADVRESOURCEUSAGEVIEW, CAdvancedFrame::OnChangeView)
     EVT_MENU(ID_CHANGEGUI, CAdvancedFrame::OnChangeGUI)


### PR DESCRIPTION
Fixes #3934 

**Description of the Change**

Removed the pre-processor directives that stopped the loading of the EVT_MENU_OPEN event. This means that `CAdvancedFrame::OnMenuOpening()` will be executed as an event as expected on all platforms and hence prevent particular menu functionality from being accessed when the client is shut down.

Changes affect the BOINC manager.

**Alternate Designs**

Adding appropriate code to shutting down and then connecting to a client was one alternative.

**Release Notes**

Options are now greyed-out when the BOINC client is shutdown on Microsoft Windows.
