### PR TITLE
Web: fix some PHP 8 deprecation warnings

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -144,7 +144,7 @@ class BoincDb extends DbConn {
 
     static function escape_string($string) {
         $db = self::get();
-        return $db->base_escape_string(trim((string) $string));
+        return $db->base_escape_string(trim($string));
     }
     static function error() {
         $db = self::get();

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -244,7 +244,7 @@ function show_user_info_private($user) {
         row2(tra("Email address"), $email_text);
     }
     if (USER_URL) {
-        if (strlen($user->url)) {
+        if ($user->url) {
             $u = normalize_user_url($user->url);
             row2(tra("URL"), sprintf('<a href="%s">%s</a>', $u, $u));
         }

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -175,7 +175,14 @@ $got_logged_in_user = false;
 
 function get_logged_in_user($must_be_logged_in=true) {
     global $g_logged_in_user, $got_logged_in_user;
-    if ($got_logged_in_user) return $g_logged_in_user;
+    if ($got_logged_in_user) {
+        // this could have been called earlier with $must_be_logged_in false
+        if ($must_be_logged_in) {
+            if ($g_logged_in_user) return $g_logged_in_user;
+        } else {
+            return $g_logged_in_user;
+        }
+    }
 
     if (web_stopped()) return null;
 

--- a/html/inc/util_basic.inc
+++ b/html/inc/util_basic.inc
@@ -46,7 +46,7 @@ function show_page($x, $y) {
     ";
 }
 
-function xml_error($num, $msg=null, $file=null, $line=null) {
+function xml_error($num=-1, $msg=null, $file=null, $line=null) {
     global $xml_outer_tag;
     if (!$msg) {
         switch($num) {

--- a/html/user/server_status.php
+++ b/html/user/server_status.php
@@ -176,11 +176,16 @@ function show_status_html($x) {
         tra("Users in last 24 hours")
     );
     foreach ($j->apps as $app) {
-        $avg = round($app->info->avg, 2);
-        $min = round($app->info->min, 2);
-        $max = round($app->info->max, 2);
-        $x = $max?"$avg ($min - $max)":"---";
-        $u = $app->info->users;
+        if ($app->info) {
+            $avg = round($app->info->avg, 2);
+            $min = round($app->info->min, 2);
+            $max = round($app->info->max, 2);
+            $x = $max?"$avg ($min - $max)":"---";
+            $u = $app->info->users;
+        } else {
+            $x = '---';
+            $u = '---';
+        }
         echo "<tr>
             <td>$app->user_friendly_name</td>
             <td>$app->unsent</td>

--- a/html/user/validate_email_addr.php
+++ b/html/user/validate_email_addr.php
@@ -33,6 +33,8 @@ function send_validate_email() {
     );
     page_head(tra("Validate email sent"));
     echo tra("An email has been sent to %1. Visit the link it contains to validate your email address.", $user->email_addr);
+    echo "<p>";
+    echo tra("If you don't receive this email, check your spam folder.");
     page_tail();
 }
 


### PR DESCRIPTION
Note: if a function expects, say, a string (and not null)
and you get a warning about a null arg,
don't fix it by casting the param to string.
That masks possible bugs.
Instead, find out where null is being passed, and fix it there.

web: server status: fix case where app has no results

web: fix case where get_logged_in_user() is called twice,
first with must_be_logged_in == false and later true.

web: xml_error(): $num default is -1

web: validate_email_addr(): tell user to check spam folder if no email

Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
