### PR TITLE
[linux] Install missed "config.h" file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,7 +59,8 @@ if INSTALL_HEADERS
 pkginclude_HEADERS = \
     version.h \
     svn_version.h \
-    project_specific_defines.h
+    project_specific_defines.h \
+    config.h
 endif
 
 # svn_version.h should always be rebuilt.


### PR DESCRIPTION
Default location of includes is $(pkgincludedir) which is $(includedir)/boinc by default.

This fixes #2964

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
