### PR TITLE
Manager: change  "Show graphics" button to "Stop graphics" when gfx running

### DIFF
--- a/client/app.h
+++ b/client/app.h
@@ -182,11 +182,6 @@ struct ACTIVE_TASK {
         return _task_state;
     }
 
-#if (defined (__APPLE__) && (defined(__i386__) || defined(__x86_64__)))
-    // PowerPC apps emulated on i386 Macs crash if running graphics
-    int powerpc_emulated_on_i386;
-    int is_native_i386_app(char*);
-#endif
     int request_reread_prefs();
     int request_reread_app_info();
     int link_user_files();

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -16,7 +16,14 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifdef __APPLE__
-#include <Carbon/Carbon.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <mach-o/loader.h>
+#include <mach-o/fat.h>
+#include <mach/machine.h>
+#include <libkern/OSByteOrder.h>
+
+extern int compareOSVersionTo(int toMajor, int toMinor);
 #endif
 
 #ifdef _WIN32
@@ -1319,6 +1326,9 @@ int CLIENT_STATE::link_app_version(PROJECT* p, APP_VERSION* avp) {
             char relpath[MAXPATHLEN], path[MAXPATHLEN];
             get_pathname(fip, relpath, sizeof(relpath));
             relative_to_absolute(relpath, path);
+#ifdef __APPLE__
+            if (!can_run_on_this_CPU(path)) continue;
+#endif
             safe_strcpy(avp->graphics_exec_path, path);
             safe_strcpy(avp->graphics_exec_file, fip->name);
         }
@@ -2358,3 +2368,125 @@ bool CLIENT_STATE::abort_sequence_done() {
 }
 
 #endif
