### PR TITLE
[Android] Update Android Gradle plugin to 4.1.

### DIFF
--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0-beta03'
+        classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0'
     }


### PR DESCRIPTION
**Description of the Change**
Update the Android Gradle plugin from 4.1 RC2 to 4.1 stable.

**Release Notes**
N/A
