### PR TITLE
client: fix overly aggressive project-wide file transfer backoff policy.

### DIFF
--- a/client/client_types.h
+++ b/client/client_types.h
@@ -188,18 +188,25 @@ struct FILE_REF {
     int write(MIOFILE&);
 };
 
-// file xfer backoff state for a project and direction (up/down)
-// if file_xfer_failures exceeds FILE_XFER_FAILURE_LIMIT,
+// File xfer backoff state for a project and direction (up/down).
+// If we get more than FILE_XFER_FAILURE_LIMIT (3) consecutive failures,
 // we switch from a per-file to a project-wide backoff policy
 // (separately for the up/down directions)
+// E.g. if we have 100 files to upload and the first 3 fail,
+// we don't try the other 97 immediately.
+//
 // NOTE: this refers to transient failures, not permanent.
 //
+
 #define FILE_XFER_FAILURE_LIMIT 3
+
 struct FILE_XFER_BACKOFF {
     int file_xfer_failures;
         // count of consecutive failures
     double next_xfer_time;
         // when to start trying again
+    bool is_upload;
+
     bool ok_to_transfer();
     void file_xfer_failed(PROJECT*);
     void file_xfer_succeeded();

--- a/client/project.cpp
+++ b/client/project.cpp
@@ -125,6 +125,8 @@ void PROJECT::init() {
     gpu_ec = 0;
     gpu_time = 0;
     app_configs.clear();
+    upload_backoff.is_upload = true;
+    download_backoff.is_upload = false;
 
 #ifdef SIM
     idle_time = 0;


### PR DESCRIPTION
Old: if we get more than 3 upload or download failures for a project,
do a backoff for each failure.

Problem: if we start a bunch of transfers (say the N output files of a job)
and they all fail, we back off for too long, e.g.:
try N uploads
back off 2^N minutes
try N uploads
back off 4^N minutes
...

New: on a failure, ignore it if we're already backed off.
So the behavior should be something like:
try N uploads
back off 1 minute
try N uploads
back off 2 minutes
...

Should fix #4572