### PR TITLE
Vboxwrapper improvements

### DIFF
--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -661,7 +661,7 @@ int VBOX_BASE::get_scratch_directory(string& dir) {
 int VBOX_BASE::get_slot_directory(string& dir) {
     char slot_dir[256];
 
-    if (getcwd(slot_dir, sizeof(slot_dir))) {;}
+    getcwd(slot_dir, sizeof(slot_dir));
     dir = slot_dir;
 
     if (!dir.empty()) {

--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -661,7 +661,7 @@ int VBOX_BASE::get_scratch_directory(string& dir) {
 int VBOX_BASE::get_slot_directory(string& dir) {
     char slot_dir[256];
 
-    getcwd(slot_dir, sizeof(slot_dir));
+    if (getcwd(slot_dir, sizeof(slot_dir))) {;}
     dir = slot_dir;
 
     if (!dir.empty()) {
@@ -1147,7 +1147,7 @@ CLEANUP:
 int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool log_error, bool retry_failures, unsigned int timeout, bool log_trace) {
     int retval = 0;
     int retry_count = 0;
-    double sleep_interval = 2.0;
+    double sleep_interval = 1.0;
     string retry_notes;
 
     // Initialize command line
@@ -1186,13 +1186,25 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
             // Error Code: VBOX_E_INVALID_OBJECT_STATE (0x80bb0007)
             //
             if (VBOX_E_INVALID_OBJECT_STATE == (unsigned int)retval) {
-                if (retry_notes.find("Another VirtualBox management") == string::npos) {
-                    retry_notes += "Another VirtualBox management application has locked the session for\n";
-                    retry_notes += "this VM. BOINC cannot properly monitor this VM\n";
-                    retry_notes += "and so this job will be aborted.\n\n";
-                }
-                if (retry_count) {
-                    sleep_interval *= 2;
+                if ((output.find("Cannot attach medium") != string::npos) &&
+                    (output.find("the media type") != string::npos) &&
+                    (output.find("MultiAttach") != string::npos) &&
+                    (output.find("can only be attached to machines that were created with VirtualBox 4.0 or later") != string::npos)) {
+                        // VirtualBox occasionally writes the 'MultiAttach' attribute to
+                        // the disk entry in VirtualBox.xml although this is not allowed there.
+                        // As a result all VMs trying to connect that disk fail.
+                        // Report the error back immediately without a retry.
+                        //
+                        break;
+                } else {
+                    if (retry_notes.find("Another VirtualBox management") == string::npos) {
+                        retry_notes += "Another VirtualBox management application has locked the session for\n";
+                        retry_notes += "this VM. BOINC cannot properly monitor this VM\n";
+                        retry_notes += "and so this job will be aborted.\n\n";
+                    }
+                    if (retry_count) {
+                        sleep_interval *= 2;
+                    }
                 }
             }
 
@@ -1482,4 +1494,3 @@ VBOX_VM::VBOX_VM() {
 
 VBOX_VM::~VBOX_VM() {
 }
-

--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -1147,7 +1147,7 @@ CLEANUP:
 int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool log_error, bool retry_failures, unsigned int timeout, bool log_trace) {
     int retval = 0;
     int retry_count = 0;
-    double sleep_interval = 1.0;
+    double sleep_interval = 2.0;
     string retry_notes;
 
     // Initialize command line

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -575,6 +575,10 @@ namespace vboxmanage {
                             (output.find("already exists") != string::npos)) {
                                 // May happen if the project admin didn't set a new UUID.
                                 set_new_uuid = "--setuuid \"\" ";
+
+                                vboxlog_msg("Disk UUID conflicts with an already existing disk.\nWill set a new UUID for '%s'.\nThe project admin should be informed to do this server side running:\nvboxmanage clonemedium <inputfile> <outputfile>\n",
+                                    multiattach_vdi_file.c_str()
+                                );
                         } else {
                             // other errors
                             vboxlog_msg("Error in check if parent hdd is registered.\nCommand:\n%s\nOutput:\n%s",

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -555,7 +555,7 @@ namespace vboxmanage {
                 vboxlog_msg("Adding virtual disk drive to VM. (%s)", multiattach_vdi_file.c_str());
                 command = "showhdinfo \"" + medium_file + "\" ";
 
-                retval = vbm_popen(command, output, "check if parent hdd is registered");
+                retval = vbm_popen(command, output, "check if parent hdd is registered", false);
                 if (retval) {
                     // showhdinfo implicitly registers unregistered hdds.
                     // Hence, this has to be handled first.
@@ -569,6 +569,10 @@ namespace vboxmanage {
                             set_new_uuid = "--setuuid \"\" ";
                     } else {
                         // other errors
+                        vboxlog_msg("Error in check if parent hdd is registered.\nCommand:\n%s\nOutput:\n%s",
+                            command.c_str(),
+                            output.c_str()
+                            );
                         return retval;
                     }
                 }
@@ -586,7 +590,7 @@ namespace vboxmanage {
                 //   Encryption:     disabled
                 //   Property:       AllocationBlockSize=1048576
                 //   Child UUIDs:    dcb0daa5-3bf9-47cb-bfff-c65e74484615
-
+                //
                 type_start = output.find("\nType: ") + 1;
                 type_end = output.find("\n", type_start) - type_start;
 
@@ -598,7 +602,7 @@ namespace vboxmanage {
                     command  = command_fix_part;
                     command += set_new_uuid + "--medium \"" + medium_file + "\" ";
 
-                    retval = vbm_popen(command, output, "register parent hdd");
+                    retval = vbm_popen(command, output, "register parent vdi");
                     if (retval) return retval;
 
                     command  = command_fix_part;

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -598,7 +598,13 @@ namespace vboxmanage {
                     // Parent hdd is not (yet) of type multiattach.
                     // Vdi files can't be registered and set to multiattach mode within 1 step.
                     // They must first be attached to a VM in normal mode, then detached from the VM
-                    //
+
+                    // ensure the medium is not registered in the global media store
+                    command = "closemedium \"" + medium_file + "\" ";
+
+                    retval = vbm_popen(command, output, "deregister parent vdi");
+                    if (retval) return retval;
+
                     command  = command_fix_part;
                     command += set_new_uuid + "--medium \"" + medium_file + "\" ";
 

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -646,7 +646,8 @@ namespace vboxmanage {
                             //
                             // After cleanup attaching the disk should be tried again.
 
-                            if ((output.find("Cannot attach medium") != string::npos) &&
+                            if ((retry_count < 1) &&
+                                (output.find("Cannot attach medium") != string::npos) &&
                                 (output.find("the media type") != string::npos) &&
                                 (output.find("MultiAttach") != string::npos) &&
                                 (output.find("can only be attached to machines that were created with VirtualBox 4.0 or later") != string::npos)) {

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -551,6 +551,8 @@ namespace vboxmanage {
 
                 vboxlog_msg("Adding virtual disk drive to VM. (%s)", multiattach_vdi_file.c_str());
 
+                int retry_count = 0;
+                bool log_error = false;
                 bool vbox_bug_mitigation = false;
 
                 do {
@@ -558,8 +560,6 @@ namespace vboxmanage {
                     string type_line = "";
                     size_t type_start;
                     size_t type_end;
-                    int retry_count = 0;
-                    bool log_error = false;
 
                     command = "showhdinfo \"" + medium_file + "\" ";
 
@@ -655,11 +655,15 @@ namespace vboxmanage {
 
                                     retval = vbm_popen(command, output, "deregister parent vdi");
                                     if (retval) return retval;
+
+                                    retry_count++;
+                                    log_error = true;
+                                    boinc_sleep(1.0);
                                     break;
                             }
 
                             if (retry_count >= 1) {
-                                // in case of other errors or if retry try also failed
+                                // in case of other errors or if retry also failed
                                 vboxlog_msg("Error in storage attach (fixed disk - multiattach mode).\nCommand:\n%s\nOutput:\n%s",
                                     command.c_str(),
                                     output.c_str()


### PR DESCRIPTION
**Description of the Change**
Vboxwrapper 26204 calls "vboxmanage -q list hdds" which can lead to a race condition when multiple instances of vboxwrapper (even older versions) are running concurrently.
This PR replaces "list hdds" with "showhdinfo ..." which implicitly asks for a lock.

Since "showhdinfo" requires a bit more error handling this is used to automatically set a new UUID to the vdi if necessary.


**Alternate Designs**
N/A

**Release Notes**
Fix possible race condition in Vboxwrapper 26204
