### PR TITLE
hostinfo_unix: Ignore tty(S|ACM) devices in TTY idle time calculation

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1567,9 +1567,19 @@ inline long device_idle_time(const char *device) {
 static const struct dir_tty_dev {
     const char *dir;
     const char *dev;
+    const vector<string> ignore_list;
+
+    bool should_ignore(const string &devname) const {
+        for (const string &ignore : ignore_list) {
+            if (devname.rfind(ignore, 0) == 0) return true;
+        }
+        return false;
+    }
 } tty_patterns[] = {
 #ifdef unix
-    { "/dev", "tty" },
+    { "/dev", "tty",
+      {"ttyS", "ttyACM"},
+    },
     { "/dev", "pty" },
     { "/dev/pts", NULL },
 #endif
@@ -1596,6 +1606,11 @@ vector<string> get_tty_list() {
             //
             if (tty_patterns[i].dev) {
                 if ((strstr(devname, tty_patterns[i].dev) != devname)) continue;
+
+                // Ignore some devices. This could be, for example,
+                // ttyS* (serial port) or devACM* (serial USB) devices
+                // which may be used even without a user being active.
+                if (tty_patterns[i].should_ignore(devname)) continue;
             }
 
             sprintf(fullname, "%s/%s", tty_patterns[i].dir, devname);


### PR DESCRIPTION
The atime (access time) of device nodes whose name starts with
/dev/ttyS (serial port) or /dev/ttyACM (serial USB) should not be used
for TTY idle time calculation. It is perfectly possible that they are
used without any user being active.

Previously BOINC would not run on some of our systems, because those systems also had a monitoring device connected via a serial port. Since this monitoring device is periodically checked, BOINC would assume that a user is active. I think it is sensible to exclude `ttyS` and `ttyACM` (and probably also `ttyUSB` devices. But those I couldn't test as we do not have one of those) from TTY idle time calculation.
