### PR TITLE
Fix empty path for message "OpenSSL found in"

### DIFF
--- a/m4/check_ssl.m4
+++ b/m4/check_ssl.m4
@@ -18,7 +18,7 @@ AC_ARG_WITH(ssl,
     [check_ssl_dir="$withval"],
     [check_ssl_dir=])
 if test "x${PKGCONFIG}" != "x" -a "x${check_ssl_dir}" = "x" ; then
-    SSLDIR="`${PKGCONFIG} openssl --cflags-only-I | sed -e 's/-I//' -e 's/\/include\/openssl//' -e 's/\/include//' | grep '[a-z]' 2>/dev/null`"
+    SSLDIR="`${PKGCONFIG} openssl --cflags-only-I 2>/dev/null | sed -e 's/-I//' -e 's/\/include\/openssl//' -e 's/\/include//'`"
     if test "x${SSLDIR}" = "x" ; then
       if test -d "/usr/include/openssl" -o -f "/usr/include/ssl.h" ; then
         SSLDIR="/usr"


### PR DESCRIPTION
1. Errors are only emitted by pkg-config so discard early
2. grep only takes paths with lower case a to z. There are plenty of path variations so don't take chances.
3. $SSLDIR is for cosmetic only and not used during compilation

**Description of the Change**
N/A

**Alternate Designs**
N/A

**Release Notes**
N/A