### PR TITLE
client: fix work-fetch logic when max concurrent limits are used

### DIFF
--- a/client/rr_sim.cpp
+++ b/client/rr_sim.cpp
@@ -328,9 +328,6 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
                 if (have_max_concurrent) {
                     switch (max_concurrent_exceeded(rp)) {
                     case CONCURRENT_LIMIT_PROJECT:
-                        // no more jobs for this project
-                        //
-                        //rsc_pwf.pending_iter = rsc_pwf.pending.end();
                         rsc_pwf.last_mc_limit_reltime = reltime;
                         p->pwf.at_max_concurrent_limit = true;
                         if (log_flags.rr_simulation) {

--- a/client/rr_sim.cpp
+++ b/client/rr_sim.cpp
@@ -88,11 +88,11 @@ static inline void set_bits(
 // refer to RESULT
 //
 struct RR_SIM {
-    vector<RESULT*> active;
+    vector<RESULT*> active_jobs;
 
     inline void activate(RESULT* rp) {
         PROJECT* p = rp->project;
-        active.push_back(rp);
+        active_jobs.push_back(rp);
         int rt = rp->avp->gpu_usage.rsc_type;
 
         // if this is a GPU app and GPU computing is suspended,
@@ -227,17 +227,22 @@ void RR_SIM::init_pending_lists() {
     }
 }
 
-// Pick jobs to run from pending lists, putting them in "active" list.
+// Pick jobs to run from pending lists, putting them in "active_jobs" list.
 // Approximate what the job scheduler would do:
 // pick a job from the project P with highest scheduling priority,
 // then adjust P's scheduling priority.
 //
-// This is called at the start of the simulation,
-// and again each time a job finishes.
-// In the latter case, some resources may be saturated.
+// This is called:
+// - at the start of the simulation
+//      It will pick jobs to use all resources
+// - each time a job finishes in the simulation
+//      It will generally pick one new job to use the resource just freed
 //
 void RR_SIM::pick_jobs_to_run(double reltime) {
-    active.clear();
+    if (log_flags.rr_simulation) {
+        msg_printf(NULL, MSG_INFO, "pick_jobs_to_run() start");
+    }
+    active_jobs.clear();
 
     if (have_max_concurrent) {
         max_concurrent_init();
@@ -268,7 +273,13 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
         for (unsigned int i=0; i<gstate.projects.size(); i++) {
             PROJECT* p = gstate.projects[i];
             RSC_PROJECT_WORK_FETCH& rsc_pwf = p->rsc_pwf[rt];
-            if (rsc_pwf.pending.size() ==0) continue;
+            unsigned int s = rsc_pwf.pending.size();
+#if 0
+            if (log_flags.rrsim_detail) {
+                msg_printf(p, MSG_INFO, "[rr_sim] %u jobs for rsc %u", s, rt);
+            }
+#endif
+            if (s == 0) continue;
             rsc_pwf.pending_iter = rsc_pwf.pending.begin();
             rsc_pwf.sim_nused = 0;
             p->pwf.rec_temp = p->pwf.rec;
@@ -296,12 +307,8 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
                 rsc_pwf.pending_iter = rsc_pwf.pending.erase(
                     rsc_pwf.pending_iter
                 );
-            } else if (p->pwf.at_max_concurrent_limit) {
-                rsc_pwf.pending_iter = rsc_pwf.pending.erase(
-                    rsc_pwf.pending_iter
-                );
             } else {
-                // add job to active list, and adjust project priority
+                // add job to active_jobs list, and adjust project priority
                 //
                 activate(rp);
                 adjust_rec_sched(rp);
@@ -314,6 +321,38 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
                         rp->rrsim_flops/1e9
                     );
                     rp->already_selected = true;
+                }
+
+                // Check if project is at a max_concurrent limit
+                //
+                if (have_max_concurrent) {
+                    switch (max_concurrent_exceeded(rp)) {
+                    case CONCURRENT_LIMIT_PROJECT:
+                        // no more jobs for this project
+                        //
+                        //rsc_pwf.pending_iter = rsc_pwf.pending.end();
+                        rsc_pwf.last_mc_limit_reltime = reltime;
+                        p->pwf.at_max_concurrent_limit = true;
+                        if (log_flags.rr_simulation) {
+                            msg_printf(p, MSG_INFO,
+                                "[rr_sim] at project max concurrent: t %f",
+                                reltime
+                            );
+                        }
+                        break;
+                    case CONCURRENT_LIMIT_APP:
+                        // no more jobs for this project/app
+                        //
+                        p->pwf.at_max_concurrent_limit = true;
+                        rsc_pwf.last_mc_limit_reltime = reltime;
+                        if (log_flags.rr_simulation) {
+                            msg_printf(p, MSG_INFO,
+                                "[rr_sim] at app max concurrent for %s; t %f",
+                                rp->app->name, reltime
+                            );
+                        }
+                        break;
+                    }
                 }
 
                 // check whether resource is saturated
@@ -337,35 +376,9 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
                 ++rsc_pwf.pending_iter;
             }
 
-            // Check if project is at a max_concurrent limit
-            //
-            if (have_max_concurrent) {
-                switch (max_concurrent_exceeded(rp)) {
-                case CONCURRENT_LIMIT_PROJECT:
-                    // no more jobs for this project
-                    //
-                    rsc_pwf.pending_iter = rsc_pwf.pending.end();
-                    p->pwf.at_max_concurrent_limit = true;
-                    if (log_flags.rr_simulation) {
-                        msg_printf(p, MSG_INFO,
-                            "[rr_sim] at project max concurrent"
-                        );
-                    }
-                    break;
-                case CONCURRENT_LIMIT_APP:
-                    // no more jobs for this project/app
-                    //
-                    p->pwf.at_max_concurrent_limit = true;
-                    if (log_flags.rr_simulation) {
-                        msg_printf(p, MSG_INFO,
-                            "[rr_sim] at app max concurrent for %s", rp->app->name
-                        );
-                    }
-                    break;
-                }
-            }
-
-            if (rsc_pwf.pending_iter == rsc_pwf.pending.end()) {
+            if (rsc_pwf.pending_iter == rsc_pwf.pending.end()
+                || p->pwf.at_max_concurrent_limit
+            ) {
                 // if this project now has no more jobs for the resource,
                 // remove it from the project heap
                 //
@@ -382,6 +395,9 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
     for (unsigned int i=0; i<gstate.projects.size(); i++) {
         PROJECT* p = gstate.projects[i];
         p->pwf.rec_temp = p->pwf.rec_temp_save;
+    }
+    if (log_flags.rr_simulation) {
+        msg_printf(NULL, MSG_INFO, "pick_jobs_to_run() end");
     }
 }
 
@@ -502,13 +518,13 @@ void RR_SIM::simulate() {
             first = false;
         }
 
-        if (!active.size()) break;
+        if (!active_jobs.size()) break;
 
         // compute finish times and see which job finishes first
         //
         rpbest = NULL;
-        for (u=0; u<active.size(); u++) {
-            rp = active[u];
+        for (u=0; u<active_jobs.size(); u++) {
+            rp = active_jobs[u];
             rp->rrsim_finish_delay = rp->rrsim_flops_left/rp->rrsim_flops;
             if (!rpbest || rp->rrsim_finish_delay < rpbest->rrsim_finish_delay) {
                 rpbest = rp;
@@ -520,7 +536,7 @@ void RR_SIM::simulate() {
         double delta_t = rpbest->rrsim_finish_delay;
         if (log_flags.rrsim_detail) {
             msg_printf(NULL, MSG_INFO,
-                "[rrsim_detail] rpbest: %s (finish delay %.2f)",
+                "[rrsim_detail] next job to finish: %s (will finish in  %.2f sec)",
                 rpbest->name,
                 delta_t
             );
@@ -537,7 +553,7 @@ void RR_SIM::simulate() {
             }
             if (log_flags.rrsim_detail) {
                 msg_printf(NULL, MSG_INFO,
-                    "[rrsim_detail] time-slice step of %.2f sec", delta_t
+                    "[rrsim_detail] taking time-slice step of %.2f sec", delta_t
                 );
             }
         } else {
@@ -575,8 +591,8 @@ void RR_SIM::simulate() {
 
         // adjust FLOPS left of other active jobs
         //
-        for (unsigned int i=0; i<active.size(); i++) {
-            rp = active[i];
+        for (unsigned int i=0; i<active_jobs.size(); i++) {
+            rp = active_jobs[i];
             rp->rrsim_flops_left -= rp->rrsim_flops*delta_t;
 
             // can be slightly less than 0 due to roundoff
@@ -656,6 +672,11 @@ void RR_SIM::simulate() {
         if (have_max_concurrent) {
             mc_update_stats(sim_now, d_time, buf_end);
         }
+    }
+    if (log_flags.rr_simulation) {
+        msg_printf(0, MSG_INFO,
+            "[rr_sim] end"
+        );
     }
 }
 

--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -73,6 +73,7 @@ void RSC_PROJECT_WORK_FETCH::rr_init(PROJECT *p) {
     nused_total = 0;
     deadlines_missed = 0;
     mc_shortfall = 0;
+    last_mc_limit_reltime = 0;
     max_nused = p->app_configs.project_min_mc;
 }
 
@@ -137,6 +138,20 @@ RSC_REASON RSC_PROJECT_WORK_FETCH::compute_rsc_project_reason(
             && queue_est > (gstate.work_buf_min() * n_not_excluded)/rwf.ninstances
         ) {
             return RSC_REASON_BUFFER_FULL;
+        }
+    }
+
+    if (p->app_configs.project_has_mc) {
+        RSC_PROJECT_WORK_FETCH &rsc_pwf = p->rsc_pwf[rsc_type];
+        if (log_flags.work_fetch_debug) {
+            msg_printf(p, MSG_INFO,
+                "rsc type %d last MC limit time %f total buf %f",
+                rsc_type, rsc_pwf.last_mc_limit_reltime, gstate.work_buf_total()
+            );
+        }
+
+        if (rsc_pwf.last_mc_limit_reltime > gstate.work_buf_total()) {
+            return RSC_REASON_MAX_CONCURRENT;
         }
     }
 
@@ -1229,6 +1244,7 @@ const char* rsc_reason_string(RSC_REASON reason) {
     case RSC_REASON_NOT_HIGHEST_PRIO: return "not highest priority project";
     case RSC_REASON_BACKED_OFF: return "project is backed off";
     case RSC_REASON_DEFER_SCHED: return "a job is deferred";
+    case RSC_REASON_MAX_CONCURRENT: return "max concurrent job limit";
     }
     return "unknown project reason";
 }

--- a/client/work_fetch.h
+++ b/client/work_fetch.h
@@ -58,7 +58,8 @@ typedef enum {
     RSC_REASON_BUFFER_FULL,
     RSC_REASON_NOT_HIGHEST_PRIO,
     RSC_REASON_BACKED_OFF,
-    RSC_REASON_DEFER_SCHED
+    RSC_REASON_DEFER_SCHED,
+    RSC_REASON_MAX_CONCURRENT
 } RSC_REASON;
 
 struct PROJECT;
@@ -111,6 +112,9 @@ struct RSC_PROJECT_WORK_FETCH {
         // This project has a coproc job of the given type for which
         // the job is deferred because of a temporary_exit() call.
         // Don't fetch more jobs of this type; they might have same problem
+    double last_mc_limit_reltime;
+        // in RR sim, last relative time when we couldn't run a job
+        // of this resource because of max concurrent limit
     RSC_REASON rsc_project_reason;
         // If zero, it's OK to ask this project for this type of work.
         // If nonzero, the reason why it's not OK


### PR DESCRIPTION
The round-robin simulation would stop simulating jobs for a project
once a max concurrent limit (app or project) was reached.
As a result it would decide there was a shortfall,
and keep requesting work up to the limit of 1000 jobs.

To fix this:
1) keep simulating a project after an MCL is reached
2) for each (project, resource) pair, keep track of the latest
    simulation time T when an MCL was reached.
3) for such a project, don't request work for a resource if
    T > now + work buf size

This allows us, e.g., to request GPU jobs from a project
even if its CPU jobs (taking MCL into account) fill the buffer.

This works in the simulation case that showed the problem (#192).

Also: add a bit more logging, and improve names

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
