### PR TITLE
configure.ac, boinc-client and boinc-manager:

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -647,7 +647,9 @@ int CLIENT_STATE::init() {
     // NOTE: this must be called AFTER
     // read_vc_config_file()
     //
+#ifdef ENABLE_NEW_VERSION_CHECK
     newer_version_startup_check();
+#endif
 
     // parse account files again,
     // now that we know the host's venue on each project

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -134,7 +134,9 @@ int SCHEDULER_OP::init_op_project(PROJECT* p, int r) {
         // and project list
         //
         if (!cc_config.no_info_fetch) {
+#ifdef ENABLE_NEW_VERSION_CHECK
             gstate.new_version_check();
+#endif
             gstate.all_projects_list_check();
         }
     }

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -195,7 +195,9 @@ BEGIN_EVENT_TABLE (CAdvancedFrame, CBOINCBaseFrame)
     EVT_MENU(ID_HELPBOINCMANAGER, CAdvancedFrame::OnHelpBOINC)
     EVT_MENU(ID_HELPBOINCWEBSITE, CAdvancedFrame::OnHelpBOINC)
     EVT_MENU(wxID_ABOUT, CAdvancedFrame::OnHelpAbout)
+#ifdef ENABLE_NEW_VERSION_CHECK
     EVT_MENU(ID_CHECK_VERSION, CAdvancedFrame::OnCheckVersion)
+#endif
     EVT_MENU(ID_REPORT_BUG, CAdvancedFrame::OnReportBug)
     EVT_HELP(wxID_ANY, CAdvancedFrame::OnHelp)
     // Custom Events & Timers
@@ -684,6 +686,7 @@ bool CAdvancedFrame::CreateMenus() {
     );
     menuHelp->AppendSeparator();
 
+#ifdef ENABLE_NEW_VERSION_CHECK
     strMenuName.Printf(
         _("Check for new %s version"),
         pSkinAdvanced->GetApplicationShortName().c_str()
@@ -698,6 +701,7 @@ bool CAdvancedFrame::CreateMenus() {
         strMenuDescription
     );
     menuHelp->AppendSeparator();
+#endif
 
     menuHelp->Append(
         ID_REPORT_BUG,

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -91,7 +91,9 @@ BEGIN_EVENT_TABLE(CSimpleFrame, CBOINCBaseFrame)
     EVT_MENU(ID_HELPBOINCMANAGER, CSimpleFrame::OnHelpBOINC)
     EVT_MENU(ID_HELPBOINCWEBSITE, CSimpleFrame::OnHelpBOINC)
     EVT_MENU(wxID_ABOUT, CSimpleFrame::OnHelpAbout)
+#ifdef ENABLE_NEW_VERSION_CHECK
     EVT_MENU(ID_CHECK_VERSION, CSimpleFrame::OnCheckVersion)
+#endif
     EVT_MENU(ID_REPORT_BUG, CSimpleFrame::OnReportBug)
     EVT_MENU(ID_EVENTLOG, CSimpleFrame::OnEventLog)
     EVT_MOVE(CSimpleFrame::OnMove)
@@ -318,6 +320,7 @@ bool CSimpleFrame::CreateMenus() {
     );
     menuHelp->AppendSeparator();
 
+#ifdef ENABLE_NEW_VERSION_CHECK
     strMenuName.Printf(
         _("Check for new %s version"),
         pSkinAdvanced->GetApplicationShortName().c_str()
@@ -332,6 +335,7 @@ bool CSimpleFrame::CreateMenus() {
         strMenuDescription
     );
     menuHelp->AppendSeparator();
+#endif
 
     menuHelp->Append(
         ID_REPORT_BUG,

--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,12 @@ AC_ARG_ENABLE(unit-tests,
     [enable_unit_tests=${enableval}],
     [enable_unit_tests=no])
 
+AC_ARG_ENABLE(new-version-check,
+    AS_HELP_STRING([--enable-new-version-check],
+                   [enable checking for new versions in boinc]),
+    [enable_new_version_check=${enableval}],
+    [enable_new_version_check=yes])
+
 AC_ARG_ENABLE(pkg-libs,
     AS_HELP_STRING([--enable-pkg-libs],
                    [Builds and installs components that would be present in a
@@ -225,6 +231,9 @@ if test x$enable_apps = xyes ; then
     enable_openclapp=yes
   fi
   configured_to_build="${configured_to_build} apps"
+fi
+if test x$enable_new_version_check = xyes ; then
+  AC_DEFINE([ENABLE_NEW_VERSION_CHECK], [1], "check for new version enabled")
 fi
 if test x$enable_unit_tests = xyes ; then
   configured_to_build="${configured_to_build} unit-tests"

--- a/version.h
+++ b/version.h
@@ -1,5 +1,6 @@
 /* Platform independent version definitions... */
 
+#include "config.h"
 #ifndef BOINC_VERSION_H
 #define BOINC_VERSION_H
 

--- a/version.h.in
+++ b/version.h.in
@@ -1,5 +1,6 @@
 /* Platform independent version definitions... */
 
+#include "config.h"
 #ifndef BOINC_VERSION_H
 #define BOINC_VERSION_H
 


### PR DESCRIPTION
make the check for new version something configurable via autoconf via switch:
--disable-new-version-check to disable it (something for package maintainers)
--enable-new-version-check to enable it (default)

This way, boinc into package repository won't try to search for new version, avoiding to
call home.

Also, include config.h into version.h, otherwise the new ENABLE_NEW_VERSION_CHECK define
is not taken into account from clientgui graphical manager.
