### PR TITLE
[Manager] Stopped shutdown client dialog from showing when told not to

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1312,6 +1312,7 @@ void CAdvancedFrame::OnClientShutdown(wxCommandEvent& WXUNUSED(event)) {
     CMainDocument*     pDoc = wxGetApp().GetDocument();
     CSkinAdvanced*     pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     int                showDialog = wxGetApp().GetBOINCMGRDisplayShutdownConnectedClientMessage();
+    int                doShutdownClient = 0;
     CDlgGenericMessage dlg(this);
     wxString           strDialogTitle = wxEmptyString;
     wxString           strDialogMessage = wxEmptyString;
@@ -1347,13 +1348,17 @@ void CAdvancedFrame::OnClientShutdown(wxCommandEvent& WXUNUSED(event)) {
         dlg.m_DialogMessage->SetLabel(strDialogMessage);
         dlg.Fit();
         dlg.Centre();
+
+        if (wxID_OK == dlg.ShowModal()) {
+            wxGetApp().SetBOINCMGRDisplayShutdownConnectedClientMessage(!dlg.m_DialogDisableMessage->GetValue());
+            doShutdownClient = 1;
+        }
     }
 
-    if (!showDialog || wxID_OK == dlg.ShowModal()) {
-        wxGetApp().SetBOINCMGRDisplayShutdownConnectedClientMessage(!dlg.m_DialogDisableMessage->GetValue());
+    if (!showDialog || doShutdownClient) {
         pDoc->CoreClientQuit();
         pDoc->ForceDisconnect();
-        
+
         // Since the core cliet we were connected to just shutdown, prompt for a new one.
         ProcessEvent(evtSelectNewComputer);
     }

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1112,15 +1112,24 @@ void CAdvancedFrame::OnMenuOpening( wxMenuEvent &event) {
         exitItem->Enable(true);
     }
 
-    // Specific menu items to keep enabled always (Switch to simple view and "other options")
+    // Specific menu items to keep enabled always
+    // View->Simple view...
     wxMenuItem* simpleViewItem = menu->FindChildItem(ID_CHANGEGUI, NULL);
     if (simpleViewItem) {
         simpleViewItem->Enable(true);
     }
 
+    // Options->Other options...
     wxMenuItem* otherOptionsItem = menu->FindChildItem(ID_OPTIONS, NULL);
     if (otherOptionsItem) {
         otherOptionsItem->Enable(true);
+    }
+
+    // Specific menu items to enable based on connected client
+    // File->Shutdown connected client...
+    wxMenuItem* shutClientItem = menu->FindChildItem(ID_SHUTDOWNCORECLIENT, NULL);
+    if (shutClientItem) {
+        shutClientItem->Enable(isConnected);
     }
     
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnMenuOpening - Function End"));
@@ -1359,7 +1368,7 @@ void CAdvancedFrame::OnClientShutdown(wxCommandEvent& WXUNUSED(event)) {
         pDoc->CoreClientQuit();
         pDoc->ForceDisconnect();
 
-        // Since the core cliet we were connected to just shutdown, prompt for a new one.
+        // Since the core client we were connected to just shutdown, prompt for a new one.
         ProcessEvent(evtSelectNewComputer);
     }
 


### PR DESCRIPTION
Fixes #3933

**Description of the Change**

The "shutdown connected client" modal will not show ever again if you check the "do not show this dialog again" box provided.

This fix only fixes the non-persistence issue and does not allow the user to make the modal appear once again and hence reverse their check of the box.

**Alternate Designs**

For future changes, people may want to be able to re-enable the modal and a setting being placed in the options was considered but not followed through.

**Release Notes**

The shutdown client dialog will no longer appear after checking the "don't show this dialog again" checkbox
