### PR TITLE
Increase msg_buf size

### DIFF
--- a/client/sandbox.cpp
+++ b/client/sandbox.cpp
@@ -185,7 +185,7 @@ static int lookup_group(const char* name, gid_t& gid) {
 #endif
 
 int remove_project_owned_file_or_dir(const char* path) {
-    char cmd[1024];
+    char cmd[5120];
 
     if (g_use_sandbox) {
         snprintf(cmd, sizeof(cmd), "/bin/rm rm -fR \"%s\"", path);

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -420,7 +420,7 @@ int read_gui_rpc_password(char* buf, string& msg) {
 #define HELP_URL "https://boinc.berkeley.edu/gui_rpc.php"
         char path[MAXPATHLEN];
         if (errno == EACCES) {
-            sprintf(msg_buf,
+            snprintf(msg_buf, sizeof(msg_buf),
                 "%s exists but can't be read.  See %s",
                 GUI_RPC_PASSWD_FILE, HELP_URL
             );
@@ -442,16 +442,16 @@ int read_gui_rpc_password(char* buf, string& msg) {
             fclose(g);
             if (p) {
                 p += strlen("data_dir=");
-                sprintf(path, "%s/%s", p, GUI_RPC_PASSWD_FILE);
+                snprintf(path, sizeof(path), "%s/%s", p, GUI_RPC_PASSWD_FILE);
                 f = fopen(path, "r");
                 if (!f) {
                     if (errno == EACCES) {
-                        sprintf(msg_buf,
+                        snprintf(msg_buf, sizeof(msg_buf),
                             "%s exists but can't be read.  See %s",
                             path, HELP_URL
                         );
                     } else {
-                        sprintf(msg_buf, "%s not found.  See %s",
+                        snprintf(msg_buf, sizeof(msg_buf), "%s not found.  See %s",
                             path, HELP_URL
                         );
                     }
@@ -459,7 +459,7 @@ int read_gui_rpc_password(char* buf, string& msg) {
                     return ERR_FOPEN;
                 }
             } else {
-                sprintf(msg_buf,
+                snprintf(msg_buf, sizeof(msg_buf),
                     "No data_dir= found in %s.  See %s",
                     LINUX_CONFIG_FILE, HELP_URL
                 );
@@ -469,18 +469,18 @@ int read_gui_rpc_password(char* buf, string& msg) {
         } else {
             // no config file; look in default data dir
             //
-            sprintf(path, "%s/%s", LINUX_DEFAULT_DATA_DIR, GUI_RPC_PASSWD_FILE);
+            snprintf(path, sizeof(path), "%s/%s", LINUX_DEFAULT_DATA_DIR, GUI_RPC_PASSWD_FILE);
             f = fopen(path, "r");
             if (!f) {
                 if (errno == EACCES) {
-                    sprintf(msg_buf,
+                    snprintf(msg_buf, sizeof(msg_buf),
                         "%s exists but can't be read.  See %s",
                         path, HELP_URL
                     );
                     msg = msg_buf;
                     return ERR_FOPEN;
                 }
-                sprintf(msg_buf, "%s not found.  See %s",
+                snprintf(msg_buf, sizeof(msg_buf), "%s not found.  See %s",
                     GUI_RPC_PASSWD_FILE, HELP_URL
                 );
                 msg = msg_buf;
@@ -491,12 +491,12 @@ int read_gui_rpc_password(char* buf, string& msg) {
         // non-Linux
 
         if (errno == EACCES) {
-            sprintf(msg_buf,
+            snprintf(msg_buf, sizeof(msg_buf),
                 "%s exists but can't be read.  Make sure your account is in the 'boinc_users' group",
                 GUI_RPC_PASSWD_FILE
             );
         } else {
-            sprintf(msg_buf, "%s not found.  Try reinstalling BOINC.",
+            snprintf(msg_buf, sizeof(msg_buf), "%s not found.  Try reinstalling BOINC.",
                 GUI_RPC_PASSWD_FILE
             );
         }

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -413,7 +413,7 @@ int RPC::parse_reply() {
 // If present, it chdirs to that directory.
 
 int read_gui_rpc_password(char* buf, string& msg) {
-    char msg_buf[1024];
+    char msg_buf[5120];
     FILE* f = fopen(GUI_RPC_PASSWD_FILE, "r");
     if (!f) {
 #if defined(__linux__)


### PR DESCRIPTION
gcc prints other warnings during compilation of the client.
They could be avoided by generously increasing the buffer size.

Would it be OK to increase it by factor 5?

```
gui_rpc_client.cpp: In function 'int read_gui_rpc_password(char*, std::string&)':
gui_rpc_client.cpp:477:26: warning: '%s' directive writing up to 4095 bytes into a region of size 1024 [-Wformat-overflow=]
  477 |                         "%s exists but can't be read.  See %s",
      |                          ^~
  478 |                         path, HELP_URL
      |                         ~~~~
gui_rpc_client.cpp:476:28: note: 'sprintf' output between 71 and 4166 bytes into a destination of size 1024
  476 |                     sprintf(msg_buf,
      |                     ~~~~~~~^~~~~~~~~
  477 |                         "%s exists but can't be read.  See %s",
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  478 |                         path, HELP_URL
      |                         ~~~~~~~~~~~~~~
  479 |                     );
      |                     ~       
gui_rpc_client.cpp:454:43: warning: '%s' directive writing up to 4095 bytes into a region of size 1024 [-Wformat-overflow=]
  454 |                         sprintf(msg_buf, "%s not found.  See %s",
      |                                           ^~
  455 |                             path, HELP_URL
      |                             ~~~~           
gui_rpc_client.cpp:454:32: note: 'sprintf' output between 56 and 4151 bytes into a destination of size 1024
  454 |                         sprintf(msg_buf, "%s not found.  See %s",
      |                         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  455 |                             path, HELP_URL
      |                             ~~~~~~~~~~~~~~
  456 |                         );
      |                         ~       
gui_rpc_client.cpp:450:30: warning: '%s' directive writing up to 4095 bytes into a region of size 1024 [-Wformat-overflow=]
  450 |                             "%s exists but can't be read.  See %s",
      |                              ^~
  451 |                             path, HELP_URL
      |                             ~~~~
gui_rpc_client.cpp:449:32: note: 'sprintf' output between 71 and 4166 bytes into a destination of size 1024
  449 |                         sprintf(msg_buf,
      |                         ~~~~~~~^~~~~~~~~
  450 |                             "%s exists but can't be read.  See %s",
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  451 |                             path, HELP_URL
      |                             ~~~~~~~~~~~~~~
  452 |                         );
      |                         ~       
```      