### PR TITLE
MACOS Bug Fix: Modify the screen saver name parameter passed to boinc_ss_helper.sh..

### DIFF
--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -217,8 +217,8 @@ int main(int /*argc*/, char** argv) {
             snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl remove edu.berkeley.boinc-ss_helper'", screensaverLoginUser);
             retval = callPosixSpawn(cmd);
 
-            snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl submit -l edu.berkeley.boinc-ss_helper -- \"/Library/Screen Savers/%s.saver/Contents/Resources/boinc_ss_helper.sh\" \"%s\"", screensaverLoginUser, argv[2], argv[1]);
-            i = 2;
+	    snprintf(cmd, sizeof(cmd), "su -l \"%s\" -c 'launchctl submit -l edu.berkeley.boinc-ss_helper -- \"/Library/Screen Savers/%s.saver/Contents/Resources/boinc_ss_helper.sh\" \"%s\" \"%s\"", screensaverLoginUser, argv[2], argv[1], argv[2]);
+            i = 3;
             while(argv[i]) {
                 safe_strcat(cmd, " ");
                 safe_strcat(cmd, argv[i++]);


### PR DESCRIPTION
… to be quoted to allow for spaces in branded screensaver names

Fixes #

**Description of the Change**
switcher.cpp sets up the command line used for boinc_ss_helper.sh on macOS Catalina or newer. The screensaver name is added to the commandline without quotes so if a branded screensaver name has spaces the parameters are off and the project specific graphics will not launch.

**Alternate Designs**
A better approach would probably be to not allow branded screensaver names to have spaces but this is a bigger change and should be done for a future version.

**Release Notes**
NA
