### PR TITLE
[CI] Single job on PRs only

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '5 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}

--- a/.github/workflows/flutter-macos.yml
+++ b/.github/workflows/flutter-macos.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '25 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.type }}-flutter-build

--- a/.github/workflows/flutter-ubuntu.yml
+++ b/.github/workflows/flutter-ubuntu.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '25 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}

--- a/.github/workflows/flutter-windows.yml
+++ b/.github/workflows/flutter-windows.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '25 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '10 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '0 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_KEY }}

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '20 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{matrix.type}}-build

--- a/.github/workflows/source-code-check.yml
+++ b/.github/workflows/source-code-check.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '25 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.type }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '10 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.type }}-build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron:  '15 12 * * 0'
 
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   AWS_ACCESS_KEY_ID: ${{secrets.S3_ACCESS_KEY}}
   AWS_SECRET_ACCESS_KEY: ${{secrets.S3_SECRET_KEY}}


### PR DESCRIPTION
Single job on PRs only.

From here:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value

> If you build the group name with a property that is only defined for specific events, you can use a fallback value. For example, github.head_ref is only defined on pull_request events. If your workflow responds to other events in addition to pull_request events, you will need to provide a fallback to avoid a syntax error. The following concurrency group cancels in-progress jobs or runs on pull_request events only; if github.head_ref is undefined, the concurrency group will fallback to the run ID, which is guaranteed to be both unique and defined for the run.
> ```yaml
> concurrency: 
>   group: ${{ github.head_ref || github.run_id }}
>   cancel-in-progress: true
> ```