### PR TITLE
Fix a typo that introduced a bug

### DIFF
--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -1325,7 +1325,7 @@ int CMainDocument::CachedProjectStatusUpdate(bool bForce) {
     if (! IsConnected()) return -1;
 
 #if USE_CACHE_TIMEOUTS
-    wxTimeSpan ts(wxDateTime::Now() - m_dtProjecStatusTimestamp);
+    wxTimeSpan ts(wxDateTime::Now() - m_dtProjectsStatusTimestamp);
     if (ts.GetSeconds() >= (2 * PROJECTSTATUSRPC_INTERVAL)) bForce = true;
 #endif
     if (m_dtProjectsStatusTimestamp.IsEqualTo(wxDateTime((time_t)0))) bForce = true;


### PR DESCRIPTION
**Description of the Change**
The variable `m_dtProjectsStatusTimestamp` was misspelled as `m_dtProjecStatusTimestamp` in this piece of code, leading to the correct variable not being used.  This fixes what should otherwise be a compiler error.

**Release Notes**
N/A
