### PR TITLE
[VS2019] Add fallback sign server timestamp.globalsign.com to use it …

### DIFF
--- a/win_build/boinc_signing.targets
+++ b/win_build/boinc_signing.targets
@@ -3,6 +3,9 @@
         <FilesToSign Include="$(OutDir)$(TargetName)$(TargetExt)" Condition="('$(TargetExt)' == '.exe' or '$(TargetExt)' == '.dll' or '$(TargetExt)' == '.scr')"/>
     </ItemGroup>
     <Target Name="Signing" DependsOnTargets="Build" AfterTargets="Build" Condition="('@(FilesToSign)' != '' and Exists('$(BUILDCODESIGN)\boinc.pfx'))">
-        <Exec Command='signtool sign /f "$(BUILDCODESIGN)/boinc.pfx" /p "$(CODESIGNBOINC)" /fd sha256 /d "BOINC Client Software" /du "http://boinc.berkeley.edu" /t "http://timestamp.verisign.com/scripts/timstamp.dll" "@(FilesToSign)"' WorkingDirectory="$(MSBuildProjectDirectory)"/>
+        <Exec Command='signtool sign /f "$(BUILDCODESIGN)/boinc.pfx" /p "$(CODESIGNBOINC)" /fd sha256 /d "BOINC Client Software" /du "http://boinc.berkeley.edu" /t "http://timestamp.verisign.com/scripts/timstamp.dll" "@(FilesToSign)"' WorkingDirectory="$(MSBuildProjectDirectory)" ContinueOnError="WarnAndContinue">
+            <Output TaskParameter="ExitCode" PropertyName="ErrorCode"/>
+        </Exec>
+        <Exec Command='signtool sign /f "$(BUILDCODESIGN)/boinc.pfx" /p "$(CODESIGNBOINC)" /fd sha256 /d "BOINC Client Software" /du "http://boinc.berkeley.edu" /t "http://timestamp.globalsign.com/scripts/timstamp.dll" "@(FilesToSign)"' WorkingDirectory="$(MSBuildProjectDirectory)" Condition="'$(ErrorCode)'=='1'"/>
     </Target>
 </Project>


### PR DESCRIPTION
…for signing when timestamp.verisign.com is not reachable

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
