### PR TITLE
[Android] Switch to new jacoco

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'org.ajoberstar.grgit' version '4.1.0'
+    id 'jacoco'
 }
 
 apply plugin: 'com.android.application'
@@ -225,3 +226,31 @@ dependencies {
 repositories {
     mavenCentral()
 }
+
+//from https://about.codecov.io/blog/code-coverage-for-android-development-using-kotlin-jacoco-github-actions-and-codecov/
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+
+    reports {
+        csv.getRequired().set(true)
+        xml.getRequired().set(true)
+        html.getRequired().set(true)
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/META-INF*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "${buildDir}/intermediates/javac/debug/classes", excludes: fileFilter) +
+            fileTree(dir: "${buildDir}/tmp/kotlin-classes/debug", excludes: fileFilter)
+    def mainSrc = "${project.projectDir}/src/main/java"
+
+    sourceDirectories.setFrom(files([mainSrc]))
+    classDirectories.setFrom(files([debugTree]))
+    executionData.setFrom(fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/code-coverage/debugAndroidTest/connected/coverage.ec"
+    ]))
+}
+
+jacoco {
+    toolVersion "$jacoco_version"
+}
+
+android.jacoco.version = "$jacoco_version"

--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -1,6 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext.kotlin_version = '1.5.21'
+    ext.jacoco_version = '0.8.7'
     repositories {
         maven {
             url 'https://maven.google.com/'
@@ -15,7 +16,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.2.2"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0"
+        classpath "org.jacoco:org.jacoco.core:$jacoco_version"
     }
 }
 
@@ -28,4 +29,4 @@ allprojects {
     }
 }
 
-apply plugin: "com.vanniktech.android.junit.jacoco"
+task jacocoTestReportDebug(dependsOn: ["app:jacocoTestReport"]) {}


### PR DESCRIPTION
jacoco 0.8.7 (for gradle 7.1.1)

https://about.codecov.io/blog/code-coverage-for-android-development-using-kotlin-jacoco-github-actions-and-codecov/
