### PR TITLE
[Improvement]: use static cast

### DIFF
--- a/api/gutil.cpp
+++ b/api/gutil.cpp
@@ -470,7 +470,7 @@ void STARFIELD::build_stars(int sz, float sp) {
 	nstars=sz;
 
     if (stars) free(stars);
-    stars = (STAR*)calloc(sizeof(STAR), (long unsigned int)nstars);
+    stars = static_cast<STAR*>(calloc(sizeof(STAR), (long unsigned int)nstars));
     if (!stars) {
         fprintf(stderr, "out of mem in STARFIELD::build_stars");
         sz = 0;
@@ -661,8 +661,8 @@ tImageJPG *LoadJPG(const char *filename) {
 
 	jpeg_create_decompress(&cinfo);
 	jpeg_stdio_src(&cinfo, pFile);
-	pImageData = (tImageJPG*)malloc(sizeof(tImageJPG));
-    if (!pImageData) {
+	pImageData = static_cast<tImageJPG*>(malloc(sizeof(tImageJPG)));
+        if (pImageData != NULL) {
         jpeg_destroy_decompress(&cinfo);
         fclose(pFile);
         fprintf(stderr, "out of mem in LoadJPG");

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -231,7 +231,7 @@ int cpu_benchmarks(BENCHMARK_DESC* bdp) {
 
 #ifdef _WIN32
 DWORD WINAPI win_cpu_benchmarks(LPVOID p) {
-    return cpu_benchmarks((BENCHMARK_DESC*)p);
+  return cpu_benchmarks(static_cast<BENCHMARK_DESC*>(p));
 }
 #endif
 

--- a/samples/example_app/slide_show.cpp
+++ b/samples/example_app/slide_show.cpp
@@ -184,7 +184,7 @@ void app_graphics_render(int xs, int ys, double time_of_day) {
     // worker application has not yet created shared memory
     //
     if (shmem == NULL) {
-        shmem = (UC_SHMEM*)boinc_graphics_get_shmem("uppercase");
+        shmem = static_cast<UC_SHMEM*>(boinc_graphics_get_shmem("uppercase"));
     }
     if (shmem) {
         shmem->countdown = 5;

--- a/samples/image_libs/tgalib.cpp
+++ b/samples/image_libs/tgalib.cpp
@@ -34,7 +34,7 @@ tImageTGA *LoadTGA(const char *filename)
 	}
 		
 	// Allocate the structure that will hold our eventual image data (must free it!)
-	pImageData = (tImageTGA*)malloc(sizeof(tImageTGA));
+	pImageData = static_cast<tImageTGA*>(malloc(sizeof(tImageTGA)));
 
 	// Read in the length in bytes from the header to the pixel data
 	fread(&length, sizeof(byte), 1, pFile);

--- a/samples/multi_thread/multi_thread.cpp
+++ b/samples/multi_thread/multi_thread.cpp
@@ -138,7 +138,7 @@ UINT WINAPI worker(void* p) {
 void* worker(void* p) {
 #endif
     char buf[256];
-    THREAD* t = (THREAD*)p;
+    THREAD* t = static_cast<THREAD*>(p);
     for (int i=0; i<units_per_thread; i++) {
         double x = do_a_giga_flop(i);
         t->units_done++;


### PR DESCRIPTION
Partially fixes #3513 

**Description of the Change**
Replace some C style cast to static cast.

**Alternate Designs**
Use another analysis tool.

**Release Notes**
Apply changes according performance, portability and style warnings through cppcheck.

**Other related PR**
constness: #4295
override keyword: #4296 
printf format: #4297
explicit keywork: #4302
static cast: #4305 (this PR)
