### PR TITLE
[WIP] Manager and web: don't pass authenticator to account_finish.php

### DIFF
--- a/clientgui/WizardAttach.cpp
+++ b/clientgui/WizardAttach.cpp
@@ -613,7 +613,7 @@ void CWizardAttach::OnFinished( wxWizardExEvent& event ) {
     } else {
         // Attached to a project
         if (GetAccountCreatedSuccessfully() && GetAttachedToProjectSuccessfully()) {
-            wxLaunchDefaultBrowser(GetProjectURL() + wxT("account_finish.php?auth=") + GetProjectAuthenticator());
+            wxLaunchDefaultBrowser(GetProjectURL() + wxT("account_finish.php"));
         }
     }
 

--- a/html/user/account_finish.php
+++ b/html/user/account_finish.php
@@ -24,13 +24,7 @@ require_once('../inc/boinc_db.inc');
 require_once('../inc/util.inc');
 require_once('../inc/countries.inc');
 
-check_get_args(array("auth"));
-
-$auth = get_str("auth");
-$user = BoincUser::lookup_auth($auth);
-if (!$user) {
-    error_page("no such account");
-}
+$user = get_logged_in_user();
 page_head(tra("Finish account setup"));
 
 echo "
@@ -58,7 +52,6 @@ row2("",
 );
 end_table();
 echo "
-    <input type=hidden name=auth value=$auth>
     </form>
 ";
 


### PR DESCRIPTION
If you attach to a project using the Manager, as a "new user",
the Manager finishes the process by opening a browser window
to account_finish.php on that project,
which asks you for your name, country, and (optionally) postal code.
It passes the authenticator to this script;
this could be viewed as a security risk.

I changed things so that:
- the Manager doesn't pass the authenticator
- account_finish.php asks you to log in (with email/passwd).

Compatibility issues:
Old manager, new project: no problem.  User will see login form.
New manager, old project: user will see confusing "no such user" message