### PR TITLE
Configure more vram to avoid VMs get stuck during boot

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -250,6 +250,18 @@ namespace vboxmanage {
         retval = vbm_popen(command, output, "modifychipset");
         if (retval) return retval;
 
+        // Tweak the VM's Graphics Controller Options
+        //
+        vboxlog_msg("Setting Graphics Controller Options for VM.");
+        sprintf(buf, "%d", (int)vram_size_mb);
+
+        command  = "modifyvm \"" + vm_name + "\" ";
+        command += "--vram " + string(buf) + " ";
+        command += "--graphicscontroller " + vm_graphics_controller_type + " ";
+
+        retval = vbm_popen(command, output, "modifygraphicscontroller");
+        if (retval) return retval;
+
         // Tweak the VM's Boot Options
         //
         vboxlog_msg("Setting Boot Options for VM.");

--- a/samples/vboxwrapper/vboxjob.cpp
+++ b/samples/vboxwrapper/vboxjob.cpp
@@ -133,6 +133,8 @@ void VBOX_JOB::clear() {
     // Initialize default values
     vm_disk_controller_type = "ide";
     vm_disk_controller_model = "PIIX4";
+    vm_graphics_controller_type = "VBoxVGA";
+    vram_size_mb = VBOX_VRAM_MIN;
 }
 
 int VBOX_JOB::parse() {
@@ -162,6 +164,12 @@ int VBOX_JOB::parse() {
         else if (xp.parse_string("vm_disk_controller_type", vm_disk_controller_type)) continue;
         else if (xp.parse_string("vm_disk_controller_model", vm_disk_controller_model)) continue;
         else if (xp.parse_string("os_name", os_name)) continue;
+        else if (xp.parse_double("vram_size_mb", vram_size_mb)) {
+            // keep it within the valid range
+            if (vram_size_mb < VBOX_VRAM_MIN) vram_size_mb = VBOX_VRAM_MIN;
+            else if (vram_size_mb > VBOX_VRAM_MAX) vram_size_mb = VBOX_VRAM_MAX;
+            continue;
+        }
         else if (xp.parse_double("memory_size_mb", memory_size_mb)) continue;
         else if (xp.parse_double("job_duration", job_duration)) continue;
         else if (xp.parse_double("minimum_checkpoint_interval", minimum_checkpoint_interval)) continue;

--- a/samples/vboxwrapper/vboxjob.h
+++ b/samples/vboxwrapper/vboxjob.h
@@ -22,6 +22,20 @@
 #define JOB_FILENAME "vbox_job.xml"
 
 
+#ifndef VBOX_VRAM_MIN
+// Default value suggested by VirtualBox v6.1.30
+// when a VM is created manually using a Linux 64-bit template.
+// VirtualBox does not complain if lower values are used (9-16 MB)
+// but certain VMs occasionally hang when they boot (Rosetta).
+// They don't hang if vram is at least 16 MB.
+#define VBOX_VRAM_MIN 16.0
+#endif
+#ifndef VBOX_VRAM_MAX
+// highest value currently accepted by VirtualBox v6.1.30
+#define VBOX_VRAM_MAX 128.0
+#endif
+
+
 // Represents the state of a intermediate upload
 class VBOX_INTERMEDIATE_UPLOAD {
 public:
@@ -67,6 +81,14 @@ public:
 
     std::string vm_disk_controller_model;
         // the disk controller model to emulate
+
+    std::string vm_graphics_controller_type;
+        // the graphics controller type to emulate
+
+    double vram_size_mb;
+        // size of the video memory allocation for the VM, in megabytes
+        // should be between VBOX_VRAM_MIN and VBOX_VRAM_MAX MB
+        // default: VBOX_VRAM_MIN MB
 
     double memory_size_mb;
         // size of the memory allocation for the VM, in megabytes


### PR DESCRIPTION
**Description of the Change**
Roughly 10% of Rosetta's vbox tasks get stuck when the VM starts.
This is most likely caused by not enough vram given to the virtual graphics adapter.

For years vboxwrapper uses a hard-wired value of 8 MB.
Recent VirtualBox versions (6.1.30) configure 16 MB when a VM is configured manually and a Linux 64-bit template is used.
A site moderator from the VirtualBox forum even requests 128 MB vram:
https://forums.virtualbox.org/viewtopic.php?f=3&t=105195#p513161

This seems to be OK for Windows guests but far too much for Linux guests.
A test with nearly 100 Rosetta vbox tasks over the last 24 h didn't result in a single stuck task when 16 MB vram are configured.

This PR makes the vram size configurable via vbox_job.xml in case future VirtualBox releases require higher settings.
In addition the virtual graphics adapter type is also configurable.
Valid adapter types depend on the VirtualBox Extensions installed in the VM.
See:
https://www.virtualbox.org/manual/ch03.html#settings-display

**Alternate Designs**
N/A

**Release Notes**
Makes VRAM size and virtual graphics adapter type for VirtualBox VMs configurable via vbox_job.xml
