### PR TITLE
client/scheduler: update NVidia detection again

### DIFF
--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -565,9 +565,20 @@ void COPROC_NVIDIA::set_peak_flops() {
             }
             break;
         case 7:    // for both cc7.0 (Titan V, Tesla V100) and cc7.5 (RTX, Tesla T4)
-        default:
             flops_per_clock = 2;
             cores_per_proc = 64;
+            break;
+        case 8:    // for cc8.0 (A100) and cc8.6 (GeForce RTX 30x0 - GA102 and above)
+        default:
+            flops_per_clock = 2;
+            switch (minor) {
+            case 0:    // special for A100 Tensor Core datacenter GPU
+                cores_per_proc = 64;
+                break;
+            default:
+                cores_per_proc = 128;
+                break;
+            }
             break;
         }
 


### PR DESCRIPTION
for new RTX 30x0 range released September 2020

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
GFLOPS peak is under-reported by a factor of 2 on the new cards, compared with other reporting tools

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->
I've been asked if we could use NvAPI_GPU_GetGpuCoreCount() instead  (available since 2014), but rejected as a more complex modification which might break backwards compatibility.

**Release Notes**
Correct detection of NVidia RTX30x0 range GPUs