### PR TITLE
Drupal: ignore temporary field

### DIFF
--- a/drupal/sites/default/boinc/modules/boincuser/boincuser.module
+++ b/drupal/sites/default/boinc/modules/boincuser/boincuser.module
@@ -557,6 +557,7 @@ function boincuser_user($op, &$edit, &$account, $category = NULL) {
         // remove them before continuing to core Drupal routines
         $edit['update_source'] = null;
         $edit['boincuser_name'] = null;
+        $edit['current_pass'] = null;
       }
       break;
 


### PR DESCRIPTION
**Description of the Change**
Ignore another form field. Its value is used for temporary purposes only.

**Alternate Designs**
none

**Release Notes**
N/A