### PR TITLE
[web] fix deprecated passing null to parameter of type string.

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -144,7 +144,7 @@ class BoincDb extends DbConn {
 
     static function escape_string($string) {
         $db = self::get();
-        return $db->base_escape_string(trim($string));
+        return $db->base_escape_string(trim((string) $string));
     }
     static function error() {
         $db = self::get();


### PR DESCRIPTION

Fixes #4768 

**Description of the Change**
Casting the parameter $string to type string before passing it to the trim function to prevent passing null to the trim function.  see https://github.com/BOINC/boinc/issues/4768

**Release Notes**
Casting the parameter $string to type string before passing it to the trim function