### PR TITLE
Avoid gcc warnings

### DIFF
--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -115,14 +115,14 @@ int main(int /*argc*/, char** argv) {
         // effective group ID and saved set_group-ID for this process
         grp = getgrnam(boinc_project_group_name);
         if (grp) {
-            (void) setgid(grp->gr_gid);
+            if (setgid(grp->gr_gid)) {;}
         }
 
         // We are running setuid root, so setuid() sets real user ID,
         // effective user ID and saved set_user-ID for this process
         pw = getpwnam(boinc_project_user_name);
         if (pw) {
-            (void) setuid(pw->pw_uid);
+            if (setuid(pw->pw_uid)) {;}
         }
     }
 


### PR DESCRIPTION
If '-Wunused-result' is set compilers usually print a warning when they expect a function to return 'something' but that 'something' is not used in the subsequent code.
The usual method to omit the warning is to precede the function call with '(void)'.

In case of gcc this doesn't work for years:
```
switcher.cpp: In function ‘int main(int, char**)’:
switcher.cpp:118:26: warning: ignoring return value of ‘int setgid(__gid_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  118 |             (void) setgid(grp->gr_gid);
      |                    ~~~~~~^~~~~~~~~~~~~
switcher.cpp:125:26: warning: ignoring return value of ‘int setuid(__uid_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  125 |             (void) setuid(pw->pw_uid);
      |                    ~~~~~~^~~~~~~~~~~~

```
The changes here compile without a warning.
