### PR TITLE
[Android] Update tests dependencies

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -157,7 +157,7 @@ ext {
     coroutines_version = '1.4.3'
     dagger_version = '2.37'
     lifecycle_version = '2.3.1'
-    powermock_version = '2.0.5'
+    powermock_version = '2.0.9'
     junit5_version = '5.7.2'
 }
 
@@ -196,11 +196,10 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$dagger_version"
 
     // Testing dependencies
-    testImplementation 'androidx.test:core:1.3.0'
+    testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'com.google.guava:guava-testlib:28.2-jre'
-    testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.5.1'
-    testImplementation "io.mockk:mockk:1.11.0"
+    testImplementation "io.mockk:mockk:1.12.0"
 
     // Powermock dependencies
     testImplementation "org.powermock:powermock-module-junit4:$powermock_version"


### PR DESCRIPTION
Update tests dependencies:
update to androidx.test:core:1.4.0
Update to mockk:1.12.0
update powermock_version to 2.0.9
Remove junit4 dependency.

Compile and run and crunch on OnePlus one (android 10). 