### PR TITLE
Fix bug in number of placeholders in repr formatting for `front_Host`

### DIFF
--- a/py/Boinc/db_mid.py
+++ b/py/Boinc/db_mid.py
@@ -35,7 +35,7 @@ class front_Team:
 
 class front_Host:
     def __repr__(self):
-        return '<Host#%s %s>'%(self.id, self.user.name, self.domain_name)
+        return '<Host#%s %s %s>'%(self.id, self.user.name, self.domain_name)
 
 class front_Workunit:
     def __repr__(self):


### PR DESCRIPTION
**Description of the Change**
No associated issue ID.
This PR fixes a bug in the string formatting for the representation of `front_Host` (an incompatible number of placeholders `%s` and substitution variables supplied, namely 2 and 3).
The one-line change is quite straightforward.

**Alternate Designs**
N/A

**Release Notes**
N/A