### PR TITLE
Unblock x11 idle detection

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -6,7 +6,6 @@ After=network-online.target
 [Service]
 Type=simple
 ProtectHome=true
-PrivateTmp=true
 ProtectSystem=strict
 ProtectControlGroups=true
 ReadWritePaths=-/var/lib/boinc -/etc/boinc-client
@@ -32,6 +31,7 @@ IOSchedulingClass=idle
 #PrivateUsers=true
 #CapabilityBoundingSet=
 #MemoryDenyWriteExecute=true
+#PrivateTmp=true  #Block X11 idle detection
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Description of the Change**
This fixes part of an issue described in #3715 - confirmed to help.

**Release Notes**
Systemd unit file - allowed access to /tmp/ to keep X11 idle detection working
