### PR TITLE
client: show IPV6 address correctly

### DIFF
--- a/client/gui_rpc_server.cpp
+++ b/client/gui_rpc_server.cpp
@@ -391,7 +391,15 @@ static void show_connect_error(sockaddr_storage& s) {
     sockaddr_in* sin = (sockaddr_in*)&s;
     safe_strcpy(buf, inet_ntoa(sin->sin_addr));
 #else
-    inet_ntop(s.ss_family, &s, buf, 256);
+    if (s.ss_family == AF_INET) {
+        sockaddr_in* sin = (sockaddr_in*)&s;
+        inet_ntop(AF_INET, (void*)(&sin->sin_addr), buf, 256);
+    } else if (s.ss_family == AF_INET6) {
+        sockaddr_in6* sin = (sockaddr_in6*)&s;
+        inet_ntop(AF_INET6, (void*)(&sin->sin6_addr), buf, 256);
+    } else {
+        sprintf(buf, "Unknown address family %d", s.ss_family);
+    }
 #endif
     msg_printf(NULL, MSG_INFO,
         "GUI RPC request from non-allowed address %s",


### PR DESCRIPTION
Fixes #3340

This is the same as #3342 but with an additional check for unknown address type