+
+#ifdef __APPLE__
+
+union headeru {
+    fat_header fat;
+    mach_header mach;
+};
+// Get the architecture of this computer's CPU: x86_64 or arm64.
+// Read the executable file's mach-o headers to determine the 
+// architecture(s) of its code.
+// Returns 1 if application can run natively on this computer,
+// else returns 0.
+//
+// ToDo: determine whether x86_64 graphics apps emulated on arm64 Macs 
+// properly run under Rosetta 2. Note: years ago, PowerPC apps emulated 
+// by Rosetta on i386 Macs crashed when running graphics.
+//
+
+int CLIENT_STATE::can_run_on_this_CPU(char* exec_path) {
+    FILE *f;
+    int retval = 0;
+    
+    headeru myHeader;
+    fat_arch fatHeader;
+    
+    static bool x86_64_CPU = false;
+    static bool arm64_cpu = false;
+    static bool need_CPU_architecture = true;
+    uint32_t n, i, len;
+    uint32_t theMagic;
+    integer_t file_architecture;
+    
+    if (need_CPU_architecture) {
+        // Determine the architecture of the CPU we are running on
+        // ToDo: adjust this code accordingly.
+        uint32_t cputype = 0;
+        size_t size = sizeof (cputype);
+        int res = sysctlbyname ("hw.cputype", &cputype, &size, NULL, 0);
+        if (res) return false;  // Should never happen
+        // Since we require MacOS >= 10.7, the CPU must be x86_64 or arm64 
+        x86_64_CPU = ((cputype &0xff) == CPU_TYPE_X86);
+        arm64_cpu = ((cputype &0xff) == CPU_TYPE_ARM);
+
+        need_CPU_architecture = false;
+    }
+    
+    f = boinc_fopen(exec_path, "rb");
+    if (!f) {
+        return retval;          // Should never happen
+    }
+    
+    myHeader.fat.magic = 0;
+    myHeader.fat.nfat_arch = 0;
+    
+    fread(&myHeader, 1, sizeof(fat_header), f);
+    theMagic = myHeader.mach.magic;
+    switch (theMagic) {
+    case MH_CIGAM:
+    case MH_MAGIC:
+    case MH_MAGIC_64:
+    case MH_CIGAM_64:
+       file_architecture = myHeader.mach.cputype;
+        if ((theMagic == MH_CIGAM) || (theMagic == MH_CIGAM_64)) {
+            file_architecture = OSSwapInt32(file_architecture);
+        }
+        if (x86_64_CPU && (file_architecture == CPU_TYPE_I386)) {
+            // Single-architecture i386 file on x86_64 CPU
+            if (compareOSVersionTo(10, 15) < 0) {   // OS >= 10.15 are 64-bit only
+                retval = 1;
+            }
+        } else
+        if (x86_64_CPU && (file_architecture == CPU_TYPE_X86_64)) {
+            retval = 1; // Single-architecture x86_64 file on x86_64 CPU
+        } else
+        if (arm64_cpu && (file_architecture == CPU_TYPE_ARM64)) {
+            retval = 1; // Single-architecture arm64 file on arm64 CPU
+        } else
+        if (arm64_cpu && (file_architecture == CPU_TYPE_X86_64)) {
+            retval = 1; // Single-architecture x86_64 file emulated on arm64 CPU
+            // ToDo: determine whether emulated graphics apps work properly
+        }
+        break;
+    case FAT_MAGIC:
+    case FAT_CIGAM:
+        n = myHeader.fat.nfat_arch;
+        if (theMagic == FAT_CIGAM) {
+            n = OSSwapInt32(myHeader.fat.nfat_arch);
+        }
+           // Multiple architecture (fat) file
+        for (i=0; i<n; i++) {
+            len = fread(&fatHeader, 1, sizeof(fat_arch), f);
+            if (len < sizeof(fat_arch)) {
+                break;          // Should never happen
+            }
+            file_architecture = fatHeader.cputype;
+            if (theMagic == FAT_CIGAM) {
+                file_architecture = OSSwapInt32(file_architecture);
+            }
+
+            if (x86_64_CPU && (file_architecture == CPU_TYPE_X86_64)) {
+                retval = 1; // file with x86_64 architecture on x86_64 CPU
+                            break;
+            } else
+            if (arm64_cpu && (file_architecture == CPU_TYPE_ARM64)) {
+                retval = 1; // file with arm64 architecture on arm64 CPU
+                break;
+            } else
+            if (arm64_cpu && (file_architecture == CPU_TYPE_X86_64)) {
+                retval = 1; // file with x86_64 architecture emulated on arm64 CPU
+                // ToDo: determine whether emulated graphics apps work properly
+            }
+        }
+        break;
+    default:
+        break;
+    }
+
+    fclose (f);
+    return retval;
+}
+#endif
+

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -296,6 +296,10 @@ struct CLIENT_STATE {
     void clear_absolute_times();
     void set_now();
     void log_show_projects();
+#ifdef __APPLE__
+    // Check whether the app can run on this CPU architecture
+    int can_run_on_this_CPU(char* exec_path);
+#endif
 
 // --------------- cpu_sched.cpp:
     double total_resource_share();

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -242,6 +242,12 @@ public:
     int                         ProjectReset(int iIndex);
     int                         ProjectSuspend(int iIndex);
     int                         ProjectResume(int iIndex);
+    RUNNING_GFX_APP*            GetRunningGraphicsApp(RESULT* result);
+#ifdef _WIN32
+    void                        KillGraphicsApp(HANDLE pid);
+#else
+    void                        KillGraphicsApp(int tpid);
+#endif
 
     //
     // Work Tab
@@ -252,14 +258,8 @@ private:
     double                      m_fResultsRPCExecutionTime;
     wxDateTime                  m_dtKillInactiveGfxTimestamp;
     std::vector<RUNNING_GFX_APP> m_running_gfx_apps;
-    RUNNING_GFX_APP*            GetRunningGraphicsApp(RESULT* result, int slot);
     void                        KillAllRunningGraphicsApps();
     void                        KillInactiveGraphicsApps();
-#ifdef _WIN32
-    void                        KillGraphicsApp(HANDLE pid);
-#else
-    void                        KillGraphicsApp(int tpid);
-#endif
 
 public:
     RESULTS                     results;

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -807,6 +807,8 @@ void CViewWork::UpdateSelection() {
     std::string         first_project_url;
     wxString            strMachineName;
     bool                wasSuspended=false;
+    bool                wasGfxRunning = false;
+    bool                isGFXRunning = false;
     bool                all_same_project=false;
     bool                enableShowGraphics = false;
     bool                enableShowVMConsole = false;
@@ -879,11 +881,35 @@ void CViewWork::UpdateSelection() {
                     _("Suspend work for this task.")
                 );
             }
+            wasGfxRunning = (pDoc->GetRunningGraphicsApp(result) != NULL);
+            isGFXRunning = wasGfxRunning;
+            if (wasGfxRunning) {
+                m_pTaskPane->UpdateTask(
+                    pGroup->m_Tasks[BTN_GRAPHICS],
+                    _("Stop graphics"),
+                    _("Close application graphics window.")
+                );
+                // Graphics might still be running even if task is suspended
+                enableShowGraphics = true;
+            } else {
+                m_pTaskPane->UpdateTask(
+                    pGroup->m_Tasks[BTN_GRAPHICS],
+                    _("Show graphics"),
+                    _("Show application graphics in a window.")
+                );
+            }
         } else {
+            isGFXRunning = (pDoc->GetRunningGraphicsApp(result) != NULL);
+
             if (wasSuspended != result->suspended_via_gui) {
                 // Disable Suspend / Resume button if the multiple selection
                 // has a mix of suspended and not suspended tasks
                 enableSuspendResume = false;
+            }
+            if (wasGfxRunning != isGFXRunning) {
+                // Disable Show / Stop Graphics button if the multiple selection
+                // has a mix of running and not running graphics apps
+                enableShowGraphics = false;
             }
         }
         
