### PR TITLE
Client: fix app_config write from RPC

### DIFF
--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1195,7 +1195,6 @@ static void handle_get_app_config(GUI_RPC_CONN& grc) {
         return;
     }
     sprintf(path, "%s/%s", p->project_dir(), APP_CONFIG_FILE_NAME);
-    // printf("path: %s\n", path);    // debug only
     int retval = read_file_string(path, s);
     if (retval) {
         grc.mfout.printf("<error>app_config.xml not found</error>\n");

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1195,7 +1195,7 @@ static void handle_get_app_config(GUI_RPC_CONN& grc) {
         return;
     }
     sprintf(path, "%s/%s", p->project_dir(), APP_CONFIG_FILE_NAME);
-    printf("path: %s\n", path);
+    // printf("path: %s\n", path);    // debug only
     int retval = read_file_string(path, s);
     if (retval) {
         grc.mfout.printf("<error>app_config.xml not found</error>\n");

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -864,19 +864,21 @@ int APP_CONFIGS::parse_file(FILE* f, MSG_VEC& mv, LOG_FLAGS& log_flags) {
 
 void APP_CONFIGS::write(MIOFILE& out) {
     out.printf(
-        "   <app_config>\n"
+        "<app_config>\n"
     );
     for (unsigned int i=0; i<app_configs.size(); i++) {
         APP_CONFIG& ac = app_configs[i];
         out.printf(
-            "       <app>\n"
-            "           <name>%s</name>\n"
-            "           <max_concurrent>%d</max_concurrent>\n"
-            "           <gpu_gpu_usage>%f</gpu_gpu_usage>\n"
-            "           <gpu_cpu_usage>%f</gpu_cpu_usage>\n"
-            "           <fraction_done_exact>%d</fraction_done_exact>\n"
-            "           <report_results_immediately>%d</report_results_immediately>\n"
-            "       </app>\n",
+            "    <app>\n"
+            "        <name>%s</name>\n"
+            "        <max_concurrent>%d</max_concurrent>\n"
+            "        <gpu_versions>\n"
+            "            <gpu_usage>%f</gpu_usage>\n"
+            "            <cpu_usage>%f</cpu_usage>\n"
+            "        </gpu_versions>\n"
+            "        <fraction_done_exact>%d</fraction_done_exact>\n"
+            "        <report_results_immediately>%d</report_results_immediately>\n"
+            "    </app>\n",
             ac.name,
             ac.max_concurrent,
             ac.gpu_gpu_usage,
@@ -888,13 +890,13 @@ void APP_CONFIGS::write(MIOFILE& out) {
     for (unsigned int i=0; i<app_version_configs.size(); i++) {
         APP_VERSION_CONFIG& avc = app_version_configs[i];
         out.printf(
-            "       <app_version>\n"
-            "           <app_name>%s</app_name>\n"
-            "           <plan_class>%s</plan_class>\n"
-            "           <cmdline>%s</cmdline>\n"
-            "           <avg_ncpus>%f</avg_ncpus>\n"
-            "           <ngpus>%f</ngpus>\n"
-            "       </app_version>\n",
+            "    <app_version>\n"
+            "        <app_name>%s</app_name>\n"
+            "        <plan_class>%s</plan_class>\n"
+            "        <cmdline>%s</cmdline>\n"
+            "        <avg_ncpus>%f</avg_ncpus>\n"
+            "        <ngpus>%f</ngpus>\n"
+            "    </app_version>\n",
             avc.app_name,
             avc.plan_class,
             avc.cmdline,
@@ -903,9 +905,9 @@ void APP_CONFIGS::write(MIOFILE& out) {
         );
     }
     out.printf(
-        "       <project_max_concurrent>%d</project_max_concurrent>\n"
-        "       <report_results_immediately>%d</report_results_immediately>\n"
-        "   </app_config>\n",
+        "    <project_max_concurrent>%d</project_max_concurrent>\n"
+        "    <report_results_immediately>%d</report_results_immediately>\n"
+        "</app_config>\n",
         project_max_concurrent,
         report_results_immediately?1:0
     );


### PR DESCRIPTION
In May 2017, a new RPC was added for reading and writing remote app_config.xml files (commit 5b6f648570cdef551b77bbabf3e69243dac69de4, no associated PR). The file written contained unparsable XML with unrecognised tags. This patch restores compliance with the existing documentation at

https://boinc.berkeley.edu/wiki/Client_configuration#Project-level_configuration
https://scienceunited.org/trac/wiki/ClientAppConfig

Fixes 5b6f648570cdef551b77bbabf3e69243dac69de4

Bug re-discovered during Beta testing of covid-19 app at World Community Grid.

**Release Notes**
Allow edit of app_config.xml files by BoincTasks