### PR TITLE
Remove */lib paths from m4 (Issue #4095: boinc fails to link with LLD)

### DIFF
--- a/m4/ax_check_gl.m4
+++ b/m4/ax_check_gl.m4
@@ -39,7 +39,7 @@ else
       GL_CFLAGS="-I${x_includes} -I${prefix}/include ${GL_CFLAGS}"
     fi
     if test -n "$x_libraries"; then
-      GL_LIBS="-L${x_libraries} -L${prefix}/lib -lX11 ${GL_LIBS}"
+      GL_LIBS="-L${x_libraries} -lX11 ${GL_LIBS}"
     fi
   fi
 
@@ -58,7 +58,7 @@ else
     else
       ax_try_lib="${ax_lib}"
     fi
-    LIBS="-L${prefix}/lib ${ax_try_lib} ${GL_LIBS} ${ax_save_LIBS}"
+    LIBS="${ax_try_lib} ${GL_LIBS} ${ax_save_LIBS}"
     AC_LINK_IFELSE(
     [AC_LANG_PROGRAM([[
 # if HAVE_WINDOWS_H && defined(_WIN32)
@@ -66,7 +66,7 @@ else
 # endif
 # include <GL/gl.h>]],
                      [[glBegin(0)]])],
-    [ax_cv_check_gl_libgl="-L${prefix}/lib ${ax_try_lib}"; break])
+    [ax_cv_check_gl_libgl="${ax_try_lib}"; break])
   done
   LIBS=${ax_save_LIBS}
   CPPFLAGS=${ax_save_CPPFLAGS}])

--- a/m4/ax_check_glu.m4
+++ b/m4/ax_check_glu.m4
@@ -19,7 +19,7 @@ if test "X${with_apple_opengl_framework}" != "Xyes"; then
     else
       ax_try_lib="${ax_lib}"
     fi
-    LIBS="-L${prefix}/lib ${ax_try_lib} ${GL_LIBS} ${ax_save_LIBS}"
+    LIBS="${ax_try_lib} ${GL_LIBS} ${ax_save_LIBS}"
     #
     # libGLU typically links with libstdc++ on POSIX platforms. However,
     # setting the language to C++ means that test program source is named
@@ -37,7 +37,7 @@ if test "X${with_apple_opengl_framework}" != "Xyes"; then
 # endif
 # include <GL/glu.h>]],
                      [[gluBeginCurve(0)]])],
-    [ax_cv_check_glu_libglu="-L${prefix}/lib ${ax_try_lib}"; break])
+    [ax_cv_check_glu_libglu="${ax_try_lib}"; break])
     if test X$ax_compiler_ms = Xyes; then
       AC_LANG_POP([C])
     fi

--- a/m4/ax_check_glut.m4
+++ b/m4/ax_check_glut.m4
@@ -41,7 +41,7 @@ else
     else
       ax_try_lib="${ax_lib}"
     fi
-    LIBS="-L${prefix}/lib ${ax_try_lib} ${GLUT_LIBS} ${ax_save_LIBS}"
+    LIBS="${ax_try_lib} ${GLUT_LIBS} ${ax_save_LIBS}"
     AC_LINK_IFELSE(
     [AC_LANG_PROGRAM([[
 #define FREEGLUT_STATIC 1
@@ -50,7 +50,7 @@ else
 # endif
 # include <GL/glut.h>]],
                      [[glutMainLoop()]])],
-    [ax_cv_check_glut_libglut="-L${prefix}/lib ${ax_try_lib}"; break])
+    [ax_cv_check_glut_libglut="${ax_try_lib}"; break])
 
   done
   LIBS=${ax_save_LIBS}

--- a/m4/check_ssl.m4
+++ b/m4/check_ssl.m4
@@ -46,7 +46,7 @@ if test "x${SSL_LIBS}" = "x" ; then
       SSLDIR="${ssldir}"
       SSL_CFLAGS="-I$ssldir/include -I$ssldir/include/openssl";
       SSL_CXXFLAGS="-I$ssldir/include -I$ssldir/include/openssl";
-      SSL_LIBS="-L$ssldir -L$ssldir/lib -lssl -lcrypto"
+      SSL_LIBS="-lssl -lcrypto"
       AC_CHECK_LIB([dl], [dlopen], 
           [SSL_LIBS="${SSL_LIBS} ${sah_lib_last}"])
       AC_CHECK_LIB([z], [gzopen], 
@@ -58,7 +58,7 @@ if test "x${SSL_LIBS}" = "x" ; then
       SSLDIR="${ssldir}"
       SSL_CFLAGS="-I$ssldir/include/"
       SSL_CXXFLAGS="-I$ssldir/include/"
-      SSL_LIBS="-L$ssldir -L$ssldir/lib -lssl -lcrypto"
+      SSL_LIBS="-lssl -lcrypto"
       AC_CHECK_LIB([dl], [dlopen], 
           [SSL_LIBS="${SSL_LIBS} ${sah_lib_last}"])
       AC_CHECK_LIB([z], [gzopen], 


### PR DESCRIPTION
Fixes #4095

**Description of the Change**
This commit removes the superfluous hard-coded injection of `-L/usr` and `-L/usr/lib` into the command line.
The resulting build system has been tested with
* Clang + LLD
* gcc + ld.bfd
* gcc + ld.gold

BOINC fails to link with LLD because of /usr/lib in the link command line.

LLD does not continue to search for the correct library, once it finds one that doesn't fit. This is made by design and will not change.
See also : https://bugs.gentoo.org/732024

The reason for LLD failing is, that its build system puts `-L/usr` and `-L/usr/lib` into the command line options. While these are not neccessary at all, they cause LLD to find 32bit libraries on 64bit systems first. As these 32bit libraries can not be used, LLD errors out.

Bug: #4095
Signed-off-by: Sven Eden <sven.eden@prydeworx.com>

**Alternate Designs**
We asked the LLD devs, whether the search for fitting libraries could be extended. The corresponding upstream bug was closed as RESOLVED-WONTFIX, because it is boinc's build system, that is being broken here. (It's explicitly passing the wrong folder)

**Release Notes**
Remove not needed search paths from linker comand line to fix linking with LLD.