### PR TITLE
[Android] Create separate notification channel for notices.

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCApplication.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCApplication.kt
@@ -18,6 +18,9 @@
  */
 package edu.berkeley.boinc
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
 import androidx.multidex.MultiDexApplication
 import androidx.preference.PreferenceManager
 import edu.berkeley.boinc.di.AppComponent
@@ -30,6 +33,23 @@ open class BOINCApplication : MultiDexApplication() {
 
         val sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
         setAppTheme(sharedPreferences.getString("theme", "light")!!)
+
+        // Create notification channels for use on API 26 and higher.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationManager = getSystemService(NotificationManager::class.java)
+
+            // Create main notification channel.
+            val mainChannelName = getString(R.string.main_notification_channel_name)
+            val mainChannel = NotificationChannel("main-channel", mainChannelName, NotificationManager.IMPORTANCE_HIGH)
+            mainChannel.description = getString(R.string.main_notification_channel_description)
+            notificationManager.createNotificationChannel(mainChannel)
+
+            // Create notice notification channel.
+            val noticeChannelName = getString(R.string.notice_notification_channel_name)
+            val noticeChannel = NotificationChannel("notice-channel", noticeChannelName, NotificationManager.IMPORTANCE_HIGH)
+            noticeChannel.description = getString(R.string.notice_notification_channel_description)
+            notificationManager.createNotificationChannel(noticeChannel)
+        }
     }
 
     val appComponent: AppComponent by lazy {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/SplashActivity.java
@@ -19,8 +19,6 @@
 package edu.berkeley.boinc;
 
 import android.app.ActivityManager;
-import android.app.NotificationChannel;
-import android.app.NotificationManager;
 import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -138,18 +136,6 @@ public class SplashActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         binding = ActivitySplashBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-
-        // Create notification channel for use on API 26 and higher.
-        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            final String name = getString(R.string.main_notification_channel_name);
-
-            final NotificationChannel notificationChannel =
-                    new NotificationChannel("main-channel", name,
-                                            NotificationManager.IMPORTANCE_HIGH);
-            notificationChannel.setDescription(getString(R.string.main_notification_channel_description));
-
-            getSystemService(NotificationManager.class).createNotificationChannel(notificationChannel);
-        }
 
         // Use BOINC logo in Recent Apps Switcher
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) { // API 21

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/NoticeNotification.java
@@ -137,7 +137,7 @@ public class NoticeNotification {
             final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(notice.getLink()));
             final PendingIntent browserIntent = PendingIntent.getActivity(context, 0, intent, 0);
 
-            final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, "main-channel")
+            final NotificationCompat.Builder builder = new NotificationCompat.Builder(context, "notice-channel")
                     .setAutoCancel(true)
                     .setContentIntent(browserIntent)
                     .setContentTitle(notice.getProjectName() + ": " + notice.getTitle())
@@ -161,7 +161,7 @@ public class NoticeNotification {
         final int smallIcon = Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ?
                               R.mipmap.ic_boinc_notice_white : R.drawable.ic_boinc_notice;
         // build new notification from scratch every time a notice arrives
-        final NotificationCompat.Builder nb = new NotificationCompat.Builder(context, "main-channel")
+        final NotificationCompat.Builder nb = new NotificationCompat.Builder(context, "notice-channel")
                 .setContentTitle(context.getResources().getQuantityString(R.plurals.notice_notification,
                                                                           notices, projectName, notices))
                 .setSmallIcon(smallIcon)

--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -299,6 +299,8 @@
     <string name="social_invite_content_url_amazon">http://www.amazon.com/gp/mas/dl/android?p=edu.berkeley.boinc
     </string>
     <!-- Main notification channel (notices) -->
-    <string name="main_notification_channel_name">Notices</string>
-    <string name="main_notification_channel_description">Displays notices from your projects.</string>
+    <string name="main_notification_channel_name">BOINC</string>
+    <string name="main_notification_channel_description">Displays non-notice notifications.</string>
+    <string name="notice_notification_channel_name">Notices</string>
+    <string name="notice_notification_channel_description">Displays notices from your projects.</string>
 </resources>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -342,7 +342,9 @@
     <string name="social_invite_content_url_amazon">http://www.amazon.com/gp/mas/dl/android?p=edu.berkeley.boinc
     </string>
 
-    <!-- Main notification channel (notices) -->
-    <string name="main_notification_channel_name">Notices</string>
-    <string name="main_notification_channel_description">Displays notices from your projects.</string>
+    <!-- Notification channels -->
+    <string name="main_notification_channel_name">BOINC</string>
+    <string name="main_notification_channel_description">Displays non-notice notifications.</string>
+    <string name="notice_notification_channel_name">Notices</string>
+    <string name="notice_notification_channel_description">Displays notices from your projects.</string>
 </resources>


### PR DESCRIPTION
**Description of the Change**
Create a separate notification channel for notices, so that users can choose to disable notice notifications if they wish.

**Release Notes**
Notice notifications can now be disabled separately on Android Oreo and higher.

**Screenshots**
![Screenshot_20200830-091852828](https://user-images.githubusercontent.com/31027858/91651156-c93e5e80-eaa6-11ea-90bd-8e0c06935c8d.jpg)
![Screenshot_20200830-091903097](https://user-images.githubusercontent.com/31027858/91651157-cc394f00-eaa6-11ea-8ca9-7b4eabafbb7b.jpg)
![Screenshot_20200830-091911223](https://user-images.githubusercontent.com/31027858/91651159-cf343f80-eaa6-11ea-8357-232b364b4b51.jpg)
