### PR TITLE
Add CTRL+TAB shortcut

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -205,6 +205,7 @@ BEGIN_EVENT_TABLE (CAdvancedFrame, CBOINCBaseFrame)
     EVT_TIMER(ID_FRAMERENDERTIMER, CAdvancedFrame::OnFrameRender)
     EVT_NOTEBOOK_PAGE_CHANGED(ID_FRAMENOTEBOOK, CAdvancedFrame::OnNotebookSelectionChanged)
     EVT_MENU(ID_SELECTALL, CAdvancedFrame::OnSelectAll)
+    EVT_MENU(ID_NEXT_PAGE, CAdvancedFrame::OnNextPage)
     EVT_SIZE(CAdvancedFrame::OnSize)
     EVT_MOVE(CAdvancedFrame::OnMove)
 #ifdef __WXMAC__
@@ -754,13 +755,14 @@ bool CAdvancedFrame::CreateMenus() {
     }
 
     m_Shortcuts[0].Set(wxACCEL_CTRL, (int)'A', ID_SELECTALL);
+    m_Shortcuts[1].Set(wxACCEL_CTRL, WXK_TAB, ID_NEXT_PAGE);
 
 #ifdef __WXMAC__
     // Set HELP key as keyboard shortcut
-    m_Shortcuts[1].Set(wxACCEL_NORMAL, WXK_HELP, ID_HELPBOINCMANAGER);
+    m_Shortcuts[2].Set(wxACCEL_NORMAL, WXK_HELP, ID_HELPBOINCMANAGER);
 #endif
 
-    m_pAccelTable = new wxAcceleratorTable(2, m_Shortcuts);
+    m_pAccelTable = new wxAcceleratorTable(3, m_Shortcuts);
     SetAcceleratorTable(*m_pAccelTable);
 
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::CreateMenu - Function End"));
@@ -1976,6 +1978,22 @@ void CAdvancedFrame::OnSelectAll(wxCommandEvent& WXUNUSED(event)) {
   for (int i = 0; i < count; i++) {
     lCtrl->SelectRow(i, true);
   }
+}
+
+
+void CAdvancedFrame::OnNextPage( wxCommandEvent& event) {
+    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnNextPage - Function Begin"));
+
+    wxWindow*       pwndNotebookPage = NULL;
+    int             selection = event.GetSelection();
+
+    pwndNotebookPage = m_pNotebook->GetPage(selection);
+
+    if ( pwndNotebookPage != NULL ) {
+      m_pNotebook->AdvanceSelection(true);
+    }
+
+    wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnNextPage - Function End"));
 }
 
 

--- a/clientgui/AdvancedFrame.h
+++ b/clientgui/AdvancedFrame.h
@@ -65,6 +65,7 @@ public:
     void OnActivitySelection( wxCommandEvent& event );
     void OnGPUSelection( wxCommandEvent& event );
     void OnNetworkSelection( wxCommandEvent& event );
+    void OnNextPage( wxCommandEvent &event);
 
     void OnSelectAll( wxCommandEvent& event );
 
@@ -112,7 +113,7 @@ public:
 protected:
     virtual int     _GetCurrentViewPage();
 
-    wxAcceleratorEntry  m_Shortcuts[2];     // For keyboard shortcut
+    wxAcceleratorEntry  m_Shortcuts[3];     // For keyboard shortcut
     wxAcceleratorTable* m_pAccelTable;
 
 private:

--- a/clientgui/Events.h
+++ b/clientgui/Events.h
@@ -154,6 +154,7 @@
 
 // Shortcuts
 #define ID_SELECTALL                            9800
+#define ID_NEXT_PAGE                            9801
 
 //
 // Simple GUI


### PR DESCRIPTION
Partially Fixes #3359

**Description of the Change**
Define shortcut on accelerator table and bind it with event table.

**Alternate Designs**
Tested only on Linux environment. It should work as well on Windows but **it should be tested on MacOS X**.

**Release Notes**
Add CTRL+TAB shortcut for advance view of boinc manager.
