### PR TITLE
Systemd service order

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -1,7 +1,8 @@
 [Unit]
 Description=Berkeley Open Infrastructure Network Computing Client
 Documentation=man:boinc(1)
-After=network-online.target
+Wants=vboxdrv.service
+After=vboxdrv.service network-online.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
**Description of the Change**
Linux/Systemd

If service dependencies are not explicitly configured systemd tries to start services in parallel.
This may occasionally lead to a situation where BOINC checks for VirtualBox although that service is not yet present.

A Rosetta user recently posted an issue that might be caused by that:
https://boinc.bakerlab.org/rosetta/forum_thread.php?id=14966&postid=105428


This PR sets a clear dependency and starting order between BOINC and VirtualBox but also ensures BOINC doesn't fail if VirtualBox is not used.


**Alternate Designs**
N/A

**Release Notes**
N/A