### PR TITLE
[WIP] Mac trigger "Install Rosetta 2?" dialog on Apple Silicon Macs

### DIFF
--- a/client/detect_rosetta_cpu.cpp
+++ b/client/detect_rosetta_cpu.cpp
@@ -36,6 +36,7 @@ int main () {
 
     len = sizeof(features);
     sysctlbyname("machdep.cpu.features", features, &len, NULL, 0);
+    chdir("/Library/Application Support/BOINC Data");
     if ((fp = boinc_fopen(EMULATED_CPU_INFO_FILENAME, "w"))) {
         fprintf(fp," %s\n", features);
         fclose(fp);

--- a/client/file_names.h
+++ b/client/file_names.h
@@ -72,7 +72,7 @@ extern void send_log_after(const char* filename, double t, MIOFILE& mf);
 #define CONFIG_FILE                 "cc_config.xml"
 #define NVC_CONFIG_FILE             "nvc_config.xml"
 #define COPROC_INFO_FILENAME        "coproc_info.xml"
-#define EMULATED_CPU_INFO_EXECUTABLE "detect_rosetta_cpu"
+#define EMULATED_CPU_INFO_EXECUTABLE "BOINC_OK_To_Run_Intel_Apps.app"
 #define EMULATED_CPU_INFO_FILENAME  "emulated_cpu_info.txt"
 #define CPU_BENCHMARKS_FILE_NAME    "cpu_benchmarks"
 #define CREATE_ACCOUNT_FILENAME     "create_account.xml"

--- a/clientgui/mac/SetVersion.cpp
+++ b/clientgui/mac/SetVersion.cpp
@@ -101,7 +101,7 @@ int main(int argc, char** argv) {
     if (err) retval = err;
     
     // detect_rosetta_cpu
-    err = FixInfoPlistFile("DetectRosettaCPU-Info.plist");
+    err = FixInfoPlistFile("BOINC_OK_To_Run_Intel_Apps-Info.plist");
     if (err) retval = err;
     
     // WaitPermissions is not currently used

--- a/clientgui/mac/SetVersion.cpp
+++ b/clientgui/mac/SetVersion.cpp
@@ -100,6 +100,10 @@ int main(int argc, char** argv) {
     err = FixInfoPlistFile("BoincCmd-Info.plist");
     if (err) retval = err;
     
+    // detect_rosetta_cpu
+    err = FixInfoPlistFile("DetectRosettaCPU-Info.plist");
+    if (err) retval = err;
+    
     // WaitPermissions is not currently used
     err = FixInfoPlistFile("WaitPermissions-Info.plist");
     if (err) retval = err;

--- a/clientgui/mac/templates/BOINC_OK_To_Run_Intel_Apps-Info.plist
+++ b/clientgui/mac/templates/BOINC_OK_To_Run_Intel_Apps-Info.plist
@@ -4,13 +4,19 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>edu.berkeley.boinc.DetectRosettaCPU</string>
+	<string>edu.berkeley.boinc.OKToRunIntelApps</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string> detect_rosetta_cpu </string>
+	<string>BOINC_OK_To_Run_Intel_Apps</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>7.17.0</string>
+	<string>5.10.7</string>
 </dict>
 </plist>

--- a/clientgui/mac/templates/DetectRosettaCPU-Info.plist
+++ b/clientgui/mac/templates/DetectRosettaCPU-Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleIdentifier</key>
+	<string>edu.berkeley.boinc.DetectRosettaCPU</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string> detect_rosetta_cpu </string>
+	<key>CFBundleVersion</key>
+	<string>7.17.0</string>
+</dict>
+</plist>

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -612,6 +612,13 @@
 			remoteGlobalIDString = DD1277B2081F3D67007B5DE1;
 			remoteInfo = Installer;
 		};
+		DD157A5E2675EB5200350364 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDAEC9E007FA583B00A7BC36;
+			remoteInfo = SetVersion;
+		};
 		DD1AFEA60A512D8700EE5B82 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
@@ -898,7 +905,6 @@
 		AAA31C97042157A800A80164 /* shmem.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = shmem.cpp; sourceTree = "<group>"; };
 		AAA31C98042157A800A80164 /* shmem.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = shmem.h; path = ../lib/shmem.h; sourceTree = SOURCE_ROOT; };
 		B13E2D0F265564D100D5C977 /* detect_rosetta_cpu */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = detect_rosetta_cpu; sourceTree = BUILT_PRODUCTS_DIR; };
-		B13E2D11265564D100D5C977 /* main.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
 		B13E2D162655655000D5C977 /* detect_rosetta_cpu.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = detect_rosetta_cpu.cpp; sourceTree = "<group>"; };
 		DD000D7324D0244C0083DE77 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = /System/Library/Frameworks/SystemConfiguration.framework; sourceTree = "<absolute>"; };
 		DD0052F710CA6F1D0067570C /* cs_proxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cs_proxy.cpp; path = ../client/cs_proxy.cpp; sourceTree = SOURCE_ROOT; };
@@ -1632,7 +1638,6 @@
 				DD81C79E144D8F97000BE61A /* jpeg */,
 				20286C2CFDCF999611CA2CEA /* Resources */,
 				20286C32FDCF999611CA2CEA /* External Frameworks and Libraries */,
-				B13E2D10265564D100D5C977 /* detect_rosetta_cpu */,
 				195DF8C9FE9D4F0611CA2CBB /* Products */,
 				DD96AFFA0811075100A06F22 /* ScreenSaver-Info.plist */,
 				DD1277B5081F3D67007B5DE1 /* PostInstall-Info.plist */,
@@ -1680,14 +1685,6 @@
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = SOURCE_ROOT;
-		};
-		B13E2D10265564D100D5C977 /* detect_rosetta_cpu */ = {
-			isa = PBXGroup;
-			children = (
-				B13E2D11265564D100D5C977 /* main.cpp */,
-			);
-			path = detect_rosetta_cpu;
-			sourceTree = "<group>";
 		};
 		DD1277BC081F3E59007B5DE1 /* mac_installer */ = {
 			isa = PBXGroup;
@@ -2250,6 +2247,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DD157A5F2675EB5200350364 /* PBXTargetDependency */,
 				B15487182667809100A9FDBA /* PBXTargetDependency */,
 			);
 			name = detect_rosetta_cpu;
