### PR TITLE
[Improvement]: add overide keyword on abstract method

### DIFF
--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -187,7 +187,7 @@ struct ACCT_MGR_OP: public GUI_HTTP_OP {
 
     int do_rpc(ACCT_MGR_INFO&, bool via_gui);
     int parse(FILE*);
-    virtual void handle_reply(int http_op_retval);
+    virtual void handle_reply(int http_op_retval) override;
 
     ACCT_MGR_OP(GUI_HTTP* p) {
         gui_http = p;

--- a/client/acct_setup.h
+++ b/client/acct_setup.h
@@ -48,7 +48,7 @@ struct GET_PROJECT_CONFIG_OP: public GUI_HTTP_OP {
     }
     virtual ~GET_PROJECT_CONFIG_OP(){}
     int do_rpc(std::string url);
-    virtual void handle_reply(int http_op_retval);
+    virtual void handle_reply(int http_op_retval) override;
 };
 
 struct LOOKUP_ACCOUNT_OP: public GUI_HTTP_OP {
@@ -61,7 +61,7 @@ struct LOOKUP_ACCOUNT_OP: public GUI_HTTP_OP {
     }
     virtual ~LOOKUP_ACCOUNT_OP(){}
     int do_rpc(ACCOUNT_IN&);
-    virtual void handle_reply(int http_op_retval);
+    virtual void handle_reply(int http_op_retval) override;
 };
 
 struct CREATE_ACCOUNT_OP: public GUI_HTTP_OP {
@@ -74,7 +74,7 @@ struct CREATE_ACCOUNT_OP: public GUI_HTTP_OP {
     }
     virtual ~CREATE_ACCOUNT_OP(){}
     int do_rpc(ACCOUNT_IN&, std::string rpc_client_name);
-    virtual void handle_reply(int http_op_retval);
+    virtual void handle_reply(int http_op_retval) override;
 };
 
 struct GET_PROJECT_LIST_OP: public GUI_HTTP_OP {
@@ -86,7 +86,7 @@ struct GET_PROJECT_LIST_OP: public GUI_HTTP_OP {
     }
     virtual ~GET_PROJECT_LIST_OP(){}
     int do_rpc();
-    virtual void handle_reply(int http_op_retval);
+    virtual void handle_reply(int http_op_retval) override;
 };
 
 struct LOOKUP_LOGIN_TOKEN_OP: public GUI_HTTP_OP {
@@ -99,7 +99,7 @@ struct LOOKUP_LOGIN_TOKEN_OP: public GUI_HTTP_OP {
     }
     virtual ~LOOKUP_LOGIN_TOKEN_OP(){}
     int do_rpc(PROJECT_LIST_ITEM*, int user_id, const char* login_token);
-    virtual void handle_reply(int http_op_retval);
+    virtual void handle_reply(int http_op_retval) override;
 };
 
 struct PROJECT_ATTACH {

--- a/clientsetup/win/CAAnnounceUpgrade.h
+++ b/clientsetup/win/CAAnnounceUpgrade.h
@@ -28,7 +28,7 @@ public:
 
     CAAnnounceUpgrade(MSIHANDLE hMSIHandle);
     ~CAAnnounceUpgrade();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 };
 
 

--- a/clientsetup/win/CACCConfigMd5sum.h
+++ b/clientsetup/win/CACCConfigMd5sum.h
@@ -28,7 +28,7 @@ public:
 
     CACCConfigMd5sum(MSIHANDLE hMSIHandle);
     ~CACCConfigMd5sum();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CACleanupOldBinaries.h
+++ b/clientsetup/win/CACleanupOldBinaries.h
@@ -28,7 +28,7 @@ public:
 
     CACleanupOldBinaries(MSIHANDLE hMSIHandle);
     ~CACleanupOldBinaries();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CACreateAcctMgrLoginFile.h
+++ b/clientsetup/win/CACreateAcctMgrLoginFile.h
@@ -28,7 +28,7 @@ public:
 
     CACreateAcctMgrLoginFile(MSIHANDLE hMSIHandle);
     ~CACreateAcctMgrLoginFile();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CACreateBOINCAccounts.h
+++ b/clientsetup/win/CACreateBOINCAccounts.h
@@ -28,7 +28,7 @@ public:
 
     CACreateBOINCAccounts(MSIHANDLE hMSIHandle);
     ~CACreateBOINCAccounts();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CACreateBOINCGroups.h
+++ b/clientsetup/win/CACreateBOINCGroups.h
@@ -28,7 +28,7 @@ public:
 
     CACreateBOINCGroups(MSIHANDLE hMSIHandle);
     ~CACreateBOINCGroups();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CACreateClientAuthFile.h
+++ b/clientsetup/win/CACreateClientAuthFile.h
@@ -28,7 +28,7 @@ public:
 
     CACreateClientAuthFile(MSIHANDLE hMSIHandle);
     ~CACreateClientAuthFile();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CACreateProjectInitFile.h
+++ b/clientsetup/win/CACreateProjectInitFile.h
@@ -30,7 +30,7 @@ public:
 
     CACreateProjectInitFile(MSIHANDLE hMSIHandle);
     ~CACreateProjectInitFile();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CADeleteBOINCAccounts.h
+++ b/clientsetup/win/CADeleteBOINCAccounts.h
@@ -28,7 +28,7 @@ public:
 
     CADeleteBOINCAccounts(MSIHANDLE hMSIHandle);
     ~CADeleteBOINCAccounts();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CADeleteBOINCGroups.h
+++ b/clientsetup/win/CADeleteBOINCGroups.h
@@ -28,7 +28,7 @@ public:
 
     CADeleteBOINCGroups(MSIHANDLE hMSIHandle);
     ~CADeleteBOINCGroups();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGetAdministratorsGroupName.h
+++ b/clientsetup/win/CAGetAdministratorsGroupName.h
@@ -28,7 +28,7 @@ public:
 
     CAGetAdministratorsGroupName(MSIHANDLE hMSIHandle);
     ~CAGetAdministratorsGroupName();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGetUsersGroupName.h
+++ b/clientsetup/win/CAGetUsersGroupName.h
@@ -28,7 +28,7 @@ public:
 
     CAGetUsersGroupName(MSIHANDLE hMSIHandle);
     ~CAGetUsersGroupName();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGrantBOINCAdminsRights.h
+++ b/clientsetup/win/CAGrantBOINCAdminsRights.h
@@ -28,7 +28,7 @@ public:
 
     CAGrantBOINCAdminsRights(MSIHANDLE hMSIHandle);
     ~CAGrantBOINCAdminsRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGrantBOINCAdminsVirtualBoxRights.h
+++ b/clientsetup/win/CAGrantBOINCAdminsVirtualBoxRights.h
@@ -28,7 +28,7 @@ public:
 
     CAGrantBOINCAdminsVirtualBoxRights(MSIHANDLE hMSIHandle);
     ~CAGrantBOINCAdminsVirtualBoxRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGrantBOINCMasterRights.h
+++ b/clientsetup/win/CAGrantBOINCMasterRights.h
@@ -28,7 +28,7 @@ public:
 
     CAGrantBOINCMasterRights(MSIHANDLE hMSIHandle);
     ~CAGrantBOINCMasterRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGrantBOINCProjectRights.h
+++ b/clientsetup/win/CAGrantBOINCProjectRights.h
@@ -28,7 +28,7 @@ public:
 
     CAGrantBOINCProjectRights(MSIHANDLE hMSIHandle);
     ~CAGrantBOINCProjectRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGrantBOINCProjectsRights.h
+++ b/clientsetup/win/CAGrantBOINCProjectsRights.h
@@ -28,7 +28,7 @@ public:
 
     CAGrantBOINCProjectsRights(MSIHANDLE hMSIHandle);
     ~CAGrantBOINCProjectsRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGrantBOINCProjectsVirtualBoxRights.h
+++ b/clientsetup/win/CAGrantBOINCProjectsVirtualBoxRights.h
@@ -28,7 +28,7 @@ public:
 
     CAGrantBOINCProjectsVirtualBoxRights(MSIHANDLE hMSIHandle);
     ~CAGrantBOINCProjectsVirtualBoxRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAGrantBOINCUsersRights.h
+++ b/clientsetup/win/CAGrantBOINCUsersRights.h
@@ -28,7 +28,7 @@ public:
 
     CAGrantBOINCUsersRights(MSIHANDLE hMSIHandle);
     ~CAGrantBOINCUsersRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CALaunchBOINCTray.h
+++ b/clientsetup/win/CALaunchBOINCTray.h
@@ -28,7 +28,7 @@ public:
 
     CALaunchBOINCTray(MSIHANDLE hMSIHandle);
     ~CALaunchBOINCTray();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARestoreExecutionState.h
+++ b/clientsetup/win/CARestoreExecutionState.h
@@ -28,7 +28,7 @@ public:
 
     CARestoreExecutionState(MSIHANDLE hMSIHandle);
     ~CARestoreExecutionState();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARestorePermissionBOINCData.h
+++ b/clientsetup/win/CARestorePermissionBOINCData.h
@@ -28,7 +28,7 @@ public:
 
     CARestorePermissionBOINCData(MSIHANDLE hMSIHandle);
     ~CARestorePermissionBOINCData();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARestoreSetupState.h
+++ b/clientsetup/win/CARestoreSetupState.h
@@ -28,7 +28,7 @@ public:
 
     CARestoreSetupState(MSIHANDLE hMSIHandle);
     ~CARestoreSetupState();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARevokeBOINCAdminsRights.h
+++ b/clientsetup/win/CARevokeBOINCAdminsRights.h
@@ -28,7 +28,7 @@ public:
 
     CARevokeBOINCAdminsRights(MSIHANDLE hMSIHandle);
     ~CARevokeBOINCAdminsRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARevokeBOINCMasterRights.h
+++ b/clientsetup/win/CARevokeBOINCMasterRights.h
@@ -28,7 +28,7 @@ public:
 
     CARevokeBOINCMasterRights(MSIHANDLE hMSIHandle);
     ~CARevokeBOINCMasterRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARevokeBOINCProjectRights.h
+++ b/clientsetup/win/CARevokeBOINCProjectRights.h
@@ -28,7 +28,7 @@ public:
 
     CARevokeBOINCProjectRights(MSIHANDLE hMSIHandle);
     ~CARevokeBOINCProjectRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARevokeBOINCProjectsRights.h
+++ b/clientsetup/win/CARevokeBOINCProjectsRights.h
@@ -28,7 +28,7 @@ public:
 
     CARevokeBOINCProjectsRights(MSIHANDLE hMSIHandle);
     ~CARevokeBOINCProjectsRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CARevokeBOINCUsersRights.h
+++ b/clientsetup/win/CARevokeBOINCUsersRights.h
@@ -28,7 +28,7 @@ public:
 
     CARevokeBOINCUsersRights(MSIHANDLE hMSIHandle);
     ~CARevokeBOINCUsersRights();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CASaveExecutionState.h
+++ b/clientsetup/win/CASaveExecutionState.h
@@ -28,7 +28,7 @@ public:
 
     CASaveExecutionState(MSIHANDLE hMSIHandle);
     ~CASaveExecutionState();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CASaveSetupState.h
+++ b/clientsetup/win/CASaveSetupState.h
@@ -28,7 +28,7 @@ public:
 
     CASaveSetupState(MSIHANDLE hMSIHandle);
     ~CASaveSetupState();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CASetPermissionBOINC.h
+++ b/clientsetup/win/CASetPermissionBOINC.h
@@ -28,7 +28,7 @@ public:
 
     CASetPermissionBOINC(MSIHANDLE hMSIHandle);
     ~CASetPermissionBOINC();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CASetPermissionBOINCData.h
+++ b/clientsetup/win/CASetPermissionBOINCData.h
@@ -28,7 +28,7 @@ public:
 
     CASetPermissionBOINCData(MSIHANDLE hMSIHandle);
     ~CASetPermissionBOINCData();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CASetPermissionBOINCDataProjects.h
+++ b/clientsetup/win/CASetPermissionBOINCDataProjects.h
@@ -28,7 +28,7 @@ public:
 
     CASetPermissionBOINCDataProjects(MSIHANDLE hMSIHandle);
     ~CASetPermissionBOINCDataProjects();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CASetPermissionBOINCDataSlots.h
+++ b/clientsetup/win/CASetPermissionBOINCDataSlots.h
@@ -28,7 +28,7 @@ public:
 
     CASetPermissionBOINCDataSlots(MSIHANDLE hMSIHandle);
     ~CASetPermissionBOINCDataSlots();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAShutdownBOINC.h
+++ b/clientsetup/win/CAShutdownBOINC.h
@@ -28,7 +28,7 @@ public:
 
     CAShutdownBOINC(MSIHANDLE hMSIHandle);
     ~CAShutdownBOINC();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAShutdownBOINCManager.h
+++ b/clientsetup/win/CAShutdownBOINCManager.h
@@ -28,7 +28,7 @@ public:
 
     CAShutdownBOINCManager(MSIHANDLE hMSIHandle);
     ~CAShutdownBOINCManager();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAShutdownBOINCScreensaver.h
+++ b/clientsetup/win/CAShutdownBOINCScreensaver.h
@@ -28,7 +28,7 @@ public:
 
     CAShutdownBOINCScreensaver(MSIHANDLE hMSIHandle);
     ~CAShutdownBOINCScreensaver();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAShutdownUD.h
+++ b/clientsetup/win/CAShutdownUD.h
@@ -28,7 +28,7 @@ public:
 
     CAShutdownUD(MSIHANDLE hMSIHandle);
     ~CAShutdownUD();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAValidateInstall.h
+++ b/clientsetup/win/CAValidateInstall.h
@@ -28,7 +28,7 @@ public:
 
     CAValidateInstall(MSIHANDLE hMSIHandle);
     ~CAValidateInstall();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
     BOOL ValidateExecutable( tstring strExecutable, tstring strDesiredVersion );
 };

