### PR TITLE
Update the GitHub cache action by unpinning the version

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Cache dependencies
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
         with:
           path: |
             3rdParty/buildCache

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -20,7 +20,7 @@ jobs:
           sudo apt-get install -y libftgl-dev freeglut3-dev libcurl4-openssl-dev libxmu-dev libxi-dev libfcgi-dev libxss-dev libnotify-dev libxcb-util0-dev libgtk2.0-dev libwebkitgtk-dev p7zip-full libxxf86vm-dev ocl-icd-opencl-dev zip
 
       - name: Cache dependencies
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
         with:
           path: |
             3rdParty/buildCache

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
           ./integration_test/installTestSuite.sh
 
       - name: Cache dependencies
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
         with:
           path: |
             3rdParty/buildCache

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Cache dependencies
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
         with:
           path: 3rdParty/buildCache
           key: osx-${{ matrix.type }}-${{ hashFiles('3rdParty/*Mac*.sh', 'mac_build/dependencyNames.sh', 'mac_build/[bB]uild*.sh') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
         run: vcpkg.exe integrate remove
 
       - name: Cache dependencies
-        uses: actions/cache@v2.1.3
+        uses: actions/cache@v2
         with:
           path: |
             ${{ github.workspace }}\3rdParty\Windows\cuda\


### PR DESCRIPTION
When GitHub Actions was introduced to the repo, for some reason the [cache action](https://github.com/actions/cache) was pinned to version 2.1.3, causing the [later updates](https://github.com/actions/cache/releases) to be missed.  This should have no effect anywhere else.

Latest cache action is 2.1.6, and includes several bugfixes since 2.1.3

**Release Notes**
N/A
