### PR TITLE
Mac: Fix BuildMacBOINC,sh script to build libboinc_zip.a on bash

### DIFF
--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -172,8 +172,7 @@ done
 
 ## For unknown reasons, this xcodebuild call generates syntax errors under zsh
 ## unless we enclose the command in quotes and invoke it with eval. 
-eval "xcodebuild -project boinc.xcodeproj ${targets} -configuration ${style} -sdk \"${SDKPATH}\" ${doclean} build ${uselibcplusplus} ${theSettings}"
-result=$?
+eval "xcodebuild -project boinc.xcodeproj ${targets} -configuration ${style} -sdk \"${SDKPATH}\" ${doclean} build ${uselibcplusplus} ${theSettings};result=$?"
 
 if [ $result -eq 0 ]; then
     # build ibboinc_zip.a for -all or -lib or default, where


### PR DESCRIPTION
Fix BuildMacBOINC,sh script to build libboinc_zip.a when running under bash, not only under zsh

Fixes a bug I introduced in my PR #4369

This is ready to be merged.