### PR TITLE
Avoid using boinc_db global.

### DIFF
--- a/sched/credit.cpp
+++ b/sched/credit.cpp
@@ -1106,7 +1106,7 @@ int write_modified_app_versions(vector<DB_APP_VERSION_VAL>& app_versions) {
             if (retval) {
                 break;
             }
-            if (boinc_db.affected_rows() == 1) {
+            if (av.db->affected_rows() == 1) {
                 break;
             }
             retval = av.lookup_id(av.id);

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -385,7 +385,7 @@ int create_work2(
             );
             return retval;
         }
-        wu.id = boinc_db.insert_id();
+        wu.id = wu.db->insert_id();
     }
 
     return 0;


### PR DESCRIPTION
Fixes #4032 (maybe)

**Description of the Change**
Use db pointer from DAL to invoke db operation instead of accessing global var.