@@ -2943,7 +2941,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n\"${BUILT_PRODUCTS_DIR}/SetVersion\"\n";
+			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n# run SetVersion in background so we can wait for it to finish running\n\"${BUILT_PRODUCTS_DIR}/SetVersion\" &\nwait\n\n";
 		};
 		DDC8FB2B1F6D398700BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3701,6 +3699,11 @@
 			target = DD1277B2081F3D67007B5DE1 /* PostInstall */;
 			targetProxy = DD127876081F44E5007B5DE1 /* PBXContainerItemProxy */;
 		};
+		DD157A5F2675EB5200350364 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDAEC9E007FA583B00A7BC36 /* SetVersion */;
+			targetProxy = DD157A5E2675EB5200350364 /* PBXContainerItemProxy */;
+		};
 		DD1AFEA50A512D8700EE5B82 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDAEC9E007FA583B00A7BC36 /* SetVersion */;
@@ -3889,7 +3892,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				INFOPLIST_FILE = "DetectRosettaCPU-Info.plist";
 				OTHER_LDFLAGS = "-lboinc";
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.DetectRosettaCPU;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Development;
@@ -3898,7 +3904,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
+				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
+				INFOPLIST_FILE = "DetectRosettaCPU-Info.plist";
 				OTHER_LDFLAGS = "-lboinc";
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.DetectRosettaCPU;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Deployment;

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				DD3AA9C2267B40E100013C96 /* PBXTargetDependency */,
 				DDF9EC15144EB36E005D6144 /* PBXTargetDependency */,
 				DDF9EC11144EB36E005D6144 /* PBXTargetDependency */,
 				DDF9EC17144EB36E005D6144 /* PBXTargetDependency */,
@@ -41,7 +42,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		B13E2D172655655000D5C977 /* detect_rosetta_cpu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B13E2D162655655000D5C977 /* detect_rosetta_cpu.cpp */; };
 		DD000D6A24D0208E0083DE77 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
 		DD000D6B24D020940083DE77 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
 		DD000D7424D0244D0083DE77 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD000D7324D0244C0083DE77 /* SystemConfiguration.framework */; };
