### PR TITLE
Mac: Enable close button in project graphics run by BOINC Manager "Show Graphics"

### DIFF
--- a/api/graphics2_unix.cpp
+++ b/api/graphics2_unix.cpp
@@ -137,9 +137,13 @@ static void maybe_render() {
                     ypos = new_ypos;
                     width = new_width;
                     height = new_height;
+
                 } else {
                     if (size_changed && (++size_changed > 10)) {
                         size_changed = 0;
+#ifdef __APPLE__
+                        ClearDocumentEditedDot();
+#endif
                         FILE *f = boinc_fopen("gfx_info", "w");
                         if (f) {
                             // ToDo: change this to XML

--- a/api/macglutfix.m
+++ b/api/macglutfix.m
@@ -59,16 +59,23 @@ int compareOSVersionTo(int toMajor, int toMinor);
 // Delay when switching to screensaver mode to reduce annoying flashes
 #define SAVERDELAY 30
 
+// NSClosableWindowMask is deprecated in OS 10.12 and is replaced by
+// NSWindowStyleMaskClosable, which is not defined before OS 10.12
+#ifndef NSWindowStyleMaskClosable
+#define NSWindowStyleMaskClosable NSClosableWindowMask
+#endif
+
+static NSWindow* myWindow = nil;
+
 void MacGLUTFix(bool isScreenSaver) {
     static int count = 0;
     static NSMenu * emptyMenu;
     NSOpenGLContext * myContext = nil;
     NSView *myView = nil;
-    NSWindow* myWindow = nil;
     static int requestedWidth, requestedHeight;
 
-    if (count > 1) return;   // Do this only twice
-    count++;
+    if (count == 2) ClearDocumentEditedDot();
+    if (count++ > 2) return;   // Do the code below only twice
     
     if (! boinc_is_standalone()) {
         if (emptyMenu == nil) {
@@ -109,9 +116,7 @@ void MacGLUTFix(bool isScreenSaver) {
             glutReshapeWindow(requestedWidth, requestedHeight);
         }
         
-        NSButton *closeButton = [myWindow standardWindowButton:NSWindowCloseButton ];
-        [closeButton setEnabled:YES];
-        [myWindow setDocumentEdited: NO];
+        [myWindow setStyleMask:[myWindow styleMask] | NSWindowStyleMaskClosable];
         
         return;
     }
@@ -128,6 +133,12 @@ void MacGLUTFix(bool isScreenSaver) {
         if ([ myWindow level ] == GlutFullScreenWindowLevel) {
             [ myWindow setLevel:RealSaverLevel+20 ];
         }
+    }
+}
+
+void ClearDocumentEditedDot(void) {
+    if (myWindow) {
+        [myWindow setDocumentEdited: NO];
     }
 }
 

--- a/api/x_opengl.h
+++ b/api/x_opengl.h
@@ -26,6 +26,7 @@ extern int xwin_glut_is_initialized();
 
 #ifdef __APPLE__
 extern void MacGLUTFix(bool isScreenSaver);
+extern void ClearDocumentEditedDot(void);
 extern void MacPassOffscreenBufferToScreenSaver(void);
 extern void BringAppToFront(void);
 extern void HideThisApp(void);


### PR DESCRIPTION
Enable close button in project graphics run by _BOINC Manager_ `Show Graphics` under MacOS 11 Big Sur.

**This is an urgent fix**, since I expect that MacOS 11, which is well into beta testing, will be released soon. **All projects should relink their graphics applications with this updated library code as soon as possible.**

When a user presses the `Show graphics` button in the _BOINC Manager_, the project graphics application is run for the selected task. On the Macintosh, the graphics app runs as a free standing process, without a functioning menu bar, so the usual way to shut it is to use the red close button at the top left corner of the application's window. But under MacOS 11 Big Sur, that button is disabled. 

There is a workaround: the user can control-click (or right-click) on the graphics app's icon in the Dock and select `Quit`. But this is not obvious, so it is important to fix the close button issue.

Note that the operation of the graphics apps under the screensaver coordinator is not affected and will continue to work properly with or without this change. However, the screensaver coordinator itself has a separate problem under Mac OS 11 Big Sur, which is addressed by my PR #3963.

This PR modifies the library _libboinc_graphics2.a_ to enable the close button on graphics apps built with it. I have tested this by building the default graphics application _boincscr_, building it both with Xcode 12 beta 4 under MacOS11 beta 4 Big Sur, and also Xcode 10 under OS 10.13 High Sierra, and testing both builds under both versions of MacOS.