### PR TITLE
Maximum CPU time - spread tasks evenly over timeslot #4181

### DIFF
--- a/client/app.h
+++ b/client/app.h
@@ -158,6 +158,9 @@ struct ACTIVE_TASK {
         // running past end of time slice because not checkpointed;
         // when we do checkpoint, reschedule
     double last_deadline_miss_time;
+    
+    unsigned int throttler_start_tick; //!< Used by the throttler thread to detemine when an active task should resume running (valid values are between 0 and 99)
+    unsigned int throttler_remaining_runtime; //!< Used by the throttler thread; counting down seconds until 0 after which the throttler thread suspends this task (max value is 100)
 
     APP_CLIENT_SHM app_client_shm;
         // core/app shared mem segment


### PR DESCRIPTION
Fixes #4181

**Description of the Change**
Modified the behavior of cpu_usage_limit to run tasks spread over a 100 second window, instead of all at once.

**Alternate Designs**
The old implementation gave a bad user experience, as all tasks where running for a short time, blocking to PC for other processes. This implementation will smooth out the cpu usage over a longer time window. 

**Release Notes**
Changed the cpu_usage_limit throttling behavior to spread out tasks over time.