@@ -96,6 +96,7 @@
 		DD35353607E1E13F00C4718D /* boinc_api.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5755AD302FE063A012012A7 /* boinc_api.cpp */; };
 		DD3741D610FC948C001257EB /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
 		DD3741D910FC94BA001257EB /* url.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDC06AB210A3E93F00C8D9A5 /* url.cpp */; };
+		DD3AA9BC267B2C9E00013C96 /* detect_rosetta_cpu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B13E2D162655655000D5C977 /* detect_rosetta_cpu.cpp */; };
 		DD3E14DB0A774397007E0084 /* boinc in Resources */ = {isa = PBXBuildFile; fileRef = DDD74D8707CF482E0065AC9D /* boinc */; };
 		DD3E14DC0A774397007E0084 /* BOINCMgr.icns in Resources */ = {isa = PBXBuildFile; fileRef = DDF3028907CCCE2C00701169 /* BOINCMgr.icns */; };
 		DD3E14DF0A774397007E0084 /* AccountInfoPage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD58C41808F3343F00C1DF66 /* AccountInfoPage.cpp */; };
@@ -584,20 +585,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		B15487172667809100A9FDBA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DD407A4907D2FB1200163EF5;
-			remoteInfo = libboinc;
-		};
-		B1A32E54265D206800896566 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B13E2D0E265564D100D5C977;
-			remoteInfo = detect_rosetta_cpu;
-		};
 		DD095D1E0F3B22DE000902F5 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
@@ -611,13 +598,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = DD1277B2081F3D67007B5DE1;
 			remoteInfo = Installer;
-		};
-		DD157A5E2675EB5200350364 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DDAEC9E007FA583B00A7BC36;
-			remoteInfo = SetVersion;
 		};
 		DD1AFEA60A512D8700EE5B82 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -639,6 +619,27 @@
 			proxyType = 1;
 			remoteGlobalIDString = DDAEC9E007FA583B00A7BC36;
 			remoteInfo = SetVersion;
+		};
+		DD3AA9BD267B2D2B00013C96 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDAEC9E007FA583B00A7BC36;
+			remoteInfo = SetVersion;
+		};
+		DD3AA9BF267B2D3200013C96 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD407A4907D2FB1200163EF5;
+			remoteInfo = libboinc;
+		};
+		DD3AA9C1267B40E100013C96 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD3AA9AA267B258500013C96;
+			remoteInfo = BOINC_Intel_Apps_OK;
 		};
 		DD3E14D50A774397007E0084 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -860,15 +861,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		B13E2D0D265564D100D5C977 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
 		DD3E15350A774397007E0084 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -904,7 +896,6 @@
 		AA8B6B1C046C364400A80164 /* app_ipc.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = app_ipc.h; path = ../lib/app_ipc.h; sourceTree = SOURCE_ROOT; };
 		AAA31C97042157A800A80164 /* shmem.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = shmem.cpp; sourceTree = "<group>"; };
 		AAA31C98042157A800A80164 /* shmem.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = shmem.h; path = ../lib/shmem.h; sourceTree = SOURCE_ROOT; };
-		B13E2D0F265564D100D5C977 /* detect_rosetta_cpu */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = detect_rosetta_cpu; sourceTree = BUILT_PRODUCTS_DIR; };
 		B13E2D162655655000D5C977 /* detect_rosetta_cpu.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = detect_rosetta_cpu.cpp; sourceTree = "<group>"; };
 		DD000D7324D0244C0083DE77 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = /System/Library/Frameworks/SystemConfiguration.framework; sourceTree = "<absolute>"; };
 		DD0052F710CA6F1D0067570C /* cs_proxy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = cs_proxy.cpp; path = ../client/cs_proxy.cpp; sourceTree = SOURCE_ROOT; };
@@ -1000,6 +991,7 @@
 		DD344BEE07C5B1770043025C /* proxy_info.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = proxy_info.h; path = ../lib/proxy_info.h; sourceTree = SOURCE_ROOT; };
 		DD344BEF07C5B1770043025C /* proxy_info.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = proxy_info.cpp; sourceTree = "<group>"; };
 		DD35353107E1E05C00C4718D /* libboinc_api.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libboinc_api.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD3AA9AB267B258500013C96 /* BOINC_OK_To_Run_Intel_Apps.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BOINC_OK_To_Run_Intel_Apps.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3E15420A774397007E0084 /* BOINCManager.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BOINCManager.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3EAAA6216A25AD00BC673C /* boinc_finish_install */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = boinc_finish_install; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD3EAAAE216A268500BC673C /* finish_install.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = finish_install.cpp; path = ../mac_installer/finish_install.cpp; sourceTree = "<group>"; };
@@ -1403,13 +1395,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		B13E2D0C265564D100D5C977 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DD1277B1081F3D67007B5DE1 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1430,6 +1415,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DD35352F07E1E05C00C4718D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DD3AA9A8267B258500013C96 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1620,7 +1612,7 @@
 				DDF9EC03144EB14B005D6144 /* libboinc_opencl.a */,
 				DD3EAAA6216A25AD00BC673C /* boinc_finish_install */,
 				DD5F654123605B41009ED2A2 /* gfx_cleanup */,
