### PR TITLE
draft: android: set LD_LIBRARY_PATH for client for OpenCL detection

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
@@ -537,7 +537,17 @@ class Monitor : LifecycleService() {
             val param = if (remote) "--allow_remote_gui_rpc" else "--gui_rpc_unix_domain"
             val cmd = arrayOf(boincWorkingDir + fileNameClient, "--daemon", param)
             if (Logging.ERROR) Log.w(Logging.TAG, "Launching '${cmd[0]}' from '$boincWorkingDir'")
-            Runtime.getRuntime().exec(cmd, null, File(boincWorkingDir))
+            var envpStr = ""
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                val envLLP = System.getenv("LD_LIBRARY_PATH")
+                envpStr = "LD_LIBRARY_PATH="
+                if (envLLP != null) envpStr += envLLP + ":"
+                if (Process.is64Bit()) envpStr += "/vendor/lib64/:/vendor/lib64/egl:"
+                envpStr += "/vendor/lib:/vendor/lib/egl"
+            }
+            val envp = arrayOf(envpStr)
+            if (Logging.DEBUG) Log.w(Logging.TAG, "Setting envp '${envp[0]}'")
+            Runtime.getRuntime().exec(cmd, envp, File(boincWorkingDir))
             success = true
         } catch (e: IOException) {
             if (Logging.ERROR) {


### PR DESCRIPTION
Draft fix for #4204 

**Description of the Change**
Before:
![Screenshot_20210401-020446_BOINC](https://user-images.githubusercontent.com/12658589/113993240-cf8b8900-9886-11eb-9ff7-6e7fb7223c00.jpg)

After:
![Screenshot_20210401-021313_BOINC](https://user-images.githubusercontent.com/12658589/113993280-dca87800-9886-11eb-8f1e-3d701e906db9.jpg)

**Alternate Designs**
Vendor libs are isolated to a different namespace by the Android linker.
Any other proper solutions, which is properly implement a way to access vendor libs for BOINC use,
will be better than this stopgap.
Though likely need to bump minimum API version to 21 to use `android_dlopen_ext()` inside client.

Read more about the cause:
https://developer.android.com/about/versions/nougat/android-7.0-changes#ndk
https://fadeevab.com/android-linker-namespace-security-flaws/

**Release Notes**
android: restore OpenCL detection