### PR TITLE
Client: use cuDeviceTotalMem_v2() if available to get >4GB mem size for NVIDIA GPUs

### DIFF
--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -227,6 +227,7 @@ int (*p_cuDeviceGet)(int*, int);
 int (*p_cuDeviceGetAttribute)(int*, int, int);
 int (*p_cuDeviceGetName)(char*, int, int);
 int (*p_cuDeviceTotalMem)(size_t*, int);
+int (*p_cuDeviceTotalMem_v2)(size_t*, int);
 int (*p_cuDeviceComputeCapability)(int*, int*, int);
 int (*p_cuCtxCreate)(void**, unsigned int, unsigned int);
 int (*p_cuCtxDestroy)(void*);

--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -312,6 +312,7 @@ void* cudalib = NULL;
     p_cuDeviceGetAttribute = (int(*)(int*, int, int)) dlsym( cudalib, "cuDeviceGetAttribute" );
     p_cuDeviceGetName = (int(*)(char*, int, int)) dlsym( cudalib, "cuDeviceGetName" );
     p_cuDeviceTotalMem = (int(*)(size_t*, int)) dlsym( cudalib, "cuDeviceTotalMem" );
+    p_cuDeviceTotalMem_v2 = (int(*)(size_t*, int)) dlsym(cudalib, "cuDeviceTotalMem_v2");
     p_cuDeviceComputeCapability = (int(*)(int*, int*, int)) dlsym( cudalib, "cuDeviceComputeCapability" );
     p_cuCtxCreate = (int(*)(void**, unsigned int, unsigned int)) dlsym( cudalib, "cuCtxCreate" );
     p_cuCtxDestroy = (int(*)(void*)) dlsym( cudalib, "cuCtxDestroy" );

--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -212,6 +212,7 @@ CUDA_GDG p_cuDeviceGet = NULL;
 CUDA_GDA p_cuDeviceGetAttribute = NULL;
 CUDA_GDN p_cuDeviceGetName = NULL;
 CUDA_GDM p_cuDeviceTotalMem = NULL;
+CUDA_GDM p_cuDeviceTotalMem_v2 = NULL;
 CUDA_GDCC p_cuDeviceComputeCapability = NULL;
 CUDA_CC p_cuCtxCreate = NULL;
 CUDA_CD p_cuCtxDestroy = NULL;
@@ -260,6 +261,7 @@ void COPROC_NVIDIA::get(
     p_cuDeviceGetAttribute = (CUDA_GDA)GetProcAddress( cudalib, "cuDeviceGetAttribute" );
     p_cuDeviceGetName = (CUDA_GDN)GetProcAddress( cudalib, "cuDeviceGetName" );
     p_cuDeviceTotalMem = (CUDA_GDM)GetProcAddress( cudalib, "cuDeviceTotalMem" );
+    p_cuDeviceTotalMem_v2 = (CUDA_GDM)GetProcAddress(cudalib, "cuDeviceTotalMem_v2");
     p_cuDeviceComputeCapability = (CUDA_GDCC)GetProcAddress( cudalib, "cuDeviceComputeCapability" );
     p_cuCtxCreate = (CUDA_CC)GetProcAddress( cudalib, "cuCtxCreate" );
     p_cuCtxDestroy = (CUDA_CD)GetProcAddress( cudalib, "cuCtxDestroy" );
@@ -337,7 +339,7 @@ void* cudalib = NULL;
         warnings.push_back("cuDeviceGetAttribute() missing from NVIDIA library");
         goto leave;
     }
-    if (!p_cuDeviceTotalMem) {
+    if (!p_cuDeviceTotalMem && !p_cuDeviceTotalMem_v2) {
         warnings.push_back("cuDeviceTotalMem() missing from NVIDIA library");
         goto leave;
     }
@@ -409,7 +411,11 @@ void* cudalib = NULL;
             goto leave;
         }
         (*p_cuDeviceComputeCapability)(&cc.prop.major, &cc.prop.minor, device);
-        (*p_cuDeviceTotalMem)(&global_mem, device);
+        if (p_cuDeviceTotalMem_v2) {
+            (*p_cuDeviceTotalMem_v2)(&global_mem, device);
+        } else {
+            (*p_cuDeviceTotalMem)(&global_mem, device);
+        }
         cc.prop.totalGlobalMem = (double) global_mem;
         (*p_cuDeviceGetAttribute)(&itemp, CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK, device);
         cc.prop.sharedMemPerBlock = (double) itemp;


### PR DESCRIPTION

Fixes #1773

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