-				B13E2D0F265564D100D5C977 /* detect_rosetta_cpu */,
+				DD3AA9AB267B258500013C96 /* BOINC_OK_To_Run_Intel_Apps.app */,
 			);
 			name = Products;
 			sourceTree = SOURCE_ROOT;
@@ -2236,25 +2228,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		B13E2D0E265564D100D5C977 /* detect_rosetta_cpu */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B13E2D13265564D100D5C977 /* Build configuration list for PBXNativeTarget "detect_rosetta_cpu" */;
-			buildPhases = (
-				B13E2D0B265564D100D5C977 /* Sources */,
-				B13E2D0C265564D100D5C977 /* Frameworks */,
-				B13E2D0D265564D100D5C977 /* CopyFiles */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DD157A5F2675EB5200350364 /* PBXTargetDependency */,
-				B15487182667809100A9FDBA /* PBXTargetDependency */,
-			);
-			name = detect_rosetta_cpu;
-			productName = detect_rosetta_cpu;
-			productReference = B13E2D0F265564D100D5C977 /* detect_rosetta_cpu */;
-			productType = "com.apple.product-type.tool";
-		};
 		DD1277B2081F3D67007B5DE1 /* PostInstall */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD9E2371091CBDAE0048316E /* Build configuration list for PBXNativeTarget "PostInstall" */;
@@ -2310,6 +2283,25 @@
 			productName = api_libboinc;
 			productReference = DD35353107E1E05C00C4718D /* libboinc_api.a */;
 			productType = "com.apple.product-type.library.static";
+		};
+		DD3AA9AA267B258500013C96 /* BOINC_Intel_Apps_OK */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD3AA9BB267B259000013C96 /* Build configuration list for PBXNativeTarget "BOINC_Intel_Apps_OK" */;
+			buildPhases = (
+				DD3AA9A7267B258500013C96 /* Sources */,
+				DD3AA9A8267B258500013C96 /* Frameworks */,
+				DD3AA9A9267B258500013C96 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DD3AA9BE267B2D2B00013C96 /* PBXTargetDependency */,
+				DD3AA9C0267B2D3200013C96 /* PBXTargetDependency */,
+			);
+			name = BOINC_Intel_Apps_OK;
+			productName = BOINC_Intel_Apps_OK;
+			productReference = DD3AA9AB267B258500013C96 /* BOINC_OK_To_Run_Intel_Apps.app */;
+			productType = "com.apple.product-type.application";
 		};
 		DD3E14D30A774397007E0084 /* mgr_boinc */ = {
 			isa = PBXNativeTarget;
@@ -2577,7 +2569,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				B1A32E55265D206800896566 /* PBXTargetDependency */,
 				DD25E20D220438090040366F /* PBXTargetDependency */,
 			);
 			name = BOINC_Client;
