### PR TITLE
Web: various changes to remove PHP 8.1 warnings and errors

### DIFF
--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -432,7 +432,7 @@ function form_checkboxes($label, $items, $attrs='') {
         FORM_LEFT_CLASS, $label, FORM_RIGHT_CLASS
     );
     $x = checkbox_item_strings($items, $attrs);
-    echo implode($x, '<br>');
+    echo implode('<br>', $x);
     echo '</div>
         </div>
     ';

--- a/html/inc/db_ops.inc
+++ b/html/inc/db_ops.inc
@@ -314,7 +314,7 @@ class SqlQueryString {
         } else {
              $order = null;
         }
-        if (strlen($value)) {
+        if ($value) {
             if ($order == 'asc') {
                 $this->query .= " order by $value asc";
                 $this->urlquery .= "&sort_by_order=".urlencode($order);
@@ -371,7 +371,7 @@ class SqlQueryString {
         $this->addeq_not_CHOOSE_ALL('client_state');
         $this->addeq_not_CHOOSE_ALL('validate_state');
         $clauses = get_str("clauses", true);
-        if (strstr($clauses, ";")) error_page("bad clause");
+        if ($clauses && strstr($clauses, ";")) error_page("bad clause");
         if ($clauses) {
             $this->addclause($clauses);
         }

--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -625,7 +625,7 @@ function host_update_credit($hostid) {
 function host_decay_credit($host) {
     $avg = $host->expavg_credit;
     $avg_time = $host->expavg_time;
-    $now = time(0);
+    $now = time();
     update_average($now, 0, 0, $avg, $avg_time);
     $host->update("expavg_credit=$avg, expavg_time=$now");
 }

--- a/html/inc/team.inc
+++ b/html/inc/team.inc
@@ -524,7 +524,7 @@ function team_edit_form($team, $label, $url) {
 function team_decay_credit($team) {
     $avg = $team->expavg_credit;
     $avg_time = $team->expavg_time;
-    $now = time(0);
+    $now = time();
     update_average($now, 0, 0, $avg, $avg_time);
     $team->update("expavg_credit=$avg, expavg_time=$now");
 

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -78,7 +78,7 @@ function get_other_projects($user) {
         //
         $remote = @json_decode(json_encode((array)$xml_object))->project;
         if (!$remote) {
-            $user->projects = null;
+            $user->projects = [];
             return $user;
         }
         if (count($remote) == 1) {
@@ -458,7 +458,7 @@ function show_user_summary_public($user) {
     if (USER_URL) {
         // don't show URL if user has no recent credit (spam suppression)
         //
-        if (strlen($user->url)) {
+        if ($user->url) {
             if (!NO_COMPUTING || $user->expavg_credit > 1) {
                 $u = normalize_user_url($user->url);
                 row2(tra("URL"), sprintf('<a href="%s">%s</a>', $u, $u));

--- a/html/inc/util_basic.inc
+++ b/html/inc/util_basic.inc
@@ -123,6 +123,7 @@ function parse_next_element($xml, $tag, &$cursor) {
         }
         $cursor = (strlen($xml) - strlen($x)) + strlen($tag) + strlen($closetag) + strlen($element);
     }
+    if (!$element) return null;
     return trim($element);
 }
 

--- a/html/ops/db_action.php
+++ b/html/ops/db_action.php
@@ -30,7 +30,7 @@ $last_pos = get_int("last_pos", true);
 $table = get_str("table", true);
 $detail = get_str("detail", true);
 $clauses = get_str("clauses", true);
-if (strstr($clauses, ";")) admin_error_page("bad clause");
+if ($clauses && strstr($clauses, ";")) admin_error_page("bad clause");
 
 $q = new SqlQueryString();
 $q->process_form_items();

--- a/html/ops/mass_email.php
+++ b/html/ops/mass_email.php
@@ -43,7 +43,9 @@ $receiver = 0;
 $receiver = post_int('receiver', true);
 $subject = post_str('subject', true);
 $body = post_str('body', true);
-$body = stripslashes($body);
+if ($body) {
+    $body = stripslashes($body);
+}
 
 admin_page_head("Send mass email");
 

--- a/html/user/cert1.php
+++ b/html/user/cert1.php
@@ -24,7 +24,7 @@ check_get_args(array("border"));
 $user = get_logged_in_user();
 
 $join = gmdate('j F Y', $user->create_time);
-$today = gmdate('j F Y', time(0));
+$today = gmdate('j F Y', time());
 
 $border = get_str("border", true);
 

--- a/html/user/cert_all.php
+++ b/html/user/cert_all.php
@@ -25,7 +25,7 @@ check_get_args(array("border"));
 $user = get_logged_in_user();
 
 $join = gmdate('j F Y', $user->create_time);
-$today = gmdate('j F Y', time(0));
+$today = gmdate('j F Y', time());
 
 $border = get_str("border", true);
 

--- a/html/user/cert_team.php
+++ b/html/user/cert_team.php
@@ -28,7 +28,7 @@ $team = BoincTeam::lookup_id($user->teamid);
 if (!$team) error_page("no team");
 
 $join = gmdate('j F Y', $team->create_time);
-$today = gmdate('j F Y', time(0));
+$today = gmdate('j F Y', time());
 
 credit_to_ops($team->total_credit, $ops, $unit);
 

--- a/html/user/forum_post.php
+++ b/html/user/forum_post.php
@@ -123,7 +123,9 @@ if ($force_title && $title){
     row2(tra("Title"), htmlspecialchars($title)."<input type=\"hidden\" name=\"title\" value=\"".htmlspecialchars($title)."\">");
 } else {
     row2(tra("Title").$submit_help,
-        '<input type="text" class="form-control" name="title" value="'.htmlspecialchars($title).'">'
+        sprintf('<input type="text" class="form-control" name="title" value="%s">',
+            $title?htmlspecialchars($title):''
+        )
     );
 }
 
@@ -131,7 +133,9 @@ row2_init(tra("Message").bbcode_info().post_warning($forum).$body_help, "");
 start_table();
 echo $bbcode_html;
 end_table();
-echo '<textarea class="form-control" name="content" rows="12" cols="80">'.htmlspecialchars($content).'</textarea>';
+echo sprintf('<textarea class="form-control" name="content" rows="12" cols="80">%s</textarea>',
+    $content?htmlspecialchars($content):''
+);
 echo "</td></tr>";
 
 if (!$logged_in_user->prefs->no_signature_by_default) {


### PR DESCRIPTION
- implode() cares about arg order
- strlen(), strstr(), stripslashes() don't take null arg
- time() takes no args

There are probably others.
I don't currently have 8.1 set up, and am working off bug reports.

Fixes #4772, #4773