### PR TITLE
Update Vboxwrapper to Release 26204

### DIFF
--- a/version.h
+++ b/version.h
@@ -16,7 +16,7 @@
 #define WRAPPER_RELEASE 26016
 
 /* vboxwrapper version number */
-#define VBOXWRAPPER_RELEASE 26203
+#define VBOXWRAPPER_RELEASE 26204
 
 /* String representation of BOINC version number */
 #define BOINC_VERSION_STRING "7.19.0"


### PR DESCRIPTION
**Description of the Change**
Last update was to version number 26203 but that number is already published as Windows version
https://boinc.berkeley.edu/dl/vboxwrapper_26203_windows_x86_64.zip

**Alternate Designs**
N/A

**Release Notes**
N/A