### PR TITLE
Fix gcc warnings

### DIFF
--- a/client/dhrystone.cpp
+++ b/client/dhrystone.cpp
@@ -90,7 +90,7 @@ int dhrystone(
     unsigned long         Loops;
     DS_DATA dd;
 
-    double                  startclock, endclock;
+    double                  startclock = 0.0, endclock = 0.0;
     double                  benchtime;
     double Dhrystones_Per_Second;
 

--- a/client/dhrystone.h
+++ b/client/dhrystone.h
@@ -1,5 +1,5 @@
 
-#ifdef __APPLE__
+#if defined __APPLE__ || __cplusplus >= 201703L
 #define REG
 #else
 #define REG register

--- a/client/whetstone.cpp
+++ b/client/whetstone.cpp
@@ -98,7 +98,7 @@ int whetstone(double& flops, double& cpu_time, double min_cpu_time) {
     SPDP x,y,z;
     long j,k,l, jjj;
     SPDP e1[4];
-    double startsec, finisec;
+    double startsec = 0.0, finisec = 0.0;
     double KIPS;
     int xtra, ii;
     int x100 = 1000;   // chosen to make each pass take about 0.1 sec


### PR DESCRIPTION
**Description of the Change**
I'm compiling BOINC on Opensuse Tumbleweed using gcc 11.2.1.
During compilation a couple of warnings appear.
This PR fixes some of them.

**Alternate Designs**
N/A

**Release Notes**
N/A