### PR TITLE
client: default to just checking first X server

### DIFF
--- a/client/cs_cmdline.cpp
+++ b/client/cs_cmdline.cpp
@@ -50,7 +50,7 @@ static void print_options(char* prog) {
         "    --allow_remote_gui_rpc         allow remote GUI RPC connections\n"
         "    --allow_multiple_clients       allow >1 instances per host\n"
         "    --attach_project <URL> <key>   attach to a project\n"
-        "    --check_all_logins             for idle detection, check remote logins too\n"
+        "    --check_all_logins             for idle detection, check remote and more than 1 local login too\n"
         "    --daemon                       run as daemon (Unix)\n"
         "    --detach_console               detach from console (Windows)\n"
         "    --detach_project <URL>         detach from a project\n"


### PR DESCRIPTION
**Description of the Change**
default to just checking first X server idle usage
You can go back to checking all using the already existing
check_all_logins boinc option. This gives us a nicer default
but still lets anyone who depends on the old functionality to
get it.

Also removed a related comment that is no longer true from a previous commit.

Resolves: #2256 

**Alternate Designs**
There have been a few.. but the most recent before trying this was to get the total number of users from utmp and then only check that number of X servers.  That led me to discover that the utmp bit I wanted to extend never ran - because of check_all_logins being false - which led me to this solution.

**Release Notes**
BOINC users who want idle detection against more than 1 XServer must specify --check_all_logins to do so now.