### PR TITLE
[Manager] Compile manager with new libwebkit2gtk lib for newer unbuntu

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,9 +27,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu bionic main universe'
           sudo apt-get -qq update
-          sudo apt-get install -y libftgl-dev freeglut3-dev libcurl4-openssl-dev libxmu-dev libxi-dev libfcgi-dev libxss-dev libnotify-dev libxcb-util0-dev libgtk2.0-dev libgtk-3-dev libsecret-1-dev libgcrypt20-dev libsystemd-dev libwebkitgtk-dev p7zip-full libxxf86vm-dev ocl-icd-opencl-dev zip
+          sudo apt-get install -y libftgl-dev freeglut3-dev libcurl4-openssl-dev libxmu-dev libxi-dev libfcgi-dev libxss-dev libnotify-dev libxcb-util0-dev libgtk-3-dev libsecret-1-dev libgcrypt20-dev libsystemd-dev libwebkit2gtk-4.0-dev p7zip-full libxxf86vm-dev ocl-icd-opencl-dev zip
 
       - name: Install dependencies for integration testing
         if: matrix.type == 'integration-test'

--- a/3rdParty/buildLinuxDependencies.sh
+++ b/3rdParty/buildLinuxDependencies.sh
@@ -137,11 +137,12 @@ if [ "${doclean}" = "yes" ]; then
     echo ${build_config} >${PREFIX}/build-config
 fi
 
+wx_ver="3.1.6"
 #download_and_build $DIRNAME $FILENAME $DOWNLOADURL $BUILDSCRIPT
 if [ "${gtest_only}" = "yes" ]; then
     download_and_build "googletest-release-1.8.1" "release-1.8.1.tar.gz" "https://github.com/google/googletest/archive/release-1.8.1.tar.gz" "${ROOTDIR}/3rdParty/buildGoogletestLinux.sh"
 else
-    download_and_build "wxWidgets-3.0.5" "wxWidgets-3.0.5.tar.bz2" "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.5/wxWidgets-3.0.5.tar.bz2" "${ROOTDIR}/3rdParty/buildWxLinux.sh ${wxoption}"
+    download_and_build "wxWidgets-$wx_ver" "wxWidgets-$wx_ver.tar.bz2" "https://github.com/wxWidgets/wxWidgets/releases/download/v$wx_ver/wxWidgets-$wx_ver.tar.bz2" "${ROOTDIR}/3rdParty/buildWxLinux.sh ${wxoption}"
 fi
 
 # change back to root directory


### PR DESCRIPTION
Compile manager with: 
- New libwebkit2gtk lib for newer unbuntu.
- Update to latest wxwidgets v3.1.6

Tested on gwsl2 on windows 11

manager with webview:
![image](https://user-images.githubusercontent.com/7043539/172067276-d071a490-d7e7-45cf-9408-ff9dc134f4bb.png)

manager without webview:
![image](https://user-images.githubusercontent.com/7043539/172067369-a0e3d08a-5bec-454b-9471-2b63c8edcbd1.png)

manager with webview with vcpkg:
![image](https://user-images.githubusercontent.com/7043539/172067548-5a510efe-f612-4f13-b7fa-632446803c86.png)
