### PR TITLE
Make DB_BASE::insert_id() correctly return numbers exceeding 32bits

### DIFF
--- a/db/db_base.cpp
+++ b/db/db_base.cpp
@@ -153,7 +153,7 @@ int DB_CONN::affected_rows() {
     return (int)x;
 }
 
-int DB_CONN::insert_id() {
+DB_ID_TYPE DB_CONN::insert_id() {
     int retval;
     MYSQL_ROW row;
     MYSQL_RES* rp;
@@ -162,7 +162,7 @@ int DB_CONN::insert_id() {
     if (retval) return retval;
     rp = mysql_store_result(mysql);
     row = mysql_fetch_row(rp);
-    int x = atoi(row[0]);
+    DB_ID_TYPE x = atol(row[0]);
     mysql_free_result(rp);
     return x;
 }

--- a/db/db_base.h
+++ b/db/db_base.h
@@ -71,7 +71,7 @@ public:
     int do_query(const char*);
     int affected_rows();
     void close();
-    int insert_id();
+    DB_ID_TYPE insert_id();
     void print_error(const char*);
     const char* error_string();
     int ping();


### PR DESCRIPTION
Fixes #4276

**Description of the Change**
Changed DB_BASE::insert_id() to return DB_ID_TYPE, which is long, and use atol instead of atoi for number parsing. This fixes the scheduler assigned-work feature.