@@ -2643,8 +2634,8 @@
 			attributes = {
 				LastUpgradeCheck = 0620;
 				TargetAttributes = {
-					B13E2D0E265564D100D5C977 = {
-						CreatedOnToolsVersion = 12.5;
+					DD3AA9AA267B258500013C96 = {
+						CreatedOnToolsVersion = 10.1;
 					};
 					DD3EAAA5216A25AD00BC673C = {
 						CreatedOnToolsVersion = 9.4.1;
@@ -2663,6 +2654,7 @@
 				Japanese,
 				French,
 				German,
+				Base,
 			);
 			mainGroup = 20286C29FDCF999611CA2CEA /* ¬´PROJECTNAME¬ª */;
 			projectDirPath = "";
@@ -2690,7 +2682,7 @@
 				DD89161C0F3B17E900DE5B1C /* ss_app */,
 				DDD336F51062235D00867C7D /* AddRemoveUser */,
 				DD5F654023605B41009ED2A2 /* gfx_cleanup */,
-				B13E2D0E265564D100D5C977 /* detect_rosetta_cpu */,
+				DD3AA9AA267B258500013C96 /* BOINC_Intel_Apps_OK */,
 			);
 		};
 /* End PBXProject section */
@@ -2710,6 +2702,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD531BC60C193D3800742E50 /* MacInstaller.icns in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DD3AA9A9267B258500013C96 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2938,10 +2937,11 @@
 				"$(SRCROOT)/English.lproj/ScreenSaver-InfoPlist.strings",
 				"$(SRCROOT)/English.lproj/Uninstaller-InfoPlist.strings",
 				"$(SRCROOT)/BoincCmd-Info.plist",
+				"$(SRCROOT)/BOINC_OK_To_Run_Intel_Apps-Info.plist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n# run SetVersion in background so we can wait for it to finish running\n\"${BUILT_PRODUCTS_DIR}/SetVersion\" &\nwait\n\n";
+			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n# run SetVersion in background so we can wait for it to finish running\n\"${BUILT_PRODUCTS_DIR}/SetVersion\" &\nwait $!\n";
 		};
 		DDC8FB2B1F6D398700BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3036,14 +3036,6 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		B13E2D0B265564D100D5C977 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B13E2D172655655000D5C977 /* detect_rosetta_cpu.cpp in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		DD1277B0081F3D67007B5DE1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -3081,6 +3073,14 @@
 				DD35353607E1E13F00C4718D /* boinc_api.cpp in Sources */,
 				DDE41C260C1FCA8F00CA1F86 /* graphics2_util.cpp in Sources */,
 				DDA45501140F7E7900D97676 /* reduce_main.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DD3AA9A7267B258500013C96 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD3AA9BC267B2C9E00013C96 /* detect_rosetta_cpu.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3679,16 +3679,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		B15487182667809100A9FDBA /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DD407A4907D2FB1200163EF5 /* libboinc */;
-			targetProxy = B15487172667809100A9FDBA /* PBXContainerItemProxy */;
-		};
-		B1A32E55265D206800896566 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = B13E2D0E265564D100D5C977 /* detect_rosetta_cpu */;
-			targetProxy = B1A32E54265D206800896566 /* PBXContainerItemProxy */;
-		};
 		DD095D1F0F3B22DE000902F5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DD89161C0F3B17E900DE5B1C /* ss_app */;
@@ -3698,11 +3688,6 @@
 			isa = PBXTargetDependency;
 			target = DD1277B2081F3D67007B5DE1 /* PostInstall */;
 			targetProxy = DD127876081F44E5007B5DE1 /* PBXContainerItemProxy */;
-		};
-		DD157A5F2675EB5200350364 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DDAEC9E007FA583B00A7BC36 /* SetVersion */;
-			targetProxy = DD157A5E2675EB5200350364 /* PBXContainerItemProxy */;
 		};
 		DD1AFEA50A512D8700EE5B82 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3718,6 +3703,21 @@
 			isa = PBXTargetDependency;
 			target = DDAEC9E007FA583B00A7BC36 /* SetVersion */;
 			targetProxy = DD25E20C220438090040366F /* PBXContainerItemProxy */;
+		};
+		DD3AA9BE267B2D2B00013C96 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDAEC9E007FA583B00A7BC36 /* SetVersion */;
+			targetProxy = DD3AA9BD267B2D2B00013C96 /* PBXContainerItemProxy */;
+		};
+		DD3AA9C0267B2D3200013C96 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD407A4907D2FB1200163EF5 /* libboinc */;
+			targetProxy = DD3AA9BF267B2D3200013C96 /* PBXContainerItemProxy */;
+		};
+		DD3AA9C2267B40E100013C96 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD3AA9AA267B258500013C96 /* BOINC_Intel_Apps_OK */;
+			targetProxy = DD3AA9C1267B40E100013C96 /* PBXContainerItemProxy */;
 		};
 		DD3E14D40A774397007E0084 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -3888,30 +3888,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		B13E2D14265564D100D5C977 /* Development */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
