### PR TITLE
[Android] Fix Tasks loading

### DIFF
--- a/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
+++ b/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2019 University of California
+ * Copyright (C) 2021 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -87,7 +87,8 @@ GlobalPreferences getPrefs();        // clientStatus.getPrefs()
 List<Project> getProjects();    // clientStatus.getProjects();
 AcctMgrInfo getClientAcctMgrInfo();   // clientStatus.getAcctMgrInfo();
 List<Transfer> getTransfers();   // clientStatus.getTransfers();
-List<Result> getTasks();          // clientStatus.getTasks();
+List<Result> getTasks(in int start, in int count, in boolean isActive);          // clientStatus.getTasks(int, int, boolean);
+int getTasksCount(); // clientStatus.getTasksCount();
 Bitmap getProjectIconByName(in String name);  // clientStatus.getProjectIconByName(entries.get(position).project_name);
 Bitmap getProjectIcon(in String id);        // clientStatus.getProjectIcon(entries.get(position).id);
 String getProjectStatus(in String url);   // clientStatus.getProjectStatus(url);

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2020 University of California
+ * Copyright (C) 2021 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -43,11 +43,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.collections.ArrayList
 import java.util.*
 
 class TasksFragment : Fragment() {
     private lateinit var recyclerViewAdapter: TaskRecyclerViewAdapter
     private val data: MutableList<TaskData> = ArrayList()
+    private var lastFullUpdateTimeStamp: Long = 0
     private val mClientStatusChangeRec: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             if (Logging.VERBOSE) {
@@ -89,29 +91,71 @@ class TasksFragment : Fragment() {
         super.onPause()
     }
 
-    private fun loadData() {
-        // try to get current client status from monitor
-        val tmpA = try {
-            BOINCActivity.monitor!!.tasks
-        } catch (e: Exception) {
-            if (Logging.WARNING) {
-                Log.w(Logging.TAG, "TasksActivity: Could not load data, clientStatus not initialized.")
-            }
-            return
+    private fun loadTasks(start: Int, count: Int, isActive: Boolean): List<Result> {
+        return BOINCActivity.monitor?.getTasks(start, count, isActive) ?: emptyList()
+    }
+
+    private fun loadTasks(isActive: Boolean): MutableList<Result> {
+        val tasks: MutableList<Result> = ArrayList()
+        var start = 0
+        val count = 10
+
+        while (true) {
+            val data = loadTasks(start, count, isActive)
+            tasks.addAll(data);
+            if (data.size < count) break
+            start += count
         }
+
+        return tasks
+    }
+
+    private fun compareTwoListsOfActiveTasks(old: List<TaskData>, new: List<Result>): Boolean {
+        if (old.size != new.size) {
+            return false
+        }
+        return old.none { o -> new.indexOfFirst { it.name == o.id } == -1 }
+    }
+
+    private fun loadData() {
+        val tasks: MutableList<Result> = ArrayList()
+        val activeTasks: MutableList<TaskData> = ArrayList()
+        val timestamp = System.currentTimeMillis()
+        // perform full update every 10 seconds
+        var fullUpdate: Boolean = (timestamp - lastFullUpdateTimeStamp) > (10 * 1000)
+
+        for (task in data) {
+            if (task.isTaskActive) {
+                activeTasks.add(task)
+            }
+        }
+
+        val newActiveTasks = loadTasks(true)
+
+        if (!fullUpdate) {
+            fullUpdate = !(compareTwoListsOfActiveTasks(activeTasks, newActiveTasks))
+        }
+
+        tasks.addAll(newActiveTasks)
+
+        if (fullUpdate) {
+            tasks.addAll(loadTasks(false))
+            lastFullUpdateTimeStamp = timestamp
+        }
+
         //setup list and adapter
-        if (tmpA != null) { //can be null before first monitor status cycle (e.g. when not logged in or during startup)
+        if (tasks.isNotEmpty()) {
             //deep copy, so ArrayList adapter actually recognizes the difference
-            updateData(tmpA)
+            updateData(tasks, fullUpdate)
             recyclerViewAdapter.notifyDataSetChanged() //force list adapter to refresh
         } else {
             if (Logging.WARNING) {
-                Log.w(Logging.TAG, "loadData: array is null, rpc failed")
+                Log.w(Logging.TAG, "loadData: array is empty, rpc failed")
             }
         }
     }
 
-    private fun updateData(newData: List<Result>) {
+    private fun updateData(newData: List<Result>, fullUpdate: Boolean) {
         //loop through all received Result items to add new results
         for (rpcResult in newData) {
             //check whether this Result is new
@@ -126,8 +170,10 @@ class TasksFragment : Fragment() {
             }
         }
 
-        //loop through the list adapter to find removed (ready/aborted) Results
-        data.removeIf { item -> newData.none { it.name == item.id } }
+        if (fullUpdate) {
+            //loop through the list adapter to find removed (ready/aborted) Results
+            data.removeIf { item -> newData.none { it.name == item.id } }
+        }
     }
 
     inner class TaskData(var result: Result) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/adapter/NavDrawerListAdapter.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2016 University of California
+ * Copyright (C) 2021 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -147,7 +147,7 @@ public class NavDrawerListAdapter extends BaseAdapter {
                     try {
                         final IMonitor monitor = BOINCActivity.monitor;
                         if (monitor != null)
-                            counter = monitor.getTasks().size();
+                            counter = monitor.getTasksCount();
                     }
                     catch(Exception e) {
                         if(Logging.ERROR) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/ClientStatus.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2012 University of California
+ * Copyright (C) 2021 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -300,14 +300,42 @@ public class ClientStatus {
         return status;
     }
 
-    public synchronized List<Result> getTasks() {
+    public synchronized List<Result> getTasks(int start, int count, boolean isActive) {
         if(results == null) { //check in case monitor is not set up yet (e.g. while logging in)
             if(Logging.DEBUG) {
-                Log.d(Logging.TAG, "state is null");
+                Log.d(Logging.TAG, "tasks is null");
             }
             return Collections.emptyList();
         }
-        return results;
+
+        List<Result> tasks = new ArrayList<>();
+        int counter = 0;
+
+        for (Result res : results) {
+            if (tasks.size() == count) {
+                break;
+            }
+
+            if (start > counter++) {
+                continue;
+            }
+
+            if ((isActive && res.isActiveTask()) || (!isActive && !res.isActiveTask())) {
+                tasks.add(res);
+            }
+        }
+
+        return tasks;
+    }
+
+    public synchronized int getTasksCount() {
+        if(results == null) { //check in case monitor is not set up yet (e.g. while logging in)
+            if(Logging.DEBUG) {
+                Log.d(Logging.TAG, "tasksCount is null");
+            }
+            return 0;
+        }
+        return results.size();
     }
 
     public synchronized List<Transfer> getTransfers() {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2020 University of California
+ * Copyright (C) 2021 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License
@@ -1062,8 +1062,13 @@ class Monitor : LifecycleService() {
         }
 
         @Throws(RemoteException::class)
-        override fun getTasks(): List<Result> {
-            return clientStatus.tasks
+        override fun getTasks(start: Int, count: Int, isActive: Boolean): List<Result> {
+            return clientStatus.getTasks(start, count, isActive)
+        }
+
+        @Throws(RemoteException::class)
+        override fun getTasksCount(): Int {
+            return clientStatus.tasksCount
         }
 
         @Throws(RemoteException::class)


### PR DESCRIPTION
On modern devices with more than 4 cores or when there is a big tasks cache set could happen a situation when 0 tasks are shown.
This happens because of the limit of 1MB to transfer data between processes.
This commit breaks this flow and instead adds a possibility to load data by chunks.
Also small optimization implemented to update only active tasks every second.
Full update is done every 10 seconds now because most of the time non-active tasks are not updated so often.

This fixes #2123

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
