### PR TITLE
Client: fix work_fetch after app_config write from RPC

### DIFF
--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -831,7 +831,7 @@ int APP_CONFIGS::parse(XML_PARSER& xp, MSG_VEC& mv, LOG_FLAGS& log_flags) {
             continue;
         }
         if (xp.parse_int("project_max_concurrent", n)) {
-            if (n >= 0) {
+            if (n > 0) {
                 have_max_concurrent = true;
                 project_has_mc = true;
                 project_max_concurrent = n;


### PR DESCRIPTION
Treat project_max_concurrent=0 as 'unspecified'.

Follow-up to #4291: further consequential change after 5b6f648570cdef551b77bbabf3e69243dac69de4

When an app_config.xml file is written by RPC (from BoincTasks or other account manager), it includes the pro-forma line
    `<project_max_concurrent>0</project_max_concurrent>`
if no value is specified. This leads to work-fetch issues like
```
20-Apr-2021 16:13:35 [Einstein@Home] choose_project: scanning
20-Apr-2021 16:13:35 [Einstein@Home] can't fetch CPU: blocked by project preferences
20-Apr-2021 16:13:35 [Einstein@Home] can fetch NVIDIA GPU
20-Apr-2021 16:13:35 [Einstein@Home] NVIDIA GPU needs work - excluded instance starved
20-Apr-2021 16:13:35 [Einstein@Home] checking CPU
20-Apr-2021 16:13:35 [Einstein@Home] CPU not high prio proj
20-Apr-2021 16:13:35 [Einstein@Home] checking NVIDIA GPU
20-Apr-2021 16:13:35 [Einstein@Home] [work_fetch] using MC shortfall 0.000000 instead of shortfall 19008.000000
20-Apr-2021 16:13:35 [Einstein@Home] [work_fetch] set_request() for NVIDIA GPU: ninst 2 nused_total 0.00 nidle_now 2.00 fetch share 1.00 req_inst 0.00 req_secs 0.00
20-Apr-2021 16:13:35 [Einstein@Home] NVIDIA GPU set_request: 0.000000
20-Apr-2021 16:13:35 [Einstein@Home] checking Intel GPU
20-Apr-2021 16:13:35 [Einstein@Home] [work_fetch] using MC shortfall 0.000000 instead of shortfall 9504.000000
20-Apr-2021 16:13:35 [Einstein@Home] [work_fetch] set_request() for Intel GPU: ninst 1 nused_total 0.00 nidle_now 1.00 fetch share 1.00 req_inst 0.00 req_secs 0.00
20-Apr-2021 16:13:35 [Einstein@Home] Intel GPU set_request: 0.000000
```
when **(and only when)** the project is at the specified concurrent level of zero tasks. Einstein is normally a very consistent supplier of GPU tasks, and has been running continuously with three concurrent tasks since my last PR. However, it had an outage yesterday...

Without a proper design document, it's hard to be certain, but I suspect that in this case "project_max_concurrent=0" was intended to have the special-case interpretation of 'unrestricted'. Certainly, removing this test for equality restored normal work fetch.
```
20-Apr-2021 16:15:51 [Einstein@Home] Sending scheduler request: To fetch work.
20-Apr-2021 16:15:51 [Einstein@Home] Requesting new tasks for NVIDIA GPU and Intel GPU
20-Apr-2021 16:15:51 [Einstein@Home] [sched_op] CPU work request: 0.00 seconds; 0.00 devices
20-Apr-2021 16:15:51 [Einstein@Home] [sched_op] NVIDIA GPU work request: 19008.00 seconds; 0.00 devices
20-Apr-2021 16:15:51 [Einstein@Home] [sched_op] Intel GPU work request: 9504.00 seconds; 0.00 devices
20-Apr-2021 16:16:12 [Einstein@Home] Scheduler request completed: got 28 new tasks
20-Apr-2021 16:16:12 [Einstein@Home] [sched_op] Server version 611
20-Apr-2021 16:16:12 [Einstein@Home] Project requested delay of 60 seconds
20-Apr-2021 16:16:12 [Einstein@Home] [sched_op] estimated total CPU task duration: 0 seconds
20-Apr-2021 16:16:12 [Einstein@Home] [sched_op] estimated total NVIDIA GPU task duration: 19115 seconds
20-Apr-2021 16:16:12 [Einstein@Home] [sched_op] estimated total Intel GPU task duration: 10859 seconds
```
