### PR TITLE
Fix Xcode build for Apple Silicon M1 Macs

### DIFF
--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -2877,7 +2877,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n\"${BUILT_PRODUCTS_DIR}/SetVersion\"\n";
+			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n\"${BUILT_PRODUCTS_DIR}/SetVersion\"\n";
 		};
 		DDC8FB2B1F6D398700BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
During the BOINC build with Xcode a utility called "SetVersion" gets built and ran.

However, on a new Apple Silicon / M1 / ARM64 Mac the build can't get beyond running SetVersion, because the built binary can't run. For some reason the arm64 version of the "SetVersion" crashes mysteriously. Actually, the process is killed by signal 9 before it actually runs, possibly it's the loader that gets killed.

However, the x86_64 version of "SetVersion" (that is also built) runs fine even on M1 Macs.

Rosetta2, which allows to run x64_86 on ARM64/M1 Macs, is required when installing Xcode, so an M1 Mac with xcode should always be able to run x86_64 binaries.

Thus, a feasible solution to the problem is to build SetVersion only for x86_64. This patch does this.