### PR TITLE
[Linux][Manger][vcpkg] Set webkit2gtk-4.0 ldflags only for wxwidgets vcpkg manager.

### DIFF
--- a/linux/ci_configure_manager.sh
+++ b/linux/ci_configure_manager.sh
@@ -14,4 +14,4 @@ export VCPKG_DIR="$VCPKG_ROOT/installed/x64-linux"
 linux/update_vcpkg_manager.sh
 
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
-./configure --enable-vcpkg --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS=-DwxDEBUG_LEVEL=0
+./configure --enable-vcpkg --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS=-DwxDEBUG_LEVEL=0 GTK_LIBS="`pkg-config --libs gtk+-3.0 webkit2gtk-4.0`"

--- a/m4/boinc_wxwidgets.m4
+++ b/m4/boinc_wxwidgets.m4
@@ -84,7 +84,9 @@ WARNING: No ${uprf} libraries for wxWidgets are installed.
 	         ;;
       esac
       GTK_CFLAGS="`pkg-config --cflags $gtkver`"
-      GTK_LIBS="`pkg-config --libs $gtkver webkit2gtk-4.0`"
+      if test "x$GTK_LIBS" = "x" ; then
+        GTK_LIBS="`pkg-config --libs $gtkver`"
+      fi
    fi
    AC_SUBST([GTK_CFLAGS])
    AC_SUBST([GTK_LIBS])


### PR DESCRIPTION
Set webkit2gtk-4.0 ldflags only for wxwidgets vcpkg manager.