### PR TITLE
Computing prefs dialog: use %f instead of %g

### DIFF
--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -252,7 +252,7 @@ void CDlgAdvPreferences::DisplayValue(double value, wxTextCtrl* textCtrl, wxChec
             return;
         }
     }
-    buffer.Printf(wxT("%g"), value);
+    buffer.Printf(wxT("%.2f"), value);
     textCtrl->ChangeValue(buffer);
     textCtrl->Enable();
 }


### PR DESCRIPTION
(which writes scientific notation for large numbers,
which then can't be read).

Fixes #4650
