### PR TITLE
Determine gtkver for wxWidgets more correctly

### DIFF
--- a/m4/boinc_wxwidgets.m4
+++ b/m4/boinc_wxwidgets.m4
@@ -76,11 +76,11 @@ WARNING: No ${uprf} libraries for wxWidgets are installed.
    AM_CONDITIONAL([GUI_GTK], echo $wx_default_config | grep -i ^gtk 2>&1 >/dev/null)
    if echo $wx_default_config | grep -i gtk 2>&1 >/dev/null ; then
      case ${wx_default_config} in
-        gtk3-*)  gtkver=gtk+-3.0
+        gtk3-*|*-gtk3-*)  gtkver=gtk+-3.0
 	         ;;
-        gtk2-*)  gtkver=gtk+-2.0
+        gtk2-*|*-gtk2-*)  gtkver=gtk+-2.0
 	         ;;
-        gtk-*)   gtkver=gtk+
+        gtk-*|*-gtk-*)    gtkver=gtk+
 	         ;;
       esac
       GTK_CFLAGS="`pkg-config --cflags $gtkver`"


### PR DESCRIPTION
Fixes #

**Description of the Change**
On several platforms (e.g. [Elbrus]()) `wx-config --selected-config` produces a value that don't start with `gtk*`. For example, it may look like `e2k-mcst-linux-gnu-gtk2-unicode-3.0`. So I've expanded detection procedure a bit to allow these configurations to be treated correctly, e.g. `boinc-wxwidgets.m4` should react properly not just to `gtk-*`, `gtk2-*`, and `gtk3-*`, but also to `*-gtk-*`, `*-gtk2-*`, and `*-gtk3-*`.

**Alternate Designs**
I have no idea how to do it better, it seems that expanding the check in `boinc-wxwidgets.m4` might be the only reasonable option. No `configure` parameters can solve this problem, as far as I guessed.

**Release Notes**
Determine GTK version for wxWidgets more correctly