--- a/clientsetup/win/CAValidateRebootRequest.h
+++ b/clientsetup/win/CAValidateRebootRequest.h
@@ -28,7 +28,7 @@ public:
 
     CAValidateRebootRequest(MSIHANDLE hMSIHandle);
     ~CAValidateRebootRequest();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 };
 
 

--- a/clientsetup/win/CAValidateSetupType.h
+++ b/clientsetup/win/CAValidateSetupType.h
@@ -28,7 +28,7 @@ public:
 
     CAValidateSetupType(MSIHANDLE hMSIHandle);
     ~CAValidateSetupType();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 

--- a/clientsetup/win/CAVerifyInstallDirectories.h
+++ b/clientsetup/win/CAVerifyInstallDirectories.h
@@ -28,7 +28,7 @@ public:
 
     CAVerifyInstallDirectories(MSIHANDLE hMSIHandle);
     ~CAVerifyInstallDirectories();
-    virtual UINT OnExecution();
+    virtual UINT OnExecution() override;
 
 };
 


### PR DESCRIPTION
Partially fixes #3513 

**Description of the Change**
Add `override` keyword on abstract method.

**Alternate Designs**
Use another analysis tool.

**Release Notes**
Apply changes according performance, portability and style warnings through cppcheck.

**Other related PR**
constness: #4295 
override keyword: #4296 (this PR)
printf format: #4297
explicit keywork: #4302
static cast: #4305 
