### PR TITLE
Fix sah_select_bitness.m4

### DIFF
--- a/m4/sah_select_bitness.m4
+++ b/m4/sah_select_bitness.m4
@@ -39,25 +39,27 @@ AC_DEFUN([SAH_DEFAULT_BITNESS],[
 
 AC_DEFUN([SAH_SELECT_BITNESS],[
   SAH_DEFAULT_BITNESS
-  AC_LANG_PUSH(C)
-  AC_MSG_CHECKING(Selecting $1 bit model)
-  echo "int main() { return 0; }" >conftest.$ac_ext 
-  if test "$1" != "${COMPILER_MODEL_BITS}"
-  then
-    ${CC} ${CFLAGS} ${CPPFLAGS} -m$1 -c conftest.$ac_ext >&5
-    if test -f conftest.${OBJEXT} ; then
-      if test -n "`file conftest.${OBJEXT} | grep -i $1-bit`"
-      then
-        CFLAGS="${CFLAGS} -m$1"
-	AC_MSG_RESULT(-m$1)
-	COMPILER_MODEL_BITS=$1
+
+  AC_LANG_PUSH([C])
+    AC_MSG_CHECKING([if C compiler can use -m$1])
+    if test "$1" != "${COMPILER_MODEL_BITS}"; then
+      echo "int main() { return 0; }" >conftest.$ac_ext
+      AC_REQUIRE_CPP
+      ${CC} ${CFLAGS} ${CPPFLAGS} -m$1 -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
+      if test -f conftest.${OBJEXT}; then
+        if test -n "$(file conftest.${OBJEXT} | grep -i ${1}-bit)"; then
+          CFLAGS="${CFLAGS} -m$1"
+          AC_MSG_RESULT([ok use $1])
+        else
+          AC_MSG_ERROR([failed still $COMPILER_MODEL_BITS])
+        fi
       fi
-      AC_MSG_RESULT(failed)
+      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
     fi
-  else
-    AC_MSG_RESULT(ok)
-  fi
-  AC_LANG_POP(C)
+    AC_MSG_RESULT([ok use $1])
+  AC_LANG_POP([C])
+
+  COMPILER_MODEL_BITS=$1
 ])
 
 AC_DEFUN([SAH_OPTION_BITNESS],[

--- a/m4/sah_select_bitness.m4
+++ b/m4/sah_select_bitness.m4
@@ -18,6 +18,22 @@ AC_DEFUN([SAH_DEFAULT_BITNESS],[
       /bin/rm conftest.$ac_ext conftest.${OBJEXT}
       AC_MSG_RESULT([$COMPILER_MODEL_BITS])
     AC_LANG_POP([C])
+
+    AC_LANG_PUSH([C++])
+      AC_MSG_CHECKING([default bitness of C++ compiler])
+      echo "int main() { return 0; }" >conftest.$ac_ext
+      AC_REQUIRE_CPP
+      ${CXX} ${CXXFLAGS} ${CPPFLAGS} -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
+      if test -f conftest.${OBJEXT}; then
+        if test -n "$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format' | grep 64)" -o -n "$(file conftest.${OBJEXT} | grep -i 64-bit)"; then
+          if test "${COMPILER_MODEL_BITS}" != "64"; then
+            AC_MSG_ERROR([64 but not same as bitness in C])
+          fi
+        fi
+      fi
+      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+      AC_MSG_RESULT([$COMPILER_MODEL_BITS])
+    AC_LANG_POP([C++])
   fi
 ])
   

--- a/m4/sah_select_bitness.m4
+++ b/m4/sah_select_bitness.m4
@@ -7,15 +7,17 @@ AC_DEFUN([SAH_DEFAULT_BITNESS],[
       ${CC} ${CFLAGS} ${CPPFLAGS} -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
       COMPILER_MODEL_BITS=32
       if test -f conftest.${OBJEXT}; then
-        if test -n "$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format' | grep 64)" -o -n "$(file conftest.${OBJEXT} | grep -i 64-bit)"; then
+        OBJDUMP_TEST="$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format')"
+        FILE_TEST="$(file conftest.${OBJEXT})"
+        if test -n "$(echo $OBJDUMP_TEST | grep 64)" -o -n "$(echo $FILE_TEST | grep -i 64-bit)"; then
           COMPILER_MODEL_BITS=64
         #else
-          #if test -n "$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format' | grep 16)"; then
+          #if test -n "$(echo $OBJDUMP_TEST | grep 16)"; then
             #COMPILER_MODEL_BITS=16
           #fi
         fi
       fi
-      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+      /bin/rm -f conftest.$ac_ext conftest.${OBJEXT}
       AC_MSG_RESULT([$COMPILER_MODEL_BITS])
     AC_LANG_POP([C])
 
@@ -25,13 +27,20 @@ AC_DEFUN([SAH_DEFAULT_BITNESS],[
       AC_REQUIRE_CPP
       ${CXX} ${CXXFLAGS} ${CPPFLAGS} -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
       if test -f conftest.${OBJEXT}; then
-        if test -n "$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format' | grep 64)" -o -n "$(file conftest.${OBJEXT} | grep -i 64-bit)"; then
+        OBJDUMP_TEST="$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format')"
+        FILE_TEST="$(file conftest.${OBJEXT})"
+        if test -n "$(echo $OBJDUMP_TEST | grep 32)" -o -n "$(echo $FILE_TEST | grep -i 32-bit)"; then
+          if test "${COMPILER_MODEL_BITS}" != "32"; then
+            AC_MSG_ERROR([32 but not same as bitness in C])
+          fi
+        fi
+        if test -n "$(echo $OBJDUMP_TEST | grep 64)" -o -n "$(echo $FILE_TEST | grep -i 64-bit)"; then
           if test "${COMPILER_MODEL_BITS}" != "64"; then
             AC_MSG_ERROR([64 but not same as bitness in C])
           fi
         fi
       fi
-      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+      /bin/rm -f conftest.$ac_ext conftest.${OBJEXT}
       AC_MSG_RESULT([$COMPILER_MODEL_BITS])
     AC_LANG_POP([C++])
   fi
@@ -47,14 +56,15 @@ AC_DEFUN([SAH_SELECT_BITNESS],[
       AC_REQUIRE_CPP
       ${CC} ${CFLAGS} ${CPPFLAGS} -m$1 -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
       if test -f conftest.${OBJEXT}; then
-        if test -n "$(file conftest.${OBJEXT} | grep -i $1-bit)"; then
+        FILE_TEST="$(file conftest.${OBJEXT})"
+        if test -n "$(echo $FILE_TEST | grep -i $1-bit)"; then
           CFLAGS="${CFLAGS} -m$1"
           AC_MSG_RESULT([ok use $1])
         else
           AC_MSG_ERROR([failed still $COMPILER_MODEL_BITS])
         fi
       fi
-      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+      /bin/rm -f conftest.$ac_ext conftest.${OBJEXT}
     else
       AC_MSG_RESULT([ok use $1])
     fi
@@ -67,14 +77,15 @@ AC_DEFUN([SAH_SELECT_BITNESS],[
       AC_REQUIRE_CPP
       ${CXX} ${CXXFLAGS} ${CPPFLAGS} -m$1 -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
       if test -f conftest.${OBJEXT}; then
-        if test -n "$(file conftest.${OBJEXT} | grep -i $1-bit)"; then
+        FILE_TEST="$(file conftest.${OBJEXT})"
+        if test -n "$(echo $FILE_TEST | grep -i $1-bit)"; then
           CXXFLAGS="${CXXFLAGS} -m$1"
           AC_MSG_RESULT([ok use $1])
         else
           AC_MSG_ERROR([failed still $COMPILER_MODEL_BITS])
         fi
       fi
-      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+      /bin/rm -f conftest.$ac_ext conftest.${OBJEXT}
     else
       AC_MSG_RESULT([ok use $1])
     fi

--- a/m4/sah_select_bitness.m4
+++ b/m4/sah_select_bitness.m4
@@ -47,7 +47,7 @@ AC_DEFUN([SAH_SELECT_BITNESS],[
       AC_REQUIRE_CPP
       ${CC} ${CFLAGS} ${CPPFLAGS} -m$1 -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
       if test -f conftest.${OBJEXT}; then
-        if test -n "$(file conftest.${OBJEXT} | grep -i ${1}-bit)"; then
+        if test -n "$(file conftest.${OBJEXT} | grep -i $1-bit)"; then
           CFLAGS="${CFLAGS} -m$1"
           AC_MSG_RESULT([ok use $1])
         else
@@ -55,8 +55,9 @@ AC_DEFUN([SAH_SELECT_BITNESS],[
         fi
       fi
       /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+    else
+      AC_MSG_RESULT([ok use $1])
     fi
-    AC_MSG_RESULT([ok use $1])
   AC_LANG_POP([C])
 
   AC_LANG_PUSH([C++])
@@ -66,7 +67,7 @@ AC_DEFUN([SAH_SELECT_BITNESS],[
       AC_REQUIRE_CPP
       ${CXX} ${CXXFLAGS} ${CPPFLAGS} -m$1 -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
       if test -f conftest.${OBJEXT}; then
-        if test -n "$(file conftest.${OBJEXT} | grep -i ${1}-bit)"; then
+        if test -n "$(file conftest.${OBJEXT} | grep -i $1-bit)"; then
           CXXFLAGS="${CXXFLAGS} -m$1"
           AC_MSG_RESULT([ok use $1])
         else
@@ -74,8 +75,9 @@ AC_DEFUN([SAH_SELECT_BITNESS],[
         fi
       fi
       /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+    else
+      AC_MSG_RESULT([ok use $1])
     fi
-    AC_MSG_RESULT([ok use $1])
   AC_LANG_POP([C++])
 
   COMPILER_MODEL_BITS=$1

--- a/m4/sah_select_bitness.m4
+++ b/m4/sah_select_bitness.m4
@@ -1,23 +1,23 @@
 AC_DEFUN([SAH_DEFAULT_BITNESS],[
-  if test -z "${COMPILER_MODEL_BITS}"
-  then
-    AC_MSG_CHECKING(default bitness of compiler)
-    echo "int main() { return 0; }" >conftest.c
-    ${CC} ${CFLAGS} -c conftest.c >&5
-    COMPILER_MODEL_BITS=32
-    if test -f conftest.${OBJEXT} ; then
-      if test -n "`objdump --file-headers conftest.${OBJEXT} | grep 'file format' | grep 64`" -o -n "`file conftest.${OBJEXT} | grep -i 64-bit`" 
-      then
-        COMPILER_MODEL_BITS=64
-#      else
-#        if test -n "`objdump --file-headers conftest.${OBJEXT} | grep 'file format' | grep 16`" 
-#	then
-#          COMPILER_MODEL_BITS=16
-#        fi
+  if test -z "${COMPILER_MODEL_BITS}"; then
+    AC_LANG_PUSH([C])
+      AC_MSG_CHECKING([default bitness of C compiler])
+      echo "int main() { return 0; }" >conftest.$ac_ext
+      AC_REQUIRE_CPP
+      ${CC} ${CFLAGS} ${CPPFLAGS} -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
+      COMPILER_MODEL_BITS=32
+      if test -f conftest.${OBJEXT}; then
+        if test -n "$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format' | grep 64)" -o -n "$(file conftest.${OBJEXT} | grep -i 64-bit)"; then
+          COMPILER_MODEL_BITS=64
+        #else
+          #if test -n "$(${OBJDUMP} --file-headers conftest.${OBJEXT} | grep 'file format' | grep 16)"; then
+            #COMPILER_MODEL_BITS=16
+          #fi
+        fi
       fi
-    fi
-    /bin/rm conftest.c
-    AC_MSG_RESULT($COMPILER_MODEL_BITS)
+      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+      AC_MSG_RESULT([$COMPILER_MODEL_BITS])
+    AC_LANG_POP([C])
   fi
 ])
   

--- a/m4/sah_select_bitness.m4
+++ b/m4/sah_select_bitness.m4
@@ -59,6 +59,25 @@ AC_DEFUN([SAH_SELECT_BITNESS],[
     AC_MSG_RESULT([ok use $1])
   AC_LANG_POP([C])
 
+  AC_LANG_PUSH([C++])
+    AC_MSG_CHECKING([if C++ compiler can use -m$1])
+    if test "$1" != "${COMPILER_MODEL_BITS}"; then
+      echo "int main() { return 0; }" >conftest.$ac_ext
+      AC_REQUIRE_CPP
+      ${CXX} ${CXXFLAGS} ${CPPFLAGS} -m$1 -fno-lto -c conftest.$ac_ext 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD
+      if test -f conftest.${OBJEXT}; then
+        if test -n "$(file conftest.${OBJEXT} | grep -i ${1}-bit)"; then
+          CXXFLAGS="${CXXFLAGS} -m$1"
+          AC_MSG_RESULT([ok use $1])
+        else
+          AC_MSG_ERROR([failed still $COMPILER_MODEL_BITS])
+        fi
+      fi
+      /bin/rm conftest.$ac_ext conftest.${OBJEXT}
+    fi
+    AC_MSG_RESULT([ok use $1])
+  AC_LANG_POP([C++])
+
   COMPILER_MODEL_BITS=$1
 ])
 

--- a/m4/sah_select_bitness.m4
+++ b/m4/sah_select_bitness.m4
@@ -36,11 +36,10 @@ AC_DEFUN([SAH_DEFAULT_BITNESS],[
     AC_LANG_POP([C++])
   fi
 ])
-  
 
 AC_DEFUN([SAH_SELECT_BITNESS],[
-  AC_LANG_PUSH(C)
   SAH_DEFAULT_BITNESS
+  AC_LANG_PUSH(C)
   AC_MSG_CHECKING(Selecting $1 bit model)
   echo "int main() { return 0; }" >conftest.$ac_ext 
   if test "$1" != "${COMPILER_MODEL_BITS}"


### PR DESCRIPTION
Fixes #853

**Description of the Change**
Rework `sah_select_bitness.m4` to:
fix bitness test,
clarify errors and messages,
clean up formatting and use 2 spaces indents,
allow user defined ${OBJDUMP},
change from hardcoded file descriptor to AS_MESSAGE_LOG_FD,
add C++ compiler bitness tests (C and C++ must be same bitness to pass test)

**Alternate Designs**
Better use declarative unit test rather than iterative unit test in the future
Tested so far on Linux and emsdk

**Release Notes**
N/A