### PR TITLE
Fix typos missed in #4538

### DIFF
--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -288,7 +288,7 @@ int diagnostics_update_thread_list() {
     // Lets start walking the structures to find the good stuff.
     pProcesses = (PSYSTEM_PROCESSES)pBuffer;
     do {
-        // Okay, found the current proccess entry now we just need to
+        // Okay, found the current process entry now we just need to
         //   update the thread data.
         if (pProcesses->ProcessId == dwCurrentProcessId) {
 

--- a/lib/mac/QBacktrace.h
+++ b/lib/mac/QBacktrace.h
@@ -35,7 +35,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/QCrashReport.h
+++ b/lib/mac/QCrashReport.h
@@ -35,7 +35,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/QMachOImage.c
+++ b/lib/mac/QMachOImage.c
@@ -36,7 +36,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:

--- a/lib/mac/dyld_gdb.h
+++ b/lib/mac/dyld_gdb.h
@@ -35,7 +35,7 @@
 *  Note: if address 1a23 is hex, use 0x1a23.  
 *
 *  To demangle mangled C++ symbols, use the c++filt command-line tool. 
-*  You may need to prefix C++ symbols with an additonal underscore before 
+*  You may need to prefix C++ symbols with an additional underscore before 
 *  passing them to c++filt (so they begin with two underscore characters).
 *
 * A very useful shell script to add symbols to a crash dump can be found at:
@@ -190,7 +190,7 @@ typedef void (*dyld_image_notifier)(enum dyld_image_mode mode, uint32_t infoCoun
  *	(dyld_image_adding) or are about to be removed (dyld_image_removing). 
  *
  * The notification is called after infoArray is updated.  This means that if gdb attaches to a process
- * and infoArray is NULL, gdb can set a break point on notification and let the proccess continue to
+ * and infoArray is NULL, gdb can set a break point on notification and let the process continue to
  * run until the break point.  Then gdb can inspect the full infoArray.
  */
  struct dyld_all_image_infos {

--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -1234,7 +1234,7 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
     }
     while (retval);
 
-    // Add all relevent notes to the output string and log errors
+    // Add all relevant notes to the output string and log errors
     //
     if (retval && log_error) {
         if (!retry_notes.empty()) {


### PR DESCRIPTION
Fixes typos missed in previous PR https://github.com/BOINC/boinc/pull/4538#issuecomment-940495064

proccess -> process (x2)
relevent -> relevant

also found
additonal -> additional (x4)

Thanks to @cwallbaum

