### PR TITLE
[Codecov] Fix unit tests coverage report

### DIFF
--- a/m4/boinc_set_compile_flags.m4
+++ b/m4/boinc_set_compile_flags.m4
@@ -121,6 +121,8 @@ fi
 if test x${enable_unit_tests} = xyes ; then
   BOINC_CHECK_CFLAG(--coverage)
   BOINC_CHECK_CXXFLAG(--coverage)
+  BOINC_CHECK_CFLAG(-fprofile-abs-path)
+  BOINC_CHECK_CXXFLAG(-fprofile-abs-path)
   LDFLAGS="$LDFLAGS --coverage"
 fi
 


### PR DESCRIPTION
Since gcc 8.1.0 release, source file is needed to generate correct coverage report.
New compilation flag `-fprofile-abs-path` was introduced to preserve correct path to source file in *.gcno file.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
