### PR TITLE
Add Javax Annotation.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -154,6 +154,7 @@ dependencies {
 
     // Dagger dependencies
     implementation "com.google.dagger:dagger:$dagger_version"
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
     annotationProcessor "com.google.dagger:dagger-compiler:$dagger_version"
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
 


### PR DESCRIPTION
**Description of the Change**
Add the Javax Annotation library, as the `javax` package doesn't appear to be available on Java 9.

**Release Notes**
N/A
