### PR TITLE
Add check for libcurl when building for server

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -451,7 +451,7 @@ AS_IF([test "x${enable_client}" = "xyes" -o "x${enable_server}" = "xyes"],
 dnl ---------- libcurl (m4/libcurl.m4) ------------------------------
 dnl curl is needed for client
 
-AS_IF([test "x${enable_client}" = "xyes"],
+AS_IF([test "x${enable_client}" = "xyes" -o "x${enable_server}" = "xyes"],
   [
     LIBCURL_CHECK_CONFIG([yes], [7.17.1], [haveCurl=yes], [haveCurl=no])
 


### PR DESCRIPTION
Fixes #3501 and #2600

**Description of the Change**
Add check for libcurl when building for server
Block early rather than fail after a long time of compile when libcurl is not supplied

`lib/remote_submit.cpp` needs `curl/curl.h`
https://github.com/BOINC/boinc/blob/faf272ff362cd9fc22bba5d2cbd4f57ff374364c/lib/remote_submit.cpp#L24

`lib/remote_submit.cpp` is built when building in `tools` folder
https://github.com/BOINC/boinc/blob/faf272ff362cd9fc22bba5d2cbd4f57ff374364c/tools/Makefile.am#L61

which is only built when ENABLE_SERVER
https://github.com/BOINC/boinc/blob/faf272ff362cd9fc22bba5d2cbd4f57ff374364c/Makefile.am#L25-L28

ENABLE_SERVER is checked here
https://github.com/BOINC/boinc/blob/faf272ff362cd9fc22bba5d2cbd4f57ff374364c/configure.ac#L1065

**Alternate Designs**
N/A

**Release Notes**
N/A