### PR TITLE
Ensure to compile switcher only for Macintosh

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -20,13 +20,11 @@ endif ## ENABLE_CLIENT_RELEASE
 
 LIBS += $(CLIENTLIBS)
 
+bin_PROGRAMS = boinc_client boinccmd boinc
+
 if OS_DARWIN
    LIBS += -framework IOKit -framework Foundation -framework ScreenSaver -framework Cocoa -framework CoreServices
-endif
-
-bin_PROGRAMS = boinc_client boinccmd boinc
-if !OS_WIN32
-bin_PROGRAMS += switcher
+   bin_PROGRAMS += switcher
 endif
 
 boinccmd_SOURCES = boinc_cmd.cpp

--- a/deploy/prepare_deployment.py
+++ b/deploy/prepare_deployment.py
@@ -21,8 +21,7 @@ import sys
 
 linux_client_list = [
     './client/boinc',
-    './client/boinccmd',
-    './client/switcher'
+    './client/boinccmd'
 ]
 
 linux_apps_list = [


### PR DESCRIPTION
Based on a comment from  @CharlieFenton made here:
#4853
"... switcher is used only on the Macintosh."
