### PR TITLE
Manager: clean up "Welcome page"

### DIFF
--- a/3rdParty/vcpkg_ports/ports/rappture/CMakeLists.txt
+++ b/3rdParty/vcpkg_ports/ports/rappture/CMakeLists.txt
@@ -91,8 +91,13 @@ add_library(rappture ${SRC_RAPPTURE_CORE})
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src/core/)
 
-find_package(EXPAT REQUIRED)
-target_link_libraries(rappture PRIVATE EXPAT::EXPAT)
+find_package(expat CONFIG REQUIRED)
+
+if(WIN32 AND NOT MINGW)
+    target_link_libraries(rappture PRIVATE expat::libexpat)
+else()
+    target_link_libraries(rappture PRIVATE expat::expat)
+endif()
 
 install(TARGETS rappture
             RUNTIME DESTINATION bin

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -767,6 +767,12 @@ int CLIENT_STATE::init() {
     process_autologin(true);
     acct_mgr_info.init();
     project_init.init();
+    // if project_init.xml specifies an account, attach
+    //
+    if (strlen(project_init.url) && strlen(project_init.account_key)) {
+        add_project(project_init.url, project_init.account_key, project_init.name, false);
+        project_init.remove();
+    }
 
     log_show_projects();    // this must follow acct_mgr_info.init()
 

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -762,15 +762,11 @@ static void handle_get_project_init_status(GUI_RPC_CONN& grc) {
         "<get_project_init_status>\n"
         "    <url>%s</url>\n"
         "    <name>%s</name>\n"
-        "    <team_name>%s</team_name>\n"
-        "    <setup_cookie>%s</setup_cookie>\n"
         "    %s\n"
         "    %s\n"
         "</get_project_init_status>\n",
         gstate.project_init.url,
         gstate.project_init.name,
-        gstate.project_init.team_name,
-        gstate.project_init.setup_cookie,
         strlen(gstate.project_init.account_key)?"<has_account_key/>":"",
         gstate.project_init.embedded?"<embedded/>":""
     );

--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -323,7 +323,10 @@ void CAccountInfoPage::OnPageChanged( wxWizardExEvent& /* event */ ) {
 
     wxString str;
     wxString name = wxString(pc.name.c_str(), wxConvUTF8);
-    str.Printf(_("Identify your account at %s"), name.c_str());
+    str.Printf(_("Identify your account at %s"),
+        name.empty()? pWA->GetProjectName().c_str() : name.c_str()
+            // one or the other is populated depending on how project was selected
+    );
     m_pTitleStaticCtrl->SetLabel(str);
 
     if (!IS_ACCOUNTMANAGERWIZARD() && !IS_ACCOUNTMANAGERUPDATEWIZARD()) {

--- a/clientgui/ProjectWelcomePage.cpp
+++ b/clientgui/ProjectWelcomePage.cpp
@@ -15,6 +15,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 //
+
+// show a "welcome" dialog showing the user what project they're about to run,
+// in the case where a project_init.xml was present on startup
+//
+// AFAIK no one uses this mechanism, so this may not be needed
+
 #if defined(__GNUG__) && !defined(__APPLE__)
 #pragma implementation "ProjectWelcomePage.h"
 #endif
@@ -129,22 +135,6 @@ void CProjectWelcomePage::CreateControls()
     project_name2_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     grid->Add(project_name2_ctrl, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
 
-    project_inst1_ctrl = new wxStaticText;
-    project_inst1_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    grid->Add(project_inst1_ctrl, 0, wxALIGN_LEFT|wxALL, 5);
-
-    project_inst2_ctrl = new wxStaticText;
-    project_inst2_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    grid->Add(project_inst2_ctrl, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
-
-    project_desc1_ctrl = new wxStaticText;
-    project_desc1_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    grid->Add(project_desc1_ctrl, 0, wxALIGN_LEFT|wxALL, 5);
-
-    project_desc2_ctrl = new wxStaticText;
-    project_desc2_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    grid->Add(project_desc2_ctrl, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
-
     project_url1_ctrl = new wxStaticText;
     project_url1_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     grid->Add(project_url1_ctrl, 0, wxALIGN_LEFT|wxALL, 5);
@@ -152,18 +142,6 @@ void CProjectWelcomePage::CreateControls()
     project_url2_ctrl = new wxStaticText;
     project_url2_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     grid->Add(project_url2_ctrl, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
-
-    user_name1_ctrl = new wxStaticText;
-    user_name1_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    grid->Add(user_name1_ctrl, 0, wxALIGN_LEFT|wxALL, 5);
-
-    user_name2_ctrl = new wxStaticText;
-    user_name2_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    grid->Add(user_name2_ctrl, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
-
-    warning_ctrl = new wxStaticText;
-    warning_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    itemBoxSizer3->Add(warning_ctrl, 0, wxALIGN_LEFT|wxALL|wxEXPAND, 5);
 
     continue_ctrl = new wxStaticText;
     continue_ctrl->Create( itemWizardPage2, wxID_STATIC, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
@@ -253,25 +231,9 @@ void CProjectWelcomePage::OnPageChanged( wxWizardExEvent& event ) {
     intro_ctrl->SetLabel(_("You have volunteered to compute for this project:"));
     project_name1_ctrl->SetLabel(_("Name:"));
     project_name2_ctrl->SetLabel(pWA->GetProjectName());
-    if (!pWA->GetProjectInstitution().IsEmpty()) {
-        project_inst1_ctrl->SetLabel(_("Home:"));
-        project_inst2_ctrl->SetLabel(pWA->GetProjectInstitution());
-    }
-    if (!pWA->GetProjectDescription().IsEmpty()) {
-        project_desc1_ctrl->SetLabel(_("Description:"));
-        project_desc2_ctrl->SetLabel(pWA->GetProjectDescription());
-    }
     project_url1_ctrl->SetLabel(_("URL:"));
     project_url2_ctrl->SetLabel(pWA->GetProjectURL());
-    if (!pWA->GetProjectUserName().IsEmpty()) {
-        user_name1_ctrl->SetLabel(_("User:"));
-        user_name2_ctrl->SetLabel(pWA->GetProjectUserName());
-    }
 
-    if (!pWA->IsProjectKnown()) {
-        warning_ctrl->SetLabel(_("WARNING: This project is not registered with BOINC.  Make sure you trust it before continuing."));
-
-    }
     continue_ctrl->SetLabel(
         _("To continue, click Next.")
     );

--- a/clientgui/WizardAttach.cpp
+++ b/clientgui/WizardAttach.cpp
@@ -285,7 +285,7 @@ bool CWizardAttach::Run(
     if (m_ProjectPropertiesPage && m_ProjectInfoPage && m_ProjectWelcomePage) {
         IsAttachToProjectWizard = true;
         IsAccountManagerWizard = false;
-        if ((strProjectName.size() && strProjectURL.size()) || !bEmbedded) {
+        if ((strProjectName.size() && strProjectURL.size())) {
             return RunWizard(m_ProjectWelcomePage);
         } else if (strProjectURL.size() && (IsCredentialsCached() || IsCredentialsDetected())) {
             return RunWizard(m_ProjectPropertiesPage);

--- a/clientgui/WizardAttach.cpp
+++ b/clientgui/WizardAttach.cpp
@@ -285,7 +285,7 @@ bool CWizardAttach::Run(
     if (m_ProjectPropertiesPage && m_ProjectInfoPage && m_ProjectWelcomePage) {
         IsAttachToProjectWizard = true;
         IsAccountManagerWizard = false;
-        if ((strProjectName.size() && strProjectURL.size())) {
+        if (strProjectName.size() && strProjectURL.size()) {
             return RunWizard(m_ProjectWelcomePage);
         } else if (strProjectURL.size() && (IsCredentialsCached() || IsCredentialsDetected())) {
             return RunWizard(m_ProjectPropertiesPage);

--- a/clientsetup/win/CACreateProjectInitFile.cpp
+++ b/clientsetup/win/CACreateProjectInitFile.cpp
@@ -67,11 +67,18 @@ UINT CACreateProjectInitFile::OnExecution()
 {
     tstring          strSetupExeName;
     tstring          strDataDirectory;
+    tstring          strProjectInitUrl;
+    tstring          strProjectInitAuthenticator;
     PROJECT_INIT     pi;
     UINT             uiReturnValue = 0;
 
-
     uiReturnValue = GetProperty( _T("DATADIR"), strDataDirectory );
+    if ( uiReturnValue ) return uiReturnValue;
+
+    uiReturnValue = GetProperty( _T("PROJINIT_URL"), strProjectInitUrl );
+    if ( uiReturnValue ) return uiReturnValue;
+
+    uiReturnValue = GetProperty( _T("PROJINIT_AUTH"), strProjectInitAuthenticator );
     if ( uiReturnValue ) return uiReturnValue;
 
     uiReturnValue = GetProperty( _T("SETUPEXENAME"), strSetupExeName );
@@ -85,8 +92,33 @@ UINT CACreateProjectInitFile::OnExecution()
         NULL,
         _T("Changing to the data directory")
     );
-
     _tchdir(strDataDirectory.c_str());
+
+    // write project_init.xml if project info was passed on cmdline
+    //
+    if (!strProjectInitUrl.empty()) {
+        LogMessage(
+            INSTALLMESSAGE_INFO,
+            NULL, 
+            NULL,
+            NULL,
+            NULL,
+            _T("Detected command line parameters")
+        );
+
+        pi.init();
+
+        strncpy(pi.url, CW2A(strProjectInitUrl.c_str()), sizeof(pi.url)-1);
+        strncpy(pi.name, CW2A(strProjectInitUrl.c_str()), sizeof(pi.name)-1);
+            // Use project URL as name
+            // TODO: add a cmdline arg for project name
+        strncpy(pi.account_key, CW2A(strProjectInitAuthenticator.c_str()), sizeof(pi.account_key)-1);
+
+        pi.embedded = false;
+
+        pi.write();
+
+    }
 
     // write installer filename to a file
     //

--- a/clientsetup/win/CACreateProjectInitFile.cpp
+++ b/clientsetup/win/CACreateProjectInitFile.cpp
@@ -69,6 +69,7 @@ UINT CACreateProjectInitFile::OnExecution()
     tstring          strDataDirectory;
     tstring          strProjectInitUrl;
     tstring          strProjectInitAuthenticator;
+    tstring          project_name;
     PROJECT_INIT     pi;
     UINT             uiReturnValue = 0;
 
@@ -77,6 +78,9 @@ UINT CACreateProjectInitFile::OnExecution()
 
     uiReturnValue = GetProperty( _T("PROJINIT_URL"), strProjectInitUrl );
     if ( uiReturnValue ) return uiReturnValue;
+
+    uiReturnValue = GetProperty(_T("PROJINIT_NAME"), project_name);
+    if (uiReturnValue) return uiReturnValue;
 
     uiReturnValue = GetProperty( _T("PROJINIT_AUTH"), strProjectInitAuthenticator );
     if ( uiReturnValue ) return uiReturnValue;
@@ -99,7 +103,7 @@ UINT CACreateProjectInitFile::OnExecution()
     if (!strProjectInitUrl.empty()) {
         LogMessage(
             INSTALLMESSAGE_INFO,
-            NULL, 
+            NULL,
             NULL,
             NULL,
             NULL,
@@ -108,10 +112,13 @@ UINT CACreateProjectInitFile::OnExecution()
 
         pi.init();
 
-        strncpy(pi.url, CW2A(strProjectInitUrl.c_str()), sizeof(pi.url)-1);
-        strncpy(pi.name, CW2A(strProjectInitUrl.c_str()), sizeof(pi.name)-1);
-            // Use project URL as name
-            // TODO: add a cmdline arg for project name
+        strncpy(pi.url, CW2A(strProjectInitUrl.c_str()), sizeof(pi.url) - 1);
+        if (!project_name.empty()) {
+            strncpy(pi.name, CW2A(project_name.c_str()), sizeof(pi.name) - 1);
+        } else {
+            strncpy(pi.name, CW2A(strProjectInitUrl.c_str()), sizeof(pi.name) - 1);
+        }
+
         strncpy(pi.account_key, CW2A(strProjectInitAuthenticator.c_str()), sizeof(pi.account_key)-1);
 
         pi.embedded = false;

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -41,10 +41,6 @@
 //   formatting failures for any software that has been localized or
 //   displays localized data.
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 #ifdef _WIN32
 #include "boinc_win.h"
 #include "../version.h"
@@ -2012,7 +2008,6 @@ int RPC_CLIENT::run_graphics_app(const char *operation, int& operand, const char
         }
     }
     return retval;
-    return rpc.parse_reply();
 }
 
 int RPC_CLIENT::set_proxy_settings(GR_PROXY_INFO& procinfo) {

--- a/lib/project_init.cpp
+++ b/lib/project_init.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2015 University of California
+// Copyright (C) 2020 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -38,7 +38,6 @@ void PROJECT_INIT::clear() {
     safe_strcpy(url, "");
     safe_strcpy(name, "");
     safe_strcpy(account_key, "");
-    safe_strcpy(team_name, "");
     embedded = false;
 }
 
@@ -57,7 +56,6 @@ int PROJECT_INIT::init() {
     while (!xp.get_tag()) {
         if (xp.match_tag("/project_init")) break;
         else if (xp.parse_str("name", name, sizeof(name))) continue;
-        else if (xp.parse_str("team_name", team_name, sizeof(team_name))) continue;
         else if (xp.parse_str("account_key", account_key, sizeof(account_key))) continue;
         else if (xp.parse_str("url", url, sizeof(url))) {
             canonicalize_master_url(url, sizeof(url));
@@ -83,13 +81,11 @@ int PROJECT_INIT::write() {
         "<project_init>\n"
         "  <url>%s</url>\n"
         "  <name>%s</name>\n"
-        "  <team_name>%s</team_name>\n"
         "  <account_key>%s</account_key>\n"
         "  <embedded>%d</embedded>\n"
         "</project_init>\n",
         url,
         name,
-        team_name,
         account_key,
         embedded
     );
@@ -97,4 +93,3 @@ int PROJECT_INIT::write() {
 
     return 0;
 }
-

--- a/lib/project_init.h
+++ b/lib/project_init.h
@@ -21,22 +21,17 @@
 #define PROJECT_INIT_FILENAME       "project_init.xml"
 
 // represents the contents of project_init.xml,
-// specifying an account to attach to initially
+// specifying a project, and optionally an account, to attach to initially
 //
 class PROJECT_INIT {
 public:
     char url[256];
     char name[256];
-    char team_name[256];
     char account_key[256];
-
-    // Opaque data, project-supplied, that must be passed to
-    // Web RPC along with account key
-    //
-    char setup_cookie[256];
 
     // Is the project_init.xml file embedded in the installer?
     // Or was it generated from of the command line of the install.
+    // No longer used.
     //
     bool embedded;
 
@@ -48,6 +43,7 @@ public:
 	// Used by installers to create/modify project_init.xml in the data
 	// directory at install time.
     // Useful for creating automated install processes.
+    //
     int write();
 };
 

--- a/win_build/boinc_ss_vs2019.vcxproj
+++ b/win_build/boinc_ss_vs2019.vcxproj
@@ -95,7 +95,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;glu32.lib;odbc32.lib;odbccp32.lib;wsock32.lib;psapi.lib;libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;zlib.lib;bz2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;odbc32.lib;odbccp32.lib;wsock32.lib;psapi.lib;libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;zlib.lib;bz2.lib;brotlicommon-static.lib;brotlidec-static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -139,7 +139,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;shell32.lib;gdi32.lib;opengl32.lib;glu32.lib;ole32.lib;psapi.lib;delayimp.lib;wsock32.lib;advapi32.lib;freetyped.lib;ftgld.lib;libpng16d.lib;zlibd.lib;bz2d.lib</AdditionalDependencies>
+      <AdditionalDependencies>libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;shell32.lib;gdi32.lib;opengl32.lib;glu32.lib;ole32.lib;psapi.lib;delayimp.lib;wsock32.lib;advapi32.lib;freetyped.lib;ftgld.lib;libpng16d.lib;zlibd.lib;bz2d.lib;brotlicommon-static.lib;brotlidec-static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/debug/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/win_build/boinccas_vs2019.vcxproj
+++ b/win_build/boinccas_vs2019.vcxproj
@@ -73,7 +73,7 @@
       <AdditionalIncludeDirectories>../win_build;..\lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>atlsd.lib;msi.lib;libcmtd.lib;libcpmtd.lib;delayimp.lib;netapi32.lib;advapi32.lib;kernel32.lib;user32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>atls.lib;msi.lib;libcmtd.lib;libcpmtd.lib;delayimp.lib;netapi32.lib;advapi32.lib;kernel32.lib;user32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <ModuleDefinitionFile>..\clientsetup\win\boinccas.def</ModuleDefinitionFile>
       <DelayLoadDLLs>netapi32.dll;advapi32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>

--- a/win_build/slide_show_vs2019.vcxproj
+++ b/win_build/slide_show_vs2019.vcxproj
@@ -91,7 +91,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;glu32.lib;odbc32.lib;odbccp32.lib;psapi.lib;libcmt.lib;libcpmt.lib;oldnames.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;odbc32.lib;odbccp32.lib;psapi.lib;libcmt.lib;libcpmt.lib;oldnames.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zlib.lib;brotlicommon-static.lib;brotlidec-static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -134,7 +134,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;gdi32.lib;opengl32.lib;glu32.lib;ole32.lib;oldnames.lib;psapi.lib;delayimp.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;gdi32.lib;opengl32.lib;glu32.lib;ole32.lib;oldnames.lib;psapi.lib;delayimp.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zlibd.lib;brotlicommon-static.lib;brotlidec-static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/debug/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/win_build/uc2_graphics_vs2019.vcxproj
+++ b/win_build/uc2_graphics_vs2019.vcxproj
@@ -91,7 +91,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>opengl32.lib;glu32.lib;odbc32.lib;odbccp32.lib;psapi.lib;libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;glu32.lib;odbc32.lib;odbccp32.lib;psapi.lib;libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zlib.lib;brotlicommon-static.lib;brotlidec-static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -134,7 +134,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;gdi32.lib;opengl32.lib;glu32.lib;ole32.lib;psapi.lib;delayimp.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;gdi32.lib;opengl32.lib;glu32.lib;ole32.lib;psapi.lib;delayimp.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zlibd.lib;brotlicommon-static.lib;brotlidec-static.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/debug/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>

--- a/win_build/wrappture_example_vs2019.vcxproj
+++ b/win_build/wrappture_example_vs2019.vcxproj
@@ -98,7 +98,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>rappture.lib;expat.lib;libcmt.lib;libcpmt.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rappture.lib;libexpatMD.lib;libcmt.lib;libcpmt.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
@@ -141,7 +141,7 @@
       <Culture>0x0409</Culture>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>rappture.lib;expat.lib;libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;gdi32.lib;ole32.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>rappture.lib;libexpatdMD.lib;libcmtd.lib;libcpmtd.lib;kernel32.lib;user32.lib;gdi32.lib;ole32.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>


### PR DESCRIPTION
When a client and manager start up and there are no projects attached,
the client checks for a project_info.xml and passes its into to the manager.
If the file has both a project URL and an account key,
the manager tells the client to attach that project, and that's it.
If the file has URL but no account key, the manager puts up a "Welcome page".
The idea is to notify the user of what they're about to sign up for.
If the user clicks Next, they go to the name/password dialog.

Both of these cases work now.
The <name> element in project_info.xml is required.
I had to do a bit more work to make things work right when the user cancels
out of the welcome page, then adds a project the usual way.

This part of Manager is convoluted.
Big chunks of it should be deleted, the Welcome page among them.
Here I took the path of least resistance.