### PR TITLE
Support plan classes with negative host_summary_regex matching

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -290,6 +290,17 @@ bool PLAN_CLASS_SPEC::check(
         }
         return false;
     }
+    if (have_host_summary_regex_negative
+        && (regexec(&(host_summary_regex_negative), g_reply->host.serialnum, 0, NULL, 0) == 0)
+    ) {
+        if (config.debug_version_select) {
+            log_messages.printf(MSG_NORMAL,
+                "[version] plan_class_spec: host summary '%s' matched negative regexp\n",
+                g_reply->host.serialnum
+            );
+        }
+        return false;
+    }
 
     // OS version
     //
@@ -1074,6 +1085,14 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
             have_host_summary_regex = true;
             continue;
         }
+        if (xp.parse_str("host_summary_regex_negative", buf, sizeof(buf))) {
+            if (regcomp(&(host_summary_regex_negative), buf, REG_EXTENDED|REG_NOSUB) ) {
+                log_messages.printf(MSG_CRITICAL, "BAD HOST SUMMARY REGEXP (negative): %s\n", buf);
+                return ERR_XML_PARSE;
+            }
+            have_host_summary_regex_negative = true;
+            continue;
+        }
         if (xp.parse_int("user_id", user_id)) continue;
         if (xp.parse_double("infeasible_random", infeasible_random)) continue;
         if (xp.parse_double("min_os_version", min_os_version)) continue;
@@ -1189,6 +1208,7 @@ PLAN_CLASS_SPEC::PLAN_CLASS_SPEC() {
     min_core_client_version = 0;
     max_core_client_version = 0;
     have_host_summary_regex = false;
+    have_host_summary_regex_negative = false;
     user_id = 0;
     infeasible_random = 0;
     min_wu_id=0;

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -60,7 +60,9 @@ struct PLAN_CLASS_SPEC {
     int max_core_client_version;
         // for non-compute-intensive, or override for GPU apps
     bool have_host_summary_regex;
+    bool have_host_summary_regex_negative;
     regex_t host_summary_regex;
+    regex_t host_summary_regex_negative;
     int user_id;
     double infeasible_random;
     long min_wu_id;


### PR DESCRIPTION
**Description of the Change**
Currently host_summary_regex field in the plan class definition only allows to send work to hosts matching a certain spec. This change allows to specify a negative regex to send work to hosts NOT matching the specified regex.

Use case: send work only to hosts without Virtualbox.

**Release Notes**
Support plan classes with negative host_summary_regex matching.
