### PR TITLE
[Windows] Fix Window create function on x64.

### DIFF
--- a/clientgui/msw/taskbarex.cpp
+++ b/clientgui/msw/taskbarex.cpp
@@ -39,7 +39,7 @@
 #endif
 
 
-LRESULT APIENTRY wxTaskBarIconExWindowProc( HWND hWnd, unsigned msg, UINT wParam, LONG lParam );
+LRESULT APIENTRY wxTaskBarIconExWindowProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam );
 
 wxChar* wxTaskBarExWindowClass = (wxChar*) wxT("wxTaskBarExWindowClass");
 wxChar* wxTaskBarExWindow      = (wxChar*) wxT("wxTaskBarExWindow");
@@ -307,10 +307,9 @@ bool wxTaskBarIconEx::IsBalloonsSupported()
     return true;
 }
 
-long wxTaskBarIconEx::WindowProc( WXHWND hWnd, unsigned int msg, unsigned int wParam, long lParam )
+LRESULT wxTaskBarIconEx::WindowProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
 {
     wxEventType eventType = 0;
-    long        lReturnValue = 0;     
 
     if      ( WM_CLOSE == msg )
     {
@@ -318,10 +317,10 @@ long wxTaskBarIconEx::WindowProc( WXHWND hWnd, unsigned int msg, unsigned int wP
         ProcessEvent(eventClose);
 
         if ( !eventClose.GetSkipped() ) {
-            lReturnValue = DefWindowProc((HWND) hWnd, msg, wParam, lParam);
-        } else {
-            lReturnValue = 0;
+            return DefWindowProc(hWnd, msg, wParam, lParam);
         }
+
+        return 0;
     }
     else if ( WM_TASKBARCREATED == msg )
     {
@@ -398,20 +397,20 @@ long wxTaskBarIconEx::WindowProc( WXHWND hWnd, unsigned int msg, unsigned int wP
     }
     else
     {
-        lReturnValue = DefWindowProc((HWND) hWnd, msg, wParam, lParam);
+        return DefWindowProc(hWnd, msg, wParam, lParam);
     }
 
     if (eventType)
     {
         wxTaskBarIconExEvent event(eventType, this);
-        lReturnValue = ProcessEvent(event);
+        return ProcessEvent(event);
     }
 
-    return lReturnValue;
+    return 0;
 }
 
-LRESULT APIENTRY wxTaskBarIconExWindowProc( HWND hWnd, unsigned msg, UINT wParam, LONG lParam )
+LRESULT APIENTRY wxTaskBarIconExWindowProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam )
 {
-    return wxGetApp().GetTaskBarIcon()->WindowProc((WXHWND) hWnd, msg, wParam, lParam);
+    return wxGetApp().GetTaskBarIcon()->WindowProc(hWnd, msg, wParam, lParam);
 }
 

--- a/clientgui/msw/taskbarex.h
+++ b/clientgui/msw/taskbarex.h
@@ -81,7 +81,7 @@ public:
 // Implementation
     WXHWND CreateTaskBarWindow( wxChar* szWindowTitle );
     bool IsBalloonsSupported();
-    long WindowProc( WXHWND hWnd, unsigned int msg, unsigned int wParam, long lParam );
+    LRESULT WindowProc( HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam );
 
 // Data members
 protected:


### PR DESCRIPTION
This issue affects only Windows 8.1/10 x64 built with VS2013 and VS2019.
The reason is a different memory addressing on these OSs in pure 64-bit mode.

This fixes #4072.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>