### PR TITLE
Remove semicolons in python code

### DIFF
--- a/lib/submit_api.py
+++ b/lib/submit_api.py
@@ -313,4 +313,4 @@ def upload_files(upload_files_req):
 # see tools/submit_api_test.py
 #
 def get_job_counts(req):
-    return do_http_post('', req.project, 'server_status.php?counts=1');
+    return do_http_post('', req.project, 'server_status.php?counts=1')

--- a/py/Boinc/boincxml.py
+++ b/py/Boinc/boincxml.py
@@ -135,7 +135,7 @@ class XMLConfig:
             self._get_elements()
         except:
             if not failopen_ok:
-                raise Exception("%s: Couldn't get elements from XML file");
+                raise Exception("%s: Couldn't get elements from XML file")
         return self
     def _get_elements(self):
         pass

--- a/py/Boinc/sched_messages.py
+++ b/py/Boinc/sched_messages.py
@@ -20,6 +20,6 @@ class SchedMessages:
             elif kind==DEBUG:
                 kind = "debug   "
             else:
-                kind = "*** internal error: invalid MessageKind ***";
+                kind = "*** internal error: invalid MessageKind ***"
             sys.stderr.write("%s [%s] " % (time.strftime("%Y/%m/%d %H:%M:%S", time.localtime()), kind))
             sys.stderr.write(format % args)

--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -309,7 +309,7 @@ def install_boinc_files(dest_dir, install_web_files, install_server_files):
             location = os.path.join(location, d )
         return location
 
-    create_project_dirs(dest_dir);
+    create_project_dirs(dest_dir)
 
     # copy html/ops files in all cases.
     # The critical one is db_update.php,
@@ -555,13 +555,13 @@ class Project:
         if os.path.exists(self.dest()):
             raise SystemExit('Project directory "%s" already exists; this would clobber it!'%self.dest())
 
-        verbose_echo(1, "Creating directories");
+        verbose_echo(1, "Creating directories")
 
-        create_project_dirs(self.project_dir);
+        create_project_dirs(self.project_dir)
 
         if not self.web_only:
             if not self.keys_exist():
-                verbose_echo(1, "Generating encryption keys");
+                verbose_echo(1, "Generating encryption keys")
                 self.create_keys()
 
         # copy the user and administrative PHP files to the project dir,

--- a/samples/vm_wrapper/VMwrapper.py
+++ b/samples/vm_wrapper/VMwrapper.py
@@ -67,9 +67,9 @@ class TASK:
    final_cpu_time = 0.0
    time_checkpointed = 0            
    # contribution of this task to overall fraction done
-   final_cpu_time = 0;
-   starting_cpu = 0;
-   ready = 0;
+   final_cpu_time = 0
+   starting_cpu = 0
+   ready = 0
    exitCode = None
 
    # how much CPU time was used by tasks before this in the job file
@@ -450,7 +450,7 @@ def read_checkpoint(filename):
    cpu = 0
 
    try:
-      f = open(filename, "r");
+      f = open(filename, "r")
    except:
       return [ntasks, cpu]
 

--- a/tests/old/test_1sec.py
+++ b/tests/old/test_1sec.py
@@ -9,7 +9,7 @@
 from test_uc import *
 
 if __name__ == '__main__':
-    test_msg("multiple projects with resource share");
+    test_msg("multiple projects with resource share")
     # create two projects with the same host/user
     host = Host()
     user = UserUC()

--- a/tests/old/test_uc.py
+++ b/tests/old/test_uc.py
@@ -74,6 +74,6 @@ class ProjectUC(TestProject):
                              )
 
 if __name__ == '__main__':
-    test_msg("standard upper_case application");
+    test_msg("standard upper_case application")
     ProjectUC()
     run_check_all()

--- a/tests/old/testbase.py
+++ b/tests/old/testbase.py
@@ -508,7 +508,7 @@ class Host:
         rmtree(self.dir())
         os.mkdir(self.dir())
 
-        verbose_echo(1, "Setting up host '%s': creating account files" % self.name);
+        verbose_echo(1, "Setting up host '%s': creating account files" % self.name)
         for (user,project) in map(None,self.users,self.projects):
             filename = self.dir(account_file_name(project.config.config.master_url))
             verbose_echo(2, "Setting up host '%s': writing %s" % (self.name, filename))
@@ -611,7 +611,7 @@ class Work:
                 verbose_echo(2, "Linking "+newhandler)
                 os.symlink(handler, newhandler)
 
-        shutil.copy(self.result_template, project.dir());
+        shutil.copy(self.result_template, project.dir())
         cmd = build_command_line("create_work",
                                  config_dir          = project.dir(),
                                  appname             = self.app.name,

--- a/tools/submit_api_test.py
+++ b/tools/submit_api_test.py
@@ -46,7 +46,7 @@ def make_batch_desc(batch_name):
     [batch.project, batch.authenticator] = get_auth()
     batch.app_name = "uppercase"
     batch.batch_name = batch_name
-    batch.app_version_num = 710;
+    batch.app_version_num = 710
     batch.jobs = []
 
     for i in range(2):


### PR DESCRIPTION
**Description of the Change**
This removes semicolons that were accidentally added to the end of statements in the python code files.

**Release Notes**
N/A
