### PR TITLE
make_project: Removed dependency of long gone files causing "failed to copy" warnings

### DIFF
--- a/py/Boinc/setup_project.py
+++ b/py/Boinc/setup_project.py
@@ -433,7 +433,6 @@ sys.path.insert(0, os.path.join('{dest_dir}', 'py'))
             'cancel_jobs',
             'create_work',
             'dbcheck_files_exist',
-            'db_query',
             'demo_query',
             'demo_submit',
             'dir_hier_move',
@@ -445,7 +444,6 @@ sys.path.insert(0, os.path.join('{dest_dir}', 'py'))
             'sign_executable',
             'stage_file',
             'update_versions',
-            'watch_tcp',
             'xadd',
         ]
     for f in command:


### PR DESCRIPTION
## Problem

During `make_project` I got these warnings:
```
Creating directories
Generating encryption keys
Copying files
failed to copy /usr/local/boinc/tools/db_query to /home/boincadm/projects/loda/bin/db_query
failed to copy /usr/local/boinc/tools/watch_tcp to /home/boincadm/projects/loda/bin/watch_tcp
Setting up database
```

When `Project.install_project` reaches `Copying files`, it attempts to copy `db_query` and `watch_tcp`, but the files aren't there causing 2 warnings to be printed.

## Fixes

**Description of the Change**

In PR #3269 the tools/Makefile.am was updated.
However `setup_project.py` continued to depended on `db_query` and `watch_tcp`, triggering these warnings.
My PR makes similar change to `setup_project.py`.

**Alternate Designs**
There may still be old installations of boinc that depends on `db_query` or `watch_tcp`, so my PR may break things.

**Release Notes**
N/A
