### PR TITLE
Allow invitation codes for create-account RPCs only

### DIFF
--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -202,9 +202,7 @@ struct USER {
     int seti_last_result_time;      // time of last result (UNIX)
     double seti_total_cpu;          // number of CPU seconds
     char signature[256];
-        // deprecated as of 9/2004 - may be used as temp
-        // currently used to store a nonce ID while email address
-        // is being verified.
+        // stores invite code, if any, for users created via RPC
     bool has_profile;
     char cross_project_id[256];
         // the "internal" cross-project ID;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -121,7 +121,7 @@ create table user (
     seti_total_cpu          double          not null,
 
     signature               varchar(254),
-        -- deprecated
+        -- stores invite code, if any, for users created via RPC
     has_profile             smallint        not null,
     cross_project_id        varchar(254)    not null,
     passwd_hash             varchar(254)    not null,

--- a/html/user/create_account.php
+++ b/html/user/create_account.php
@@ -44,12 +44,19 @@ if (parse_bool($config, "disable_account_creation_rpc")) {
     }
 }
 
-if (defined('INVITE_CODES')) {
-    $invite_code = get_str("invite_code");
-    if (!preg_match(INVITE_CODES, $invite_code)) {
-        xml_error(-1, "Invalid invitation code");
-    }
-} 
+if (defined('INVITE_CODES_RPC')) {
+        $invite_code = get_str("invite_code");
+        if (!preg_match(INVITE_CODES_RPC, $invite_code)) {
+            xml_error(-1, "Invalid invitation code");
+        }
+} else {
+    if (defined('INVITE_CODES')) {
+        $invite_code = get_str("invite_code");
+        if (!preg_match(INVITE_CODES, $invite_code)) {
+            xml_error(-1, "Invalid invitation code");
+        }
+    } 
+}
 
 $email_addr = get_str("email_addr");
 $email_addr = strtolower($email_addr);
@@ -129,7 +136,13 @@ if ($user) {
         xml_error(ERR_DB_NOT_UNIQUE);
     }
     
-    if (defined('INVITE_CODES')) {
+
+    if (defined('INVITE_CODES_RPC')) {
+        // record the invite code
+        //
+        $r = BoincDb::escape_string($invite_code);
+        $user->update("signature='$r'");
+    } else if (defined('INVITE_CODES')) {
         error_log("Account for '$email_addr' created using invitation code '$invite_code'");
     }
 

--- a/html/user/validate_email_addr.php
+++ b/html/user/validate_email_addr.php
@@ -19,12 +19,12 @@
 require_once("../inc/boinc_db.inc");
 require_once("../inc/util.inc");
 require_once("../inc/email.inc");
+require_once("../inc/account.inc");
 
 function send_validate_email() {
     global $master_url;
     $user = get_logged_in_user();
-    $x2 = uniqid(rand(), true);
-    $user->update("signature='$x2'");
+    $x2 = make_login_token($user);
     send_email(
         $user,
         tra("Validate BOINC email address"),
@@ -44,7 +44,7 @@ function validate() {
         error_page(tra("No such user."));
     }
 
-    $x2 = $user->signature;
+    $x2 = $user->login_token;
     if ($x2 != $x) {
         error_page(tra("Error in URL data - can't validate email address"));
     }


### PR DESCRIPTION
If you define INVITE_CODES_RPC, create-account RPCs must include
a matching invitation code.
Record this code in user.signature to keep track
of where the RPCs are coming from.