### PR TITLE
[Android] Remove old sched method in client

### DIFF
--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -1078,18 +1078,6 @@ int ACTIVE_TASK::start(bool test) {
                 perror("setpriority");
             }
 #endif
-#ifdef ANDROID
-            // Android has its own notion of background scheduling
-            if (!high_priority) {
-                FILE* f = fopen("/dev/cpuctl/apps/bg_non_interactive/tasks", "w");
-                if (!f) {
-                    msg_printf(NULL, MSG_INFO, "Can't open /dev/cpuctl/apps/bg_non_interactive/tasks");
-                } else {
-                    fprintf(f, "%d", getpid());
-                    fclose(f);
-                }
-            }
-#endif
 #if HAVE_SCHED_SETSCHEDULER && defined(SCHED_IDLE) && defined (__linux__)
             if (!high_priority) {
                 struct sched_param sp;


### PR DESCRIPTION
Fix #2549 

**Description of the Change**
Remove old Android scheduling method and use Linux scheduling policies instead

**Alternate Designs**
Newer NDK have `SCHED_IDLE` defined and we should use that instead.

I am also not a fan of directly writing to files instead of using system calls.

Direct access to `/dev/cpuctl` directory is not available Android 10 anyway without root.

`set_sched_policy()` can be used to update this code but its considered legacy, see https://source.android.com/devices/tech/perf/cgroups

This is a cgroup feature used by Android system internally and should not be used by app.
see `PCY` sections:
https://stackoverflow.com/questions/10051152/does-any-one-know-the-top-command-s-results-meaning-in-android
https://stackoverflow.com/questions/32701187/adb-shell-top-shows-my-application-in-foreground-but-actually-its-in-background
https://android.googlesource.com/platform/external/toybox/+/master/toys/posix/ps.c

**Release Notes**
Client: Remove old Android scheduling method