@@ -904,7 +930,9 @@ void CViewWork::UpdateSelection() {
             result->project_suspended_via_gui || 
             (result->scheduler_state != CPU_SCHED_SCHEDULED)
         ) {
-            enableShowGraphics = false;
+            if (!isGFXRunning) {
+                enableShowGraphics = false;
+            }
         }
        
         // Disable Abort button if any selected task already aborted

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -486,7 +486,9 @@ void CSimpleFrame::OnMenuOpening( wxMenuEvent &event) {
             item->Enable(true);
         } else {
             // Disable other menu items if not connected to client
-            item->Enable(isConnected);
+            if (!isConnected) {
+                item->Enable(false);
+            }
         }
     }
     

--- a/clientgui/sg_TaskCommandPopup.cpp
+++ b/clientgui/sg_TaskCommandPopup.cpp
@@ -145,6 +145,17 @@ void CSimpleTaskPopupButton::ShowTaskCommandsMenu(wxPoint pos) {
         enableShowGraphics = false;
     }
     
+    if (pDoc->GetRunningGraphicsApp(result) != NULL) {
+        m_ShowGraphicsMenuItem->SetItemLabel(_("Stop graphics"));
+        m_ShowGraphicsMenuItem->SetHelp(_("Close application graphics window."));
+        // Graphics might still be running even if task is suspended
+        enableShowGraphics = true;
+        
+    } else {
+        m_ShowGraphicsMenuItem->SetItemLabel(_("Show graphics"));
+        m_ShowGraphicsMenuItem->SetHelp(_("Show application graphics in a window."));
+    }
+
     m_ShowGraphicsMenuItem->Enable(enableShowGraphics);
    
     // Disable Abort button if any selected task already aborted


### PR DESCRIPTION
This is an important feature in preparation for the imminent release of MacOS 11 Big Sur, and complements PR #3964 by providing another workaround. As explained in that PR:
> When a user presses the Show graphics button in the _BOINC Manager_, the project graphics application is run for the selected task. On the Macintosh, the graphics app runs as a free standing process, without a functioning menu bar, so the usual way to shut it is to use the red close button at the top left corner of the application's window. But under MacOS 11 Big Sur, that button is disabled.

Until projects relink their graphics apps with the new code from #3964, when a user clicks the _Show graphics_ button, the only way to stop the graphics app will be by a control-click (or right-click) on the graphics app's icon in the Dock and selecting `Quit`, which is not obvious,

This PR adds a more convenient and clearer alternative. The _Show graphics_ button label changes to _Stop graphics_ while the graphics app is running. Clicking on it stops the graphics app. This is a useful addition to the GUI even when the close button / close box is available.

This PR also fixes a related issue. Some projects have not provided a 64 bit (_x86_64_) Macintosh graphics application. They only have a 32 bit (_i686_) version, which cannot run on Macs with MacOS 10.15 or later. So nothing happens when the user clicks on the _Show graphics_ button. This PR adds code which checks each graphics app to determine whether it's architecture is compatible with the CPU hardware and OS version, and disables the _Show graphics_ button for incompatible graphics apps.

Because Apple has announced it will release _Apple Silicon_ (_arm64_) Macs very soon, this code also adds compatibility checks for _x86_64_ and _arm64_ graphics apps on _x86_64_ and _arm64_ CPUs.