### PR TITLE
[Android] Fix delicate api warning

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/utils/BOINCUtils.kt
@@ -24,7 +24,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.ConnectivityManager
 import android.os.Build
-import android.os.RemoteException
 import android.util.Log
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -34,13 +33,13 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
 import edu.berkeley.boinc.BOINCActivity
 import edu.berkeley.boinc.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.GlobalScope
 import java.io.IOException
 import java.io.Reader
-import java.lang.Exception
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -103,16 +102,15 @@ fun Context.translateRPCReason(reason: Int) = when (reason) {
     else -> resources.getString(R.string.rpcreason_unknown)
 }
 
-@Suppress("NOTHING_TO_INLINE")
-inline fun Long.secondsToLocalDateTime(
+fun Long.secondsToLocalDateTime(
         zoneId: ZoneId = ZoneId.systemDefault()
 ): LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochSecond(this), zoneId)
 
-@Suppress("NOTHING_TO_INLINE")
-inline fun Context.getColorCompat(@ColorRes colorId: Int) = ContextCompat.getColor(this, colorId)
+fun Context.getColorCompat(@ColorRes colorId: Int) = ContextCompat.getColor(this, colorId)
 
-class TaskRunner<V>(private val callback: ((V) -> Unit)? , private val callable: Callable<V>) {
-    private var deferred = GlobalScope.async {
+class TaskRunner<V>(private val callback: ((V) -> Unit)?, private val callable: Callable<V>) {
+    val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val deferred =  applicationScope.async {
         try {
             val result = callable.call()
             callback?.invoke(result)


### PR DESCRIPTION
Fix `delicate api` warning
Remove inline modifier

Compile and run and crunch:
OnePlus One (Android 10)
Galaxy gio (Android 4.4)