### PR TITLE
Use `is None` instead of `== None`

### DIFF
--- a/py/Boinc/boincxml.py
+++ b/py/Boinc/boincxml.py
@@ -28,7 +28,7 @@ def get_element(node, name, optional=True):
         raise SystemExit("ERROR: Couldn't find xml node <%s>"% name)
 
 def _None2Str(object):
-    if object == None:
+    if object is None:
         return ''
     else:
         return object

--- a/py/Boinc/db_base.py
+++ b/py/Boinc/db_base.py
@@ -69,13 +69,13 @@ def _commit_object(tablename, paramdict, id=None):
     equalcommands = []
     for key in paramdict.keys():
         value = paramdict[key]
-        if value == None:
+        if value is None:
             continue
         elif isinstance(value, int):
             equalcommands.append('%s=%d' %(key,value))
         else:
             equalcommands.append("%s='%s'"%(key,dbconnection.escape_string(str(value))))
-    if id == None:
+    if id is None:
         command = 'INSERT INTO %s SET %s' % \
             (tablename, ', '.join(equalcommands))
         if debug.mysql:
@@ -97,7 +97,7 @@ def _remove_object(command, id=None):
         id is given, it assembles the SQL command and deletes the object
         from the database.  Does nothing if no id is given."""
     assert(dbconnection)
-    if id == None:
+    if id is None:
         pass
     else:
         cursor = dbconnection.cursor()
@@ -122,7 +122,7 @@ def _select_object(table, searchdict, extra_args="", extra_params=[], select_wha
     if join:
         command += "," + join
     for (key,value) in searchdict.items():
-        if value == None:
+        if value is None:
             value = ''
         escaped_value = dbconnection.escape_string(str(value))
         if key == 'text':

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -57,7 +57,7 @@ def verbose_sleep(msg, wait):
 
 def get_env_var(name, default = None):
     value = os.environ.get(name, default)
-    if value == None:
+    if value is None:
         print("Environment variable %s not defined" % name)
         sys.exit(1)
     return value
@@ -209,7 +209,7 @@ def _check_vars(dict, **names):
     for key in names:
         value = names[key]
         if not key in dict:
-            if value == None:
+            if value is None:
                 raise SystemExit('error in test script: required parameter "%s" not specified'%key)
             dict[key] = value
     for key in dict:

--- a/sched/assimilator.py
+++ b/sched/assimilator.py
@@ -180,7 +180,7 @@ class Assimilator():
                 if result == wu.canonical_result:
                     canonical_result=result
     
-            if canonical_result == None and wu.error_mask == 0:
+            if canonical_result is None and wu.error_mask == 0:
                 # If no canonical result found and WU had no other errors,
                 # something is wrong, e.g. result records got deleted prematurely.
                 # This is probably unrecoverable, so mark the WU as having

--- a/tests/old/testbase.py
+++ b/tests/old/testbase.py
@@ -125,7 +125,7 @@ def _check_vars(dict, **names):
     for key in names:
         value = names[key]
         if not key in dict:
-            if value == None:
+            if value is None:
                 raise SystemExit('error in test script: required parameter "%s" not specified'%key)
             dict[key] = value
     for key in dict:


### PR DESCRIPTION
**Description of the Change**
This changes all instances of `== None` to `is None`.  This is considered best practice in Python.
> When you compare an object to None, use `is` rather than `==`. None is a singleton object, comparing using `==` invokes the `__eq__ `method on the object in question, which may be slower than identity comparison. Comparing to None using the `is` operator is also easier for other programmers to read.

Reference: https://lgtm.com/rules/7900090/

**Release Notes**
N/A
