### PR TITLE
forward rtc setting from host to guest

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.h
+++ b/samples/vboxwrapper/vbox_vboxmanage.h
@@ -52,6 +52,7 @@ namespace vboxmanage {
         bool is_disk_image_registered();
         bool is_extpack_installed();
         bool is_virtualbox_installed();
+        bool is_hostrtc_set_to_utc();
 
         int get_install_directory(std::string& dir);
         int get_version_information(std::string& version_raw, std::string& version_display);


### PR DESCRIPTION
**Description of the Change**
Nearly all modern computer systems have a CMOS real time clock (rtc) to store the time when the computer is switched off.
A more detailed description can be found here:
https://man7.org/linux/man-pages/man8/hwclock.8.html

The manual and many other sources describe that the rtc is usually set to UTC on most non-Windows systems and why Windows should also be set to UTC.

When BOINC (vboxwrapper) creates a VirtualBox VM it configures that VM to use localtime instead of UTC.
This can be changed using the "--rtcuseutc on" option of vboxmanage and should be the new default.

Windows hosts can be configured with a registry key to either use localtime or UTC.
That setting should be forwarded to the guest. 
This PR introduces the necessary changes.


Since I don't have a Windows system to compile/test the Windows part of the change it would be nice if somebody else could test it.
It would be necessary to compile the modified vboxwrapper for Windows and use it to run 2 tasks from a vbox project.

Before the 1st run:
Open a powershell with administrator rights and run:
`reg add "HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\TimeZoneInformation" /v RealTimeIsUniversal /d 1 /t REG_DWORD /f`
Before the 2nd run:
Open a powershell with administrator rights and run:
`reg delete "HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\TimeZoneInformation" /v RealTimeIsUniversal /f`

In both cases a reboot is required.


The 1st run should create a VM where the rtc is set to UTC.
The 2nd run should create a VM where the rtc is **not** set to UTC.
The setting can be checked e.g. using the VirtualBox Manager.

**Alternate Designs**
N/A

**Release Notes**
Forwards CMOS clock setting (localtime/UTC) from the host to VirtualBox guests