### PR TITLE
Update third party wxWidgets with bugfix builds

### DIFF
--- a/3rdParty/buildLinuxDependencies.sh
+++ b/3rdParty/buildLinuxDependencies.sh
@@ -141,7 +141,7 @@ fi
 if [ "${gtest_only}" = "yes" ]; then
     download_and_build "googletest-release-1.8.1" "release-1.8.1.tar.gz" "https://github.com/google/googletest/archive/release-1.8.1.tar.gz" "${ROOTDIR}/3rdParty/buildGoogletestLinux.sh"
 else
-    download_and_build "wxWidgets-3.0.2" "wxWidgets-3.0.2.tar.bz2" "https://sourceforge.net/projects/wxwindows/files/3.0.2/wxWidgets-3.0.2.tar.bz2" "${ROOTDIR}/3rdParty/buildWxLinux.sh ${wxoption}"
+    download_and_build "wxWidgets-3.0.5" "wxWidgets-3.0.5.tar.bz2" "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5.tar.bz2" "${ROOTDIR}/3rdParty/buildWxLinux.sh ${wxoption}"
 fi
 
 # change back to root directory

--- a/3rdParty/buildWxLinux.sh
+++ b/3rdParty/buildWxLinux.sh
@@ -20,7 +20,7 @@
 # Script to build a wxWidgets GTK version for BOINC
 
 # Usage:
-#  cd [path]/wxWidgets-3.0.2/
+#  cd [path]/wxWidgets-3.0.5/
 #  source path_to_this_script [--clean] [--debug] [--prefix PATH]
 #
 # the --clean argument will force a full rebuild.


### PR DESCRIPTION
**Description of the Change**
This updates the third party Linux dependency build script to pull the latest 3.0- version of wxWidgets, which is fully backwards compatible.  The previous version, 3.0.2, is from 2015.  The new version 3.0.5 is from April 2020.  
The full changelog for releases 3.0.3, 3.0.4, and 3.0.5 can be found here:
https://raw.githubusercontent.com/wxWidgets/wxWidgets/v3.0.5/docs/changes.txt

**Alternate Designs**
The previous version could continued to be used.

**Release Notes**
N/A
