### PR TITLE
fix non-BOINC CPU usage limit on Win and Linux

### DIFF
--- a/lib/procinfo.h
+++ b/lib/procinfo.h
@@ -83,7 +83,7 @@ extern double process_tree_cpu_time(int pid);
     // get the CPU time of the given process and its descendants
 
 extern double total_cpu_time();
-    // total CPU time, as reported by OS
+    // total user-mode CPU time, as reported by OS
 
 extern double boinc_related_cpu_time(PROC_MAP&, bool using_vbox);
     // total CPU of current BOINC processes, low-priority processes,

--- a/lib/procinfo.h
+++ b/lib/procinfo.h
@@ -82,4 +82,10 @@ extern void procinfo_non_boinc(PROCINFO&, PROC_MAP&);
 extern double process_tree_cpu_time(int pid);
     // get the CPU time of the given process and its descendants
 
+extern double total_cpu_time();
+    // total CPU time, as reported by OS
+
+extern double boinc_related_cpu_time(PROC_MAP&, bool using_vbox);
+    // total CPU of current BOINC processes, low-priority processes,
+    // and (if using vbox) the Vbox daemon
 #endif

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -263,3 +263,24 @@ int procinfo_setup(PROC_MAP& pm) {
     find_children(pm);
     return 0;
 }
+
+// get total user-mode CPU time
+// see https://www.baeldung.com/linux/get-cpu-usage
+//
+double total_cpu_time() {
+    char buf[1024];
+    static FILE *f=NULL;
+    static double scale;
+    if (!f) {
+        f = fopen("/proc/stat", "r");
+        long hz = sysconf(_SC_CLK_TCK);
+        scale = 1./hz;
+    } else {
+        fflush(f);
+        rewind(f);
+    }
+    if (!fgets(buf, 256, f)) return 0;
+    double user, nice;
+    sscanf(buf, "cpu %lf %lf", &user, &nice);
+    return (user+nice)*scale;
+}

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -273,14 +273,25 @@ double total_cpu_time() {
     static double scale;
     if (!f) {
         f = fopen("/proc/stat", "r");
+        if (!f) {
+            fprintf(stderr, "can't open /proc/stat\n");
+            return 0;
+        }
         long hz = sysconf(_SC_CLK_TCK);
         scale = 1./hz;
     } else {
         fflush(f);
         rewind(f);
     }
-    if (!fgets(buf, 256, f)) return 0;
+    if (!fgets(buf, 256, f)) {
+        fprintf(stderr, "can't read /proc/stat\n");
+        return 0;
+    }
     double user, nice;
-    sscanf(buf, "cpu %lf %lf", &user, &nice);
+    int n = sscanf(buf, "cpu %lf %lf", &user, &nice);
+    if (n != 2) {
+        fprintf(stderr, "can't parse /proc/stat: %s\n", buf);
+        return 0;
+    }
     return (user+nice)*scale;
 }

--- a/lib/procinfo_win.cpp
+++ b/lib/procinfo_win.cpp
@@ -159,6 +159,5 @@ double total_cpu_time() {
     ULARGE_INTEGER x;
     x.LowPart = u.dwLowDateTime;
     x.HighPart = u.dwHighDateTime;
-    user  = (double)x.QuadPart/1e7;
-    return user;
+    return (double)x.QuadPart/1e7;
 }

--- a/lib/procinfo_win.cpp
+++ b/lib/procinfo_win.cpp
@@ -149,3 +149,16 @@ int procinfo_setup(PROC_MAP& pm) {
     }
     return 0;
 }
+
+// get total CPU time
+// see https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getsystemtimes
+//
+double total_cpu_time() {
+    FILETIME i, s, u;
+    GetSystemTimes(&i, &s, &u);
+    ULARGE_INTEGER x;
+    x.LowPart = u.dwLowDateTime;
+    x.HighPart = u.dwHighDateTime;
+    user  = (double)x.QuadPart/1e7;
+    return user;
+}


### PR DESCRIPTION
Fixes #4327, #4328

The pref "suspend_cpu_usage" lets you suspend BOINC computing
when the non-BOINC CPU usage (NBCU) exceeds a threshold T.

NBCU excludes BOINC-related processes
- the BOINC client
- the BOINC Manager
- BOINC apps and their process trees
- graphics apps
- VBox daemon
    This can use significant time.
    We count it as BOINC-related only if BOINC is running a Vbox app

NBCU also excludes low-priority processors:
"niced" on Linux, idle class on Win.
We don't want such processes to keep BOINC from computing.

This preference is enforced every 10 seconds.
The client estimates the NBCU over the last 10 sec,
and suspends BOINC processing if the load exceeds T

Currently, NBCU is estimated by scanning the list of all processes,
skipping the types of processes listed above,
and adding up the user and kernel time of others.
This gives a value Tcur.
Let Tprev be the previous value (from 10 seconds ago).
Let X = (Tcur - Tprev)/(ncpus*10).
We suspend processing if X/(ncpus*10) > T

This approach is fundamentally flawed.
It would be fine if processes never exited.
But if a process exits during a given 10-sec period,
its time is included in Tprev but not Tcur,
in which case X is wrong; it may be negative.
This can cause false negatives (not suspending when we should have suspended).

To fix this, we need a different approach.
We shouldn't estimate total CPU by adding up current processes.
Fortunately, most OS's have an API for getting total CPU time.
On Linux this is broken down into a lot of categories,
including "niced" processes.
On Win it's only broken down by user/kernel.

The new approach is basically:
every 10 sec, get the increase Y in total CPU (as reported by the OS).
Then estimate the total CPU time B
used by BOINC-related and low-priority processes in the last 10 sec,
and let X = Y - B.
Suspend processing if X/(ncpus*10) > T

We'll estimate B by scanning the process list and adding up
the totals for BOINC-related processes,
and computing the delta since 10 sec ago.
This is subject to the same error as above:
when these processes exit, B will be underestimated (typically negative),
so X will be overestimated, causing a false positive.
However, this happens infrequently;
BOINC jobs low-priority processes are generally long-running.
And we can avoid false positives by setting X to zero if B is negative.

Because of the possible error in X,
we'll use a conservative approach to resuming from a suspension:
if we're currently suspended because of CPU usage,
unsuspend only if X < T for two consecutive 10-sec periods
