### PR TITLE
Make file_upload_handler stop early when low disk space

### DIFF
--- a/sched/file_upload_handler.cpp
+++ b/sched/file_upload_handler.cpp
@@ -59,6 +59,8 @@ using std::string;
 #define ERR_TRANSIENT   true
 #define ERR_PERMANENT   false
 
+#define FUH_MIN_FREE_SPACE 1e9
+
 char this_filename[256];
 string variety = "";
 double start_time();
@@ -462,7 +464,7 @@ bool volume_full(char* path) {
     double total, avail;
     int retval = get_filesystem_info(total, avail, path);
     if (retval) return false;
-    if (avail<1e6) {
+    if (avail < FUH_MIN_FREE_SPACE) {
         return true;
     }
     return false;


### PR DESCRIPTION
**Description of the Change**
Currently file_upload_handler stops accepting new uploads when there is less than 1MB free disk space. That is too late as multiple concurrent writes can hit the disk limits, so increasing this limit to 1GB and making it configurable instead of using a hardcoded constant.

**Alternate Designs**
Could also read from config file, but this would entail more disk accesses where they aren't really needed.

**Release Notes**
Make file_upload_handler stop accepting uploads early when low disk space