### PR TITLE
Add pkg-config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@
 ## files created by _autosetup (autoreconf):
 *.in
 *.in~
+!*.pc.in
 aclocal.m4
 autom4te.cache/
 compile
@@ -96,6 +97,7 @@ test-driver
 ## files created by configure:
 Makefile
 .deps/
+*.pc
 boinc_path_config.py
 pkginfo
 prototype

--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -55,6 +55,7 @@ libboinc_graphics2_la_LDFLAGS = -version-number $(LIBBOINC_VERSION) -ljpeg
 endif #BUILD_GRAPHICS_API
 
 lib_LTLIBRARIES += libboinc_opencl.la
+pkgconfig_DATA += libboinc_opencl.pc
 libboinc_opencl_la_SOURCES = $(opencl_files)
 libboinc_opencl_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 

--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -42,6 +42,7 @@ AM_CXXFLAGS += @GLUT_CFLAGS@
 endif
 
 lib_LTLIBRARIES = libboinc_api.la
+pkgconfig_DATA = libboinc_api.pc
 libboinc_api_la_SOURCES = $(api_files)
 libboinc_api_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 

--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -48,6 +48,7 @@ libboinc_api_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 
 if BUILD_GRAPHICS_API
 lib_LTLIBRARIES += libboinc_graphics2.la
+pkgconfig_DATA += libboinc_graphics2.pc
 libboinc_graphics2_la_SOURCES = $(graphics2_files)
 libboinc_graphics2_la_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_srcdir)/samples/image_libs
 libboinc_graphics2_la_LDFLAGS = -version-number $(LIBBOINC_VERSION) -ljpeg

--- a/api/libboinc_api.pc.in
+++ b/api/libboinc_api.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: boinc_api
+Description: BOINC API
+Version: @PACKAGE_VERSION@
+URL: https://boinc.berkeley.edu/trac/wiki/BasicApi
+
+Cflags: -I${includedir}/boinc
+Cflags.private: @GLUT_CFLAGS@
+Libs: -L${libdir} -lboinc_api

--- a/api/libboinc_graphics2.pc.in
+++ b/api/libboinc_graphics2.pc.in
@@ -1,0 +1,15 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: boinc_graphics2
+Description: BOINC graphics API
+Version: @PACKAGE_VERSION@
+URL: https://boinc.berkeley.edu/trac/wiki/GraphicsApps
+
+Cflags: -I${includedir}/boinc
+Cflags.private: @GLUT_CFLAGS@
+Libs: -L${libdir} -lboinc_graphics2
+Libs.private: -lm
+Requires.private: libjpeg

--- a/api/libboinc_opencl.pc.in
+++ b/api/libboinc_opencl.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: boinc_opencl
+Description: BOINC OpenCL API
+Version: @PACKAGE_VERSION@
+URL: https://boinc.berkeley.edu/trac/wiki/OpenclApps
+
+Cflags: -I${includedir}/boinc
+Cflags.private: @GLUT_CFLAGS@
+Libs: -L${libdir} -lboinc_opencl

