### PR TITLE
Mac: FIx screensaver coordinator to run properly under Mac OS 11 Big Sur

### DIFF
--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -26,6 +26,8 @@
 #endif
 
 #ifdef __APPLE__
+#define VERBOSE 0
+
 #include <Carbon/Carbon.h>
 #include <sys/wait.h>
 #include <app_ipc.h>
@@ -48,6 +50,17 @@ extern pthread_mutex_t saver_mutex;
 #include "str_util.h"
 #include "str_replace.h"
 #include "screensaver.h"
+
+#ifdef __APPLE__
+#undef BOINCTRACE
+#if VERBOSE
+#define BOINCTRACE print_to_log_file
+#else
+#define BOINCTRACE(...)
+#endif
+
+#define _T
+#endif
 
 // Platform specific application includes
 //


### PR DESCRIPTION
These changes are necessary for the BOINC screensaver controller to run on MacOS 11 Big Sur. I have tested this code on OS 10.13 High Sierra, OS 10.15 Catalina and OS 11.0 Beta 4 Big Sur. This PR is ready to merge needs to be included in the next release of BOINC for the Macintosh.
