### PR TITLE
fix resource leakage in stage_file in writing to gzip

### DIFF
--- a/tools/stage_file_native.cpp
+++ b/tools/stage_file_native.cpp
@@ -141,14 +141,14 @@ int stage_file(
             return -1;
         }
         int bytes = gzwrite(gz, file_buf.str().c_str(), file_buf.str().size());
-        if (!bytes) {
-            fprintf(stderr, "failed to write to gz: %s\n", strerror(errno));
-            return -1;
-        }
         retval = gzclose(gz);
         if (retval != Z_OK) {
             fprintf(stderr, "failed to close gz\n");
             return retval;
+        }
+        if (!bytes) {
+            fprintf(stderr, "failed to write to gz: %s\n", strerror(errno));
+            return -1;
         }
         if (verbose) {
             fprintf(stdout, "created .gzip file for %s\n", dl_hier_path);


### PR DESCRIPTION
**Description of the Change**
Coverity tool found the bug in my tool: there was resource leakage to storage (gzFile) if written bytes equaled 0.
https://github.com/BOINC/boinc/pull/4816#issuecomment-1186534073

Fix: close gzFile right after the writes.
<!-- We must be able to understand the design of your change from this description. -->


**Release Notes**
Bugfix in stage_file in writing to gzip
