### PR TITLE
Update switcher.cpp to include mac_spawn only if the system is APPLE

### DIFF
--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -34,7 +34,9 @@
 #include "app_ipc.h"
 #include "filesys.h"
 #include "str_replace.h"
+#ifdef __APPLE__
 #include "mac_spawn.h"
+#endif
 
 using std::strcpy;
 


### PR DESCRIPTION
this fixes a build failure on Linux/Debian systems where mac/* directory is stripped from the source tarball.

