### PR TITLE
Mac: fixes for #4386

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -809,13 +809,13 @@ static void get_cpu_info_mac(HOST_INFO& host) {
     char features[P_FEATURES_SIZE];
     char *p;
     char *sep=" ";
-    int family, stepping, model, feature;
-    string feature_string;
 
     len = sizeof(brand_string);
     sysctlbyname("machdep.cpu.brand_string", brand_string, &len, NULL, 0);
 
 #if defined(__i386__) || defined(__x86_64__)
+
+    int family, stepping, model;
 
     // on an Apple M1 chip the cpu.vendor is broken, family, model and stepping don't exist
     if (!strncmp(brand_string, "Apple M", strlen("Apple M"))) {
@@ -848,6 +848,9 @@ static void get_cpu_info_mac(HOST_INFO& host) {
     sysctlbyname("machdep.cpu.features", features, &len, NULL, 0);
 
 #else // defined(__i386__) || defined(__x86_64__)
+
+    int feature;
+    string feature_string;
 
     strcpy(host.p_vendor, "Apple");
     strncpy(host.p_model, brand_string, sizeof(host.p_model));

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -584,19 +584,19 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		B15487172667809100A9FDBA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD407A4907D2FB1200163EF5;
+			remoteInfo = libboinc;
+		};
 		B1A32E54265D206800896566 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = B13E2D0E265564D100D5C977;
 			remoteInfo = detect_rosetta_cpu;
-		};
-		B1A32E57265D20FB00896566 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DD407A4907D2FB1200163EF5;
-			remoteInfo = libboinc;
 		};
 		DD095D1E0F3B22DE000902F5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2250,6 +2250,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B15487182667809100A9FDBA /* PBXTargetDependency */,
 			);
 			name = detect_rosetta_cpu;
 			productName = detect_rosetta_cpu;
@@ -2578,7 +2579,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				B1A32E58265D20FB00896566 /* PBXTargetDependency */,
 				B1A32E55265D206800896566 /* PBXTargetDependency */,
 				DD25E20D220438090040366F /* PBXTargetDependency */,
 			);
@@ -3681,15 +3681,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		B15487182667809100A9FDBA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD407A4907D2FB1200163EF5 /* libboinc */;
+			targetProxy = B15487172667809100A9FDBA /* PBXContainerItemProxy */;
+		};
 		B1A32E55265D206800896566 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = B13E2D0E265564D100D5C977 /* detect_rosetta_cpu */;
 			targetProxy = B1A32E54265D206800896566 /* PBXContainerItemProxy */;
-		};
-		B1A32E58265D20FB00896566 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DD407A4907D2FB1200163EF5 /* libboinc */;
-			targetProxy = B1A32E57265D20FB00896566 /* PBXContainerItemProxy */;
 		};
 		DD095D1F0F3B22DE000902F5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
Fixes two minor issues noticed by Charlie in #4386 after merging

- Xcode: add libboinc dependency to detect_rosetta_cpu instead of the client

- client/hostinfo_unix.cpp: variables 'family', 'stepping' and 'model' are
  only used on Intel, 'feature' and 'feature_string' only on ARM64
  (resulted in 'unused variable' warnings before)