### PR TITLE
ci: update Codecov action to v3

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -118,7 +118,7 @@ jobs:
           path: android/BOINC/app/build/test-results/testDebugUnitTest/TEST-*.xml
 
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: ${{ success() && matrix.type == 'manager' }}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -141,13 +141,10 @@ jobs:
           name: Linux_tests_results
           path: "tests/gtest/**/*_xml_report.xml"
 
-      - name: Run GCov
-        if: success() && matrix.type == 'unit-test'
-        run: bash -c "find . -type f -name '*.gcno' -exec gcov -pb {} +" || true
-
       - name: Upload coverage report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         if: success() && matrix.type == 'unit-test'
         with:
           fail_ci_if_error: true
+          gcov: true
           verbose: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload coverage report
         if: success() && matrix.platform == 'x64'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
           verbose: false


### PR DESCRIPTION
Fixes #

**Description of the Change**
The `v3` version of the Codecov Action now runs `gcov`. This PR removes the call to run `gcov` before the Action and bumps all occurrences of the Action to `v3`

**Alternate Designs**
Codecov will now run `gcov` as part of the `v3` offering so that it doesn't need to be run separately. 

**Release Notes**
Remove `gcov` step in CI as a result of Codecov Action bump from v2 to v3
