### PR TITLE
[CI] make build artifacts available through github

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -45,3 +45,8 @@ jobs:
           PULL_REQUEST: ${{ github.event.number }}
           PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
         run: ./deploy/prepare_deployment.sh android_${{ matrix.type }} && ./deploy/deploy_to_bintray.sh deploy/android_${{ matrix.type }}/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: android_${{ matrix.type }}_${{ github.event.pull_request.head.sha }}
+          path: deploy/android_${{ matrix.type }}/*.7z

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,3 +88,9 @@ jobs:
           PULL_REQUEST: ${{ github.event.number }}
           PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
         run: ./deploy/prepare_deployment.sh linux_${{ matrix.type }} && ./deploy/deploy_to_bintray.sh deploy/linux_${{ matrix.type }}/
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ ! contains(matrix.type, 'libs') && ! contains(matrix.type, 'server') && ! contains(matrix.type, 'test') }}
+        with:
+          name: linux_${{ matrix.type }}_${{ github.event.pull_request.head.sha }}
+          path: deploy/linux_${{ matrix.type }}/*.7z

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -38,3 +38,9 @@ jobs:
           PULL_REQUEST: ${{ github.event.number }}
           PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
         run: ./deploy/prepare_deployment.sh win_${{ matrix.type }} && ./deploy/deploy_to_bintray.sh deploy/win_${{ matrix.type }}/
+
+      - uses: actions/upload-artifact@v2
+        if: ${{ ! contains(matrix.type, 'libs') }}
+        with:
+          name: win_${{ matrix.type }}_${{ github.event.pull_request.head.sha }}
+          path: deploy/win_${{ matrix.type }}/*.7z

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,3 +70,16 @@ jobs:
         run: |
           call deploy\prepare_deployment.bat
           call deploy\deploy_to_bintray.bat
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: win_apps_${{ github.event.pull_request.head.sha }}
+          path: deploy/win_apps/*.7z
+      - uses: actions/upload-artifact@v2
+        with:
+          name: win_client_${{ github.event.pull_request.head.sha }}
+          path: deploy/win_client/*.7z
+      - uses: actions/upload-artifact@v2
+        with:
+          name: win_manager_${{ github.event.pull_request.head.sha }}
+          path: deploy/win_manager/*.7z


### PR DESCRIPTION
**Description of the Change**
Make build artifacts available through github. When PRs are generated from forked repositories the upload to bintray is not working. This is an alternative.

**Alternate Designs**
None avilable.

**Release Notes**
N/A
