### PR TITLE
Revise column ID order.

### DIFF
--- a/clientgui/ViewTransfers.cpp
+++ b/clientgui/ViewTransfers.cpp
@@ -47,9 +47,9 @@
 #define COLUMN_PROGRESS             2
 #define COLUMN_SIZE                 3
 #define COLUMN_TIME                 4
-#define COLUMN_SPEED                5
-#define COLUMN_STATUS               6
-#define COLUMN_TOCOMPLETION         7
+#define COLUMN_TOCOMPLETION         5
+#define COLUMN_SPEED                6
+#define COLUMN_STATUS               7
 
 // DefaultShownColumns is an array containing the
 // columnIDs of the columns to be shown by default,


### PR DESCRIPTION
Fixes #

**Description of the Change**
The Master was having a wxWidgets debug error that was caused from #4825 and prevented the manger from running .  After discussing with @AenBleidd privately, we have decided the column ID order for estimated transfer time remaining should be after the Elapsed column.  I did some testing by having different columns selected and/or moved, and there were no issues.

**Alternate Designs**
m_aStdColNameOrder and m_aStdColWidthOrder could have been corrected to match the ID order, but then the estimated time remaining would have appeared at the end of the page, which seems out of place.

**Release Notes**
"N/A"