### PR TITLE
client: be conservative about non-BOINC CPU usage on underflow

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -505,9 +505,10 @@ void ACTIVE_TASK_SET::get_memory_usage() {
     double new_cpu_time = pi.user_time + pi.kernel_time;
     if (!first) {
         non_boinc_cpu_usage = (new_cpu_time - last_cpu_time)/(diff*gstate.host_info.p_ncpus);
-        // processes might have exited in the last 10 sec,
-        // causing this to be negative.
-        if (non_boinc_cpu_usage < 0) non_boinc_cpu_usage = 0;
+        // Processes might have exited in the last 10 sec, causing
+        // this to be negative. In that case, be conservative about
+        // the non-BOINC CPU usage and assume it to be 50%.
+        if (non_boinc_cpu_usage < 0) non_boinc_cpu_usage = 0.5;
         if (log_flags.mem_usage_debug) {
             msg_printf(NULL, MSG_INFO,
                 "[mem_usage] non-BOINC CPU usage: %.2f%%", non_boinc_cpu_usage*100


### PR DESCRIPTION
Instead of assume that the non-BOINC CPU usage was 0%, assume that it
was 50%. This potentially prevents BOINC from kicking-in in the
presence of short-lived processes (if configured to run only if
non-BOINC CPU usage is below 50%).

The main issue is that BOINC's calculation of non-BOINC CPU usage time
is incorrect, as processes which exited within the sample
interval (typically 10 seconds) are not taken into consideration. This
leads to BOINC underestimating the non-BOINC CPU usage, especially in
situations where a lot of short-lived processes are present. This
commit does not fix that, but mitigates the effects of this. For more
information, see issue #4327.