### PR TITLE
Add a GUI RPC "reset_host_info" that tells the client to get host params again (RAM size, disk, NCPUs, etc.).

### DIFF
--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -89,6 +89,7 @@ Commands:\n\
  --quit_acct_mgr                    same as --acct_mgr detach\n\
  --read_cc_config\n\
  --read_global_prefs_override\n\
+ --reset_host_info                  have client get mem size, #CPUs etc. again\n\
  --run_benchmarks\n\
  --run_graphics_app id op         (Macintosh only) run, test or stop graphics app\n\
    op = run | runfullscreen | stop | test\n\
@@ -669,6 +670,8 @@ int main(int argc, char** argv) {
     } else if (!strcmp(cmd, "--read_cc_config")) {
         retval = rpc.read_cc_config();
         printf("retval %d\n", retval);
+    } else if (!strcmp(cmd, "--reset_host_info")) {
+        retval = rpc.reset_host_info();
     } else if (!strcmp(cmd, "--network_available")) {
         retval = rpc.network_available();
     } else if (!strcmp(cmd, "--set_app_config")) {

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -631,6 +631,16 @@ static void handle_get_host_info(GUI_RPC_CONN& grc) {
     gstate.host_info.write(grc.mfout, true, true);
 }
 
+static void handle_reset_host_info(GUI_RPC_CONN& grc) {
+    gstate.host_info.get_host_info(true);
+    // the amount of RAM or #CPUs may have changed
+    //
+    gstate.set_ncpus();
+    gstate.request_schedule_cpus("reset_host_info");
+    gstate.show_host_info();
+    grc.mfout.printf("<success/>\n");
+}
+
 static void handle_get_screensaver_tasks(GUI_RPC_CONN& grc) {
     unsigned int i;
     ACTIVE_TASK* atp;
@@ -1743,10 +1753,7 @@ struct GUI_RPC {
     char alt_req_tag[256];
     GUI_RPC_HANDLER handler;
     bool auth_required;
-        // operations that require authentication only for non-local clients.
-        // Use this only for information that should be available to people
-        // sharing this computer (e.g. what jobs are running)
-        // but not for anything sensitive (passwords etc.)
+        // operations that require authentication with RPC key
     bool enable_network;
         // RPCs that should enable network communication for 5 minutes,
         // overriding other factors.
@@ -1764,7 +1771,7 @@ struct GUI_RPC {
     }
 };
 
-                                                                    // local auth required
+                                                                    // auth required
                                                                             // enable network
                                                                                     // read-only
 GUI_RPC gui_rpcs[] = {
@@ -1819,6 +1826,7 @@ GUI_RPC gui_rpcs[] = {
     GUI_RPC("read_global_prefs_override", handle_read_global_prefs_override,
                                                                     true,   false,  false),
     GUI_RPC("report_device_status", handle_report_device_status,    true,   false,  false),
+    GUI_RPC("reset_host_info", handle_reset_host_info,              true,   false,  false),
     GUI_RPC("resume_result", handle_resume_result,                  true,   false,  false),
     GUI_RPC("run_benchmarks", handle_run_benchmarks,                true,   false,  false),
     GUI_RPC("set_app_config", handle_set_app_config,                true,   false,  false),

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -378,8 +378,9 @@ int RPC::parse_reply() {
     char buf[256], error_msg[256];
     int n;
     while (fin.fgets(buf, 256)) {
-        if (strstr(buf, "boinc_gui_rpc_reply>"))
-                continue;
+        if (strstr(buf, "boinc_gui_rpc_reply>")) {
+            continue;
+        }
         if (strstr(buf, "<success")) return 0;
         if (parse_int(buf, "<status>", n)) {
             return n;

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -716,6 +716,7 @@ struct RPC_CLIENT {
     int result_op(RESULT&, const char*);
     int get_host_info(HOST_INFO&);
     int set_host_info(HOST_INFO&);
+    int reset_host_info();
     int quit();
     int acct_mgr_info(ACCT_MGR_INFO&);
     const char* mode_name(int mode);

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -2228,6 +2228,17 @@ int RPC_CLIENT::set_host_info(HOST_INFO& h) {
     return rpc.parse_reply();
 }
 
+int RPC_CLIENT::reset_host_info() {
+    SET_LOCALE sl;
+    RPC rpc(this);
+    char buf[1024];
+
+    snprintf(buf, sizeof(buf), "<reset_host_info>\n</reset_host_info>\n");
+    int retval = rpc.do_rpc(buf);
+    if (retval) return retval;
+    return rpc.parse_reply();
+}
+
 int RPC_CLIENT::quit() {
     int retval;
     SET_LOCALE sl;


### PR DESCRIPTION
This is so that if you're running the client in a container,
and you change the params of the container (e.g. reduce its memory size)
the client can learn of this.