### PR TITLE
Change error message

### DIFF
--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -398,7 +398,7 @@ string VBOX_BASE::get_error(int num){
           "   NOTE: VM failed to enter an online state within the timeout period.\n \
               This might be a temporary problem and so this job will be rescheduled for another time.\n",
 
-          "VM environment needed to be cleaned up.",
+          "VM environment needs to be cleaned up.",
 
           "Foreign VM Hypervisor locked hardware acceleration features.",
 


### PR DESCRIPTION
**Description of the Change**
A volunteer recently complained it's bad English because it's past tense instead of present tense.

**Alternate Designs**
N/A

**Release Notes**
N/A