--- a/configure.ac
+++ b/configure.ac
@@ -1339,6 +1339,7 @@ AC_CONFIG_FILES([
                  version.h
                  api/Makefile
                  api/libboinc_api.pc
+                 api/libboinc_graphics2.pc
                  apps/Makefile
                  clientgui/Makefile
                  clientgui/res/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1352,6 +1352,7 @@ AC_CONFIG_FILES([
                  doc/manpages/Makefile
                  html/Makefile
                  lib/Makefile
+                 lib/libboinc.pc
                  locale/Makefile
                  Makefile
                  py/Boinc/version.py

--- a/configure.ac
+++ b/configure.ac
@@ -1353,6 +1353,7 @@ AC_CONFIG_FILES([
                  html/Makefile
                  lib/Makefile
                  lib/libboinc.pc
+                 lib/libboinc_crypt.pc
                  locale/Makefile
                  Makefile
                  py/Boinc/version.py

--- a/configure.ac
+++ b/configure.ac
@@ -1340,6 +1340,7 @@ AC_CONFIG_FILES([
                  api/Makefile
                  api/libboinc_api.pc
                  api/libboinc_graphics2.pc
+                 api/libboinc_opencl.pc
                  apps/Makefile
                  clientgui/Makefile
                  clientgui/res/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1338,6 +1338,7 @@ AC_SUBST(FULLNAME)
 AC_CONFIG_FILES([
                  version.h
                  api/Makefile
+                 api/libboinc_api.pc
                  apps/Makefile
                  clientgui/Makefile
                  clientgui/res/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,9 @@ SAH_LINKS
 AC_LANG_PUSH(C)
 AM_PROG_CC_C_O
 
+PKG_PROG_PKG_CONFIG
+PKG_INSTALLDIR
+
 m4_divert_once([HELP_ENABLE],
   AS_HELP_STRING([BOINC Default enable values], [--enable-server --enable-client --enable-libraries --enable-manager: builds server, client, and libraries]))
 

--- a/configure.ac
+++ b/configure.ac
@@ -1385,6 +1385,7 @@ AC_CONFIG_FILES([
                  tools/Makefile
                  vda/Makefile
                  zip/Makefile
+                 zip/libboinc_zip.pc
                  zip/zip/Makefile
                  zip/unzip/Makefile
                  m4/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -1354,6 +1354,7 @@ AC_CONFIG_FILES([
                  lib/Makefile
                  lib/libboinc.pc
                  lib/libboinc_crypt.pc
+                 lib/libboinc_fcgi.pc
                  locale/Makefile
                  Makefile
                  py/Boinc/version.py

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -205,6 +205,7 @@ endif
 
 if ENABLE_FCGI
 lib_LTLIBRARIES += libboinc_fcgi.la
+pkgconfig_DATA += libboinc_fcgi.pc
 libboinc_fcgi_la_SOURCES = $(libfcgi_sources) $(mac_sources) $(win_sources)
 libboinc_fcgi_la_CFLAGS = -D_USING_FCGI_ $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
 libboinc_fcgi_la_CXXFLAGS = -D_USING_FCGI_ $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -183,6 +183,7 @@ noinst_HEADERS = \
     unix_util.h
 
 lib_LTLIBRARIES = libboinc.la
+pkgconfig_DATA = libboinc.pc
 libboinc_la_SOURCES = $(generic_sources) $(mac_sources) $(win_sources)
 libboinc_la_CFLAGS = $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
 libboinc_la_CXXFLAGS = $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -195,6 +195,7 @@ libboinc_la_LIBADD =
 
 if ENABLE_BOINCCRYPT
 lib_LTLIBRARIES += libboinc_crypt.la
+pkgconfig_DATA += libboinc_crypt.pc
 libboinc_crypt_la_SOURCES = crypt.cpp
 libboinc_crypt_la_CFLAGS = $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(SSL_CFLAGS)
 libboinc_crypt_la_CXXFLAGS = $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(SSL_CXXFLAGS)

--- a/lib/libboinc.pc.in
+++ b/lib/libboinc.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: boinc
+Description: BOINC library
+Version: @PACKAGE_VERSION@
+
+Cflags: -I${includedir}/boinc
+Cflags.private: @PTHREAD_CFLAGS@
+Libs: -L${libdir} -lboinc
+Libs.private: @PTHREAD_LIBS@

--- a/lib/libboinc_crypt.pc.in
+++ b/lib/libboinc_crypt.pc.in
@@ -1,0 +1,14 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: boinc_crypt
+Description: BOINC cryptography library
+Version: @PACKAGE_VERSION@
+
+Cflags: -I${includedir}/boinc
+Cflags.private: @PTHREAD_CFLAGS@
+Libs: -L${libdir} -lboinc_crypt
+Libs.private: @PTHREAD_LIBS@
+Requires.private: openssl

--- a/lib/libboinc_fcgi.pc.in
+++ b/lib/libboinc_fcgi.pc.in
@@ -1,0 +1,13 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: boinc_fcgi
+Description: BOINC FastCGI library
+Version: @PACKAGE_VERSION@
+
+Cflags: -D_USING_FCGI_ -I${includedir}/boinc
+Cflags.private: @PTHREAD_CFLAGS@
+Libs: -L${libdir} -lboinc_fcgi
+Libs.private: @PTHREAD_LIBS@

--- a/zip/Makefile.am
+++ b/zip/Makefile.am
@@ -60,6 +60,7 @@ libboinc_zip_sources += \
 endif
 
 lib_LTLIBRARIES = libboinc_zip.la
+pkgconfig_DATA = libboinc_zip.pc
 libboinc_zip_la_SOURCES = $(libboinc_zip_sources)
 libboinc_zip_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 libboinc_zip_la_LIBADD =

--- a/zip/libboinc_zip.pc.in
+++ b/zip/libboinc_zip.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: boinc_zip
+Description: Compression functions for BOINC applications
+Version: @PACKAGE_VERSION@
+URL: https://boinc.berkeley.edu/trac/wiki/FileCompression
+
+Cflags: -I${includedir}/boinc
+Libs: -L${libdir} -lboinc_zip


### PR DESCRIPTION
**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
Autoconf generates .pc files from .pc.in files, substituting certain variables.

`PKG_INSTALLDIR` macro from pkg.m4 sets `pkgconfigdir` for `pkgconfig_DATA` targets, which install pkg-config files on the system.

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->
Libtool archives (.la) are historically used to find packages and track static library dependencies but only autotools support them. pkg-config files are build-system agnostic and more portable.

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
N/A - only app developers might find it useful

**Checks**

Testing configure and installation on different systems is needed.