### PR TITLE
[Android] Fix deprecated hard coded data dir

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
@@ -184,7 +184,7 @@ class Monitor : LifecycleService() {
         Log.d(Logging.TAG, "Monitor onCreate()")
 
         // populate attributes with XML resource values
-        boincWorkingDir = getString(R.string.client_path)
+        boincWorkingDir = applicationInfo.dataDir + "/" + getString(R.string.client_path)
         fileNameClient = getString(R.string.client_name)
         fileNameCABundle = getString(R.string.client_cabundle)
         fileNameClientConfig = getString(R.string.client_config)

--- a/android/BOINC/app/src/main/res/values/configuration.xml
+++ b/android/BOINC/app/src/main/res/values/configuration.xml
@@ -18,7 +18,7 @@
 -->
 <resources>
     <!-- path and file configuration -->
-    <string name="client_path" translatable="false">/data/data/edu.berkeley.boinc/client/</string>
+    <string name="client_path" translatable="false">client/</string>
     <string name="client_name" translatable="false">boinc</string>
     <string name="client_cabundle" translatable="false">ca-bundle.crt</string>
     <string name="client_config" translatable="false">cc_config.xml</string>

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/MonitorTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/MonitorTest.kt
@@ -53,7 +53,7 @@ class MonitorTest {
 
     @Test
     fun `Expect default config location when getAuthFilePath() is called`() {
-        Assert.assertEquals("/data/data/edu.berkeley.boinc/client/gui_rpc_auth.cfg", monitor.authFilePath)
+        Assert.assertTrue(monitor.authFilePath.endsWith("/client/gui_rpc_auth.cfg"))
     }
 
     @Test


### PR DESCRIPTION
Fix deprecated hard coded data dir:
https://stackoverflow.com/questions/20391671/warning-do-not-hardcode-data-use-context-getfilesdir-getpath-instead
With this solution:
https://stackoverflow.com/a/19630415/550384


I compile and run and crunch on OnePlus one (Android 10). 