### PR TITLE
[Improvement]: use printf %u instead of %d format

### DIFF
--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -453,7 +453,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
 
     njobs += (int)new_results.size();
     msg_printf(0, MSG_INFO, "Got %lu tasks", new_results.size());
-    sprintf(buf, "got %lu tasks<br>", new_results.size());
+    sprintf(buf, "got %zu tasks<br>", new_results.size());
     html_msg += buf;
 
     SCHEDULER_REPLY sr;
@@ -1044,7 +1044,7 @@ void make_graph(const char* title, const char* fname, int field) {
     );
     for (unsigned int i=0; i<gstate.projects.size(); i++) {
         PROJECT* p = gstate.projects[i];
-        fprintf(f, "\"%srec.dat\" using 1:%d title \"%s\" with lines%s",
+        fprintf(f, "\"%srec.dat\" using 1:%u title \"%s\" with lines%s",
             outfile_prefix, 2+i+field, p->project_name,
             (i==gstate.projects.size()-1)?"\n":", \\\n"
         );

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -122,7 +122,7 @@ void boinc_catch_signal_invalid_parameter(
 ) {
 	fprintf(
 		stderr,
-        "ERROR: Invalid parameter detected in function %s. File: %s Line: %d\n",
+        "ERROR: Invalid parameter detected in function %s. File: %s Line: %u\n",
 		function,
 		file,
 		line

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -304,12 +304,12 @@ void SIMPLE_GUI_INFO::print() {
     unsigned int i;
     printf("======== Projects ========\n");
     for (i=0; i<projects.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         projects[i]->print();
     }
     printf("\n======== Tasks ========\n");
     for (i=0; i<results.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         results[i]->print();
     }
 }
@@ -337,27 +337,27 @@ void CC_STATE::print() {
     unsigned int i;
     printf("======== Projects ========\n");
     for (i=0; i<projects.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         projects[i]->print();
     }
     printf("\n======== Applications ========\n");
     for (i=0; i<apps.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         apps[i]->print();
     }
     printf("\n======== Application versions ========\n");
     for (i=0; i<app_versions.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         app_versions[i]->print();
     }
     printf("\n======== Workunits ========\n");
     for (i=0; i<wus.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         wus[i]->print();
     }
     printf("\n======== Tasks ========\n");
     for (i=0; i<results.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         results[i]->print();
     }
     printf("\n======== Time stats ========\n");
@@ -411,7 +411,7 @@ void PROJECTS::print() {
     unsigned int i;
     printf("======== Projects ========\n");
     for (i=0; i<projects.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         projects[i]->print();
     }
 }
@@ -429,7 +429,7 @@ void DISK_USAGE::print() {
     printf("total: %.2fMB\n", d_total/MEGA);
     printf("free: %.2fMB\n", d_free/MEGA);
     for (i=0; i<projects.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         projects[i]->print_disk_usage();
     }
 }
@@ -438,7 +438,7 @@ void RESULTS::print() {
     unsigned int i;
     printf("\n======== Tasks ========\n");
     for (i=0; i<results.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         results[i]->print();
     }
 }
@@ -447,7 +447,7 @@ void FILE_TRANSFERS::print() {
     unsigned int i;
     printf("\n======== File transfers ========\n");
     for (i=0; i<file_transfers.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         file_transfers[i]->print();
     }
 }
@@ -456,7 +456,7 @@ void MESSAGES::print() {
     unsigned int i;
     printf("\n======== Messages ========\n");
     for (i=0; i<messages.size(); i++) {
-        printf("%d) -----------\n", i+1);
+        printf("%u) -----------\n", i+1);
         messages[i]->print();
     }
 }

--- a/zip/unzip/win32/win32.c
+++ b/zip/unzip/win32/win32.c
@@ -346,7 +346,7 @@ static int SetSD(__G__ path, fperms, eb_ptr, eb_len)
         if (SecuritySet(path, &VolumeCaps, security_data)) {
             error = PK_COOL;
             if (!uO.tflag && QCOND2)
-                Info(slide, 0, ((char *)slide, " (%ld bytes security)",
+                Info(slide, 0, ((char *)slide, " (%lu bytes security)",
                   ntsd_ucSize));
         }
     }

--- a/zip/zip/win32/win32zip.c
+++ b/zip/zip/win32/win32zip.c
@@ -1838,7 +1838,7 @@ local void GetSD(char *path, char **bufptr, ush *size,
                        (char *)buffer, bytes);
 
   if (cbytes > 0x7FFF) {
-    sprintf(errbuf, "security info too large to store (%ld bytes), %d max", bytes, 0x7FFF);
+    sprintf(errbuf, "security info too large to store (%lu bytes), %d max", bytes, 0x7FFF);
     zipwarn(errbuf, "");
     zipwarn("security info not stored: ", path);
     if(DynBuffer) free(DynBuffer);
@@ -1863,7 +1863,7 @@ local void GetSD(char *path, char **bufptr, ush *size,
   pCentralHeader->lSize = bytes;
 
   if (noisy) {
-    sprintf(errbuf, " (%ld bytes security)", bytes);
+    sprintf(errbuf, " (%lu bytes security)", bytes);
     zipmessage_nl(errbuf, 0);
   }
 

--- a/zip/zip/z_fileio.c
+++ b/zip/zip/z_fileio.c
@@ -2314,7 +2314,7 @@ int ask_for_split_write_path(current_disk)
   }
   if (mesg_line_started)
     fprintf(mesg, "\n");
-  fprintf(mesg, "\nOpening disk %d\n", num);
+  fprintf(mesg, "\nOpening disk %u\n", num);
   fprintf(mesg, "Hit ENTER to write to default path of\n");
   fprintf(mesg, "  %s\n", split_dir);
   fprintf(mesg, "or enter a new directory path (. for cur dir) and hit ENTER\n");

--- a/zip/zip/zip.c
+++ b/zip/zip/zip.c
@@ -1699,11 +1699,11 @@ local int DisplayRunningStats()
   }
   if (display_counts) {
     if (noisy) {
-      fprintf(mesg, "%3ld/%3ld ", files_so_far, files_total - files_so_far);
+      fprintf(mesg, "%3lu/%3lu ", files_so_far, files_total - files_so_far);
       mesg_line_started = 1;
     }
     if (logall) {
-      fprintf(logfile, "%3ld/%3ld ", files_so_far, files_total - files_so_far);
+      fprintf(logfile, "%3lu/%3lu ", files_so_far, files_total - files_so_far);
       logfile_line_started = 1;
     }
   }
@@ -3441,7 +3441,7 @@ char **argv;            /* command line tokens */
 
         default:
           /* should never get here as get_option will exit if not in table */
-          sprintf(errbuf, "no such option ID: %ld", option);
+          sprintf(errbuf, "no such option ID: %lu", option);
           ZIPERR(ZE_PARMS, errbuf);
 
      }  /* switch */
@@ -3994,7 +3994,7 @@ char **argv;            /* command line tokens */
         struct tm *now;
         time_t clocktime;
 
-        fprintf(logfile, "\nTotal %ld entries (", files_total);
+        fprintf(logfile, "\nTotal %lu entries (", files_total);
         DisplayNumString(logfile, bytes_total);
         fprintf(logfile, " bytes)");
 
@@ -5991,7 +5991,7 @@ char **argv;            /* command line tokens */
       struct tm *now;
       time_t clocktime;
 
-      fprintf(logfile, "\nTotal %ld entries (", files_total);
+      fprintf(logfile, "\nTotal %lu entries (", files_total);
       if (good_bytes_so_far != bytes_total) {
         fprintf(logfile, "planned ");
         DisplayNumString(logfile, bytes_total);


### PR DESCRIPTION
Partially fixes #3513 

**Description of the Change**
Use printf %u instead of %d format.

**Alternate Designs**
Use another analysis tool.

**Release Notes**
Apply changes according performance, portability and style warnings through cppcheck.

**Other related PR**
constness: #4295 
override keyword: #4296 
printf format: #4297 (this PR)
explicit keywork: #4302
static cast: #4305 