### PR TITLE
Detect GLIBC version by calling gnu_get_libc_version()

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -41,6 +41,10 @@
 #include <cstring>
 #endif
 
+#ifdef __GLIBC__
+#include <gnu/libc-version.h>
+#endif
+
 #if HAVE_XSS
 #include <X11/extensions/scrnsaver.h> //X-based idle detection
 // prevents naming collision between X.h define of Always and boinc's
@@ -1371,6 +1375,12 @@ int HOST_INFO::get_memory_info() {
 // return BOINC_SUCCESS if at least version could be found (extra_info may remain empty)
 // return ERR_NOT_FOUND if ldd couldn't be opened or no version information was found
 //
+#ifdef __GLIBC__
+int get_libc_version(string& version, string& extra_info) {
+    version = string(gnu_get_libc_version());
+    return BOINC_SUCCESS;
+}
+#else
 int get_libc_version(string& version, string& extra_info) {
     char buf[1024] = "";
     string strbuf;
@@ -1405,6 +1415,7 @@ int get_libc_version(string& version, string& extra_info) {
     }
     return BOINC_SUCCESS;
 }
+#endif
 #endif
 
 // get os_name, os_version


### PR DESCRIPTION
**Description of the Change**
GLIBC version string can be detected easier by calling gnu_get_libc_version() instead of parsing it from ldd output.

Not all systems even have ldd script itself available to begin with as it is not required for normal system runtime. This function was made available around libc 2.1 I think so it is pretty safe nowadays.

**Alternate Designs**
There was also __GLIBC__ and __GLIBC_MINOR__ macros but those are compile time.

**Release Notes**
Detect and report GLIBC version from a glibc function call rather than from parsing ldd output when possible.