### PR TITLE
Make sata/IntelAHCI the default virtual disk controller

### DIFF
--- a/samples/vboxwrapper/vboxjob.cpp
+++ b/samples/vboxwrapper/vboxjob.cpp
@@ -131,8 +131,8 @@ void VBOX_JOB::clear() {
     copy_cmdline_to_shared = false;
 
     // Initialize default values
-    vm_disk_controller_type = "ide";
-    vm_disk_controller_model = "PIIX4";
+    vm_disk_controller_type = "sata";
+    vm_disk_controller_model = "IntelAHCI";
 }
 
 int VBOX_JOB::parse() {


### PR DESCRIPTION
**Description of the Change**
Vboxwrapper configures the default virtual disk controller as ide/PIIX4.

According to the VirtualBox manual sata/IntelAHCI should be the default for different reasons:
https://www.virtualbox.org/manual/ch05.html#harddiskcontrollers

The same chapter from an older VirtualBox manual (5.0.0) is a bit more verbose:
https://download.virtualbox.org/virtualbox/5.0.0/UserManual.pdf#section.5.1

"VirtualBox’s virtual SATA controller operates faster and also
consumes fewer CPU resources than the virtual IDE controller"

"...starting with **version 3.2** and depending on the selected guest operating
system, VirtualBox uses SATA as the default for newly created virtual machines"

"The entire SATA controller ... will not be seen by operating systems that do not
have device support for AHCI. In particular, there is no support for AHCI in Windows
before Windows Vista, so Windows XP (even SP3) will not see such disks unless you
install additional drivers"

It should be save not to focus on the last comment since I'm not aware of a BOINC project running Windows XP as VirtualBox guest.
Even then the disk controller could be be set back to ide/PIIX4 via vbox_job.xml.


Existing Linux VMs from LHC@home and Rosetta@home are running fine with sata/IntelAHCI.

**Alternate Designs**
N/A

**Release Notes**
vboxwrapper: change default virtual disk controller from ide/PIIX4 to sata/IntelAHCI