-				INFOPLIST_FILE = "DetectRosettaCPU-Info.plist";
-				OTHER_LDFLAGS = "-lboinc";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.DetectRosettaCPU;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Development;
-		};
-		B13E2D15265564D100D5C977 /* Deployment */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
-				INFOPLIST_FILE = "DetectRosettaCPU-Info.plist";
-				OTHER_LDFLAGS = "-lboinc";
-				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.DetectRosettaCPU;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-			};
-			name = Deployment;
-		};
 		DD1AFEB60A512D8700EE5B82 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -3954,6 +3930,34 @@
 				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.Installer;
 				PRODUCT_NAME = "BOINC Installer";
 				STRIP_INSTALLED_PRODUCT = YES;
+			};
+			name = Deployment;
+		};
+		DD3AA9B9267B259000013C96 /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = NO;
+				INFOPLIST_FILE = "BOINC_OK_To_Run_Intel_Apps-Info.plist";
+				OTHER_LDFLAGS = "-lboinc";
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.OKToRunIntelApps;
+				PRODUCT_NAME = BOINC_OK_To_Run_Intel_Apps;
+				STRIP_INSTALLED_PRODUCT = NO;
+			};
+			name = Development;
+		};
+		DD3AA9BA267B259000013C96 /* Deployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = NO;
+				INFOPLIST_FILE = "BOINC_OK_To_Run_Intel_Apps-Info.plist";
+				OTHER_LDFLAGS = "-lboinc";
+				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.OKToRunIntelApps;
+				PRODUCT_NAME = BOINC_OK_To_Run_Intel_Apps;
+				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Deployment;
 		};
@@ -4856,20 +4860,20 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		B13E2D13265564D100D5C977 /* Build configuration list for PBXNativeTarget "detect_rosetta_cpu" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B13E2D14265564D100D5C977 /* Development */,
-				B13E2D15265564D100D5C977 /* Deployment */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Development;
-		};
 		DD1AFEB50A512D8700EE5B82 /* Build configuration list for PBXNativeTarget "Install_BOINC" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DD1AFEB60A512D8700EE5B82 /* Development */,
 				DD1AFEB90A512D8700EE5B82 /* Deployment */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Development;
+		};
+		DD3AA9BB267B259000013C96 /* Build configuration list for PBXNativeTarget "BOINC_Intel_Apps_OK" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD3AA9B9267B259000013C96 /* Development */,
+				DD3AA9BA267B259000013C96 /* Deployment */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Development;

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -2941,7 +2941,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n# run SetVersion in background so we can wait for it to finish running\n\"${BUILT_PRODUCTS_DIR}/SetVersion\" &\nwait $!\n";
+			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n# run SetVersion in background so we can wait for it to finish running\n# Important: Xcode considers this script finished when all the files specified\n# in the \"Output Files\" list below have been written. If a target is dependent \n# on a file created by SetVersion, be sure it is listed as an Output File to \n# this script. Otherwise, the build may fail due to a race condition.\n\"${BUILT_PRODUCTS_DIR}/SetVersion\" &\nwait $!\n";
 		};
 		DDC8FB2B1F6D398700BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/mac_installer/myDistribution
+++ b/mac_installer/myDistribution
@@ -24,7 +24,7 @@
             <bundle CFBundleVersion="x.y.z" id="edu.berkeley.boincsaver" path="Library/Screen Savers/BOINCSaver.saver"/>
         </bundle-version>
     </pkg-ref>
-    <options customize="never" require-scripts="false" rootVolumeOnly="true"/>
+    <options customize="never" require-scripts="false" rootVolumeOnly="true" hostArchitectures="x86_64,arm64"/>
     <title>BOINC Manager</title>
     <readme file="ReadMe.rtf" mime-type="text/rtf"/>
     <license file="License.rtf" mime-type="text/rtf"/>

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -54,7 +54,7 @@
 ## Updated 11/22/20 by Charlie Fenton to build DMG bare-core (apple-darwin) release
 ## Updated 11/26/20 by Charlie Fenton to let installer show message if MacOS too old
 ## Updated 5/27/21 to support zsh & detecting X86_64 features emulated by Rosetta 2
