### PR TITLE
Manager: Add option to restore 'shutdown client' confirmation.

### DIFF
--- a/clientgui/DlgOptions.cpp
+++ b/clientgui/DlgOptions.cpp
@@ -101,6 +101,7 @@ bool CDlgOptions::Create(wxWindow* parent, wxWindowID id, const wxString& captio
     m_EnableBOINCManagerAutoStartCtrl = NULL;
     m_EnableRunDaemonCtrl = NULL;
     m_EnableBOINCManagerExitMessageCtrl = NULL;
+    m_EnableBOINCClientShutdownMessageCtrl = NULL;
     m_DialupStaticBoxCtrl = NULL;
 #if defined(__WXMSW__)
     m_DialupConnectionsCtrl = NULL;
@@ -228,6 +229,16 @@ void CDlgOptions::CreateControls() {
     if (ShowToolTips())
         m_EnableBOINCManagerExitMessageCtrl->SetToolTip(_("Display the exit dialog when shutting down the Manager."));
     itemFlexGridSizer6->Add(m_EnableBOINCManagerExitMessageCtrl, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+
+    wxStaticText* itemStaticText13 = new wxStaticText;
+    itemStaticText13->Create( itemPanel4, wxID_STATIC, _("Enable Client shutdown dialog?"), wxDefaultPosition, wxDefaultSize, 0 );
+    itemFlexGridSizer6->Add(itemStaticText13, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
+
+    m_EnableBOINCClientShutdownMessageCtrl = new wxCheckBox;
+    m_EnableBOINCClientShutdownMessageCtrl->Create( itemPanel4, ID_ENABLESHUTDOWNMESSAGE, wxT(""), wxDefaultPosition, wxDefaultSize, wxCHK_2STATE);
+    if (ShowToolTips())
+        m_EnableBOINCClientShutdownMessageCtrl->SetToolTip(_("Display confirmation dialog when shutting down the connected client."));
+    itemFlexGridSizer6->Add(m_EnableBOINCClientShutdownMessageCtrl, 0, wxALIGN_LEFT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     itemNotebook3->AddPage(itemPanel4, _("General"));
 
@@ -628,6 +639,7 @@ bool CDlgOptions::ReadSettings() {
     //m_ReminderFrequencyCtrl->SetValue(m_iReminderFrequency);
 
     m_EnableBOINCManagerExitMessageCtrl->SetValue(wxGetApp().GetBOINCMGRDisplayExitMessage() != 0);
+    m_EnableBOINCClientShutdownMessageCtrl->SetValue(wxGetApp().GetBOINCMGRDisplayShutdownConnectedClientMessage() != 0);
 #ifdef __WXMSW__
     m_EnableBOINCManagerAutoStartCtrl->SetValue(!wxGetApp().GetBOINCMGRDisableAutoStart());
 
@@ -743,6 +755,7 @@ bool CDlgOptions::SaveSettings() {
     }
 
     wxGetApp().SetBOINCMGRDisplayExitMessage(m_EnableBOINCManagerExitMessageCtrl->GetValue());
+    wxGetApp().SetBOINCMGRDisplayShutdownConnectedClientMessage(m_EnableBOINCClientShutdownMessageCtrl->GetValue());
 #ifdef __WXMSW__
     wxGetApp().SetBOINCMGRDisableAutoStart(!m_EnableBOINCManagerAutoStartCtrl->GetValue());
 

--- a/clientgui/DlgOptions.h
+++ b/clientgui/DlgOptions.h
@@ -56,6 +56,7 @@
 #define ID_ENABLEAUTOSTART 10031
 #define ID_ENABLEEXITMESSAGE 10032
 #define ID_ENABLERUNDAEMON 10033
+#define ID_ENABLESHUTDOWNMESSAGE 10034
 #define ID_CONNECTONS 10019
 #define ID_NETWORKAUTODETECT 10020
 #define ID_NETWORKLAN 10021
@@ -167,6 +168,7 @@ private:
     wxComboBox* m_ReminderFrequencyCtrl;
     wxCheckBox* m_EnableBOINCManagerAutoStartCtrl;
     wxCheckBox* m_EnableBOINCManagerExitMessageCtrl;
+    wxCheckBox* m_EnableBOINCClientShutdownMessageCtrl;
     wxCheckBox* m_EnableRunDaemonCtrl;
     wxStaticBoxSizer* m_DialupStaticBoxCtrl;
     wxListBox* m_DialupConnectionsCtrl;


### PR DESCRIPTION
Fixes #3968

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
Adds an additional checkbox to the 'Other options' dialog, to restore display of the 'Shut down connected client' confirmation dialog.

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
Added option to restore display of 'shutdown client' confirmation.

**Testing status**
Built and tested locally in Windows VS2013/x64
Will test again, plus Linux version, from CI versions.

**Other notes**
Linux repo managers who remove the 'Shutdown connected client' menu item may wish to remove this control as well.