### PR TITLE
Remove redundant test in if-statement

### DIFF
--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -602,7 +602,7 @@ int HTTP_OP::libcurl_exec(
     if (is_post) {
         want_upload = true;
         want_download = false;
-        if (infile && strlen(infile)>0) {
+        if (strlen(infile)>0) {
             fileIn = boinc_fopen(infile, "rb");
             if (!fileIn) {
                 msg_printf(NULL, MSG_INTERNAL_ERROR, "No HTTP input file %s", infile);


### PR DESCRIPTION
While compiling the BOINC client on Linux using gcc I stumbled over another warning:

```
http_curl.cpp: In member function ‘int HTTP_OP::libcurl_exec(const char*, const char*, const char*, double, double, bool)’:
http_curl.cpp:605:13: warning: the address of ‘HTTP_OP::infile’ will never be NULL [-Waddress]
  605 |         if (infile && strlen(infile)>0) {
      |             ^~~~~~
In file included from gui_http.h:53,
                 from cs_notice.h:58,
                 from client_types.h:45,
                 from client_msgs.h:26,
                 from http_curl.cpp:44:
http_curl.h:86:10: note: ‘HTTP_OP::infile’ declared here
   86 |     char infile[256];
      |          ^~~~~~
```

      
Wouldn't it be enough to just test:
`if (strlen(infile)>0) {`
