### PR TITLE
client: allow an empty GUI RPC password, but generate alert message

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -56,7 +56,7 @@ static const char *run_mode_name[] = {"", "always", "auto", "never"};
 int ACCT_MGR_OP::do_rpc(ACCT_MGR_INFO& _ami, bool _via_gui) {
     int retval;
     unsigned int i;
-    char buf[256];
+    char buf[1024];
 
     ami = _ami;
 

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -163,6 +163,30 @@ void acct_mgr_do_rpc(
     }
 }
 
+// Get messages from client, and show any that are USER_ALERT priority.
+// Intended use: show user that GUI RPCs are not password-protected.
+// For now, do this after attach to project or AM
+//
+void show_alerts(RPC_CLIENT &rpc) {
+    MESSAGES messages;
+    int retval = rpc.get_messages(0, messages);
+    if (retval) {
+        fprintf(stderr, "Can't get alerts from client: %s\n",
+            boincerror(retval)
+        );
+        return;
+    }
+    for (unsigned int j=0; j<messages.messages.size(); j++) {
+        MESSAGE& md = *messages.messages[j];
+        if (md.priority != MSG_USER_ALERT) continue;
+        if (!md.project.empty()) continue;
+        strip_whitespace(md.body);
+        fprintf(stderr, "\nAlert from client: %s\n",
+            md.body.c_str()
+        );
+    }
+}
+
 int main(int argc, char** argv) {
     RPC_CLIENT rpc;
     int i, retval, port=0;
@@ -382,6 +406,7 @@ int main(int argc, char** argv) {
         canonicalize_master_url(url, sizeof(url));
         char* auth = next_arg(argc, argv, i);
         retval = rpc.project_attach(url, auth, "");
+        show_alerts(rpc);
     } else if (!strcmp(cmd, "--file_transfer")) {
         FILE_TRANSFER ft;
 
@@ -529,6 +554,7 @@ int main(int argc, char** argv) {
             char* am_name = next_arg(argc, argv, i);
             char* am_passwd = next_arg(argc, argv, i);
             acct_mgr_do_rpc(rpc, am_url, am_name, am_passwd);
+            show_alerts(rpc);
         } else if (!strcmp(op, "info")) {
             ACCT_MGR_INFO ami;
             retval = rpc.acct_mgr_info(ami);

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
     MESSAGES messages;
     NOTICES notices;
     char passwd_buf[256], hostname_buf[256], *hostname=0;
-    char* passwd = passwd_buf, *p, *q;
+    char* passwd=0, *p, *q;
     bool unix_domain = false;
     string msg;
 
@@ -202,12 +202,6 @@ int main(int argc, char** argv) {
 #elif defined(__APPLE__)
     chdir("/Library/Application Support/BOINC Data");
 #endif
-    safe_strcpy(passwd_buf, "");
-    retval = read_gui_rpc_password(passwd_buf, msg);
-    if (retval) {
-        fprintf(stderr, "Can't get RPC password: %s\n", msg.c_str());
-        fprintf(stderr, "Only operations not requiring authorization will be allowed.\n");
-    }
 
 #if defined(_WIN32) && defined(USE_WINSOCK)
     WSADATA wsdata;
@@ -217,6 +211,11 @@ int main(int argc, char** argv) {
         exit(1);
     }
 #endif
+
+    // parse command line.
+    // TODO: do this the right way.
+    // shouldn't require args to be in a particular order.
+
     if (argc < 2) usage();
     i = 1;
     if (!strcmp(argv[i], "--help")) usage();
@@ -268,6 +267,16 @@ int main(int argc, char** argv) {
         i++;
     }
     if (i == argc) usage();
+
+    if (!passwd) {
+        passwd = passwd_buf;
+        safe_strcpy(passwd_buf, "");
+        retval = read_gui_rpc_password(passwd_buf, msg);
+        if (retval) {
+            fprintf(stderr, "Can't get RPC password: %s\n", msg.c_str());
+            fprintf(stderr, "Only operations not requiring authorization will be allowed.\n");
+        }
+    }
 
     // change the following to debug GUI RPC's asynchronous connection mechanism
     //

--- a/client/gui_rpc_server.cpp
+++ b/client/gui_rpc_server.cpp
@@ -120,7 +120,7 @@ bool GUI_RPC_CONN_SET::recent_rpc_needs_network(double interval) {
 }
 
 // read the GUI RPC password from gui_rpc_auth.cfg;
-// create one if missing or empty.
+// create one if missing
 //
 void GUI_RPC_CONN_SET::get_password() {
     int retval;
@@ -132,16 +132,15 @@ void GUI_RPC_CONN_SET::get_password() {
             strip_whitespace(password);
         }
         fclose(f);
-        if (strlen(password)) {
-            return;
-        }
 
-        // File is empty; don't allow this.
-        // Fall through and create a password.
+        // if password is empty, allow it but issue a warning
         //
-        msg_printf(NULL, MSG_INFO,
-            "%s is empty - assigning new GUI RPC password", GUI_RPC_PASSWD_FILE
-        );
+        if (!strlen(password)) {
+            msg_printf(NULL, MSG_USER_ALERT,
+                "Warning: GUI RPC password is empty.  BOINC can be controlled by any user on this computer.  See https://boinc.berkeley.edu/gui_rpc_passwd.php for more information."
+            );
+        }
+        return;
     }
 
     // make a random password

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -48,14 +48,15 @@ int main(int /*argc*/, char** argv) {
     APP_INIT_DATA   aid;
     FILE            *f;
     int             retval = -1;
-    int             i;
     char            libpath[8192];
     char            newlibs[256];
     char            *projectDirName;
     const char      *screensaverLoginUser = NULL;
+#ifdef __APPLE__
+    int             i;
     bool            launching_gfx=false;
     char            current_dir[MAXPATHLEN];
-
+#endif
 
     strcpy(boinc_project_user_name, "boinc_project");
     strcpy(boinc_project_group_name, "boinc_project");

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -376,7 +376,14 @@ struct DEVICE_STATUS {
 #else
 #define DEFAULT_SS_EXECUTABLE       "boincscr"
 #endif
+
 #define LINUX_CONFIG_FILE           "/etc/boinc-client/config.properties"
+
+// Used by Manager and boinccmd to locate the data dir.
+// You can define this in "configure" if you want.
+//
+#ifndef LINUX_DEFAULT_DATA_DIR
 #define LINUX_DEFAULT_DATA_DIR      "/var/lib/boinc-client"
+#endif
 
 #endif

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -377,5 +377,6 @@ struct DEVICE_STATUS {
 #define DEFAULT_SS_EXECUTABLE       "boincscr"
 #endif
 #define LINUX_CONFIG_FILE           "/etc/boinc-client/config.properties"
+#define LINUX_DEFAULT_DATA_DIR      "/var/lib/boinc-client"
 
 #endif

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -478,16 +478,10 @@ int read_gui_rpc_password(char* buf, string& msg) {
         return ERR_FOPEN;
 #endif
     }
-    char* p = fgets(buf, 256, f);
-    if (p) {
-        // trim CR
-        //
-        int n = (int)strlen(buf);
-        if (n && buf[n-1]=='\n') {
-            buf[n-1] = 0;
-        }
+    buf[0] = 0;
+    if (fgets(buf, 256, f)) {
+        strip_whitespace(buf);
     }
     fclose(f);
     return 0;
 }
-

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -455,8 +455,13 @@ int read_gui_rpc_password(char* buf, string& msg) {
                 return ERR_FOPEN;
             }
         } else {
-            sprintf(msg_buf, "%s not found.  Try reinstalling BOINC.",
-                GUI_RPC_PASSWD_FILE
+            char buf2[MAXPATHLEN];
+            if (!getcwd(buf2, MAXPATHLEN)) {
+                strcpy(buf2, "");
+            }
+            sprintf(msg_buf, "No BOINC data directory was specified, and %s was not found in the current directory (%s).  See https://boinc.berkeley.edu/gui_rpc.php for more information.",
+                GUI_RPC_PASSWD_FILE,
+                buf2
             );
             msg = msg_buf;
             return ERR_FOPEN;

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -416,11 +416,12 @@ int read_gui_rpc_password(char* buf, string& msg) {
     FILE* f = fopen(GUI_RPC_PASSWD_FILE, "r");
     if (!f) {
 #if defined(__linux__)
+#define HELP_URL "https://boinc.berkeley.edu/gui_rpc.php"
         char path[MAXPATHLEN];
         if (errno == EACCES) {
             sprintf(msg_buf,
-                "%s exists but can't be read.  Check the file permissions.",
-                GUI_RPC_PASSWD_FILE
+                "%s exists but can't be read.  See %s",
+                GUI_RPC_PASSWD_FILE, HELP_URL
             );
             msg = msg_buf;
             return ERR_FOPEN;
@@ -445,12 +446,12 @@ int read_gui_rpc_password(char* buf, string& msg) {
                 if (!f) {
                     if (errno == EACCES) {
                         sprintf(msg_buf,
-                            "%s exists but can't be read.  Check the file permissions.",
-                            path
+                            "%s exists but can't be read.  See %s",
+                            path, HELP_URL
                         );
                     } else {
-                        sprintf(msg_buf, "%s not found.  Try reinstalling BOINC.",
-                            path
+                        sprintf(msg_buf, "%s not found.  See %s",
+                            path, HELP_URL
                         );
                     }
                     msg = msg_buf;
@@ -458,8 +459,8 @@ int read_gui_rpc_password(char* buf, string& msg) {
                 }
             } else {
                 sprintf(msg_buf,
-                    "No data_dir= found in %s.  Try reinstalling BOINC.",
-                    LINUX_CONFIG_FILE
+                    "No data_dir= found in %s.  See %s",
+                    LINUX_CONFIG_FILE, HELP_URL
                 );
                 msg = msg_buf;
                 return ERR_FOPEN;
@@ -472,19 +473,14 @@ int read_gui_rpc_password(char* buf, string& msg) {
             if (!f) {
                 if (errno == EACCES) {
                     sprintf(msg_buf,
-                        "%s exists but can't be read.  Check the file permissions.",
-                        path
+                        "%s exists but can't be read.  See %s",
+                        path, HELP_URL
                     );
                     msg = msg_buf;
                     return ERR_FOPEN;
                 }
-                char buf2[MAXPATHLEN];
-                if (!getcwd(buf2, MAXPATHLEN)) {
-                    strcpy(buf2, "");
-                }
-                sprintf(msg_buf, "No BOINC data directory was specified, and %s was not found in the current directory (%s).  See https://boinc.berkeley.edu/gui_rpc.php for more information.",
-                    GUI_RPC_PASSWD_FILE,
-                    buf2
+                sprintf(msg_buf, "%s not found.  See %s",
+                    GUI_RPC_PASSWD_FILE, HELP_URL
                 );
                 msg = msg_buf;
                 return ERR_FOPEN;


### PR DESCRIPTION
boinccmd: show alert messages after attach RPCs

PR #3709 disallowed empty GUI RPC password files.
This increased security on shared machines.
But it meant that on Linux, after installing BOINC as a package,
the user had to locate and change the protection
and/or the ownership of the password file, which is undesirable.

This change allows empty password files but tells the user
that they should think about the security implications.
With the Manager this is delivered as a notice.
With boinccmd the message is written to stderr after an attach operation.