### PR TITLE
Fix bug in new version check

### DIFF
--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -239,13 +239,19 @@ void newer_version_startup_check() {
 
 #define NEW_VERSION_CHECK_PERIOD (14*86400)
 
+// get client version info from the BOINC server if we haven't done so recently.
+// Called periodically from the main loop.
+// Also called with force=true for the get_newer_version() GUI RPC
+//
 void CLIENT_STATE::new_version_check(bool force) {
-    if (force || (new_version_check_time == 0) ||
-        (now - new_version_check_time > NEW_VERSION_CHECK_PERIOD)) {
-            // get_current_version_op.handle_reply()
-            // updates new_version_check_time
-            //
-            get_current_version_op.do_rpc();
-        }
+    if (force
+        || (new_version_check_time == 0)
+        || (now - new_version_check_time > NEW_VERSION_CHECK_PERIOD)
+    ) {
+        // get_current_version_op.handle_reply()
+        // updates new_version_check_time
+        //
+        get_current_version_op.do_rpc();
+    }
 }
 

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1095,7 +1095,14 @@ static void handle_acct_mgr_rpc_poll(GUI_RPC_CONN& grc) {
 
 static void handle_get_newer_version(GUI_RPC_CONN& grc) {
     gstate.new_version_check(true);
-
+    // this initiates an RPC to get version info.
+    // Wait for it to finish.
+    //
+    while (gstate.get_current_version_op.gui_http->gui_http_state != HTTP_STATE_IDLE) {
+        if (!gstate.poll_slow_events()) {
+            gstate.do_io_or_sleep(1.0);
+        }
+    }
     grc.mfout.printf(
         "<newer_version>%s</newer_version>\n"
         "<download_url>%s</download_url>\n",


### PR DESCRIPTION
client: the get_newer_version() GUI RPC (from the Manager) initiates
an RPC to the BOINC server to get new version info,
but it wasn't waiting for the RPC to finish.
Make it do so.
