### PR TITLE
Remove unused variable in GLOBAL_PREFS.

### DIFF
--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -161,7 +161,6 @@ struct GLOBAL_PREFS {
     bool dont_verify_images;
     bool hangup_if_dialed;
     double idle_time_to_run;
-    double idle_time_to_suspend;
     bool leave_apps_in_memory;
     double max_bytes_sec_down;
     double max_bytes_sec_up;


### PR DESCRIPTION
I made a mistake in #4600.  I added a variable to the GLOBAL_PREFS structure that isn't used.  This removes that variable.