### PR TITLE
Mac: Fix high CPU use by Simple View when run on MacOS 10.14 and later

### DIFF
--- a/clientgui/mac/MacBitmapComboBox.cpp
+++ b/clientgui/mac/MacBitmapComboBox.cpp
@@ -17,6 +17,7 @@
 
 #include "stdwx.h"
 #include "MacBitmapComboBox.h"
+#include "mac_util.h"
 
 #define POPUPBUTTONCONTROLHEIGHT 40
 
@@ -275,7 +276,7 @@ void CBOINCBitmapComboBox::OnPaint(wxPaintEvent& event) {
     wxBrush oldBrush = myDC.GetBrush();
     int oldMode = myDC.GetBackgroundMode();
 
-    myDC.SetPen(*wxMEDIUM_GREY_PEN);
+    myDC.SetPen(*wxLIGHT_GREY_PEN);
     myDC.SetBrush(*wxWHITE_BRUSH);
     myDC.SetBackgroundMode(wxSOLID);
 
@@ -287,8 +288,10 @@ void CBOINCBitmapComboBox::OnPaint(wxPaintEvent& event) {
     myDC.SetPen(oldPen);
     myDC.SetBrush(oldBrush);
 
-    CDrawLargeBitmapEvent newEvent(wxEVT_DRAW_LARGEBITMAP, this);
-    AddPendingEvent(newEvent);
+    if (compareOSVersionTo(10, 14) < 0) {
+        CDrawLargeBitmapEvent newEvent(wxEVT_DRAW_LARGEBITMAP, this);
+        AddPendingEvent(newEvent);
+    }
 }
 
 


### PR DESCRIPTION
Fixes excessive CPU use by Simple View when run on MacOS 10.14 and later
