### PR TITLE
client and wrapper: fix process priority mismatch

### DIFF
--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -287,6 +287,9 @@ void ACTIVE_TASK::init_app_init_data(APP_INIT_DATA& aid) {
         FILE_REF& fref = avp->app_files[i];
         aid.app_files.push_back(string(fref.file_name));
     }
+    aid.no_priority_change = cc_config.no_priority_change;
+    aid.process_priority = cc_config.process_priority;
+    aid.process_priority_special = cc_config.process_priority_special;
 }
 
 // write the app init file.
@@ -509,22 +512,22 @@ static int get_priority(bool is_high_priority) {
     int p = is_high_priority?cc_config.process_priority_special:cc_config.process_priority;
 #ifdef _WIN32
     switch (p) {
-    case 0: return IDLE_PRIORITY_CLASS;
-    case 1: return BELOW_NORMAL_PRIORITY_CLASS;
-    case 2: return NORMAL_PRIORITY_CLASS;
-    case 3: return ABOVE_NORMAL_PRIORITY_CLASS;
-    case 4: return HIGH_PRIORITY_CLASS;
-    case 5: return REALTIME_PRIORITY_CLASS;
+    case CONFIG_PRIORITY_LOWEST: return IDLE_PRIORITY_CLASS;
+    case CONFIG_PRIORITY_LOW: return BELOW_NORMAL_PRIORITY_CLASS;
+    case CONFIG_PRIORITY_NORMAL: return NORMAL_PRIORITY_CLASS;
+    case CONFIG_PRIORITY_HIGH: return ABOVE_NORMAL_PRIORITY_CLASS;
+    case CONFIG_PRIORITY_HIGHEST: return HIGH_PRIORITY_CLASS;
+    case CONFIG_PRIORITY_REALTIME: return REALTIME_PRIORITY_CLASS;
     }
     return is_high_priority ? BELOW_NORMAL_PRIORITY_CLASS : IDLE_PRIORITY_CLASS;
 #else
     switch (p) {
-    case 0: return PROCESS_IDLE_PRIORITY;
-    case 1: return PROCESS_MEDIUM_PRIORITY;
-    case 2: return PROCESS_NORMAL_PRIORITY;
-    case 3: return PROCESS_ABOVE_NORMAL_PRIORITY;
-    case 4: return PROCESS_HIGH_PRIORITY;
-    case 5: return PROCESS_REALTIME_PRIORITY;
+    case CONFIG_PRIORITY_LOWEST: return PROCESS_IDLE_PRIORITY;
+    case CONFIG_PRIORITY_LOW: return PROCESS_MEDIUM_PRIORITY;
+    case CONFIG_PRIORITY_NORMAL: return PROCESS_NORMAL_PRIORITY;
+    case CONFIG_PRIORITY_HIGH: return PROCESS_ABOVE_NORMAL_PRIORITY;
+    case CONFIG_PRIORITY_HIGHEST: return PROCESS_HIGH_PRIORITY;
+    case CONFIG_PRIORITY_REALTIME: return PROCESS_REALTIME_PRIORITY;
     }
     return is_high_priority ? PROCESS_MEDIUM_PRIORITY : PROCESS_IDLE_PRIORITY;
 #endif

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -241,8 +241,8 @@ void CC_CONFIG::defaults() {
     no_opencl = false;
     no_priority_change = false;
     os_random_only = false;
-    process_priority = -1;
-    process_priority_special = -1;
+    process_priority = CONFIG_PRIORITY_UNSPECIFIED;
+    process_priority_special = CONFIG_PRIORITY_UNSPECIFIED;
     proxy_info.clear();
     rec_half_life = 10*86400;
 #ifdef ANDROID

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -186,7 +186,7 @@ struct CC_CONFIG {
     bool no_opencl;
     bool no_priority_change;
     bool os_random_only;
-    int process_priority;
+    int process_priority;       // values in common_defs.h
     int process_priority_special;
     PROXY_INFO proxy_info;
     double rec_half_life;

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -79,6 +79,8 @@
 #define NGRAPHICS_MSGS  7
 
 // process priorities
+// Unfortunately different areas of code use two different numbering schemes.
+// The following is used in wrapper job.xml files
 //
 #define PROCESS_PRIORITY_UNSPECIFIED    0
 #define PROCESS_PRIORITY_LOWEST     1
@@ -91,6 +93,17 @@
     // win: ABOVE_NORMAL; unix: -10
 #define PROCESS_PRIORITY_HIGHEST    5
     // win: HIGH; unix: -16
+
+// The following is used in cc_config.xml,
+// and passed to apps in the APP_INIT_DATA structure
+//
+#define CONFIG_PRIORITY_UNSPECIFIED -1
+#define CONFIG_PRIORITY_LOWEST      0
+#define CONFIG_PRIORITY_LOW         1
+#define CONFIG_PRIORITY_NORMAL      2
+#define CONFIG_PRIORITY_HIGH        3
+#define CONFIG_PRIORITY_HIGHEST     4
+#define CONFIG_PRIORITY_REALTIME    5
 
 // priorities for client messages
 //

--- a/lib/proc_control.cpp
+++ b/lib/proc_control.cpp
@@ -287,11 +287,11 @@ int process_priority_value(int priority) {
     return 0;
 #else
     switch (priority) {
-    case PROCESS_PRIORITY_LOWEST: return 19;
-    case PROCESS_PRIORITY_LOW: return 10;
-    case PROCESS_PRIORITY_NORMAL: return 0;
-    case PROCESS_PRIORITY_HIGH: return -10;
-    case PROCESS_PRIORITY_HIGHEST: return -16;
+    case PROCESS_PRIORITY_LOWEST: return PROCESS_IDLE_PRIORITY;
+    case PROCESS_PRIORITY_LOW: return PROCESS_MEDIUM_PRIORITY;
+    case PROCESS_PRIORITY_NORMAL: return PROCESS_NORMAL_PRIORITY;
+    case PROCESS_PRIORITY_HIGH: return PROCESS_ABOVE_NORMAL_PRIORITY;
+    case PROCESS_PRIORITY_HIGHEST: return PROCESS_HIGH_PRIORITY;
     }
     return 0;
 #endif

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -747,7 +747,10 @@ int TASK::run(int argct, char** argvt) {
         priority_val = 0;
     } else {
         if (aid.process_priority > 0) {
-            priority_val = process_priority_value(aid.process_priority);
+            // priority coming from the client is on scale where 0 is idle.
+            // for us, 1 is idle
+            //
+            priority_val = process_priority_value(aid.process_priority+1);
         } else {
             priority_val = process_priority_value(priority);
         }


### PR DESCRIPTION
It turns out we have two different encodings of process priority:
1) specified in cc_config.xml and used by the client: 0 (low) to 4 (high)
2) specified in job.xml and used by the wrapper: 1 (low) to 5 (high).

This didn't cause any problems until recently when I added code
to pass the cc_config.xml info to the wrapper;
it was interpreting it on the 1-5 scale.

Fix: have the wrapper convert it (add one).

Also: I forgot to have the client actually put the priority into
in the app_init_data.xml file.