### PR TITLE
Miscellaneous spelling and typo fixes

### DIFF
--- a/android/ProjectApp/src/com/example/projectapp/BoincInteractionService.java
+++ b/android/ProjectApp/src/com/example/projectapp/BoincInteractionService.java
@@ -132,7 +132,7 @@ public class BoincInteractionService extends Service {
     	//busy waiting until interface returns true
     	Boolean ready = false;
 		Integer counter = 0;
-		Integer sleepDuration = 500; //in mili seconds
+		Integer sleepDuration = 500; //in milli seconds
 		Integer maxLoops = getResources().getInteger(R.integer.busy_waiting_timeout_ms) / sleepDuration;
 		while(!ready && (counter < maxLoops)) {
 			try {

--- a/android/Vagrant.README.md
+++ b/android/Vagrant.README.md
@@ -25,7 +25,7 @@ Provide a turn-key VM for Android development
 ## HOWTO
 
 1. On your host: open a terminal
-   1. Clone the [BOINC repo](https://github.com/BOINC/boinc) and `cd <BOINC_REPO>/android` or just dowload the [Vagrantfile from GitHub](https://github.com/BOINC/boinc/blob/master/android/Vagrantfile)
+   1. Clone the [BOINC repo](https://github.com/BOINC/boinc) and `cd <BOINC_REPO>/android` or just download the [Vagrantfile from GitHub](https://github.com/BOINC/boinc/blob/master/android/Vagrantfile)
    1. `vagrant up`
    1. Wait until the final reboot finished
    1. **From this point on you don't need Vagrant anymore**
@@ -37,7 +37,7 @@ Provide a turn-key VM for Android development
       1. `cd ~/BOINC/android`
       1. `./build_client.sh`
    1. Start Android Studio
-   1. No need to change anything in the setup assitant (just complete it)
+   1. No need to change anything in the setup assistant (just complete it)
       * OK / Next / Next / Finish / Finish
    1. Import the BOINC App as *Gradle* project from: `~/BOINC/android/BOINC`
    1. Ignore potential Gradle Plugin warning: *Don't remind me again*
@@ -65,7 +65,7 @@ If you want to do a `push` without username and password prompt, you have to do 
 1. Verify that the remote URL has changed: `git remote -v`
 1. Generate a new SSH key: `ssh-keygen -t rsa -b 4096 -C "your_email@example.com"`
    1. When you're prompted to "Enter a file in which to save the key," press Enter. This accepts the default file location.
-   1. When you're promted to "Enter passphrase (empty for no passphrase)" type a secure passphrase.
+   1. When you're prompted to "Enter passphrase (empty for no passphrase)" type a secure passphrase.
 1. Add your SSH key to the ssh-agent.
    1. Start the ssh-agent in the background: `eval "$(ssh-agent -s)"`
    1. Add your SSH private key to the ssh-agent: `ssh-add ~/.ssh/id_rsa`

--- a/android/WSL.README.md
+++ b/android/WSL.README.md
@@ -10,7 +10,7 @@ Allow Windows users to use built-in WSL for setting up for BOINC Android develop
 * WSL1: fork/exec error - [Microsoft/WSL#2469](https://github.com/microsoft/WSL/issues/2469)
 * WSL1: wget HSTS error - <https://superuser.com/questions/1539972/wget-error-bash-windows-subsystem-for-linux>
 * WSL2: High vmmem memory usage - [Microsoft/WSL#4166](https://github.com/microsoft/WSL/issues/4166) - Note: Users can check out [this workaround](https://github.com/microsoft/WSL/issues/4166#issuecomment-526725261). Based on our testing, setting `memory=3GB` should be sufficient if users don't have more than that.
-* WSL2: Unable to use hardware accleration in Android Emulator or VirtualBox - [WSL2 FAQ](https://docs.microsoft.com/en-us/windows/wsl/wsl2-faq#will-i-be-able-to-run-wsl-2-and-other-3rd-party-virtualization-tools-such-as-vmware-or-virtualbox)
+* WSL2: Unable to use hardware acceleration in Android Emulator or VirtualBox - [WSL2 FAQ](https://docs.microsoft.com/en-us/windows/wsl/wsl2-faq#will-i-be-able-to-run-wsl-2-and-other-3rd-party-virtualization-tools-such-as-vmware-or-virtualbox)
 
 ## Prerequisites
 

--- a/api/windows_opengl.cpp
+++ b/api/windows_opengl.cpp
@@ -243,14 +243,14 @@ static void set_mode(int mode) {
         if (NULL == hOriginalWindowStation) {
             hOriginalWindowStation = GetProcessWindowStation();
             if (NULL == hOriginalWindowStation) {
-                BOINCINFO("Failed to retrieve the orginal window station\n");
+                BOINCINFO("Failed to retrieve the original window station\n");
             }
         }
 
         if (NULL == hOriginalDesktop) {
             hOriginalDesktop = GetThreadDesktop(GetCurrentThreadId());
             if (NULL == hOriginalDesktop) {
-                BOINCINFO("Failed to retrieve the orginal desktop\n");
+                BOINCINFO("Failed to retrieve the original desktop\n");
             }
         }
 

--- a/api/x_opengl.cpp
+++ b/api/x_opengl.cpp
@@ -392,7 +392,7 @@ void KillWindow() {
             glutReshapeWindow(win_width, win_height);
         }
         
-        // On Intel Macs (but not on PowerPC Macs) GLUT's destuctors often crash when 
+        // On Intel Macs (but not on PowerPC Macs) GLUT's destructors often crash when 
         // glutDestroyWindow() is called.  So far, this has only been reported for
         // SETI@home. Since it doesn't occur on PowerPC Macs, we suspect a bug in GLUT.  
         // To work around this, we just hide the window instead.  Though this does not 

--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -104,8 +104,8 @@ int use_sandbox, int isManager, char* path_to_error, int len
 #endif
 #endif      // _DEBUG
 
-// GDB can't attach to applications which are running as a diferent user or group so
-//  it ignores the S_ISUID and S_ISGID permisison bits when launching an application.
+// GDB can't attach to applications which are running as a different user or group so
+//  it ignores the S_ISUID and S_ISGID permission bits when launching an application.
 // To work around this, and to allow testing the uninstalled Deployment version, we
 //  assume that the BOINC Client has the correct user and group. 
 // We must get the BOINC Client's user and group differently depending on whether we

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1934,7 +1934,7 @@ int CLIENT_STATE::report_result_error(RESULT& res, const char* err_msg) {
         // called from:
         // ACTIVE_TASK::start (if couldn't start app)
         // ACTIVE_TASK::restart (if files missing)
-        // ACITVE_TASK_SET::restart_tasks (catch other error returns)
+        // ACTIVE_TASK_SET::restart_tasks (catch other error returns)
         // ACTIVE_TASK::handle_exited_app (on nonzero exit or signal)
         // ACTIVE_TASK::abort_task (if exceeded resource limit)
         // CLIENT_STATE::schedule_cpus (catch-all for resume/start errors)

--- a/client/cpp.h
+++ b/client/cpp.h
@@ -16,7 +16,7 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // Don't include config.h or C++ header files from here.
-// there are #defines that alter the behiour of the standard C and C++ headers.
+// there are #defines that alter the behaviour of the standard C and C++ headers.
 // In this case we need to use the "small files" environment on some unix
 // systems.  That can't be done if we include "cpp.h"
 

--- a/client/detect_rosetta_cpu.cpp
+++ b/client/detect_rosetta_cpu.cpp
@@ -16,8 +16,8 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // This helper program is used to detect an emulated x86_64 CPU on Apples
-// ARM64 CPUs (M1). It should be compiiled _only_ for x86_64 architecture.
-// It writes the feature string of the meulated CPU to a file
+// ARM64 CPUs (M1). It should be compiled _only_ for x86_64 architecture.
+// It writes the feature string of the emulated CPU to a file
 // EMULATED_CPU_INFO_FILENAME in the current working directory.
 
 #include <stdio.h>

--- a/client/gpu_opencl.cpp
+++ b/client/gpu_opencl.cpp
@@ -436,7 +436,7 @@ void COPROCS::get_opencl(
                     // Mac OpenCL does not recognize all NVIDIA GPUs returned by
                     // CUDA but we assume that OpenCL and CUDA return devices 
                     // with identical model name strings and that OpenCL returns
-                    // devices in order of acending PCI slot.
+                    // devices in order of ascending PCI slot.
                     //
                     // On other systems, assume OpenCL and CUDA return devices 
                     // in the same order.

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1865,7 +1865,7 @@ static int handle_rpc_aux(GUI_RPC_CONN& grc) {
     int retval = 0;
     grc.mfin.init_buf_read(grc.request_msg);
     if (grc.xp.get_tag()) {    // parse <boinc_gui_rpc_request>
-        grc.mfout.printf("<error>missing boing_gui_rpc_request tag</error>\n");
+        grc.mfout.printf("<error>missing boinc_gui_rpc_request tag</error>\n");
         return 0;
     }
     if (grc.xp.get_tag()) {    // parse the request tag

--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -859,7 +859,7 @@ void HTTP_OP::setup_proxy_session(bool no_proxy) {
         curl_easy_setopt(curlEasy, CURLOPT_PROXYPORT, (long) pi.socks_server_port);
         curl_easy_setopt(curlEasy, CURLOPT_PROXY, (char*) pi.socks_server_name);
         // libcurl uses blocking sockets with socks proxy, so limit timeout.
-        // - imlemented with local patch to libcurl
+        // - implemented with local patch to libcurl
         curl_easy_setopt(curlEasy, CURLOPT_CONNECTTIMEOUT, 20L);
 
         if (

--- a/client/os2/ReadMe.txt
+++ b/client/os2/ReadMe.txt
@@ -46,7 +46,7 @@ Please use the seti-warp mailing list at http://groups.yahoo.com
 Donations
 ---------
 Since this software is ported for free, donations are welcome! you can use PayPal
-to donate me and support OS/2 developement. See my homepage for details, or ask :-)
+to donate me and support OS/2 development. See my homepage for details, or ask :-)
 At least, a post card is welcome!
 
 

--- a/client/os2/boinc.wis
+++ b/client/os2/boinc.wis
@@ -17,9 +17,9 @@
 </PCK>
 
 <PCK INDEX=2
-     PACKAGEID="Berkeley University\Boinc 5.x client code for OS/2\Boinc developement kit\<$BOINC\Ver>"
+     PACKAGEID="Berkeley University\Boinc 5.x client code for OS/2\Boinc development kit\<$BOINC\Ver>"
      TARGET="$(WARPIN_DEFAULTAPPSPATH)\Boinc5" BASE
-     TITLE="Boinc Developement Kit"
+     TITLE="Boinc Development Kit"
      >Select to install BOINC for OS/2 sdk (headers and libraries for C/C++)
 </PCK>
 

--- a/client/setprojectgrp.cpp
+++ b/client/setprojectgrp.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
     fflush(stderr);
 #endif
 
-    // chown() doesn't change ownershp of symbolic links; it follows the link and 
+    // chown() doesn't change ownership of symbolic links; it follows the link and 
     // changes the file is not available in OS 10.3.9.
     //
     // But we don't really need to worry about this, because the system ignores 

--- a/client/whetstone.cpp
+++ b/client/whetstone.cpp
@@ -239,7 +239,7 @@ int whetstone(double& flops, double& cpu_time, double min_cpu_time) {
      }
     extern_array[8] = x;
 
-    /* Section 7, Array refrences */
+    /* Section 7, Array references */
     j = 0;
     k = 1;
     l = 2;

--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -282,7 +282,7 @@ void CAccountInfoPage::OnPageChanged( wxWizardExEvent& /* event */ ) {
 
     pWA->EnableNextButton();
 
-    // We are entering this page, so reterieve the previously used email
+    // We are entering this page, so retrieve the previously used email
     // address and/or username.
     pConfig->SetPath(strBaseConfigLocation);
     m_strAccountEmailAddress = pConfig->Read(wxT("DefaultEmailAddress"));
@@ -507,7 +507,7 @@ void CAccountInfoPage::OnPageChanging( wxWizardExEvent& event ) {
 
         pConfig->Flush();
         
-        // Construct potiental dialog title
+        // Construct potential dialog title
         if (IS_ATTACHTOPROJECTWIZARD()) {
             strTitle = _("Add project");
         } else if (IS_ACCOUNTMANAGERWIZARD() && IS_ACCOUNTMANAGERUPDATEWIZARD()) {

--- a/clientgui/AccountManagerProcessingPage.cpp
+++ b/clientgui/AccountManagerProcessingPage.cpp
@@ -337,7 +337,7 @@ void CAccountManagerProcessingPage::OnStateChange( CAccountManagerProcessingPage
             SetNextState(ATTACHACCTMGR_END);
             break;
         default:
-            // Allow a glimps of what the result was before advancing to the next page.
+            // Allow a glimpse of what the result was before advancing to the next page.
             wxSleep(1);
             pWA->EnableNextButton();
             pWA->EnableBackButton();

--- a/clientgui/AccountManagerPropertiesPage.cpp
+++ b/clientgui/AccountManagerPropertiesPage.cpp
@@ -386,7 +386,7 @@ void CAccountManagerPropertiesPage::OnStateChange( CAccountManagerPropertiesPage
             SetNextState(ACCTMGRPROP_END);
             break;
         default:
-            // Allow a glimps of what the result was before advancing to the next page.
+            // Allow a glimpse of what the result was before advancing to the next page.
             wxSleep(1);
             pWA->EnableNextButton();
             pWA->EnableBackButton();

--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -602,7 +602,7 @@ void CBOINCBaseFrame::ShowDaemonStartFailedAlert() {
     //    i.e. 'BOINC', 'GridRepublic'
 #ifdef __WXMSW__
     strDialogMessage.Printf(
-        _("%s is not able to start a %s client.\nPlease launch the Control Panel->Administative Tools->Services applet and start the BOINC service."),
+        _("%s is not able to start a %s client.\nPlease launch the Control Panel->Administrative Tools->Services applet and start the BOINC service."),
         pSkinAdvanced->GetApplicationName().c_str(),
         pSkinAdvanced->GetApplicationShortName().c_str()
     );

--- a/clientgui/BOINCBaseView.cpp
+++ b/clientgui/BOINCBaseView.cpp
@@ -163,7 +163,7 @@ const char** CBOINCBaseView::GetViewIcon() {
 
 
 // The rate at which the view is refreshed.
-//   If it has not been defined by the view 1 second is retrned.
+//   If it has not been defined by the view 1 second is returned.
 //
 int CBOINCBaseView::GetViewRefreshRate() {
     return 1;

--- a/clientgui/BOINCListCtrl.cpp
+++ b/clientgui/BOINCListCtrl.cpp
@@ -235,7 +235,7 @@ bool CBOINCListCtrl::OnRestoreState(wxConfigBase* pConfig) {
         TokenizedStringToArray(strColumnOrder, ";", &orderArray);
         SetListColumnOrder(orderArray);
 
-        // If the user installed a new vesion of BOINC, new columns may have
+        // If the user installed a new version of BOINC, new columns may have
         // been added that didn't exist in the older version. Check for this.
         //
         // This will also be triggered if the locale is changed, which will cause 
@@ -659,7 +659,7 @@ void MyEvtHandler::OnPaint(wxPaintEvent & event)
 //
 // Post a special event.  This will allow this mouse event to
 // propogate through the chain to complete any selection or
-// deselection operatiion, then the special event will trigger
+// deselection operation, then the special event will trigger
 // CBOINCBaseView::OnCheckSelectionChanged() to respond to the
 // selection change, if any.
 //

--- a/clientgui/BOINCTaskBar.cpp
+++ b/clientgui/BOINCTaskBar.cpp
@@ -583,7 +583,7 @@ void CTaskBarIcon::AdjustMenuItems(wxMenu* pMenu) {
     }
 
 #ifdef __WXMSW__
-    // Wierd things happen with menus and wxWidgets on Windows when you try
+    // Weird things happen with menus and wxWidgets on Windows when you try
     //   to change the font and use the system default as the baseline, so 
     //   instead of fighting the system get the original font and tweak it 
     //   a bit. It shouldn't hurt other platforms.

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -281,12 +281,12 @@ void CDlgAdvPreferences::ReadPreferenceSettings() {
 
     // ######### proc usage page
     // max cpus
-    // 0 means "no retriction" but we don't use a checkbox here
+    // 0 means "no restriction" but we don't use a checkbox here
     if (prefs.max_ncpus_pct == 0.0) prefs.max_ncpus_pct = 100.0;
     DisplayValue(prefs.max_ncpus_pct, m_txtProcUseProcessors);
     
             //cpu limit
-    // 0 means "no retriction" but we don't use a checkbox here
+    // 0 means "no restriction" but we don't use a checkbox here
     if (prefs.cpu_usage_limit == 0.0) prefs.cpu_usage_limit = 100.0;
     DisplayValue(prefs.cpu_usage_limit, m_txtProcUseCPUTime);
     

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -969,11 +969,11 @@ void CDlgEventLog::ResetMessageFiltering() {
 
 void CDlgEventLog::UpdateButtons() {
     bool enableFilterButton = s_bIsFiltered; 
-    bool enableCopySelectedButon = false; 
+    bool enableCopySelectedButton = false; 
     if (m_iTotalDocCount > 0) {
         int n = m_pList->GetSelectedItemCount();
         if (n > 0) {
-            enableCopySelectedButon = true;
+            enableCopySelectedButton = true;
         }
         
         if ((n == 1) && (! s_bIsFiltered)) {
@@ -985,7 +985,7 @@ void CDlgEventLog::UpdateButtons() {
         }
     }
     m_pFilterButton->Enable(enableFilterButton);
-    m_pCopySelectedButton->Enable(enableCopySelectedButon);
+    m_pCopySelectedButton->Enable(enableCopySelectedButton);
 }
 
 

--- a/clientgui/Localization.cpp
+++ b/clientgui/Localization.cpp
@@ -35,9 +35,9 @@ CLocalization::CLocalization() {
         _("Help");
     m_strSAHHelpDescription =
         _("Ask questions and report problems");
-    m_strSAHYourAccuontName = 
+    m_strSAHYourAccountName = 
         _("Your account");
-    m_strSAHYourAccuontDescription =
+    m_strSAHYourAccountDescription =
         _("View your account information and credit totals");
     m_strSAHYourPreferencesName =
         _("Your preferences");
@@ -61,9 +61,9 @@ CLocalization::CLocalization() {
         _("Common questions");
     m_strEAHCommonQuestionsDesc =
         _("Read the Einstein@Home Frequently Asked Question list");
-    m_strEAHSceensaverInfoName =
+    m_strEAHScreensaverInfoName =
         _("Screensaver info");
-    m_strEAHSceensaverInfoDesc =
+    m_strEAHScreensaverInfoDesc =
         _("Read a detailed description of the Einstein@Home screensaver");
     m_strEAHMessageBoardsName =
         _("Message boards");
@@ -116,7 +116,7 @@ CLocalization::CLocalization() {
     m_strPAHTeamDesc =
         _("Info about your Team");
 
-    // ClimatePrediciton.net
+    // ClimatePrediction.net
     m_strCPDNHelpName =
         _("Help");
     m_strCPDNHelpDesc =

--- a/clientgui/Localization.h
+++ b/clientgui/Localization.h
@@ -35,8 +35,8 @@ public:
     wxString m_strSAHMessageBoardsDescription;
     wxString m_strSAHHelpName;
     wxString m_strSAHHelpDescription;
-    wxString m_strSAHYourAccuontName;
-    wxString m_strSAHYourAccuontDescription;
+    wxString m_strSAHYourAccountName;
+    wxString m_strSAHYourAccountDescription;
     wxString m_strSAHYourPreferencesName;
     wxString m_strSAHYourPreferencesDescription;
     wxString m_strSAHYourResultsName;
@@ -49,8 +49,8 @@ public:
     // Einstein@home
     wxString m_strEAHCommonQuestionsName;
     wxString m_strEAHCommonQuestionsDesc;
-    wxString m_strEAHSceensaverInfoName;
-    wxString m_strEAHSceensaverInfoDesc;
+    wxString m_strEAHScreensaverInfoName;
+    wxString m_strEAHScreensaverInfoDesc;
     wxString m_strEAHMessageBoardsName;
     wxString m_strEAHMessageBoardsDesc;
     wxString m_strEAHEinsteinStatusName;

--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -187,7 +187,7 @@ void CNoticeListCtrl::SetItemCount(int newCount) {
             // Since the html comes from a web server via http, the scheme is
             // assumed to also be http.  But we have cached the html in a local
             // file, so it is no longer associated with the http protocol / scheme.
-            // Therefore all our URLs must explicity specify the http protocol.
+            // Therefore all our URLs must explicitly specify the http protocol.
             //
             // The second argument to wxWebView::SetPage is supposed to take care
             // of this automatically, but fails to do so under Windows, so we do

--- a/clientgui/ProjectProcessingPage.cpp
+++ b/clientgui/ProjectProcessingPage.cpp
@@ -608,7 +608,7 @@ void CProjectProcessingPage::OnStateChange( CProjectProcessingPageEvent& WXUNUSE
             SetNextState(ATTACHPROJECT_END);
             break;
         default:
-            // Allow a glimps of what the result was before advancing to the next page.
+            // Allow a glimpse of what the result was before advancing to the next page.
             wxSleep(1);
             pWA->EnableNextButton();
             pWA->EnableBackButton();

--- a/clientgui/ProjectPropertiesPage.cpp
+++ b/clientgui/ProjectPropertiesPage.cpp
@@ -520,7 +520,7 @@ void CProjectPropertiesPage::OnStateChange( CProjectPropertiesPageEvent& WXUNUSE
             SetNextState(PROJPROP_END);
             break;
         default:
-            // Allow a glimps of what the result was before advancing to the next page.
+            // Allow a glimpse of what the result was before advancing to the next page.
             wxSleep(1);
             pWAP->EnableNextButton();
             pWAP->EnableBackButton();

--- a/clientgui/SkinManager.cpp
+++ b/clientgui/SkinManager.cpp
@@ -716,7 +716,7 @@ bool CSkinAdvanced::InitializeDelayedValidation() {
     }
     if (m_strOrganizationReportBugUrl.IsEmpty()) {
         if (show_error_msgs) {
-            fprintf(stderr, "Skin Manager: Origanization report bug url was not defined. Using defaults.\n");
+            fprintf(stderr, "Skin Manager: Organization report bug url was not defined. Using defaults.\n");
         }
         m_strOrganizationReportBugUrl = wxT("https://boinc.berkeley.edu/trac/wiki/ReportBugs");
         wxASSERT(!m_strOrganizationReportBugUrl.IsEmpty());

--- a/clientgui/ViewProjects.cpp
+++ b/clientgui/ViewProjects.cpp
@@ -257,7 +257,7 @@ CViewProjects::CViewProjects(wxNotebook* pNotebook) :
     m_aStdColNameOrder->Insert(_("Status"), COLUMN_STATUS);
 
     // m_iStdColWidthOrder is an array of the width for each column.
-    // Entries must be in order of ascending Column ID.  We initalize
+    // Entries must be in order of ascending Column ID.  We initialize
     // it here to the default column widths.  It is updated by
     // CBOINCListCtrl::OnRestoreState() and also when a user resizes
     // a column by dragging the divider between two columns.

--- a/clientgui/ViewStatistics.cpp
+++ b/clientgui/ViewStatistics.cpp
@@ -1220,7 +1220,7 @@ void CPaintStatistics::DrawAll(wxDC &dc) {
 		dc.SetFont(m_font_bold);
 		DrawMainHead(dc, heading);
 		dc.SetFont(m_font_standart);
-	//How many rows/colums?
+	//How many rows/columns?
 		int nb_proj_show = 0;
 		for (std::vector<PROJECT*>::const_iterator i = proj->projects.begin(); i != proj->projects.end(); ++i) {
 			if (!(m_HideProjectStatistic.count( wxString((*i)->master_url, wxConvUTF8) ))){

--- a/clientgui/ViewTransfers.cpp
+++ b/clientgui/ViewTransfers.cpp
@@ -215,7 +215,7 @@ CViewTransfers::CViewTransfers(wxNotebook* pNotebook) :
     m_aStdColNameOrder->Insert(_("Status"), COLUMN_STATUS);
 
     // m_iStdColWidthOrder is an array of the width for each column.
-    // Entries must be in order of ascending Column ID.  We initalize
+    // Entries must be in order of ascending Column ID.  We initialize
     // it here to the default column widths.  It is updated by
     // CBOINCListCtrl::OnRestoreState() and also when a user resizes
     // a column by dragging the divider between two columns.

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -267,7 +267,7 @@ CViewWork::CViewWork(wxNotebook* pNotebook) :
     m_aStdColNameOrder->Insert(_("Name"), COLUMN_NAME);
     
     // m_iStdColWidthOrder is an array of the width for each column.
-    // Entries must be in order of ascending Column ID.  We initalize
+    // Entries must be in order of ascending Column ID.  We initialize
     // it here to the default column widths.  It is updated by
     // CBOINCListCtrl::OnRestoreState() and also when a user resizes
     // a column by dragging the divider between two columns.

--- a/clientgui/mac/MacGUI.pch
+++ b/clientgui/mac/MacGUI.pch
@@ -32,7 +32,7 @@
 // This assumes wxWidgets-3.0 was built using the buildWxMac.sh script.
 //
 // NOTE: normally, wxWidgets internal asserts are always enabled when running the
-// Development build, and USE_DEBUG_WXMAC afects only wxAssert() calls in the
+// Development build, and USE_DEBUG_WXMAC affects only wxAssert() calls in the
 // BOINC Manager code.  However, you can disable ALL wxAssert() calls by BOTH:
 // [1] calling wxSetAssertHandler(NULL) in the code AND 
 // [2] setting USE_DEBUG_WXMAC to 1.

--- a/clientgui/mac/Mac_GUI.cpp
+++ b/clientgui/mac/Mac_GUI.cpp
@@ -41,13 +41,13 @@ void ThisDummyRoutineIsNeverCalled() {
 /* End items to include "BOINC Manager" Mac menu items in localization templates */
 
 
-// Determine if the currently logged-in user is auhorized to 
+// Determine if the currently logged-in user is authorized to 
 // perform operations which have potential security risks.  
 // An example is "Attach to Project", where a dishonest user might
 // attach to a rogue project which could then read private files 
 // belonging to the user who owns the BOINC application.  This 
 // would be possible because the BOINC Manager runs with the 
-// effectve user ID of its owner on the Mac.
+// effective user ID of its owner on the Mac.
 
 Boolean Mac_Authorize()
 {

--- a/clientgui/mac/SecurityUtility.cpp
+++ b/clientgui/mac/SecurityUtility.cpp
@@ -17,7 +17,7 @@
 
 // Standalone utility to set up BOINC security owners, groups, permissions
 // usage:
-// first cd to the dir3ctory containing BOINCManager.app (usually /Applications)
+// first cd to the directory containing BOINCManager.app (usually /Applications)
 // then run this application from Terminal
 //
 

--- a/clientgui/mac/SetVersion.cpp
+++ b/clientgui/mac/SetVersion.cpp
@@ -295,7 +295,7 @@ int MakeBOINCPackageInfoPlistFile(char* myPath, char* brand) {
 }
 
 
-// Create a MetaPackage whcih runs only BOINC,pkg but specifies Restart Required
+// Create a MetaPackage which runs only BOINC,pkg but specifies Restart Required
 int MakeBOINCRestartPackageInfoPlistFile(char* myPath, char* brand) {
     int retval = 0;
     FILE *f;

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -58,7 +58,7 @@ extern void print_to_log_file(const char *format, ...);
 #define REAL_BOINC_PROJECT_NAME "boinc_project"
 
 #ifdef _DEBUG
-// GDB can't attach to applications which are running as a diferent user or group so
+// GDB can't attach to applications which are running as a different user or group so
 // it ignores the S_ISUID and S_ISGID permission bits when launching an application.
 // To work around this, the _DEBUG version uses the current user and group.
 //
@@ -936,8 +936,8 @@ OSStatus ResynchDSSystem() {
 
 
 #ifdef _DEBUG
-// GDB can't attach to applications which are running as a diferent user or group so 
-//  it ignores the S_ISUID and S_ISGID permisison bits when launching an application.
+// GDB can't attach to applications which are running as a different user or group so 
+//  it ignores the S_ISUID and S_ISGID permission bits when launching an application.
 // To work around this, the _DEBUG version uses the current user and group.
 static OSStatus SetFakeMasterNames() {
     passwd              *pw;

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -827,7 +827,7 @@ void CSimpleFrame::OnConnect(CFrameEvent& WXUNUSED(event)) {
         // Fall through
         //
         // There isn't a need to bring up the attach wizard, the account manager will
-        // take care of ataching to projects when it completes the RPCs
+        // take care of attaching to projects when it completes the RPCs
         //
     } else if (ami.acct_mgr_url.size() && !ami.have_credentials) {
         wasShown = IsShown();

--- a/clientgui/sg_DlgMessages.cpp
+++ b/clientgui/sg_DlgMessages.cpp
@@ -518,7 +518,7 @@ bool CDlgMessages::SaveState() {
     //
     pConfig->SetPath(strBaseConfigLocation);
 
-    // Reterieve and store the latest window dimensions.
+    // Retrieve and store the latest window dimensions.
     SaveWindowDimensions();
 
     // Save the list ctrl state

--- a/clientgui/sg_DlgPreferences.cpp
+++ b/clientgui/sg_DlgPreferences.cpp
@@ -694,7 +694,7 @@ bool CPanelPreferences::ReadPreferenceSettings() {
     }
 
     //cpu limit
-    // 0 means "no retriction" but we don't use a checkbox here
+    // 0 means "no restriction" but we don't use a checkbox here
     if (global_preferences_working.cpu_usage_limit == 0.0) global_preferences_working.cpu_usage_limit = 100.0;
     DisplayValue(global_preferences_working.cpu_usage_limit, m_txtProcUseCPUTime);
     

--- a/clientgui/wizardex.cpp
+++ b/clientgui/wizardex.cpp
@@ -286,7 +286,7 @@ void wxWizardEx::AddBitmapRow(wxBoxSizer *mainColumn)
     mainColumn->Add(
         m_sizerBmpAndPage,
         1, // Vertically stretchable
-        wxEXPAND // Horizonal stretching, no border
+        wxEXPAND // Horizontal stretching, no border
     );
     mainColumn->Add(0,5,
         0, // No vertical stretching
@@ -684,7 +684,7 @@ void wxWizardEx::OnBackOrNext(wxCommandEvent& event)
     wxCHECK_RET( m_page, _T("should have a valid current page") );
 
     // ask the current page first: notice that we do it before calling
-    // GetNext/Prev() because the data transfered from the controls of the page
+    // GetNext/Prev() because the data transferred from the controls of the page
     // may change the value returned by these methods
     if (event.GetEventObject() == m_btnNext)
     {

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -382,8 +382,8 @@ int CScreensaver::Create() {
 
     // Calculate the estimated blank time by adding the starting
     //  time and and the user-specified time which is in minutes
-    // On dual-GPU Macbok Pros, the CScreensaver class will be
-    // constructed and destructed each time we switch beteen
+    // On dual-GPU Macbook Pros, the CScreensaver class will be
+    // constructed and destructed each time we switch between
     // battery and AC power, so we need to get the starting time
     // only once.
     if (!ScreenSaverStartTime) {
@@ -799,7 +799,7 @@ void CScreensaver::HandleRPCError() {
         // There is a possible race condition where the Core Client was in the  
         // process of shutting down just as ScreenSaver started, so initBOINCApp() 
         // found it already running but now it has shut down.  This code takes 
-        // care of that and other situations where the Core Client quits unexpectedy.  
+        // care of that and other situations where the Core Client quits unexpectedly.  
         // Code in initBOINC_App() limits # launch retries to 3 to prevent thrashing.
         if (getClientPID() == 0) {
             saverState = SaverState_RelaunchCoreClient;

--- a/clientscr/screensaver_win.cpp
+++ b/clientscr/screensaver_win.cpp
@@ -249,7 +249,7 @@ HRESULT CScreensaver::Create(HINSTANCE hInstance) {
         m_dwBlankTime = (DWORD)time(0) + m_dwBlankTime;
     }
     
-    // Create the infrastructure mutexes so we can properly aquire them to report
+    // Create the infrastructure mutexes so we can properly acquire them to report
     //   errors
     if (!CreateInfrastructureMutexes()) {
         return E_FAIL;

--- a/clientscr/screensaver_x11.cpp
+++ b/clientscr/screensaver_x11.cpp
@@ -28,7 +28,7 @@
 //
 // When run, this screensaver connects to the BOINC client via RPC, asks for
 // graphics providing tasks and starts a random graphics application. The window
-// created by the graphics appliacation is then searched for using X11 window
+// created by the graphics application is then searched for using X11 window
 // properties, such as "WM_COMMAND". Not every graphics application seems to
 // support this, but this method has been successfully tested with Einstein@Home
 // and climateprediction.net. When the graphics application window
@@ -60,7 +60,7 @@ extern "C" {
 /// A screensaver window class.
 /** Creates a window in the size of the given parent.
     When not in windowed mode, it is overwrite-redirected.
-    It shows the text "screensaver loading" when redrwan.
+    It shows the text "screensaver loading" when redrawn.
     A client window may be xembedded into it, which will also be resized.
 */
 class scr_window {
@@ -165,7 +165,7 @@ public:
         // directly use the parent window
         win = parent;
 
-        // cahnge window attributes like above
+        // change window attributes like above
         mask = XCB_CW_BACK_PIXEL | XCB_CW_EVENT_MASK;
         values[0] = scr->black_pixel;
         values[1] = XCB_EVENT_MASK_EXPOSURE;
@@ -222,7 +222,7 @@ public:
 
   /// Redraws the window.
   /** Draws a black background with white text.
-      Should be calld when an expose event is received.
+      Should be called when an expose event is received.
   */
   void redraw() {
     // convert the text to be displayed.

--- a/clientsetup/win/CACreateBOINCAccounts.cpp
+++ b/clientsetup/win/CACreateBOINCAccounts.cpp
@@ -458,7 +458,7 @@ UINT CACreateBOINCAccounts::OnExecution()
 // Function:    CreateBOINCAccounts
 //
 // Description: This custom action creates the two user accounts that'll
-//              be used to enfore the account based sandboxing scheme
+//              be used to enforce the account based sandboxing scheme
 //              on Windows.
 //
 /////////////////////////////////////////////////////////////////////

--- a/clientsetup/win/CACreateBOINCGroups.cpp
+++ b/clientsetup/win/CACreateBOINCGroups.cpp
@@ -497,7 +497,7 @@ UINT CACreateBOINCGroups::OnExecution()
 // Function:    CreateBOINCGroups
 //
 // Description: This custom action creates the three user groups that'll
-//              be used to enfore the account based sandboxing scheme
+//              be used to enforce the account based sandboxing scheme
 //              on Windows.
 //
 /////////////////////////////////////////////////////////////////////

--- a/clientsetup/win/CACreateClientAuthFile.cpp
+++ b/clientsetup/win/CACreateClientAuthFile.cpp
@@ -123,7 +123,7 @@ UINT CACreateClientAuthFile::OnExecution()
                     NULL,
                     NULL,
                     NULL,
-                    _T("The client_auth.xml could not be deleted from the data direvtory. ")
+                    _T("The client_auth.xml could not be deleted from the data directory. ")
                     _T("Please delete the file and rerun setup.")
                 );
                 return ERROR_INSTALL_FAILURE;

--- a/clientsetup/win/CADeleteBOINCAccounts.cpp
+++ b/clientsetup/win/CADeleteBOINCAccounts.cpp
@@ -153,7 +153,7 @@ UINT CADeleteBOINCAccounts::OnExecution()
 // Function:    DeleteBOINCAccounts
 //
 // Description: This custom action delete the two user accounts that
-//              are used to enfore the account based sandboxing scheme
+//              are used to enforce the account based sandboxing scheme
 //              on Windows.
 //
 /////////////////////////////////////////////////////////////////////

--- a/clientsetup/win/CADeleteBOINCGroups.cpp
+++ b/clientsetup/win/CADeleteBOINCGroups.cpp
@@ -169,7 +169,7 @@ UINT CADeleteBOINCGroups::OnExecution()
 // Function:    DeleteBOINCGroups
 //
 // Description: This custom action deletes the three user groups that
-//              are used to enfore the account based sandboxing scheme
+//              are used to enforce the account based sandboxing scheme
 //              on Windows.
 //
 /////////////////////////////////////////////////////////////////////

--- a/clientsetup/win/CARevokeBOINCUsersRights.cpp
+++ b/clientsetup/win/CARevokeBOINCUsersRights.cpp
@@ -155,7 +155,7 @@ UINT CARevokeBOINCUsersRights::OnExecution()
 // 
 // Function:    RevokeBOINCUsersRights
 //
-// Description: This custom action revokess the 'boinc_users' group the
+// Description: This custom action revokes the 'boinc_users' group the
 //              required rights.
 //
 /////////////////////////////////////////////////////////////////////

--- a/clientsetup/win/CASetPermissionBOINC.cpp
+++ b/clientsetup/win/CASetPermissionBOINC.cpp
@@ -91,7 +91,7 @@ UINT CASetPermissionBOINC::OnExecution()
     uiReturnValue = GetProperty( _T("ENABLEUSEBYALLUSERS"), strEnableUseByAllUsers );
     if ( uiReturnValue ) return uiReturnValue;
 
-    // We should only tweek the permissions on the executable directory if we are installing
+    // We should only tweak the permissions on the executable directory if we are installing
     // as a service.
     if (_T("1") != strEnableProtectedApplicationExecution) {
         return ERROR_SUCCESS;

--- a/clientsetup/win/dirops.cpp
+++ b/clientsetup/win/dirops.cpp
@@ -78,7 +78,7 @@ BOOL RecursiveCopyFolder(tstring& csPath, tstring& csNewPath)
                 bRet = FALSE;
             }
         }
-        else // it is a directory -> Copying recursivly
+        else // it is a directory -> Copying recursively
         { 
             if( (_tcscmp(ffData.cFileName, _T(".")) != 0) &&
                 (_tcscmp(ffData.cFileName, _T("..")) != 0) ) 
@@ -137,7 +137,7 @@ BOOL RecursiveDeleteFolder(tstring& csPath)
 				bRet = FALSE;
 			}
 		}
-		else // it is a directory -> Copying recursivly
+		else // it is a directory -> Copying recursively
 		{ 
 			if( (_tcscmp(ffData.cFileName, _T(".")) != 0) &&
 				(_tcscmp(ffData.cFileName, _T("..")) != 0) ) 

--- a/clientsetup/win/launcher.cpp
+++ b/clientsetup/win/launcher.cpp
@@ -33,7 +33,7 @@ typedef enum _MANDATORY_LEVEL {
 #endif //!SECURITY_MANDATORY_UNTRUSTED_RID
 
 /*!
-@brief Function enables/disables/removes a privelege associated with the given token
+@brief Function enables/disables/removes a privilege associated with the given token
 @detailed Calls LookupPrivilegeValue() and AdjustTokenPrivileges()
 @param[in] hToken - access token handle
 @param[in] lpszPrivilege - name of privilege to enable/disable
@@ -78,7 +78,7 @@ inline HRESULT SetPrivilege(
 }
 
 /*!
-Function removes the priveleges which are not associated by default with explorer.exe at Medium Integration Level in Vista
+Function removes the privileges which are not associated by default with explorer.exe at Medium Integration Level in Vista
 @returns HRESULT of the operation on SE_CREATE_GLOBAL_NAME (="SeCreateGlobalPrivilege")
 */
 inline HRESULT ReducePrivilegesForMediumIL(HANDLE hToken) 
@@ -181,8 +181,8 @@ If the integration levels are equal, CreateProcess is called.
 If Explorer has Medium IL, and the current process has High IL, new token is created, its rights are adjusted 
 and CreateProcessWithTokenW is called. 
 If Explorer has Medium IL, and the current process has High IL, error is returned.
-@param[in] szProcessName - the name of exe file (see CreatePorcess()) 
-@param[in] szCmdLine - the name of exe file (see CreatePorcess())
+@param[in] szProcessName - the name of exe file (see CreateProcess()) 
+@param[in] szCmdLine - the name of exe file (see CreateProcess())
 @return HRESULT code
 @note The function cannot be used in services, due to if uses USER32.FindWindow() to get the proper instance of Explorer. 
 The parent of new process in taskmgr.exe, but not the current process.

--- a/clientsetup/win/lsaprivs.cpp
+++ b/clientsetup/win/lsaprivs.cpp
@@ -18,7 +18,7 @@ Abstract:
     Lan Manager API call can be used to get the primary domain controller
     computer name from a domain name.
 
-    For a list of privilges, consult winnt.h, and search for
+    For a list of privileges, consult winnt.h, and search for
     SE_ASSIGNPRIMARYTOKEN_NAME.
 
     For a list of logon rights, which can also be assigned using this

--- a/clientsetup/win/lsaprivs.h
+++ b/clientsetup/win/lsaprivs.h
@@ -18,7 +18,7 @@ Abstract:
     Lan Manager API call can be used to get the primary domain controller
     computer name from a domain name.
 
-    For a list of privilges, consult winnt.h, and search for
+    For a list of privileges, consult winnt.h, and search for
     SE_ASSIGNPRIMARYTOKEN_NAME.
 
     For a list of logon rights, which can also be assigned using this

--- a/coprocs/NVIDIA/include/nvapi.h
+++ b/coprocs/NVIDIA/include/nvapi.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|
@@ -2456,7 +2456,7 @@ typedef  NV_GPU_PERF_PSTATES_INFO_V2 NV_GPU_PERF_PSTATES_INFO;
 //!                      - pstates[i].voltages[j].mvolt is the voltage in mV
 //!                  inputFlags(IN)   - This can be used to select various options:
 //!                    - if bit 0 is set, pPerfPstatesInfo would contain the default settings
-//!                        instead of the current, possibily overclocked settings.
+//!                        instead of the current, possibly overclocked settings.
 //!                    - if bit 1 is set, pPerfPstatesInfo would contain the maximum clock 
 //!                        frequencies instead of the nominal frequencies.
 //!                    - if bit 2 is set, pPerfPstatesInfo would contain the minimum clock 
@@ -3211,7 +3211,7 @@ typedef enum _NV_GPU_HDCP_KEY_SOURCE_STATE
 //! HDPC support status - used in NvAPI_GPU_GetHDCPSupportStatus()
 typedef struct 
 {
-    NvU32                        version;               //! Structure version constucted by macro #NV_GPU_GET_HDCP_SUPPORT_STATUS
+    NvU32                        version;               //! Structure version constructed by macro #NV_GPU_GET_HDCP_SUPPORT_STATUS
     NV_GPU_HDCP_FUSE_STATE       hdcpFuseState;         //! GPU's HDCP fuse state
     NV_GPU_HDCP_KEY_SOURCE       hdcpKeySource;         //! GPU's HDCP key source
     NV_GPU_HDCP_KEY_SOURCE_STATE hdcpKeySourceState;    //! GPU's HDCP key source state    
@@ -3679,7 +3679,7 @@ typedef struct _NV_SCANOUT_INFORMATION
     NvSBox     targetViewportRect;      //!< Area inside the rect described by targetDisplayWidth/Height sourceViewportRect is scanned out to.
     NvU32      targetDisplayWidth;      //!< Horizontal size of the active resolution scanned out to the display.
     NvU32      targetDisplayHeight;     //!< Vertical size of the active resolution scanned out to the display.
-    NvU32      cloneImportance;         //!< If targets are cloned views of the sourceDesktopRect the cloned targets have an imporantce assigned (0:primary,1 secondary,...).
+    NvU32      cloneImportance;         //!< If targets are cloned views of the sourceDesktopRect the cloned targets have an importance assigned (0:primary,1 secondary,...).
     NV_ROTATE  sourceToTargetRotation;  //!< Rotation performed between the sourceViewportRect and the targetViewportRect.
 } NV_SCANOUT_INFORMATION;
 
@@ -3751,8 +3751,8 @@ typedef enum _NV_GPU_ILLUMINATION_ATTRIB
 //! DESCRIPTION:   This function reports if the specified illumination attribute is supported.
 //!
 //! \note Only a single GPU can manage an given attribute on a given HW element,
-//!       regardless of how many are attatched. I.E. only one GPU will be used to control
-//!       the brightness of the LED on an SLI bridge, regardless of how many are physicaly attached.
+//!       regardless of how many are attached. I.E. only one GPU will be used to control
+//!       the brightness of the LED on an SLI bridge, regardless of how many are physically attached.
 //!       You should enumerate thru the GPUs with this call to determine which GPU is managing the attribute.
 //!
 //! SUPPORTED OS:  Windows Vista and higher
@@ -3760,7 +3760,7 @@ typedef enum _NV_GPU_ILLUMINATION_ATTRIB
 //! \since Version: 300.05
 //!
 //! \param [in]  hPhysicalGpu        Physical GPU handle
-//! \param       Attribute           An enumeration value specifying the Illumination attribute to be querried
+//! \param       Attribute           An enumeration value specifying the Illumination attribute to be queried
 //! \param [out] pSupported          A boolean indicating if the attribute is supported.
 //! 
 //! \return See \ref nvapistatus for the list of possible return values.
@@ -3775,11 +3775,11 @@ typedef struct _NV_GPU_QUERY_ILLUMINATION_SUPPORT_PARM_V1 {
     NvPhysicalGpuHandle hPhysicalGpu;		//!< The handle of the GPU that you are checking for the specified attribute.
                                             //!< note that this is the GPU that is managing the attribute.
                                             //!< Only a single GPU can manage an given attribute on a given HW element,
-                                            //!< regardless of how many are attatched.
+                                            //!< regardless of how many are attached.
                                             //!< I.E. only one GPU will be used to control the brightness of the LED on an SLI bridge,
-                                            //!< regardless of how many are physicaly attached.
+                                            //!< regardless of how many are physically attached.
                                             //!< You enumerate thru the GPUs with this call to determine which GPU is managing the attribute.
-    NV_GPU_ILLUMINATION_ATTRIB Attribute;   //!< An enumeration value specifying the Illumination attribute to be querried.
+    NV_GPU_ILLUMINATION_ATTRIB Attribute;   //!< An enumeration value specifying the Illumination attribute to be queried.
                                             //!<     refer to enum \ref NV_GPU_ILLUMINATION_ATTRIB.
     
     // OUT
@@ -3808,8 +3808,8 @@ NVAPI_INTERFACE NvAPI_GPU_QueryIlluminationSupport(__inout NV_GPU_QUERY_ILLUMINA
 //! DESCRIPTION:   This function reports value of the specified illumination attribute.
 //!
 //! \note Only a single GPU can manage an given attribute on a given HW element,
-//!       regardless of how many are attatched. I.E. only one GPU will be used to control
-//!       the brightness of the LED on an SLI bridge, regardless of how many are physicaly attached.
+//!       regardless of how many are attached. I.E. only one GPU will be used to control
+//!       the brightness of the LED on an SLI bridge, regardless of how many are physically attached.
 //!       You should enumerate thru the GPUs with the \ref NvAPI_GPU_QueryIlluminationSupport call to
 //!       determine which GPU is managing the attribute.
 //!
@@ -3818,13 +3818,13 @@ NVAPI_INTERFACE NvAPI_GPU_QueryIlluminationSupport(__inout NV_GPU_QUERY_ILLUMINA
 //! \since Version: 300.05
 //!
 //! \param [in]  hPhysicalGpu        Physical GPU handle
-//! \param       Attribute           An enumeration value specifying the Illumination attribute to be querried
+//! \param       Attribute           An enumeration value specifying the Illumination attribute to be queried
 //! \param [out] Value               A DWORD containing the current value for the specified attribute.
 //!                                  This is specified as a percentage of the full range of the attribute
 //!                                  (0-100; 0 = off, 100 = full brightness)
 //! 
 //! \return See \ref nvapistatus for the list of possible return values. Return values of special interest are:
-//!             NVAPI_INVALID_ARGUMENT The specified attibute is not known to the driver.
+//!             NVAPI_INVALID_ARGUMENT The specified attribute is not known to the driver.
 //!             NVAPI_NOT_SUPPORTED:   The specified attribute is not supported on the specified GPU
 //
 //////////////////////////////////////////////////////////////////////////////
@@ -3837,11 +3837,11 @@ typedef struct _NV_GPU_GET_ILLUMINATION_PARM_V1 {
     NvPhysicalGpuHandle hPhysicalGpu;		//!< The handle of the GPU that you are checking for the specified attribute.
                                             //!< Note that this is the GPU that is managing the attribute.
                                             //!< Only a single GPU can manage an given attribute on a given HW element,
-                                            //!< regardless of how many are attatched.
+                                            //!< regardless of how many are attached.
                                             //!< I.E. only one GPU will be used to control the brightness of the LED on an SLI bridge,
-                                            //!< regardless of how many are physicaly attached.
+                                            //!< regardless of how many are physically attached.
                                             //!< You enumerate thru the GPUs with this call to determine which GPU is managing the attribute.
-    NV_GPU_ILLUMINATION_ATTRIB Attribute;   //!< An enumeration value specifying the Illumination attribute to be querried.
+    NV_GPU_ILLUMINATION_ATTRIB Attribute;   //!< An enumeration value specifying the Illumination attribute to be queried.
                                             //!< refer to enum \ref NV_GPU_ILLUMINATION_ATTRIB.
     
     // OUT
@@ -3872,8 +3872,8 @@ NVAPI_INTERFACE NvAPI_GPU_GetIllumination(NV_GPU_GET_ILLUMINATION_PARM *pIllumin
 //! DESCRIPTION:   This function sets the value of the specified illumination attribute.
 //!
 //! \note Only a single GPU can manage an given attribute on a given HW element,
-//!       regardless of how many are attatched. I.E. only one GPU will be used to control
-//!       the brightness of the LED on an SLI bridge, regardless of how many are physicaly attached.
+//!       regardless of how many are attached. I.E. only one GPU will be used to control
+//!       the brightness of the LED on an SLI bridge, regardless of how many are physically attached.
 //!       You should enumerate thru the GPUs with the \ref NvAPI_GPU_QueryIlluminationSupport call to
 //!       determine which GPU is managing the attribute.
 //!
@@ -3889,7 +3889,7 @@ NVAPI_INTERFACE NvAPI_GPU_GetIllumination(NV_GPU_GET_ILLUMINATION_PARM *pIllumin
 //!                                  If a value is specified outside this range, NVAPI_INVALID_ARGUMENT will be returned.
 //! 
 //! \return See \ref nvapistatus for the list of possible return values. Return values of special interest are:
-//!             NVAPI_INVALID_ARGUMENT	The specified attibute is not known to the driver, or the specified value is out of range.
+//!             NVAPI_INVALID_ARGUMENT	The specified attribute is not known to the driver, or the specified value is out of range.
 //!             NVAPI_NOT_SUPPORTED     The specified attribute is not supported on the specified GPU.
 //
 ///////////////////////////////////////////////////////////////////////////////
@@ -3902,11 +3902,11 @@ typedef struct _NV_GPU_SET_ILLUMINATION_PARM_V1 {
     NvPhysicalGpuHandle hPhysicalGpu;		//!< The handle of the GPU that you are checking for the specified attribute.
                                             //!< Note that this is the GPU that is managing the attribute.
                                             //!< Only a single GPU can manage an given attribute on a given HW element,
-                                            //!< regardless of how many are attatched.
+                                            //!< regardless of how many are attached.
                                             //!< I.E. only one GPU will be used to control the brightness of the LED on an SLI bridge,
-                                            //!< regardless of how many are physicaly attached.
+                                            //!< regardless of how many are physically attached.
                                             //!< You enumerate thru the GPUs with this call to determine which GPU is managing the attribute.
-    NV_GPU_ILLUMINATION_ATTRIB Attribute;   //!< An enumeration value specifying the Illumination attribute to be querried.
+    NV_GPU_ILLUMINATION_ATTRIB Attribute;   //!< An enumeration value specifying the Illumination attribute to be queried.
                                             //!< refer to enum \ref NV_GPU_ILLUMINATION_ATTRIB.
     NvU32    Value;                         //!< A DWORD containing the new value for the specified attribute.
                                             //!< This should be specified as a percentage of the full range of the attribute

--- a/coprocs/NVIDIA/include/nvapi_lite_common.h
+++ b/coprocs/NVIDIA/include/nvapi_lite_common.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|

--- a/coprocs/NVIDIA/include/nvapi_lite_d3dext.h
+++ b/coprocs/NVIDIA/include/nvapi_lite_d3dext.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|
@@ -166,7 +166,7 @@ NVAPI_INTERFACE NvAPI_D3D11_CreateDeviceAndSwapChain(IDXGIAdapter* pAdapter,
 //!                                 The valid values for fMinDepth and fMaxDepth
 //!                                 are such that 0 <= fMinDepth <= fMaxDepth <= 1
 //!
-//! \return  ::NVAPI_OK if the depth bounds test was correcly enabled or disabled
+//! \return  ::NVAPI_OK if the depth bounds test was correctly enabled or disabled
 //!
 //! \ingroup dx
 ///////////////////////////////////////////////////////////////////////////////

--- a/coprocs/NVIDIA/include/nvapi_lite_salend.h
+++ b/coprocs/NVIDIA/include/nvapi_lite_salend.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|

--- a/coprocs/NVIDIA/include/nvapi_lite_salstart.h
+++ b/coprocs/NVIDIA/include/nvapi_lite_salstart.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|

--- a/coprocs/NVIDIA/include/nvapi_lite_sli.h
+++ b/coprocs/NVIDIA/include/nvapi_lite_sli.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|
@@ -198,7 +198,7 @@ NVAPI_INTERFACE NvAPI_D3D_BeginResourceRendering(IUnknown *pDev, NVDX_ObjectHand
 //!
 //! \since Release: 185
 //!
-//! \param [in]  pDev         The ID3D10Device or IDirect3DDevice9 thatis a using the resource
+//! \param [in]  pDev         The ID3D10Device or IDirect3DDevice9 that is a using the resource
 //! \param [in]  obj          Previously obtained HV resource handle
 //! \param [in]  Flags        Reserved, must be zero
 //

--- a/coprocs/NVIDIA/include/nvapi_lite_stereo.h
+++ b/coprocs/NVIDIA/include/nvapi_lite_stereo.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|
@@ -96,7 +96,7 @@ NVAPI_INTERFACE NvAPI_Stereo_Disable(void);
 //!
 //! \param [out]     pIsStereoEnabled   Address where the result of the inquiry will be placed.
 //!
-//! \retval ::NVAPI_OK                       Check was sucessfully completed and result reflects current state of stereo availability.
+//! \retval ::NVAPI_OK                       Check was successfully completed and result reflects current state of stereo availability.
 //! \retval ::NVAPI_API_NOT_INTIALIZED 
 //! \retval ::NVAPI_STEREO_NOT_INITIALIZED   Stereo part of NVAPI not initialized.
 //! \retval ::NVAPI_ERROR 
@@ -232,7 +232,7 @@ NVAPI_INTERFACE NvAPI_Stereo_Deactivate(StereoHandle stereoHandle);
 //! \param [in]    stereoHandle  Stereo handle that corresponds to the device interface.
 //! \param [in]    pIsStereoOn   Address where result of the inquiry will be placed.
 //! 
-//! \retval ::NVAPI_OK - Check was sucessfully completed and result reflects current state of stereo (on/off).
+//! \retval ::NVAPI_OK - Check was successfully completed and result reflects current state of stereo (on/off).
 //! \retval ::NVAPI_STEREO_INVALID_DEVICE_INTERFACE - Device interface is not valid. Create again, then attach again.
 //! \retval ::NVAPI_API_NOT_INTIALIZED - NVAPI not initialized.
 //! \retval ::NVAPI_STEREO_NOT_INITIALIZED - Stereo part of NVAPI not initialized.

--- a/coprocs/NVIDIA/include/nvapi_lite_surround.h
+++ b/coprocs/NVIDIA/include/nvapi_lite_surround.h
@@ -1,6 +1,6 @@
  /************************************************************************************************************************************\
 |*                                                                                                                                    *|
-|*     Copyright © 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
+|*     Copyright Â© 2012 NVIDIA Corporation.  All rights reserved.                                                                     *|
 |*                                                                                                                                    *|
 |*  NOTICE TO USER:                                                                                                                   *|
 |*                                                                                                                                    *|
@@ -49,7 +49,7 @@ extern "C" {
 //!
 //! \param [out]     displayId   Display ID of the GDI Primary display.
 //!
-//! \retval ::NVAPI_OK:                          Capabilties have been returned.
+//! \retval ::NVAPI_OK:                          Capabilites have been returned.
 //! \retval ::NVAPI_NVIDIA_DEVICE_NOT_FOUND:     GDI Primary not on an NVIDIA GPU.
 //! \retval ::NVAPI_INVALID_ARGUMENT:            One or more args passed in are invalid.
 //! \retval ::NVAPI_API_NOT_INTIALIZED:          The NvAPI API needs to be initialized first
@@ -87,7 +87,7 @@ NVAPI_INTERFACE NvAPI_DISP_GetGDIPrimaryDisplayId(NvU32* displayId);
 //! \param [out]     bezelCorrected  Returns 1 if the requested resolution is
 //!                                  bezel corrected. May be NULL.
 //!
-//! \retval ::NVAPI_OK                          Capabilties have been returned.
+//! \retval ::NVAPI_OK                          Capabilites have been returned.
 //! \retval ::NVAPI_INVALID_ARGUMENT            One or more args passed in are invalid.
 //! \retval ::NVAPI_API_NOT_INTIALIZED          The NvAPI API needs to be initialized first
 //! \retval ::NVAPI_MOSAIC_NOT_ACTIVE           The display does not belong to an active Mosaic Topology

--- a/lib/cal_boinc.h
+++ b/lib/cal_boinc.h
@@ -708,7 +708,7 @@ CALAPI CALresult CALAPIENTRY calCtxDestroy(CALcontext ctx);
  * for use by the context <i>ctx</i>.
  *
  * @param mem (out) - created memory handle. On error, mem will be zero.
- * @param ctx (in) - context in which resouce is mapped
+ * @param ctx (in) - context in which resource is mapped
  * @param res (in) - resource to map to context
  *
  * @return Returns CAL_RESULT_OK on success, CAL_RESULT_ERROR if there was an error.
@@ -724,7 +724,7 @@ CALAPI CALresult CALAPIENTRY calCtxGetMem(CALmem* mem, CALcontext ctx, CALresour
  *
  * releases memory handle <i>mem</i> that is obtained by <i>calCtxGetMem</i>.
  *
- * @param ctx (in) - context in which resouce is mapped
+ * @param ctx (in) - context in which resource is mapped
  * @param mem (in) - memory handle to release
  *
  * @return Returns CAL_RESULT_OK on success, CAL_RESULT_ERROR if there was an error.

--- a/lib/crypt.h
+++ b/lib/crypt.h
@@ -124,7 +124,7 @@ extern int generate_signature(
 );
 
 //   Check if sfileMsg (of length sfsize) has been created from sha1_md using the
-//   private key beloning to the public key file cFile
+//   private key belonging to the public key file cFile
 //   Return:
 //    1: YES
 //    0: NO or error

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -257,9 +257,9 @@ int main(int argc, char** argv) {
         if (retval) die("cannot scan_hex_data");
         certpath = check_validity(argv[4], argv[2], signature.data, argv[5]);
         if (certpath == NULL) {
-            die("signature cannot be verfied.\n\n");
+            die("signature cannot be verified.\n\n");
         } else {
-            printf("siganture verified using certificate '%s'.\n\n", certpath);
+            printf("signature verified using certificate '%s'.\n\n", certpath);
             free(certpath);
         }
         // this converts, but an executable signed with sign_executable,
@@ -328,7 +328,7 @@ int main(int argc, char** argv) {
         //enc=EVP_get_cipherbyname("des");
         //if (enc == NULL)
         //    die("could not get cypher.\n");
-        // no encription yet.
+        // no encryption yet.
         bio_out=BIO_new(BIO_s_file());
         if (BIO_write_filename(bio_out,argv[5]) <= 0) {
             perror(argv[5]);

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -582,7 +582,7 @@ int diagnostics_finish() {
     }
 #endif
 
-    // Set initalization flag to false.
+    // Set initialization flag to false.
     diagnostics_initialized = false;
 
     return BOINC_SUCCESS;

--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -106,7 +106,7 @@ static BOINC_PROCESSENTRY diagnostics_process;
 //   SEH exception is thrown.
 //
 
-// This structure is used to keep track of stuff nessassary
+// This structure is used to keep track of stuff necessary
 //   to dump backtraces for all threads during an abort or
 //   crash.  This is platform specific in nature since it
 //   depends on the OS datatypes.
@@ -154,7 +154,7 @@ int diagnostics_init_thread_list() {
     size_t i;
     size_t size;
 
-    // Create a Mutex that can be used to syncronize data access
+    // Create a Mutex that can be used to synchronize data access
     //   to the global thread list.
     hThreadListSync = CreateMutex(NULL, TRUE, NULL);
     if (!hThreadListSync) {
@@ -288,7 +288,7 @@ int diagnostics_update_thread_list() {
     // Lets start walking the structures to find the good stuff.
     pProcesses = (PSYSTEM_PROCESSES)pBuffer;
     do {
-        // Okay, found the current procceses entry now we just need to
+        // Okay, found the current proccess entry now we just need to
         //   update the thread data.
         if (pProcesses->ProcessId == dwCurrentProcessId) {
 
@@ -584,7 +584,7 @@ char* diagnostics_format_thread_priority(int thread_priority) {
 }
 
 
-// Provide a mechinism to trap and report messages sent to the debugger's
+// Provide a mechanism to trap and report messages sent to the debugger's
 //   viewport.  This should only been enabled if a debugger isn't running
 //   against the current process already.
 //
@@ -634,7 +634,7 @@ int diagnostics_init_message_monitor() {
     SetSecurityDescriptorDacl(&sd, TRUE, (PACL)NULL, FALSE);
 
 
-    // Create a mutex that can be used to syncronize data access
+    // Create a mutex that can be used to synchronize data access
     //   to the global thread list.
     hMessageMonitorSync = CreateMutex(NULL, TRUE, NULL);
     if (!hMessageMonitorSync) {
@@ -759,7 +759,7 @@ int diagnostics_finish_message_monitor() {
     SetEvent(hMessageQuitEvent);
 
     // Wait until it is message monitoring thread is shutdown before
-    //   cleaning up the structure since we'll need to aquire the
+    //   cleaning up the structure since we'll need to acquire the
     //   MessageMonitorSync mutex.
     WaitForSingleObject(hMessageQuitFinishedEvent, INFINITE);
     WaitForSingleObject(hMessageMonitorSync, INFINITE);
@@ -1009,11 +1009,11 @@ int diagnostics_trace_to_debugger(const char* msg) {
 //   be referencing the same corrupted area of memory.  Previous
 //   implementations of the runtime debugger would have just terminated
 //   the process believing it was a nested unhandled exception instead
-//   of believing it to be two seperate exceptions thrown from different
+//   of believing it to be two separate exceptions thrown from different
 //   threads.
 //
 
-// This structure is used to keep track of stuff nessassary
+// This structure is used to keep track of stuff necessary
 //   to dump information about the top most window during
 //   a crash event.
 typedef struct _BOINC_WINDOWCAPTURE {
@@ -1063,7 +1063,7 @@ int diagnostics_init_unhandled_exception_monitor() {
 
     // The following event is thrown by a thread that has experienced an
     //   unhandled exception after storing its exception record but before
-    //   it attempts to aquire the halt mutex.
+    //   it attempts to acquire the halt mutex.
     hExceptionDetectedEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (!hExceptionDetectedEvent) {
         fprintf(
@@ -1131,7 +1131,7 @@ int diagnostics_finish_unhandled_exception_monitor() {
     SetEvent(hExceptionQuitEvent);
 
     // Wait until it is message monitoring thread is shutdown before
-    //   cleaning up the structure since we'll need to aquire the
+    //   cleaning up the structure since we'll need to acquire the
     //   MessageMonitorSync mutex.
     WaitForSingleObject(hExceptionQuitFinishedEvent, INFINITE);
 
@@ -1547,7 +1547,7 @@ UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID /* lpParameter */) {
     // We should not suspend our crash dump thread.
     diagnostics_set_thread_exempt_suspend();
 
-    // Aquire the mutex that will keep all the threads that throw an exception
+    // Acquire the mutex that will keep all the threads that throw an exception
     //   at bay until we are ready to deal with them.
     WaitForSingleObject(hExceptionMonitorHalt, INFINITE);
 

--- a/lib/mac/QBacktrace.c
+++ b/lib/mac/QBacktrace.c
@@ -36,7 +36,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:
@@ -1955,7 +1955,7 @@ static int Intel64CrossSignalFrame(QBTContext *context, QTMAddr thisFrame, QTMAd
         err = 0;
         
         // If none of the alignments worked, just take a guess.  This is 
-        // sufficienly bad that we want to know about it in the debug version.
+        // sufficiently bad that we want to know about it in the debug version.
         
         if (align == 0x020) {
             assert(false);

--- a/lib/mac/QBacktrace.h
+++ b/lib/mac/QBacktrace.h
@@ -208,7 +208,7 @@ extern "C" {
                     
                     o You can also use a hybrid of these approaches.  Start by 
                       allocating an array with N entries, where N is likely to be 
-                      enough to accomodate a typical backtrace.  Then call the 
+                      enough to accommodate a typical backtrace.  Then call the 
                       backtrace function.  If it indicates that you missed some 
                       elements, grow the array and call the backtrace function 
                       again.

--- a/lib/mac/QCrashReport.c
+++ b/lib/mac/QCrashReport.c
@@ -36,7 +36,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:
@@ -240,7 +240,7 @@ extern int QCRCreateFromTask(
     // This does less than you might think.  A lot of the work, like getting the 
     // state and backtrace for each thread, is done lazily.  The goal is to make 
     // it relatively cheap to create a crash report object, only paying the 
-    // penality for things like getting the backtrace if you actually need them.
+    // penalty for things like getting the backtrace if you actually need them.
 {
     int                     err;
     kern_return_t           kr;
@@ -303,7 +303,7 @@ extern int QCRCreateFromTask(
             // back, or disposes of them.  We need this silliness because we 
             // can't get a thread count (to calloc the array) without also 
             // getting rights at the same time, and we have to make sure that 
-            // those rights get cleaned up if calloc fais.
+            // those rights get cleaned up if calloc fails.
 
             for (threadIndex = 0; threadIndex < crRef->threadCount; threadIndex++) {
                 if (crRef->threads == NULL) {
@@ -1261,7 +1261,7 @@ static int ForkExecWithBootstrap(const char *toolArgs[], mach_port_t newBootstra
       target's EUID matches its RUID, that is, it's not a setuid binary)
     
     Starting with the release of the Intel-based Macintosh computers, task_for_pid 
-    security has been tightened up.  The new policy is that task_for_pid suceeds:
+    security has been tightened up.  The new policy is that task_for_pid succeeds:
     
     o if the caller was running as root (EUID 0)
     
@@ -1290,7 +1290,7 @@ static int ForkExecWithBootstrap(const char *toolArgs[], mach_port_t newBootstra
        reason, and it's not your place to subvert that change.
     
     3. get into group "procmod" or "procview" -- This is the solution used by 
-       Apple's tools, but it is tricky for third party developers in practise.  
+       Apple's tools, but it is tricky for third party developers in practice.  
        You have to make your executable set-group-id to one of these groups, and 
        that requires you to have some sort of installer to 'bless' the executable.
        

--- a/lib/mac/QCrashReport.h
+++ b/lib/mac/QCrashReport.h
@@ -247,7 +247,7 @@ typedef struct QCrashReport *QCrashReportRef;
                     can also set the crashed thread later by calling 
                     QCRSetCrashedThreadIndex.
                     
-                    It is accepatble to pass mach_thread_self to this parameter, 
+                    It is acceptable to pass mach_thread_self to this parameter, 
                     but it may not do what you expect.  See the discussion 
                     above for details.  
                     

--- a/lib/mac/QMachOImage.c
+++ b/lib/mac/QMachOImage.c
@@ -196,7 +196,7 @@ typedef struct QMOImage QMOImage;
 // Image Type Callbacks
 // --------------------
 // There are various types of QMOImage (local, from a remote task, from disk) that have 
-// lots in common.  However, in some cases it's necessary to do things diffently for each 
+// lots in common.  However, in some cases it's necessary to do things differently for each 
 // type of image to do different things.  In that case, the common code calls the image 
 // type specific code to do the work.
 
@@ -808,7 +808,7 @@ static int QMOImageCreate(
         // It is vital that we call the create callback (if any) before any 
         // other failure (other than the calloc).  If there was a failure 
         // point before this, we could end up calling the destroy callback 
-        // before calling the create callback.  Thatd woul be bad for image 
+        // before calling the create callback.  That would be bad for image 
         // types where a NULL refcon isn't appropriate as a nil value.  
         //
         // An example of this is the file image type.  The in this case, the 

--- a/lib/mac/QMachOImage.h
+++ b/lib/mac/QMachOImage.h
@@ -35,7 +35,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:
@@ -390,7 +390,7 @@ extern int QMOImageCreateFromTask(
                     to guarantee that you'll get the same CPU type as the current 
                     process, use the result of QMOGetLocalCPUType.
                     
-                    This parameter is necessary beacuse it is possible for 
+                    This parameter is necessary because it is possible for 
                     a process to be running more than one dynamic linker.  
                     The most common example is a process being run using 
                     Rosetta.  In this case, there's a native dynamic linker that's 
@@ -869,7 +869,7 @@ extern cpu_type_t QMOGetLocalCPUType(void);
     @abstract       Converts an 8-bit quantity from image format to native format.
 
     @discussion     Yes, I know that this routine is a NOP, but it makes the code 
-                    more symmentric.
+                    more symmetric.
     
     @param qmoImage Must be a valid image object.
 

--- a/lib/mac/QMachOImageList.c
+++ b/lib/mac/QMachOImageList.c
@@ -36,7 +36,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/QMachOImageList.h
+++ b/lib/mac/QMachOImageList.h
@@ -35,7 +35,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/QSymbols.c
+++ b/lib/mac/QSymbols.c
@@ -36,7 +36,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/QSymbols.h
+++ b/lib/mac/QSymbols.h
@@ -35,7 +35,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:
@@ -216,7 +216,7 @@ typedef struct QSymbols * QSymbolsRef;
     
     @abstract       Creates a symbols object for an arbitrary process.
     
-    @discussion     Creates a symbols object for the specified procses.
+    @discussion     Creates a symbols object for the specified process.
 
                     Once you're done with the object, call QSymDestroy to 
                     destroy it.
@@ -258,7 +258,7 @@ extern int QSymCreateFromTask(
     
     @abstract       Creates a symbols object for the current process.
     
-    @discussion     Creates a symbols object for the current procses.  This is 
+    @discussion     Creates a symbols object for the current process.  This is 
                     equivalent to calling QSymCreateFromTask, passing it 
                     mach_task_self and the current CPU type.
 

--- a/lib/mac/QTaskMemory.c
+++ b/lib/mac/QTaskMemory.c
@@ -36,7 +36,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/QTaskMemory.h
+++ b/lib/mac/QTaskMemory.h
@@ -35,7 +35,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/mac_backtrace.cpp
+++ b/lib/mac/mac_backtrace.cpp
@@ -49,7 +49,7 @@
 *  * For more information on using atos, see the atos man page.
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/mac_backtrace.h
+++ b/lib/mac/mac_backtrace.h
@@ -37,7 +37,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 *  Flags in backtrace:

--- a/lib/procinfo_mac.cpp
+++ b/lib/procinfo_mac.cpp
@@ -112,7 +112,7 @@ int procinfo_setup(PROC_MAP& pm) {
         }
     } while (c != '\n');
 
-    // Ensure %lf works corectly if called from non-English Manager 
+    // Ensure %lf works correctly if called from non-English Manager 
     old_locale = setlocale(LC_ALL, NULL);
     setlocale(LC_ALL, "C");
     

--- a/lib/shmem.cpp
+++ b/lib/shmem.cpp
@@ -214,7 +214,7 @@ HANDLE attach_shmem(LPCTSTR seg_name, void** pp) {
 
     // The 'Global' prefix must be included in the shared memory
     // name if the shared memory segment is going to cross
-    // terminal server session boundries.
+    // terminal server session boundaries.
     //
     snprintf(global_seg_name, sizeof(global_seg_name), "Global\\%s", seg_name);
 
@@ -449,7 +449,7 @@ int create_shmem(key_t key, int size, gid_t gid, void** pp) {
 // On Mac OS X and some other systems, this command also 
 // prevents any more processes from attaching (by clearing 
 // the key in the shared memory structure), so BOINC does it 
-// only after we are completey done with the segment.
+// only after we are completely done with the segment.
 //
 int destroy_shmem(key_t key){
     struct shmid_ds buf;

--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -10,7 +10,7 @@
  *		Stackwalker.cpp
  *
  *	Remarks:
- *    Dumps the stack of an thread if an exepction occurs
+ *    Dumps the stack of an thread if an exception occurs
  *
  *	Author:
  *		Jochen Kalmbach, Germany

--- a/lib/str_replace.h
+++ b/lib/str_replace.h
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// declare replacement string functions for platforms that lack themn
+// declare replacement string functions for platforms that lack them
 
 #ifndef BOINC_STR_REPLACE_H
 #define BOINC_STR_REPLACE_H

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -518,7 +518,7 @@ const char* boincerror(int which_error) {
         case ERR_DB_NOT_FOUND: return "no database rows found in lookup/enumerate";
         case ERR_DB_NOT_UNIQUE: return "database lookup not unique";
         case ERR_DB_CANT_CONNECT: return "can't connect to database";
-        case ERR_GETS: return "gets()/fgets() failedj";
+        case ERR_GETS: return "gets()/fgets() failed";
         case ERR_SCANF: return "scanf()/fscanf() failed";
         case ERR_READDIR: return "readdir() failed";
         case ERR_SHMGET: return "shmget() failed";

--- a/lib/submit_api.py
+++ b/lib/submit_api.py
@@ -286,7 +286,7 @@ def upload_files(upload_files_req):
     upload_files_req.boinc_names = boinc_names
     upload_files_req.local_names = local_names
 
-    # make a description of upoad files for "requests"
+    # make a description of upload files for "requests"
     #
     files = []
     for i in range(len(boinc_names)):

--- a/lib/translate.cpp
+++ b/lib/translate.cpp
@@ -30,7 +30,7 @@
 // language, then for each desired catalog (*.mo) file for the
 // user's second preferred language and (optionally) then for each
 // desired catalog (*.mo) file for the user's third preferred
-// language.  This will make it more likley that a translation 
+// language.  This will make it more likely that a translation 
 // will be found in some language useful to the user.
 //
 
@@ -273,7 +273,7 @@ static bool LoadCatalog(const char * catalogsDir,
 
 // Searches through the catalogs in the order they were added
 // until it finds a translation for the src string, and
-// returns a ponter to the UTF-8 encoded localized string.
+// returns a pointer to the UTF-8 encoded localized string.
 // Returns a pointer to the original string if no translation
 // was found.
 //

--- a/lib/translate.h
+++ b/lib/translate.h
@@ -28,7 +28,7 @@
 // We recommended that you first call BOINCTranslationAddCatalog()
 // for the user's preferred language, then for the user's second
 // preferred language and (optionally) then for the user's third
-// preferred language.  This will make it more likley that a
+// preferred language.  This will make it more likely that a
 // translation will be found in some language useful to the user.
 //
 
@@ -60,7 +60,7 @@ bool BOINCTranslationAddCatalog(const char * catalogsDir,
 
 // Searches through the catalogs in the order they were added
 // until it finds a translation for the src string, and
-// returns a ponter to the UTF-8 encoded localized string.
+// returns a pointer to the UTF-8 encoded localized string.
 // Returns a pointer to the original string if no translation
 // was found.
 //

--- a/m4/gtk-2.0.m4
+++ b/m4/gtk-2.0.m4
@@ -103,7 +103,7 @@ main ()
              gtk_major_version, gtk_minor_version, gtk_micro_version);
       printf ("*** was found! If pkg-config was correct, then it is best\n");
       printf ("*** to remove the old version of GTK+. You may also be able to fix the error\n");
-      printf("*** by modifying your LD_LIBRARY_PATH enviroment variable, or by editing\n");
+      printf("*** by modifying your LD_LIBRARY_PATH environment variable, or by editing\n");
       printf("*** /etc/ld.so.conf. Make sure you have run ldconfig if that is\n");
       printf("*** required on your system.\n");
       printf("*** If pkg-config was wrong, set the environment variable PKG_CONFIG_PATH\n");
@@ -139,7 +139,7 @@ main ()
         printf("*** being found. The easiest way to fix this is to remove the old version\n");
         printf("*** of GTK+, but you can also set the PKG_CONFIG environment to point to the\n");
         printf("*** correct copy of pkg-config. (In this case, you will have to\n");
-        printf("*** modify your LD_LIBRARY_PATH enviroment variable, or edit /etc/ld.so.conf\n");
+        printf("*** modify your LD_LIBRARY_PATH environment variable, or edit /etc/ld.so.conf\n");
         printf("*** so that the correct libraries are found at run-time))\n");
       }
     }
@@ -181,7 +181,7 @@ main ()
           echo "*** If you have an old version installed, it is best to remove it, although"
           echo "*** you may also be able to get things to work by modifying LD_LIBRARY_PATH" ],
         [ echo "*** The test program failed to compile or link. See the file config.log for the"
-          echo "*** exact error that occured. This usually means GTK+ is incorrectly installed."])
+          echo "*** exact error that occurred. This usually means GTK+ is incorrectly installed."])
           CFLAGS="$ac_save_CFLAGS"
           LIBS="$ac_save_LIBS"
        fi

--- a/m4/sah_check_lib.m4
+++ b/m4/sah_check_lib.m4
@@ -129,7 +129,7 @@ AC_DEFUN([SAH_LINKAGE_FLAGS],[
 #    3) linking with the static flags "$STATIC_FLAGS -l{name}"
 AC_DEFUN([SAH_STATIC_LIB_REQUIRED],[
 SAH_LINKAGE_FLAGS
-# upercase the library name for our definition
+# uppercase the library name for our definition
 ac_uc_defn=HAVE_LIB`echo $1 | sed -e 's/[^a-zA-Z0-9_]/_/g' \
     -e 'y/abcdefghijklmnopqrstuvwxyz/ABCDEFGHIJKLMNOPQRSTUVWXYZ/'`
 # Build our cache variable names

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -1286,7 +1286,7 @@ Boolean CheckDeleteFile(char *name)
 
 
 // If there are other copies of BOINC Manager with different branding
-// on the system, Noitifications may display the icon for the wrong
+// on the system, Notifications may display the icon for the wrong
 // branding, due to the Launch Services database having one of the
 // other copies of BOINC Manager as the first entry. Each user has
 // their own copy of the Launch Services database, so this must be
@@ -2213,7 +2213,7 @@ int check_rosetta2_installed() {
     int retval = 0;
 
     // write the EMULATED_CPU_INFO into the BOINC data dir
-    // the execuable should be in BOINC data dir
+    // the executable should be in BOINC data dir
     strncpy(execpath, data_dir, sizeof(execpath));
     strncat(execpath, "/" EMULATED_CPU_INFO_EXECUTABLE, sizeof(execpath) - strlen(execpath) - 1);
 

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -146,7 +146,7 @@ long GetBrandID(char *path)
 
 
 // If there are other copies of BOINC Manager with different branding
-// on the system, Noitifications may display the icon for the wrong
+// on the system, Notifications may display the icon for the wrong
 // branding, due to the Launch Services database having one of the
 // other copies of BOINC Manager as the first entry. Each user has
 // their own copy of the Launch Services database, so this must be

--- a/packages/solaris/CSW/boincclient/boinc.1
+++ b/packages/solaris/CSW/boincclient/boinc.1
@@ -25,7 +25,7 @@ primarily in the form of "volunteer" computing and "desktop grid" computing.
 It is well suited for problems which are often described as "trivially
 parallel" or "embarrassingly parallel". 
 BOINC is the underlying software used by projects such as SETI@home,
-Einstein@Home, ClimatePrediciton.net, the World Community Grid, and
+Einstein@Home, ClimatePrediction.net, the World Community Grid, and
 many others.
 The BOINC client software runs on Windows, MacOS X, and Unix,
 including Linux.

--- a/packages/solaris/CSW/boincclient/boinc_client.1
+++ b/packages/solaris/CSW/boincclient/boinc_client.1
@@ -36,7 +36,7 @@ called the BOINC Manager,
 .BR boincmgr (1),
 or a command line tool called
 .BR boinc_cmd (1),
-by means of Remote Proceedure Calls (RPCs) over port 31416.
+by means of Remote Procedure Calls (RPCs) over port 31416.
 
 .PP
 
@@ -101,7 +101,7 @@ you should use a separate program,
 .RB ( boincmgr (1)
 or
 .BR boinc_cmd (1))
-which communicates with it by means of Remote Proceedure Calls (RPCs).
+which communicates with it by means of Remote Procedure Calls (RPCs).
 
 
 .TP
@@ -129,7 +129,7 @@ Reset (clear) the project associated with the given URL
 Attach to the project associated with the given URL.
 The 
 .B key 
-is the authenthentication token (account key)
+is the authentication token (account key)
 of an existing account on the project.
 
 .TP

--- a/packages/solaris/CSW/boincmanager/boinc_manager.1
+++ b/packages/solaris/CSW/boincmanager/boinc_manager.1
@@ -79,7 +79,7 @@ waiting to be return after being run.
 
 .TP 
 .I Transfers
-Shows files being transfered to or from project servers.
+Shows files being transferred to or from project servers.
 
 .TP
 .I Messages

--- a/packages/solaris/CSW/boincmanager/boincmgr.1
+++ b/packages/solaris/CSW/boincmanager/boincmgr.1
@@ -79,7 +79,7 @@ waiting to be return after being run.
 
 .TP 
 .I Transfers
-Shows files being transfered to or from project servers.
+Shows files being transferred to or from project servers.
 
 .TP
 .I Messages

--- a/samples/vboxwrapper/floppyio.cpp
+++ b/samples/vboxwrapper/floppyio.cpp
@@ -186,7 +186,7 @@ void FloppyIO::reset() {
     return;
   }
   
-  // Reset to the beginnig of file and fill with zeroes
+  // Reset to the beginning of file and fill with zeroes
   this->fIO->seekp(0);
   char * buffer = new char[this->szFloppy];
   memset(buffer, 0, this->szFloppy);
@@ -198,7 +198,7 @@ void FloppyIO::reset() {
 // Send data to the floppy image I/O
 //
 // @param strData   The string to send
-// @return          The number of bytes sent if successful or -1 if an error occured.
+// @return          The number of bytes sent if successful or -1 if an error occurred.
 //
 int FloppyIO::send(string strData) {
     // Prepare send buffer
@@ -278,7 +278,7 @@ string FloppyIO::receive() {
 // Receive the input buffer contents
 //
 // @param string   A pointer to a string object that will receive the data
-// @return         Returns the length of the data received or -1 if an error occured.
+// @return         Returns the length of the data received or -1 if an error occurred.
 //
 int FloppyIO::receive(string * ansBuffer) {
     char * dataToReceive = new char[this->szInput];
@@ -328,7 +328,7 @@ int FloppyIO::receive(string * ansBuffer) {
 // @param controlByteOffset The offset (from the beginning of file) where to look for the control byte
 // @param state             The state the controlByte must be for this function to exit.
 // @param timeout           The time (in seconds) to wait for a change. 0 Will wait forever
-// @return                  Returns 0 if everything succeeded, -1 if an error occured, -2 if timed out.
+// @return                  Returns 0 if everything succeeded, -1 if an error occurred, -2 if timed out.
 
 int  FloppyIO::waitForSync(int controlByteOffset, char state, int timeout) {
     time_t tExpired = time (NULL) + timeout;

--- a/samples/vboxwrapper/floppyio.h
+++ b/samples/vboxwrapper/floppyio.h
@@ -68,10 +68,10 @@ namespace FloppyIONS {
     //
     // Error code constants
     //
-    #define FPIO_NOERR          0  // No error occured
+    #define FPIO_NOERR          0  // No error occurred
     #define FPIO_ERR_IO        -1  // There was an I/O error on the strea,
     #define FPIO_ERR_TIMEOUT   -2  // The operation timed out
-    #define FPIO_ERR_CREATE    -3  // Unable to freate the floppy file
+    #define FPIO_ERR_CREATE    -3  // Unable to create the floppy file
     #define FPIO_ERR_NOTREADY  -4  // The I/O object is not ready
 
     //
@@ -83,7 +83,7 @@ namespace FloppyIONS {
     //
     // It's purpose is to force the entire floppy image
     // to be re-written/re-read by the hypervisor/guest OS and
-    // to synchronize the I/O in case of large ammount of
+    // to synchronize the I/O in case of large amount of
     // data being exchanged.
     //
     typedef struct fpio_ctlbyte {

--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -1174,13 +1174,13 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
             // it is running without a session lock.
             //
             // If a volunteer opens another VirtualBox management application and goes poking around
-            // that application can aquire the session lock and not give it up for some time.
+            // that application can acquire the session lock and not give it up for some time.
             //
             // If we detect that condition retry the desired command.
             //
             // Experiments performed by jujube suggest changing the sleep interval to an exponential
             // style backoff would increase our chances of success in situations where the previous
-            // lock is held by a previous instance of vboxmanage whos instance data hasn't been
+            // lock is held by a previous instance of vboxmanage whose instance data hasn't been
             // cleaned up within vboxsvc yet.
             //
             // Error Code: VBOX_E_INVALID_OBJECT_STATE (0x80bb0007)
@@ -1234,7 +1234,7 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
     }
     while (retval);
 
-    // Add all relivent notes to the output string and log errors
+    // Add all relevent notes to the output string and log errors
     //
     if (retval && log_error) {
         if (!retry_notes.empty()) {

--- a/samples/vboxwrapper/vbox_mscom_impl.cpp
+++ b/samples/vboxwrapper/vbox_mscom_impl.cpp
@@ -126,7 +126,7 @@ void __stdcall virtualbox_com_raise_error(HRESULT rc, IErrorInfo* perrinfo) {
 }
 
 
-// We want to recurisively walk the snapshot tree so that we can get the most recent children first.
+// We want to recursively walk the snapshot tree so that we can get the most recent children first.
 // We also want to skip whatever the most current snapshot is.
 //
 void TraverseSnapshots(std::string& current_snapshot_id, std::vector<std::string>& snapshots, ISnapshot* pSnapshot) {
@@ -171,7 +171,7 @@ void TraverseSnapshots(std::string& current_snapshot_id, std::vector<std::string
 }
 
 
-// We want to recurisively walk the medium tree so that we can get the most recent children first.
+// We want to recursively walk the medium tree so that we can get the most recent children first.
 //
 void TraverseMediums(std::vector<CComPtr<IMedium>>& mediums, IMedium* pMedium) {
     HRESULT rc;
@@ -2297,7 +2297,7 @@ int VBOX_VM::get_default_network_interface(string& iface) {
             // Automatically clean up array after use
             aNICS.Attach(pNICS);
 
-            // We only need the 'default' nic, which is usally the first one.
+            // We only need the 'default' nic, which is usually the first one.
             pNIC = (IHostNetworkInterface*)((LPDISPATCH)aNICS[0]);
 
             // Get the name for future use

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -1524,7 +1524,7 @@ namespace vboxmanage {
     // 2. Vboxmanage not being able to communicate with vboxsvc for some reason
     // 3. VirtualBox driver not loaded for the current Linux kernel.
     //
-    // Luckly both of the above conditions can be detected by attempting to detect the host information
+    // Luckily both of the above conditions can be detected by attempting to detect the host information
     // via vboxmanage and it is cross platform.
     //
     bool VBOX_VM::is_system_ready(std::string& message) {

--- a/samples/vm_wrapper/VMwrapper.py
+++ b/samples/vm_wrapper/VMwrapper.py
@@ -591,7 +591,7 @@ try:
      
       VM_MANAGE = xmlrpclib.ServerProxy(SERVER_PROXY)
 
-      # wait until VMmanageTasks started succesfully
+      # wait until VMmanageTasks started successfully
       tic = time.time()
       time.sleep(5)
       VMmanageRunning = 0

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -93,7 +93,7 @@ using std::string;
 
 PLAN_CLASS_SPECS plan_class_specs;
 
-/* is there a plan class spec that restricts the worunit (or batch) */
+/* is there a plan class spec that restricts the workunit (or batch) */
 bool wu_restricted_plan_class;
 
 GPU_REQUIREMENTS gpu_requirements[NPROC_TYPES];
@@ -712,7 +712,7 @@ static inline bool app_plan_opencl(
 ) {
     // opencl_*_<ver> plan classes check for a trailing integer which is
     // used as the opencl version number.  This is compatible with the old
-    // opencl_nvidia_101 and opencl_ati_101 plan classes, but doens't require
+    // opencl_nvidia_101 and opencl_ati_101 plan classes, but doesn't require
     // modifications if someone wants a opencl_nvidia_102 plan class.
     const char *p=plan_class+strlen(plan_class);
     while (isnum(p[-1])) {

--- a/sched/sched_locality.cpp
+++ b/sched/sched_locality.cpp
@@ -1391,4 +1391,4 @@ void send_file_deletes() {
 // (7) there are no feasible results for the host, we are finished:
 // (7) exit.
 
-// (8) If addtional results are needed, return to step 4 above.
+// (8) If additional results are needed, return to step 4 above.

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -595,7 +595,7 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
 
     fprintf(fout,
         "<scheduler_request>\n"
-        "  <authenticator>%s</authentiicator>\n"
+        "  <authenticator>%s</authenticator>\n"
         "  <platform_name>%s</platform_name>\n"
         "  <cross_project_id>%s</cross_project_id>\n"
         "  <hostid>%lu</hostid>\n"

--- a/sched/target_batch.cpp
+++ b/sched/target_batch.cpp
@@ -9,7 +9,7 @@
 
      The project dir must be defined in the projects config.xml file.
 
-     Input parameter of the form 'batch=[id]' can be passed via url or commmand line.
+     Input parameter of the form 'batch=[id]' can be passed via url or command line.
 
      Example usage from command line:
      ./target_batch batch=1
@@ -42,7 +42,7 @@ Create a batch of low-priority tasks:
 Target batch to dedicated workers:
 /bin/target_batch batch=0
 
-Start dedicated work with USER_ID corresonding to DEDICATED_USER_ID.
+Start dedicated work with USER_ID corresponding to DEDICATED_USER_ID.
 
 Check that these tasks are only assigned to dedicated workers.
 

--- a/tests/old/concat_correct_output
+++ b/tests/old/concat_correct_output
@@ -529,7 +529,7 @@
       <li>
               <code>unparsed-entity-uri()</code>.</li>
       </ul>
-          <p CLASS="">As for the fuctions that <i>are</i> implemented, the
+          <p CLASS="">As for the functions that <i>are</i> implemented, the
       following is a list of differences from the spec:
       </p>
           <ul>

--- a/tests/old/input
+++ b/tests/old/input
@@ -529,7 +529,7 @@
       <li>
               <code>unparsed-entity-uri()</code>.</li>
       </ul>
-          <p CLASS="">As for the fuctions that <i>are</i> implemented, the
+          <p CLASS="">As for the functions that <i>are</i> implemented, the
       following is a list of differences from the spec:
       </p>
           <ul>

--- a/tests/old/test.inc
+++ b/tests/old/test.inc
@@ -32,7 +32,7 @@ assert_options(ASSERT_CALLBACK, 'my_assert_handler');
 
 $errors = 0;
 
-// get an enviroment variable, and abort script if missing
+// get an environment variable, and abort script if missing
 //
 function get_env_var($name, $defvalue = -1) {
     $x = getenv($name);

--- a/tests/old/test_sched_moved.py
+++ b/tests/old/test_sched_moved.py
@@ -2,7 +2,7 @@
 
 ## $Id$
 
-# DOESN"T WORK YET
+# DOESN'T WORK YET
 
 from test_uc import *
 

--- a/todo
+++ b/todo
@@ -167,7 +167,7 @@ CPU benchmarking
     what to do when tests show hardware problem?
     How should we weight factors for credit?
     run CPU tests unobtrusively, periodically
-    check that on/conn/active fracs are maintainted correctly
+    check that on/conn/active fracs are maintained correctly
     check that bandwidth is measured correctly
     measure disk/mem size on all platforms
     get timezone to work

--- a/tools/update_versions
+++ b/tools/update_versions
@@ -221,7 +221,7 @@ function confirm_sig_gen($name) {
     NOTICE: You have not provided a signature file for $name,
     and your project's code-signing private key is on your server.
 
-    IF YOUR PROJECT IS PUBLICLY ACCESSABLE, THIS IS A SECURITY VULNERABILITY.
+    IF YOUR PROJECT IS PUBLICLY ACCESSIBLE, THIS IS A SECURITY VULNERABILITY.
     PLEASE STOP YOUR PROJECT IMMEDIATELY AND READ:
     https://boinc.berkeley.edu/trac/wiki/CodeSigning
 


### PR DESCRIPTION
**Description of the Change**
This PR consists of over 200 spelling and typo fixes touching 117 files.  I apologize in advance for reviewers.  To help, I have divided this into 9 commits, arranged by the folders in the source.

Note some of these typos are in user facing messages, such as error messages.

**Release Notes**
Many typos corrected
