### PR TITLE
fix API build for C apps

### DIFF
--- a/lib/diagnostics.h
+++ b/lib/diagnostics.h
@@ -34,7 +34,9 @@
 #include <dlfcn.h>
 #endif
 
+#ifdef __cplusplus
 extern bool main_exited;
+#endif
 
 // some of the Android stuff below causes seg faults on some devices.
 // Disable by default.


### PR DESCRIPTION
**Description of the Change**
Fixes build and install of the API (headers) for building C apps

- there's a declaration of a `bool` variable in `diagnostics.h`, which makes C compilers throw an error. Protect this with `#ifdef __cplusplus`
