### PR TITLE
[Android] Fix onNewIntent() warning in the event log.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.kt
@@ -142,9 +142,8 @@ class BOINCActivity : AppCompatActivity() {
         if (targetFragId < 0 && savedInstanceState != null) {
             targetFragId = savedInstanceState.getInt("navBarSelectionId")
         }
-        val item: NavDrawerItem?
-        item = if (targetFragId < 0) {
-            // if non of the above, go to default
+        val item: NavDrawerItem? = if (targetFragId < 0) {
+            // if none of the above, go to default
             mDrawerListAdapter.getItem(0)
         } else {
             mDrawerListAdapter.getItemForId(targetFragId)
@@ -185,12 +184,13 @@ class BOINCActivity : AppCompatActivity() {
         if (Logging.DEBUG) {
             Log.d(Logging.TAG, "BOINCActivity onNewIntent() for target fragment: $id")
         }
-        val item = mDrawerListAdapter.getItemForId(id)
-        if (item != null) {
-            dispatchNavBarOnClick(item, false)
-        } else if (Logging.WARNING) {
-            Log.w(Logging.TAG, "onNewIntent: requested target fragment is null, for id: $id")
+        val item: NavDrawerItem? = if (id < 0) {
+            // if ID is -1, go to default
+            mDrawerListAdapter.getItem(0)
+        } else {
+            mDrawerListAdapter.getItemForId(id)
         }
+        dispatchNavBarOnClick(item, false)
     }
 
     override fun onResume() { // gets called by system every time activity comes to front. after onCreate upon first creation

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -29,6 +29,7 @@ import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
 import org.apache.commons.lang3.StringUtils;
@@ -87,6 +88,7 @@ public class NavDrawerListAdapter extends BaseAdapter {
         return navDrawerItems.get(position).id;
     }
 
+    @Nullable
     public NavDrawerItem getItemForId(int id) {
         for(NavDrawerItem item : navDrawerItems) {
             if(item.id == id) {


### PR DESCRIPTION
**Description of the Change**
Add a check to ensure that the first navigation bar item is retrieved if the target fragment ID is -1.

**Release Notes**
The `onNewIntent` warning in the event log should no longer appear.