### PR TITLE
Add a project-customizable hook to result pages

### DIFF
--- a/html/inc/result.inc
+++ b/html/inc/result.inc
@@ -731,6 +731,9 @@ function show_result($result, $show_outfile_links=false) {
         }
         row2(tra("Output files"), $x);
     }
+    if (function_exists('project_result')) {
+        project_result($result);
+    }
     end_table();
     echo "<h3>".tra("Stderr output")."</h3> <pre>"
         .htmlspecialchars(


### PR DESCRIPTION
**Description of the Change**
Workunit pages already have a hook to display project-specific data for a workunit, but result pages lack such functionality. This change adds a similar hook to the result pages.

**Release Notes**
Add a hook to easily specify project-specific information in the result pages.