-## Updated 6/13/21 to support Install Rosetta 2 dialog from MacOS
+## Updated 6/17/21 to support Install Rosetta 2 dialog from MacOS
 ##
 ## NOTE: This script requires Mac OS 10.7 or later, and uses XCode developer
 ##   tools.  So you must have installed XCode Developer Tools on the Mac 
@@ -314,7 +314,7 @@ cp -fp clientscr/res/boinc_logo_black.jpg ../BOINC_Installer/Pkg_Root/Library/Ap
 cp -fp api/ttf/liberation-fonts-ttf-2.00.0/LiberationSans-Regular.ttf ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/LiberationSans-Regular.ttf
 cp -fp clientscr/ss_config.xml ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
 cp -fpRL "${BUILDPATH}/boincscr" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
-cp -fpRL "${BUILDPATH}/detect_rosetta_cpu" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
+cp -fpRL "${BUILDPATH}/BOINC_OK_To_Run_Intel_Apps.app" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
 
 cp -fpRL "${BUILDPATH}/BOINCManager.app" ../BOINC_Installer/Pkg_Root/Applications/
 
@@ -421,7 +421,7 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/boincscr"
 
     # Code Sign the detect_rosetta_cpu helper app if we have a signing identity
-    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/detect_rosetta_cpu"
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/BOINC_OK_To_Run_Intel_Apps.app"
 
     # Code Sign the BOINC screensaver code for OS 10.6 and OS 10.7 if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver/Contents/MacOS/BOINCSaver_MacOS10_6_7"
@@ -536,7 +536,7 @@ sudo chmod -R 644 ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-a
 mkdir -p ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir
 cp -fpRL "${BUILDPATH}/boinc" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 cp -fpRL "${BUILDPATH}/boinccmd" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
-cp -fpRL "${BUILDPATH}/detect_rosetta_cpu" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
+cp -fpRL "${BUILDPATH}/BOINC_OK_To_Run_Intel_Apps.app" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 cp -fpRL curl/ca-bundle.crt ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 
 mkdir -p ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher
@@ -562,7 +562,7 @@ if [ -n "${APPSIGNINGIDENTITY}" ]; then
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/boinc"
 
     # Code Sign detect_rosetta_cpu for the stand-alone boinc client if we have a signing identity
-    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/detect_rosetta_cpu"
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/BOINC_OK_To_Run_Intel_Apps.app"
 
     # Code Sign setprojectgrp for the stand-alone boinc client if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher/setprojectgrp"

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -54,6 +54,7 @@
 ## Updated 11/22/20 by Charlie Fenton to build DMG bare-core (apple-darwin) release
 ## Updated 11/26/20 by Charlie Fenton to let installer show message if MacOS too old
 ## Updated 5/27/21 to support zsh & detecting X86_64 features emulated by Rosetta 2
+## Updated 6/13/21 to support Install Rosetta 2 dialog from MacOS
 ##
 ## NOTE: This script requires Mac OS 10.7 or later, and uses XCode developer
 ##   tools.  So you must have installed XCode Developer Tools on the Mac 
@@ -152,6 +153,11 @@
 ## - for more information:
 ##  $ xcrun altool --help
 ##  $ man stapler
