### PR TITLE
Scheduler: allow negation of regular expressions in plan class XML specs (standard)

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -33,12 +33,16 @@ int REGEX_CLAUSE::init(const char* p) {
     present = true;
     negate = false;
     expr = p;
-    if (*p == '!') {
-        p++;
+    if (!strncmp(p,"(?!",3) && p[strlen(p)-1] == ')') {
+        p += 3;
+        p[strlen(p)-1] = '\0'; // don't parse trailing ')'
         negate = true;
     }
     if (regcomp(&regex, p, REG_EXTENDED|REG_NOSUB) ) {
         return ERR_XML_PARSE;
+    }
+    if (negate) {
+        p[strlen(p)] = ')'; // restore trailing ')'
     }
     return 0;
 }


### PR DESCRIPTION
This MR is an extension of #4390 with the changes discussed but not (yet) implemented there, i.e. using the standard `(?!regex)` as proposed by @Rytiss instead of the simple but non-standard `!regex` proposed by me and implemented by @davidpanderson . The branch is based on David's `dpa_regex` with an extra commit.