+##
+## TODO: Add code to optionally automate notarization either in this script or
+## TODO: in a separate script. Perhaps adapt notarization and stapler code from 
+## TODO: <https://github.com/smittytone/scripts/blob/master/packcli.zsh>
+##
 
 if [ $# -lt 3 ]; then
 echo "Usage:"
@@ -241,6 +247,21 @@ cp -fp mac_installer/myDistribution ../BOINC_Installer/Installer\ templates
 # Update version number
 sed -i "" s/"<VER_NUM>"/"$1.$2.$3"/g ../BOINC_Installer/Installer\ Resources/ReadMe.rtf
 sed -i "" s/"x.y.z"/"$1.$2.$3"/g ../BOINC_Installer/Installer\ templates/myDistribution
+
+# Fix hostArchitectures option
+has_x86_64="no"
+has_arm64="no"
+client_archs=`lipo -info "${BUILDPATH}/boinc"`
+if [[ "${client_archs}" = *"x86_64"* ]]; then has_x86_64="yes"; fi
+if [[ "${client_archs}" = *"arm64"* ]]; then has_arm64="yes"; fi
+
+if [ $has_x86_64 = "no" ]; then
+    sed -i "" s/"x86_64,arm64"/"arm64"/g ../BOINC_Installer/Installer\ templates/myDistribution
+else
+    if [ $has_arm64 = "no" ]; then
+        sed -i "" s/"x86_64,arm64"/"x86_64"/g ../BOINC_Installer/Installer\ templates/myDistribution
+    fi
+fi
 
 ## Add a statement in the ReadMe telling Minimum required MacOS version, if known
 OSVersion=`/usr/libexec/PlistBuddy -c "Print :LSMinimumSystemVersion" "${BUILDPATH}/BOINCManager.app/Contents/Info.plist"`

--- a/mac_installer/release_brand.sh
+++ b/mac_installer/release_brand.sh
@@ -254,7 +254,7 @@ cp -fp clientscr/res/boinc_logo_black.jpg ../BOINC_Installer/Pkg_Root/Library/Ap
 cp -fp api/ttf/liberation-fonts-ttf-2.00.0/LiberationSans-Regular.ttf ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/LiberationSans-Regular.ttf
 cp -fp clientscr/ss_config.xml ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
 cp -fpRL "${BUILDPATH}/boincscr" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
-cp -fpRL "${BUILDPATH}/detect_rosetta_cpu" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
+cp -fpRL "${BUILDPATH}/BOINC Data/BOINC_OK_To_Run_Intel_Apps.app" ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/
 
 cp -fpRL "${BUILDPATH}/BOINCManager.app/." "../BOINC_Installer/Pkg_Root/Applications/${MANAGERAPPNAME}.app/"
 sed -i "" s/BOINCManager/"${MANAGERAPPNAME}"/g "../BOINC_Installer/Pkg_Root/Applications/${MANAGERAPPNAME}.app/Contents/Info.plist"
@@ -394,7 +394,7 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/boincscr"
 
     # Code Sign the detect_rosetta_cpu helper app if we have a signing identity
-    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/detect_rosetta_cpu"
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/BOINC Data/BOINC_OK_To_Run_Intel_Apps.app"
 
     # Code Sign the BOINC screensaver code for OS 10.6 and OS 10.7 if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/${SSAVERAPPNAME}.saver/Contents/MacOS/BOINCSaver_MacOS10_6_7"
@@ -453,7 +453,7 @@ sudo chmod -R 644 ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SH
 mkdir -p ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir
 cp -fpRL "${BUILDPATH}/boinc" ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 cp -fpRL "${BUILDPATH}/boinccmd" ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
-cp -fpRL "${BUILDPATH}/detect_rosetta_cpu" ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
+cp -fpRL "${BUILDPATH}/BOINC Data/BOINC_OK_To_Run_Intel_Apps.app" ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 cp -fpRL curl/ca-bundle.crt ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/
 
 mkdir -p ../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher
@@ -479,7 +479,7 @@ if [ -n "${APPSIGNINGIDENTITY}" ]; then
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/boinc"
 
     # Code Sign detect_rosetta_cpu for the stand-alone boinc client if we have a signing identity
-    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/detect_rosetta_cpu"
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/BOINC_OK_To_Run_Intel_Apps.app"
 
     # Code Sign setprojectgrp for the stand-alone boinc client if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_$arch-apple-darwin/move_to_boinc_dir/switcher/setprojectgrp"


### PR DESCRIPTION
Apple Silicon (arm64) Macs can run X86_64 executables using Apple's Rosetta 2 x86_64 translation / emulation software. For BOINC projects to take advantage of this, the BOINC client must report the emulated x86_64 CPU features to project servers. The BOINC client launches its detect_rosetta_cpu helper app to determine these features so the client can report them. 

But Rosetta 2 is not installed by default on Apple Silicon Macs. MacOS automatically displays its built-in "Install Rosetta 2?" dialog when a user launches an x86_64-only application if Rosetta 2 has not yet been installed. But detect_rosetta_cpu, which is a bare (command-line) executable rather than a full MacOS application, apparently does not trigger this dialog.

This PR is intended to update the detect_rosetta_cpu helper app to trigger the dialog when appropriate, by embedding an info.plist section in it. We hope that is sufficient to trigger the dialog. If not, we may need to convert the detect_rosetta_cpu command-line executable into a full Mac application bundle.
