### PR TITLE
[client] Replace sprintf with snprintf

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -306,7 +306,7 @@ static int setup_shared_mem() {
     app_client_shm = new APP_CLIENT_SHM;
 
 #ifdef _WIN32
-    sprintf(buf, "%s%s", SHM_PREFIX, aid.shmem_seg_name);
+    snprintf(buf, sizeof(buf), "%s%s", SHM_PREFIX, aid.shmem_seg_name);
     hSharedMem = attach_shmem(buf, (void**)&app_client_shm->shm);
     if (hSharedMem == NULL) {
         delete app_client_shm;
@@ -412,7 +412,7 @@ static bool update_app_progress(double cpu_t, double cp_cpu_t) {
 
     if (standalone) return true;
 
-    sprintf(msg_buf,
+    snprintf(msg_buf, sizeof(msg_buf),
         "<current_cpu_time>%e</current_cpu_time>\n"
         "<checkpoint_cpu_time>%e</checkpoint_cpu_time>\n",
         cpu_t, cp_cpu_t
@@ -423,15 +423,15 @@ static bool update_app_progress(double cpu_t, double cp_cpu_t) {
     if (fraction_done >= 0) {
         double range = aid.fraction_done_end - aid.fraction_done_start;
         double fdone = aid.fraction_done_start + fraction_done*range;
-        sprintf(buf, "<fraction_done>%e</fraction_done>\n", fdone);
+        snprintf(buf, sizeof(buf), "<fraction_done>%e</fraction_done>\n", fdone);
         strlcat(msg_buf, buf, sizeof(msg_buf));
     }
     if (bytes_sent) {
-        sprintf(buf, "<bytes_sent>%f</bytes_sent>\n", bytes_sent);
+        snprintf(buf, sizeof(buf), "<bytes_sent>%f</bytes_sent>\n", bytes_sent);
         strlcat(msg_buf, buf, sizeof(msg_buf));
     }
     if (bytes_received) {
-        sprintf(buf, "<bytes_received>%f</bytes_received>\n", bytes_received);
+        snprintf(buf, sizeof(buf), "<bytes_received>%f</bytes_received>\n", bytes_received);
         strlcat(msg_buf, buf, sizeof(msg_buf));
     }
 #ifdef MSGS_FROM_FILE
@@ -962,7 +962,7 @@ int boinc_report_app_status_aux(
     char msg_buf[MSG_CHANNEL_SIZE], buf[1024];
     if (standalone) return 0;
 
-    sprintf(msg_buf,
+    snprintf(msg_buf, sizeof(msg_buf),
         "<current_cpu_time>%e</current_cpu_time>\n"
         "<checkpoint_cpu_time>%e</checkpoint_cpu_time>\n"
         "<fraction_done>%e</fraction_done>\n",
@@ -971,15 +971,15 @@ int boinc_report_app_status_aux(
         _fraction_done
     );
     if (other_pid) {
-        sprintf(buf, "<other_pid>%d</other_pid>\n", other_pid);
+        snprintf(buf, sizeof(buf), "<other_pid>%d</other_pid>\n", other_pid);
         safe_strcat(msg_buf, buf);
     }
     if (_bytes_sent) {
-        sprintf(buf, "<bytes_sent>%f</bytes_sent>\n", _bytes_sent);
+        snprintf(buf, sizeof(buf), "<bytes_sent>%f</bytes_sent>\n", _bytes_sent);
         safe_strcat(msg_buf, buf);
     }
     if (_bytes_received) {
-        sprintf(buf, "<bytes_received>%f</bytes_received>\n", _bytes_received);
+        snprintf(buf, sizeof(buf), "<bytes_received>%f</bytes_received>\n", _bytes_received);
         safe_strcat(msg_buf, buf);
     }
 #ifdef MSGS_FROM_FILE
@@ -1338,7 +1338,7 @@ static void timer_handler() {
     // send graphics-related messages
     //
     if (send_web_graphics_url && !app_client_shm->shm->graphics_reply.has_msg()) {
-        sprintf(buf,
+        snprintf(buf, sizeof(buf),
             "<web_graphics_url>%s</web_graphics_url>",
             web_graphics_url
         );
@@ -1346,7 +1346,7 @@ static void timer_handler() {
         send_web_graphics_url = false;
     }
     if (send_remote_desktop_addr && !app_client_shm->shm->graphics_reply.has_msg()) {
-        sprintf(buf,
+        snprintf(buf, sizeof(buf),
             "<remote_desktop_addr>%s</remote_desktop_addr>",
             remote_desktop_addr
         );
@@ -1625,7 +1625,7 @@ int boinc_upload_file(std::string& name) {
 
     retval = boinc_resolve_filename_s(name.c_str(), pname);
     if (retval) return retval;
-    sprintf(buf, "%s%s", UPLOAD_FILE_REQ_PREFIX, name.c_str());
+    snprintf(buf, sizeof(buf), "%s%s", UPLOAD_FILE_REQ_PREFIX, name.c_str());
     FILE* f = boinc_fopen(buf, "w");
     if (!f) return ERR_FOPEN;
     have_new_upload_file = true;

--- a/api/graphics_lib.cpp
+++ b/api/graphics_lib.cpp
@@ -98,7 +98,7 @@ int boinc_init_options_graphics_lib(
     // if it's not a symlink, put "./" in front of it
     //
     if (!strcmp(graphics_lib, resolved_name)) {
-        sprintf(resolved_name, "./%s", graphics_lib);
+        snprintf(resolved_name, sizeof(resolved_name), "./%s", graphics_lib);
     }
   
     // get handle for shared library.

--- a/api/mac_icon.cpp
+++ b/api/mac_icon.cpp
@@ -172,7 +172,7 @@ void getPathToThisApp(char* pathBuf, size_t bufSize) {
     // (or the soft-link to it.)  So all we need for the path to this
     // application is the file name.  We use the -c option so ps strips off
     // any command-line arguments for us.
-    sprintf(buf, "ps -wcp %d -o command=", myPID);
+    snprintf(buf, sizeof(buf), "ps -wcp %d -o command=", myPID);
     f = popen(buf,  "r");
     if (!f)
         return;

--- a/api/ttfont.cpp
+++ b/api/ttfont.cpp
@@ -98,7 +98,7 @@ void ttf_load_fonts(
     char vpath[MAXPATHLEN];
     g_iFont = -1;
     for (unsigned int i=0 ; i < NUM_FONT; i++){
-        sprintf(vpath, "%s/%s", dir, g_cstrFont[i]);
+        snprintf(vpath, sizeof(vpath), "%s/%s", dir, g_cstrFont[i]);
         if (boinc_file_exists(vpath)) {
             //g_font[i] = new FTBitmapFont(vpath);
             //g_font[i] = new FTPixmapFont(vpath);

--- a/client/acct_setup.cpp
+++ b/client/acct_setup.cpp
@@ -213,7 +213,7 @@ int GET_PROJECT_LIST_OP::do_rpc() {
     int retval;
     char buf[256];
 
-    sprintf(buf, "https://boinc.berkeley.edu/project_list.php");
+    snprintf(buf, sizeof(buf), "https://boinc.berkeley.edu/project_list.php");
     retval = gui_http->do_rpc(
         this, buf, ALL_PROJECTS_LIST_FILENAME_TEMP, true
     );

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -630,7 +630,7 @@ bool ACTIVE_TASK::finish_file_present(int &exit_code) {
 
     exit_code = 0;
 
-    sprintf(path, "%s/%s", slot_dir, BOINC_FINISH_CALLED_FILE);
+    snprintf(path, sizeof(path), "%s/%s", slot_dir, BOINC_FINISH_CALLED_FILE);
     FILE* f = boinc_fopen(path, "r");
     if (!f) return false;
     char* p = fgets(buf, sizeof(buf), f);
@@ -657,7 +657,7 @@ bool ACTIVE_TASK::temporary_exit_file_present(
     double& x, char* buf, bool& is_notice
 ) {
     char path[MAXPATHLEN], buf2[256];
-    sprintf(path, "%s/%s", slot_dir, TEMPORARY_EXIT_FILE);
+    snprintf(path, sizeof(path), "%s/%s", slot_dir, TEMPORARY_EXIT_FILE);
     FILE* f = boinc_fopen(path, "r");
     if (!f) return false;
     strcpy(buf, "");
@@ -888,7 +888,7 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
         atp = active_tasks[i];
         if (atp->task_state() != PROCESS_EXECUTING) continue;
         if (!atp->result->non_cpu_intensive() && (atp->elapsed_time > atp->max_elapsed_time)) {
-            sprintf(buf, "exceeded elapsed time limit %.2f (%.2fG/%.2fG)",
+            snprintf(buf, sizeof(buf), "exceeded elapsed time limit %.2f (%.2fG/%.2fG)",
                 atp->max_elapsed_time,
                 atp->result->wup->rsc_fpops_bound/1e9,
                 atp->result->avp->flops/1e9
@@ -908,7 +908,7 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
         // accurate bounds.
         //
         if (atp->procinfo.working_set_size_smoothed > atp->max_mem_usage) {
-            sprintf(buf, "working set size > workunit.rsc_memory_bound: %.2fMB > %.2fMB",
+            snprintf(buf, sizeof(buf), "working set size > workunit.rsc_memory_bound: %.2fMB > %.2fMB",
                 atp->procinfo.working_set_size_smoothed/MEGA, atp->max_mem_usage/MEGA
             );
             msg_printf(atp->result->project, MSG_INFO,
@@ -921,7 +921,7 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
         }
 #endif
         if (atp->procinfo.working_set_size_smoothed > max_ram) {
-            sprintf(buf, "working set size > client RAM limit: %.2fMB > %.2fMB",
+            snprintf(buf, sizeof(buf), "working set size > client RAM limit: %.2fMB > %.2fMB",
                 atp->procinfo.working_set_size_smoothed/MEGA, max_ram/MEGA
             );
             msg_printf(atp->result->project, MSG_INFO,
@@ -987,7 +987,7 @@ int ACTIVE_TASK::read_stderr_file() {
     // it's unlikely that more than that will be useful
     //
     int max_len = 63*1024;
-    sprintf(path, "%s/%s", slot_dir, STDERR_FILE);
+    snprintf(path, sizeof(path), "%s/%s", slot_dir, STDERR_FILE);
     if (!boinc_file_exists(path)) return 0;
     int retval  = read_file_malloc(
         path, buf1, max_len, !cc_config.stderr_head
@@ -1560,7 +1560,7 @@ void ACTIVE_TASK_SET::get_msgs() {
         if (atp->get_app_status_msg()) {
             if (old_time != atp->checkpoint_cpu_time) {
                 char buf[512];
-                sprintf(buf, "%s checkpointed", atp->result->name);
+                snprintf(buf, sizeof(buf), "%s checkpointed", atp->result->name);
                 if (atp->overdue_checkpoint) {
                     gstate.request_schedule_cpus(buf);
                 }
@@ -1589,7 +1589,7 @@ void ACTIVE_TASK_SET::get_msgs() {
 //
 void ACTIVE_TASK::write_task_state_file() {
     char path[MAXPATHLEN];
-    sprintf(path, "%s/%s", slot_dir, TASK_STATE_FILENAME);
+    snprintf(path, sizeof(path), "%s/%s", slot_dir, TASK_STATE_FILENAME);
     FILE* f = boinc_fopen(path, "w");
     if (!f) return;
     fprintf(f,
@@ -1620,7 +1620,7 @@ void ACTIVE_TASK::write_task_state_file() {
 //
 void ACTIVE_TASK::read_task_state_file() {
     char buf[4096], path[MAXPATHLEN], s[1024];
-    sprintf(path, "%s/%s", slot_dir, TASK_STATE_FILENAME);
+    snprintf(path, sizeof(path), "%s/%s", slot_dir, TASK_STATE_FILENAME);
     FILE* f = boinc_fopen(path, "r");
     if (!f) return;
     buf[0] = 0;

--- a/client/app_graphics.cpp
+++ b/client/app_graphics.cpp
@@ -60,15 +60,15 @@ void ACTIVE_TASK::request_graphics_mode(GRAPHICS_MSG& m) {
 
     safe_strcpy(buf, xml_graphics_modes[m.mode]);
     if (strlen(m.window_station)) {
-        sprintf(buf2, "<window_station>%s</window_station>", m.window_station);
+        snprintf(buf2, sizeof(buf2), "<window_station>%s</window_station>", m.window_station);
         strcat(buf, buf2);
     }
     if (strlen(m.desktop)) {
-        sprintf(buf2, "<desktop>%s</desktop>", m.desktop);
+        snprintf(buf2, sizeof(buf2), "<desktop>%s</desktop>", m.desktop);
         strcat(buf, buf2);
     }
     if (strlen(m.display)) {
-        sprintf(buf2, "<display>%s</display>", m.display);
+        snprintf(buf2, sizeof(buf2), "<display>%s</display>", m.display);
         strcat(buf, buf2);
     }
 

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -122,7 +122,7 @@ static void coproc_cmdline(
             );
             k = 0;
         }
-        sprintf(buf, " --device %d", coproc->device_nums[k]);
+        snprintf(buf, sizeof(buf), " --device %d", coproc->device_nums[k]);
         strlcat(cmdline, buf, cmdline_len);
     }
 }
@@ -137,7 +137,7 @@ int ACTIVE_TASK::get_shmem_seg_name() {
 
     bool try_global = (sandbox_account_service_token != NULL);
     for (i=0; i<1024; i++) {
-        sprintf(seg_name, "%sboinc_%d", SHM_PREFIX, i);
+        snprintf(seg_name, sizeof(seg_name), "%sboinc_%d", SHM_PREFIX, i);
         shm_handle = create_shmem(
             seg_name, sizeof(SHARED_MEM), (void**)&app_client_shm.shm,
             try_global
@@ -145,7 +145,7 @@ int ACTIVE_TASK::get_shmem_seg_name() {
         if (shm_handle) break;
     }
     if (!shm_handle) return ERR_SHMGET;
-    sprintf(shmem_seg_name, "boinc_%d", i);
+    snprintf(shmem_seg_name, sizeof(shmem_seg_name), "boinc_%d", i);
 #else
     char init_data_path[MAXPATHLEN];
 #ifndef __EMX__
@@ -155,7 +155,7 @@ int ACTIVE_TASK::get_shmem_seg_name() {
         return 0;
     }
 #endif
-    sprintf(init_data_path, "%s/%s", slot_dir, INIT_DATA_FILE);
+    snprintf(init_data_path, sizeof(init_data_path), "%s/%s", slot_dir, INIT_DATA_FILE);
 
     // ftok() only works if there's a file at the given location
     //
@@ -293,7 +293,7 @@ int ACTIVE_TASK::write_app_init_file(APP_INIT_DATA& aid) {
     );
 #endif
 
-    sprintf(init_data_path, "%s/%s", slot_dir, INIT_DATA_FILE);
+    snprintf(init_data_path, sizeof(init_data_path), "%s/%s", slot_dir, INIT_DATA_FILE);
 
     // delete the file using the switcher (Unix)
     // in case it's owned by another user and we don't have write access
@@ -869,7 +869,7 @@ int ACTIVE_TASK::start(bool test) {
     //
     retval = chdir(slot_dir);
     if (retval) {
-        sprintf(buf, "Can't change directory to %s: %s", slot_dir, boincerror(retval));
+        snprintf(buf, sizeof(buf), "Can't change directory to %s: %s", slot_dir, boincerror(retval));
         goto error;
     }
 

--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -261,7 +261,7 @@ int use_sandbox, int isManager, char* path_to_error, int len
         if (use_sandbox) {
             for (int i=0; i<NUMBRANDS; i++) {
                 // Does gfx_switcher exist in screensaver bundle?
-                sprintf(full_path, "/Library/Screen Savers/%s.saver/Contents/Resources/gfx_switcher", saverName[i]);
+                snprintf(full_path, sizeof(full_path), "/Library/Screen Savers/%s.saver/Contents/Resources/gfx_switcher", saverName[i]);
                 retval = stat(full_path, &sbuf);
                 if (! retval) {
 #ifdef _DEBUG
@@ -631,7 +631,7 @@ static void GetPathToThisProcess(char* outbuf, size_t maxLen) {
 
     *outbuf = '\0';
     
-    sprintf(buf, "ps -xwo command -p %d", (int)aPID);
+    snprintf(buf, sizeof(buf), "ps -xwo command -p %d", (int)aPID);
     f = popen(buf, "r");
     if (f == NULL)
         return;

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1910,7 +1910,7 @@ int CLIENT_STATE::report_result_error(RESULT& res, const char* err_msg) {
     res.set_ready_to_report();
     res.completed_time = now;
 
-    sprintf(buf, "Unrecoverable error for task %s", res.name);
+    snprintf(buf, sizeof(buf), "Unrecoverable error for task %s", res.name);
 #ifndef SIM
     scheduler_op->project_rpc_backoff(res.project, buf);
 #endif
@@ -1952,7 +1952,7 @@ int CLIENT_STATE::report_result_error(RESULT& res, const char* err_msg) {
         //
         for (i=0; i<res.output_files.size(); i++) {
             if (res.output_files[i].file_info->had_failure(failnum)) {
-                sprintf(buf,
+                snprintf(buf, sizeof(buf),
                     "<upload_error>\n"
                     "    <file_name>%s</file_name>\n"
                     "    <error_code>%d</error_code>\n"
@@ -2297,7 +2297,7 @@ void CLIENT_STATE::log_show_projects() {
     for (unsigned int i=0; i<projects.size(); i++) {
         PROJECT* p = projects[i];
         if (p->hostid) {
-            sprintf(buf, "%d", p->hostid);
+            snprintf(buf, sizeof(buf), "%d", p->hostid);
         } else {
             safe_strcpy(buf, "not assigned yet");
         }

--- a/client/file_names.cpp
+++ b/client/file_names.cpp
@@ -323,7 +323,7 @@ bool is_image_file(const char* filename) {
 }
 
 void boinc_version_dir(PROJECT& p, VERSION_INFO& vi, char* buf) {
-    sprintf(buf, "%s/boinc_version_%d_%d_%d",
+    snprintf(buf, sizeof(&buf), "%s/boinc_version_%d_%d_%d",
         p.project_dir(), vi.major, vi.minor, vi.release
     );
 }

--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -304,7 +304,7 @@ void* cudalib = NULL;
     cudalib = dlopen("libcuda.so", RTLD_NOW);
 #endif
     if (!cudalib) {
-        sprintf(buf, "NVIDIA: %s", dlerror());
+        snprintf(buf, sizeof(buf), "NVIDIA: %s", dlerror());
         warnings.push_back(buf);
         return;
     }
@@ -378,14 +378,14 @@ void* cudalib = NULL;
 #endif
     
     if (retval) {
-        sprintf(buf, "NVIDIA drivers present but no GPUs found");
+        snprintf(buf, sizeof(buf), "NVIDIA drivers present but no GPUs found");
         warnings.push_back(buf);
         goto leave;
     }
 
     retval = (*p_cuDriverGetVersion)(&cuda_version);
     if (retval) {
-        sprintf(buf, "cuDriverGetVersion() returned %d", retval);
+        snprintf(buf, sizeof(buf), "cuDriverGetVersion() returned %d", retval);
         warnings.push_back(buf);
         goto leave;
     }
@@ -394,11 +394,11 @@ void* cudalib = NULL;
 
     retval = (*p_cuDeviceGetCount)(&cuda_ndevs);
     if (retval) {
-        sprintf(buf, "cuDeviceGetCount() returned %d", retval);
+        snprintf(buf, sizeof(buf), "cuDeviceGetCount() returned %d", retval);
         warnings.push_back(buf);
         goto leave;
     }
-    sprintf(buf, "NVIDIA library reports %d GPU%s", cuda_ndevs, (cuda_ndevs==1)?"":"s");
+    snprintf(buf, sizeof(buf), "NVIDIA library reports %d GPU%s", cuda_ndevs, (cuda_ndevs==1)?"":"s");
     warnings.push_back(buf);
 
     for (j=0; j<cuda_ndevs; j++) {
@@ -406,13 +406,13 @@ void* cudalib = NULL;
         CUdevice device;
         retval = (*p_cuDeviceGet)(&device, j);
         if (retval) {
-            sprintf(buf, "cuDeviceGet(%d) returned %d", j, retval);
+            snprintf(buf, sizeof(buf), "cuDeviceGet(%d) returned %d", j, retval);
             warnings.push_back(buf);
             goto leave;
         }
         retval = (*p_cuDeviceGetName)(cc.prop.name, 256, device);
         if (retval) {
-            sprintf(buf, "cuDeviceGetName(%d) returned %d", j, retval);
+            snprintf(buf, sizeof(buf), "cuDeviceGetName(%d) returned %d", j, retval);
             warnings.push_back(buf);
             goto leave;
         }

--- a/client/gpu_opencl.cpp
+++ b/client/gpu_opencl.cpp
@@ -226,7 +226,7 @@ void COPROCS::get_opencl(
     }
 #endif
     if (!opencl_lib) {
-        sprintf(buf, "OpenCL: %s", dlerror());
+        snprintf(buf, sizeof(buf), "OpenCL: %s", dlerror());
         warnings.push_back(buf);
         return;
     }
@@ -622,7 +622,7 @@ void COPROCS::get_opencl(
                 }
                 if (prop.peak_flops <= 0 || prop.peak_flops > GPU_MAX_PEAK_FLOPS) {
                     char buf2[256];
-                    sprintf(buf2,
+                    snprintf(buf2, sizeof(buf2),
                         "OpenCL generic: bad peak FLOPS; Max units %u, max freq %u MHz",
                         prop.max_compute_units, prop.max_clock_frequency
                     );

--- a/client/gui_rpc_server.cpp
+++ b/client/gui_rpc_server.cpp
@@ -397,7 +397,7 @@ static void show_connect_error(sockaddr_storage& s) {
         sockaddr_in6* sin = (sockaddr_in6*)&s;
         inet_ntop(AF_INET6, (void*)(&sin->sin6_addr), buf, 256);
     } else {
-        sprintf(buf, "Unknown address family %d", s.ss_family);
+        snprintf(buf, sizeof(buf), "Unknown address family %d", s.ss_family);
     }
 #endif
     msg_printf(NULL, MSG_INFO,

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -82,7 +82,7 @@ static void auth_failure(MIOFILE& fout) {
 }
 
 void GUI_RPC_CONN::handle_auth1(MIOFILE& fout) {
-    sprintf(nonce, "%f", dtime());
+    snprintf(nonce, sizeof(nonce), "%f", dtime());
     fout.printf("<nonce>%s</nonce>\n", nonce);
 }
 
@@ -1202,7 +1202,7 @@ static void handle_get_app_config(GUI_RPC_CONN& grc) {
         grc.mfout.printf("<error>no such project</error>");
         return;
     }
-    sprintf(path, "%s/%s", p->project_dir(), APP_CONFIG_FILE_NAME);
+    snprintf(path, sizeof(path), "%s/%s", p->project_dir(), APP_CONFIG_FILE_NAME);
     int retval = read_file_string(path, s);
     if (retval) {
         grc.mfout.printf("<error>app_config.xml not found</error>\n");
@@ -1263,7 +1263,7 @@ static void handle_set_app_config(GUI_RPC_CONN& grc) {
         return;
     }
     char path[MAXPATHLEN];
-    sprintf(path, "%s/app_config.xml", p->project_dir());
+    snprintf(path, sizeof(path), "%s/app_config.xml", p->project_dir());
     FILE* f = boinc_fopen(path, "w");
     if (!f) {
         msg_printf(p, MSG_INTERNAL_ERROR,
@@ -1545,7 +1545,7 @@ static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
             argc = 5;
         } else {
             char theSlot[10];
-            sprintf(theSlot, "%d", slot);
+            snprintf(theSlot, sizeof(theSlot), "%d", slot);
             argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
             argv[1] = execDir;
             argv[2] = saverName[iBrandID];

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -703,15 +703,15 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
     if (family>=0 || model>=0 || stepping>0) {
         safe_strcat(model_buf, " [");
         if (family>=0) {
-            sprintf(buf, "Family %d ", family);
+            snprintf(buf, sizeof(buf), "Family %d ", family);
             safe_strcat(model_buf, buf);
         }
         if (model>=0) {
-            sprintf(buf, "Model %d ", model);
+            snprintf(buf, sizeof(buf), "Model %d ", model);
             safe_strcat(model_buf, buf);
         }
         if (stepping>=0) {
-            sprintf(buf, "Stepping %d", stepping);
+            snprintf(buf, sizeof(buf), "Stepping %d", stepping);
             safe_strcat(model_buf, buf);
         }
         safe_strcat(model_buf, "]");
@@ -720,23 +720,23 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
     if (model_info_found) {
         safe_strcat(model_buf, " [");
         if (strlen(implementer)>0) {
-            sprintf(buf, "Impl %s ", implementer);
+            snprintf(buf, sizeof(buf), "Impl %s ", implementer);
             safe_strcat(model_buf, buf);
         }
         if (strlen(architecture)>0) {
-            sprintf(buf, "Arch %s ", architecture);
+            snprintf(buf, sizeof(buf), "Arch %s ", architecture);
             safe_strcat(model_buf, buf);
         }
         if (strlen(variant)>0) {
-            sprintf(buf, "Variant %s ", variant);
+            snprintf(buf, sizeof(buf), "Variant %s ", variant);
             safe_strcat(model_buf, buf);
         }
         if (strlen(cpu_part)>0) {
-            sprintf(buf, "Part %s ", cpu_part);
+            snprintf(buf, sizeof(buf), "Part %s ", cpu_part);
             safe_strcat(model_buf, buf);
         }
         if (strlen(revision)>0) {
-            sprintf(buf, "Rev %s", revision);
+            snprintf(buf, sizeof(buf), "Rev %s", revision);
             safe_strcat(model_buf, buf);
         }
         safe_strcat(model_buf, "]");
@@ -1747,7 +1747,7 @@ vector<string> get_tty_list() {
                 if (tty_patterns[i].should_ignore(devname)) continue;
             }
 
-            sprintf(fullname, "%s/%s", tty_patterns[i].dir, devname);
+            snprintf(fullname, sizeof(fullname), "%s/%s", tty_patterns[i].dir, devname);
 
             // check for ignored paths
             //

--- a/client/hostinfo_unix_test.cpp
+++ b/client/hostinfo_unix_test.cpp
@@ -580,15 +580,15 @@ int main(void) {
     if (family>=0 || model>=0 || stepping>0) {
         safe_strcat(model_buf, " [");
         if (family>=0) {
-            sprintf(buf, "Family %d ", family);
+            snprintf(buf, sizeof(buf), "Family %d ", family);
             safe_strcat(model_buf, buf);
         }
         if (model>=0) {
-            sprintf(buf, "Model %d ", model);
+            snprintf(buf, sizeof(buf), "Model %d ", model);
             safe_strcat(model_buf, buf);
         }
         if (stepping>=0) {
-            sprintf(buf, "Stepping %d", stepping);
+            snprintf(buf, sizeof(buf), "Stepping %d", stepping);
             safe_strcat(model_buf, buf);
         }
         safe_strcat(model_buf, "]");
@@ -597,23 +597,23 @@ int main(void) {
     if (model_info_found) {
         safe_strcat(model_buf, " [");
         if (strlen(implementer)>0) {
-            sprintf(buf, "Impl %s ", implementer);
+            snprintf(buf, sizeof(buf), "Impl %s ", implementer);
             safe_strcat(model_buf, buf);
         }
         if (strlen(architecture)>0) {
-            sprintf(buf, "Arch %s ", architecture);
+            snprintf(buf, sizeof(buf), "Arch %s ", architecture);
             safe_strcat(model_buf, buf);
         }
         if (strlen(variant)>0) {
-            sprintf(buf, "Variant %s ", variant);
+            snprintf(buf, sizeof(buf), "Variant %s ", variant);
             safe_strcat(model_buf, buf);
         }
         if (strlen(cpu_part)>0) {
-            sprintf(buf, "Part %s ", cpu_part);
+            snprintf(buf, sizeof(buf), "Part %s ", cpu_part);
             safe_strcat(model_buf, buf);
         }
         if (strlen(revision)>0) {
-            sprintf(buf, "Rev %s", revision);
+            snprintf(buf, sizeof(buf), "Rev %s", revision);
             safe_strcat(model_buf, buf);
         }
         safe_strcat(model_buf, "]");

--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -186,7 +186,7 @@ void libcurl_logdebug(
     char hdr[256];
     char buf[2048], *p = buf;
 
-    sprintf(hdr, "[ID#%u] %s", phop->trace_id, desc);
+    snprintf(hdr, sizeof(hdr), "[ID#%u] %s", phop->trace_id, desc);
 
     strlcpy(buf, data, sizeof(buf));
 

--- a/client/mac_address.cpp
+++ b/client/mac_address.cpp
@@ -135,7 +135,7 @@ GetMACAddress(io_iterator_t intfIterator, char* buffer)
                 UInt8 MACAddress[ kIOEthernetAddressSize ];
 
                 CFDataGetBytes(refData, CFRangeMake(0,CFDataGetLength(refData)), MACAddress);
-                sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x",
+                snprintf(buffer, sizeof(buffer), "%02x:%02x:%02x:%02x:%02x:%02x",
                         MACAddress[0], MACAddress[1], MACAddress[2], MACAddress[3], MACAddress[4], MACAddress[5]);
                 CFRelease(MACAddressAsCFData);
             }
@@ -163,7 +163,7 @@ int get_mac_address(char* address) {
     strcpy(address, "");
     PIP_ADAPTER_INFO pAdapterInfo = AdapterInfo; // Contains pointer to current adapter info
     while (pAdapterInfo) {
-        sprintf(address, "%02x:%02x:%02x:%02x:%02x:%02x",
+        snprintf(address, sizeof(address), "%02x:%02x:%02x:%02x:%02x:%02x",
             pAdapterInfo->Address[0], pAdapterInfo->Address[1], pAdapterInfo->Address[2], 
             pAdapterInfo->Address[3], pAdapterInfo->Address[4], pAdapterInfo->Address[5]
         );

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -455,7 +455,7 @@ int RESULT::write_gui(MIOFILE& out) {
                     safe_strcpy(buf, n>1?" (devices ":" (device ");
                     for (int i=0; i<n; i++) {
                         char buf2[256];
-                        sprintf(buf2, "%d", cp.device_nums[coproc_indices[i]]);
+                        snprintf(buf2, sizeof(buf2), "%d", cp.device_nums[coproc_indices[i]]);
                         if (i > 0) {
                             safe_strcat(buf, ", ");
                         }

--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -258,12 +258,12 @@ void CLIENT_STATE::handle_completed_results(PROJECT* p) {
         RESULT* rp = *result_iter;
         if (rp->project == p && rp->ready_to_report) {
             if (gstate.now > rp->report_deadline) {
-                sprintf(buf, "result %s reported; "
+                snprintf(buf, sizeof(buf), "result %s reported; "
                     "<font color=#cc0000>MISSED DEADLINE by %f</font><br>\n",
                     rp->name, gstate.now - rp->report_deadline
                 );
             } else {
-                sprintf(buf, "result %s reported; "
+                snprintf(buf, sizeof(buf), "result %s reported; "
                     "<font color=#00cc00>MADE DEADLINE</font><br>\n",
                     rp->name
                 );
@@ -354,7 +354,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
     }
     p->last_rpc_time = now;
     if (!avail) {
-        sprintf(buf, "RPC to %s skipped - project down<br>", p->project_name);
+        snprintf(buf, sizeof(buf), "RPC to %s skipped - project down<br>", p->project_name);
         html_msg += buf;
         msg_printf(p, MSG_INFO, "RPC skipped: project down");
         gstate.scheduler_op->project_rpc_backoff(p, "project down");
@@ -389,7 +389,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
     }
 
     work_fetch.request_string(buf2, sizeof(buf2));
-    sprintf(buf, "RPC to %s: %s<br>", p->project_name, buf2);
+    snprintf(buf, sizeof(buf), "RPC to %s: %s<br>", p->project_name, buf2);
     html_msg += buf;
 
     msg_printf(p, MSG_INFO, "RPC: %s", buf2);
@@ -443,7 +443,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
         results.push_back(rp);
         new_results.push_back(rp);
 #if 0
-        sprintf(buf, "got job %s: CPU time %.2f, deadline %s<br>",
+        snprintf(buf, sizeof(buf), "got job %s: CPU time %.2f, deadline %s<br>",
             rp->name, rp->final_cpu_time, time_to_string(rp->report_deadline)
         );
         html_msg += buf;
@@ -453,7 +453,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
 
     njobs += (int)new_results.size();
     msg_printf(0, MSG_INFO, "Got %lu tasks", new_results.size());
-    sprintf(buf, "got %lu tasks<br>", new_results.size());
+    snprintf(buf, sizeof(buf), "got %lu tasks<br>", new_results.size());
     html_msg += buf;
 
     SCHEDULER_REPLY sr;
@@ -629,7 +629,7 @@ bool ACTIVE_TASK_SET::poll() {
             rp->ready_to_report = true;
             gstate.request_schedule_cpus("job finished");
             gstate.request_work_fetch("job finished");
-            sprintf(buf, "result %s finished<br>", rp->name);
+            snprintf(buf, sizeof(buf), "result %s finished<br>", rp->name);
             html_msg += buf;
             action = true;
         }
@@ -859,7 +859,7 @@ void show_resource(int rsc_type) {
             );
         }
         if (rsc_type) {
-            sprintf(buf, "<td>%d</td>", rp->coproc_indices[0]);
+            snprintf(buf, sizeof(buf), "<td>%d</td>", rp->coproc_indices[0]);
         } else {
             safe_strcpy(buf, "");
         }
@@ -900,7 +900,7 @@ void show_resource(int rsc_type) {
 void html_start() {
     char buf[256];
 
-    sprintf(buf, "%s%s", outfile_prefix, TIMELINE_FNAME);
+    snprintf(buf, sizeof(buf), "%s%s", outfile_prefix, TIMELINE_FNAME);
     html_out = fopen(buf, "w");
     if (!html_out) {
         fprintf(stderr, "can't open %s for writing\n", buf);
@@ -1033,7 +1033,7 @@ void write_recs() {
 void make_graph(const char* title, const char* fname, int field) {
     char gp_fname[256], cmd[256], png_fname[256];
 
-    sprintf(gp_fname, "%s%s.gp", outfile_prefix, fname);
+    snprintf(gp_fname, sizeof(gp_fname), "%s%s.gp", outfile_prefix, fname);
     FILE* f = fopen(gp_fname, "w");
     fprintf(f,
         "set terminal png small size 1024, 768\n"
@@ -1050,15 +1050,15 @@ void make_graph(const char* title, const char* fname, int field) {
         );
     }
     fclose(f);
-    sprintf(png_fname, "%s%s.png", outfile_prefix, fname);
-    sprintf(cmd, "gnuplot < %s > %s", gp_fname, png_fname);
+    snprintf(png_fname, sizeof(png_fname), "%s%s.png", outfile_prefix, fname);
+    snprintf(cmd, sizeof(cmd), "gnuplot < %s > %s", gp_fname, png_fname);
     fprintf(index_file, "<br><a href=%s.png>Graph of %s</a>\n", fname, title);
     system(cmd);
 }
 
 static void write_inputs() {
     char buf[256];
-    sprintf(buf, "%s/%s", outfile_prefix, INPUTS_FNAME);
+    snprintf(buf, sizeof(buf), "%s/%s", outfile_prefix, INPUTS_FNAME);
     FILE* f = fopen(buf, "w");
     fprintf(f,
         "Existing jobs only: %s\n"
@@ -1413,12 +1413,12 @@ void do_client_simulation() {
     int retval;
     FILE* f;
 
-    sprintf(buf, "%s%s", infile_prefix, CONFIG_FILE);
+    snprintf(buf, sizeof(buf), "%s%s", infile_prefix, CONFIG_FILE);
     cc_config.defaults();
     read_config_file(true, buf);
 
     log_flags.init();
-    sprintf(buf, "%s%s", outfile_prefix, "log_flags.xml");
+    snprintf(buf, sizeof(buf), "%s%s", outfile_prefix, "log_flags.xml");
     f = fopen(buf, "r");
     if (f) {
         MIOFILE mf;
@@ -1430,7 +1430,7 @@ void do_client_simulation() {
     }
 
     gstate.add_platform("client simulator");
-    sprintf(buf, "%s%s", infile_prefix, STATE_FILE_NAME);
+    snprintf(buf, sizeof(buf), "%s%s", infile_prefix, STATE_FILE_NAME);
     if (!boinc_file_exists(buf)) {
         fprintf(stderr, "No client state file\n");
         exit(1);
@@ -1457,8 +1457,8 @@ void do_client_simulation() {
     cc_config.show();
     log_flags.show();
 
-    sprintf(buf, "%s%s", infile_prefix, GLOBAL_PREFS_FILE_NAME);
-    sprintf(buf2, "%s%s", infile_prefix, GLOBAL_PREFS_OVERRIDE_FILE);
+    snprintf(buf, sizeof(buf), "%s%s", infile_prefix, GLOBAL_PREFS_FILE_NAME);
+    snprintf(buf2, sizeof(buf2), "%s%s", infile_prefix, GLOBAL_PREFS_OVERRIDE_FILE);
     gstate.read_global_prefs(buf, buf2);
     fprintf(index_file,
         "<h3>Output files</h3>\n"
@@ -1507,11 +1507,11 @@ void do_client_simulation() {
 
     sim_results.compute_figures_of_merit();
 
-    sprintf(buf, "%s%s", outfile_prefix, RESULTS_DAT_FNAME);
+    snprintf(buf, sizeof(buf), "%s%s", outfile_prefix, RESULTS_DAT_FNAME);
     f = fopen(buf, "w");
     sim_results.print(f);
     fclose(f);
-    sprintf(buf, "%s%s", outfile_prefix, RESULTS_TXT_FNAME);
+    snprintf(buf, sizeof(buf), "%s%s", outfile_prefix, RESULTS_TXT_FNAME);
     f = fopen(buf, "w");
     sim_results.print(f, true);
     fclose(f);
@@ -1588,10 +1588,10 @@ int main(int argc, char** argv) {
         exit(1);
     }
 
-    sprintf(buf, "%s%s", outfile_prefix, "index.html");
+    snprintf(buf, sizeof(buf), "%s%s", outfile_prefix, "index.html");
     index_file = fopen(buf, "w");
 
-    sprintf(log_filename, "%s%s", outfile_prefix, LOG_FNAME);
+    snprintf(log_filename, sizeof(log_filename), "%s%s", outfile_prefix, LOG_FNAME);
     logfile = fopen(log_filename, "w");
     if (!logfile) {
         fprintf(stderr, "Can't open %s\n", buf);
@@ -1599,10 +1599,10 @@ int main(int argc, char** argv) {
     }
     setbuf(logfile, 0);
 
-    sprintf(buf, "%s%s", outfile_prefix, REC_FNAME);
+    snprintf(buf, sizeof(buf), "%s%s", outfile_prefix, REC_FNAME);
     rec_file = fopen(buf, "w");
 
-    sprintf(buf, "%s%s", outfile_prefix, SUMMARY_FNAME);
+    snprintf(buf, sizeof(buf), "%s%s", outfile_prefix, SUMMARY_FNAME);
     summary_file = fopen(buf, "w");
 
     srand(1);       // make it deterministic

--- a/client/sim_util.cpp
+++ b/client/sim_util.cpp
@@ -62,9 +62,9 @@ char* sim_time_string(int t) {
         int n = t/86400;
         t %= 86400;
         if (n == 1) {
-            sprintf(buf2, "1 day ");
+            snprintf(buf2, sizeof(buf2), "1 day ");
         } else {
-            sprintf(buf2, "%d days ", n);
+            snprintf(buf2, sizeof(buf2), "%d days ", n);
         }
     } else {
         safe_strcpy(buf2, "");
@@ -73,7 +73,7 @@ char* sim_time_string(int t) {
     t %= 3600;
     int mins = t/60;
     int secs = t%60;
-    sprintf(buf, "%s%02d:%02d:%02d", buf2, hours, mins, secs);
+    snprintf(buf, sizeof(buf), "%s%02d:%02d:%02d", buf2, hours, mins, secs);
     return buf;
 }
 
@@ -129,7 +129,7 @@ int ACTIVE_TASK::resume_or_start(bool first_time) {
     }
     set_task_state(PROCESS_EXECUTING, "start");
     char buf[256];
-    sprintf(buf, "Starting %s<br>&nbsp;&nbsp;%s<br>&nbsp;&nbsp;deadline %s<br>",
+    snprintf(buf, sizeof(buf), "Starting %s<br>&nbsp;&nbsp;%s<br>&nbsp;&nbsp;deadline %s<br>",
         result->name, result->project->get_project_name(),
         sim_time_string(result->report_deadline)
     );

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -144,7 +144,7 @@ int main(int /*argc*/, char** argv) {
         } else {
             projectDirName = aid.project_dir;
         }
-        sprintf(newlibs, "../../%s:.:../..", projectDirName);
+        snprintf(newlibs, sizeof(newlibs), "../../%s:.:../..", projectDirName);
 #ifdef __APPLE__
         strcat(newlibs, ":/usr/local/cuda/lib/");
 #endif
@@ -161,7 +161,7 @@ int main(int /*argc*/, char** argv) {
 #ifdef __APPLE__
         p = getenv("DYLD_LIBRARY_PATH");
         if (p) {
-            sprintf(libpath, "%s:%s", newlibs, p);
+            snprintf(libpath, sizeof(libpath), "%s:%s", newlibs, p);
         } else {
             safe_strcpy(libpath, newlibs);
         }

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -246,7 +246,7 @@ struct COPROC {
     inline bool bad_gpu_peak_flops(const char* source, std::string& msg) {
         if (peak_flops <= 0 || peak_flops > GPU_MAX_PEAK_FLOPS) {
             char buf[256];
-            sprintf(buf, "%s reported bad GPU peak FLOPS %f; using %f",
+            snprintf(buf, sizeof(buf), "%s reported bad GPU peak FLOPS %f; using %f",
                 source, peak_flops, GPU_DEFAULT_PEAK_FLOPS
             );
             msg = buf;

--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -778,7 +778,7 @@ static int boinc_rename_aux(const char* old, const char* newf) {
     int retval = rename(old, newf);
     if (retval) {
         char buf[MAXPATHLEN+MAXPATHLEN];
-        sprintf(buf, "mv \"%s\" \"%s\"", old, newf);
+        snprintf(buf, sizeof(buf), "mv \"%s\" \"%s\"", old, newf);
 #ifdef __APPLE__
         // system() is deprecated in Mac OS 10.10.
         // Apple says to call posix_spawn instead.

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1451,7 +1451,7 @@ int RPC_CLIENT::exchange_versions(string client_name, VERSION_INFO& server) {
     char buf[256];
     RPC rpc(this);
 
-    sprintf(buf,
+    snprintf(buf, sizeof(buf),
         "<exchange_versions>\n"
         "   <major>%d</major>\n"
         "   <minor>%d</minor>\n"
@@ -1496,7 +1496,7 @@ int RPC_CLIENT::get_results(RESULTS& t, bool active_only) {
 
     t.clear();
 
-    sprintf(buf, "<get_results>\n<active_only>%d</active_only>\n</get_results>\n",
+    snprintf(buf, sizeof(buf), "<get_results>\n<active_only>%d</active_only>\n</get_results>\n",
         active_only?1:0
     );
     retval = rpc.do_rpc(buf);

--- a/lib/mac/mac_backtrace.cpp
+++ b/lib/mac/mac_backtrace.cpp
@@ -341,7 +341,7 @@ void GetNameOfAndPathToThisProcess(char *nameBuf, size_t nameBufLen, char* outbu
     *outbuf = '\0';
     *nameBuf = '\0';
     
-    sprintf(buf, "ps -wo command -p %d", (int)aPID);
+    snprintf(buf, sizeof(buf), "ps -wo command -p %d", (int)aPID);
     f = popen(buf, "r");
     if (f == NULL)
         return;
@@ -350,7 +350,7 @@ void GetNameOfAndPathToThisProcess(char *nameBuf, size_t nameBufLen, char* outbu
     BT_PersistentFGets (outbuf, outBufLen, f);     // Get the UNIX command which ran us
     pclose(f);
 
-    sprintf(buf, "ps -p %d -c -o command", aPID);
+    snprintf(buf, sizeof(buf), "ps -p %d -c -o command", aPID);
     f = popen(buf,  "r");
     if (!f)
         return;

--- a/lib/msg_log.cpp
+++ b/lib/msg_log.cpp
@@ -98,7 +98,7 @@ void MSG_LOG::vprintf(int kind, const char* format, va_list va) {
     const char* now_timestamp = precision_time_to_string(dtime());
     if (!v_message_wanted(kind)) return;
     if (pid) {
-        sprintf(buf, " [PID=%-5d]", pid);
+        snprintf(buf, sizeof(buf), " [PID=%-5d]", pid);
     } else {
         buf[0] = 0;
     }

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -191,7 +191,7 @@ int procinfo_setup(PROC_MAP& pm) {
 
 #if defined(HAVE_PROCFS_H) && defined(HAVE__PROC_SELF_PSINFO)  // solaris
         psinfo_t psinfo;
-        sprintf(pidpath, "/proc/%s/psinfo", piddir->d_name);
+        snprintf(pidpath, sizeof(pidpath), "/proc/%s/psinfo", piddir->d_name);
         fd = fopen(pidpath, "r");
         if (!fd) continue;
         PROCINFO p;
@@ -204,7 +204,7 @@ int procinfo_setup(PROC_MAP& pm) {
             strlcpy(p.command, psinfo.pr_fname, sizeof(p.command));
         }
         fclose(fd);
-        sprintf(pidpath, "/proc/%s/usage", piddir->d_name);
+        snprintf(pidpath, sizeof(pidpath), "/proc/%s/usage", piddir->d_name);
         prusage_t prusage;
         fd = fopen(pidpath, "r");
         if (!fd) continue;
@@ -220,7 +220,7 @@ int procinfo_setup(PROC_MAP& pm) {
         p.is_boinc_app = (p.id == pid || strcasestr(p.command, "boinc"));
         pm.insert(std::pair<int, PROCINFO>(p.id, p));
 #else  // linux
-        sprintf(pidpath, "/proc/%s/stat", piddir->d_name);
+        snprintf(pidpath, sizeof(pidpath), "/proc/%s/stat", piddir->d_name);
         fd = fopen(pidpath, "r");
         if (!fd) continue;
         if (fgets(buf, sizeof(buf), fd) == NULL) {

--- a/lib/remote_submit.cpp
+++ b/lib/remote_submit.cpp
@@ -127,7 +127,7 @@ static int do_http_post(
         CURLFORM_END
     );
     for (unsigned int i=0; i<send_files.size(); i++) {
-        sprintf(buf, "file_%d", i);
+        snprintf(buf, sizeof(buf), "file_%d", i);
         string s = send_files[i];
         curl_formadd(&formpost, &lastptr,
             CURLFORM_COPYNAME, buf,
@@ -165,20 +165,20 @@ int query_files(
     string req_msg;
     char buf[256];
     req_msg = "<query_files>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     req_msg += string(buf);
     if (batch_id) {
-        sprintf(buf, "<batch_id>%d</batch_id>\n", batch_id);
+        snprintf(buf, sizeof(buf), "<batch_id>%d</batch_id>\n", batch_id);
         req_msg += string(buf);
     }
     for (unsigned int i=0; i<boinc_names.size(); i++) {
-        sprintf(buf, "   <phys_name>%s</phys_name>\n", boinc_names[i].c_str());
+        snprintf(buf, sizeof(buf), "   <phys_name>%s</phys_name>\n", boinc_names[i].c_str());
         req_msg += string(buf);
     }
     req_msg += "</query_files>\n";
     FILE* reply = tmpfile();
     char url[256];
-    sprintf(url, "%sjob_file.php", project_url);
+    snprintf(url, sizeof(url), "%sjob_file.php", project_url);
     vector<string> xx;
     int retval = do_http_post(url, req_msg.c_str(), reply, xx);
     if (retval) {
@@ -225,20 +225,20 @@ int upload_files (
 ) {
     char buf[1024];
     string req_msg = "<upload_files>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     req_msg += string(buf);
     if (batch_id) {
-        sprintf(buf, "<batch_id>%d</batch_id>\n", batch_id);
+        snprintf(buf, sizeof(buf), "<batch_id>%d</batch_id>\n", batch_id);
         req_msg += string(buf);
     }
     for (unsigned int i=0; i<boinc_names.size(); i++) {
-        sprintf(buf, "<phys_name>%s</phys_name>\n", boinc_names[i].c_str());
+        snprintf(buf, sizeof(buf), "<phys_name>%s</phys_name>\n", boinc_names[i].c_str());
         req_msg += string(buf);
     }
     req_msg += "</upload_files>\n";
     FILE* reply = tmpfile();
     char url[256];
-    sprintf(url, "%sjob_file.php", project_url);
+    snprintf(url, sizeof(url), "%sjob_file.php", project_url);
     int retval = do_http_post(url, req_msg.c_str(), reply, paths);
     if (retval) {
         fclose(reply);
@@ -282,7 +282,7 @@ int create_batch(
 ) {
     char request[1024];
     char url[1024];
-    sprintf(request,
+    snprintf(request, sizeof(request),
         "<create_batch>\n"
         "   <authenticator>%s</authenticator>\n"
         "   <batch_name>%s</batch_name>\n"
@@ -294,7 +294,7 @@ int create_batch(
         app_name,
         expire_time
     );
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request, reply, x);
@@ -335,7 +335,7 @@ int estimate_batch(
     string& error_msg
 ) {
     char buf[1024], url[1024];
-    sprintf(buf,
+    snprintf(buf, sizeof(buf),
         "<estimate_batch>\n"
         "<authenticator>%s</authenticator>\n"
         "<batch>\n"
@@ -353,7 +353,7 @@ int estimate_batch(
         request += "</job>\n";
     }
     request += "</batch>\n</estimate_batch>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -420,7 +420,7 @@ int submit_jobs_params(
     int app_version_num
 ) {
     char buf[1024], url[1024];
-    sprintf(buf,
+    snprintf(buf, sizeof(buf),
         "<submit_batch>\n"
         "<authenticator>%s</authenticator>\n"
         "<batch>\n"
@@ -448,7 +448,7 @@ int submit_jobs_params(
     for (unsigned int i=0; i<jobs.size(); i++) {
         JOB job = jobs[i];
         request += "<job>\n";
-        sprintf(buf, "  <name>%s</name>\n", job.job_name);
+        snprintf(buf, sizeof(buf), "  <name>%s</name>\n", job.job_name);
         request += buf;
         if (!job.cmdline_args.empty()) {
             request += "<command_line>" + job.cmdline_args + "</command_line>\n";
@@ -457,7 +457,7 @@ int submit_jobs_params(
             INFILE infile = job.infiles[j];
             switch (infile.mode) {
             case FILE_MODE_LOCAL_STAGED:
-                sprintf(buf,
+                snprintf(buf, sizeof(buf),
                     "<input_file>\n"
                     "<mode>local_staged</mode>\n"
                     "<source>%s</source>\n"
@@ -466,7 +466,7 @@ int submit_jobs_params(
                 );
                 break;
             case FILE_MODE_REMOTE:
-                sprintf(buf,
+                snprintf(buf, sizeof(buf),
                     "<input_file>\n"
                     "<mode>remote</mode>\n"
                     "<url>%s</url>\n"
@@ -487,7 +487,7 @@ int submit_jobs_params(
         request += "</job>\n";
     }
     request += "</batch>\n</submit_batch>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -535,16 +535,16 @@ int query_batch_set(
     int batch_size;
 
     request = "<query_batch2>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
-    sprintf(buf, "<min_mod_time>%f</min_mod_time>\n", min_mod_time);
+    snprintf(buf, sizeof(buf), "<min_mod_time>%f</min_mod_time>\n", min_mod_time);
     request += string(buf);
     for (unsigned int i=0; i<batch_names.size(); i++) {
-        sprintf(buf, "<batch_name>%s</batch_name>\n", batch_names[i].c_str());
+        snprintf(buf, sizeof(buf), "<batch_name>%s</batch_name>\n", batch_names[i].c_str());
         request += string(buf);
     }
     request += "</query_batch2>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -667,10 +667,10 @@ int query_batches(
     string request;
     char url[1024], buf[256];
     request = "<query_batches>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
     request += "</query_batches>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -747,16 +747,16 @@ int query_batch(
     string request;
     char url[1024], buf[256];
     request = "<query_batch>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
     if (batch_id) {
-        sprintf(buf, "<batch_id>%d</batch_id>\n", batch_id);
+        snprintf(buf, sizeof(buf), "<batch_id>%d</batch_id>\n", batch_id);
     } else {
-        sprintf(buf, "<batch_name>%s</batch_name>\n", batch_name);
+        snprintf(buf, sizeof(buf), "<batch_name>%s</batch_name>\n", batch_name);
     }
     request += string(buf);
     request += "</query_batch>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -797,14 +797,14 @@ int abort_jobs(
     string request;
     char url[1024], buf[256];
     request = "<abort_jobs>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
     for (unsigned int i=0; i<job_names.size(); i++) {
-        sprintf(buf, "<job_name>%s</job_name>\n", job_names[i].c_str());
+        snprintf(buf, sizeof(buf), "<job_name>%s</job_name>\n", job_names[i].c_str());
         request += string(buf);
     }
     request += "</abort_jobs>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -850,17 +850,17 @@ int get_templates(
     string request;
     char url[1024], buf[256];
     request = "<get_templates>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
     if (app_name) {
-        sprintf(buf, "<app_name>%s</app_name>\n", app_name);
+        snprintf(buf, sizeof(buf), "<app_name>%s</app_name>\n", app_name);
         request += string(buf);
     } else {
-        sprintf(buf, "<job_name>%s</job_name>\n", job_name);
+        snprintf(buf, sizeof(buf), "<job_name>%s</job_name>\n", job_name);
         request += string(buf);
     }
     request += "</get_templates>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -949,7 +949,7 @@ int get_output_file(
 ) {
     char url[1024], job_name_esc[1024];
     escape_url(job_name, job_name_esc, sizeof(job_name_esc));
-    sprintf(url, "%sget_output.php?cmd=workunit_file&auth_str=%s&wu_name=%s&file_num=%d",
+    snprintf(url, sizeof(url), "%sget_output.php?cmd=workunit_file&auth_str=%s&wu_name=%s&file_num=%d",
         project_url, authenticator, job_name_esc, file_num
     );
     //printf("fetching %s to %s\n", url, dst_path);
@@ -957,7 +957,7 @@ int get_output_file(
     error_msg = "";
     if (retval) {
         char buf[1024];
-        sprintf(buf, "couldn't fetch %s: %d", url, retval);
+        snprintf(buf, sizeof(buf), "couldn't fetch %s: %d", url, retval);
         error_msg = string(buf);
     }
     return retval;
@@ -973,12 +973,12 @@ int query_completed_job(
     string request;
     char url[1024], buf[256];
     request = "<query_completed_job>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
-    sprintf(buf, "<job_name>%s</job_name>\n", job_name);
+    snprintf(buf, sizeof(buf), "<job_name>%s</job_name>\n", job_name);
     request += string(buf);
     request += "</query_completed_job>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -1020,12 +1020,12 @@ int retire_batch(
     string request;
     char url[1024], buf[256];
     request = "<retire_batch>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
-    sprintf(buf, "<batch_name>%s</batch_name>\n", batch_name);
+    snprintf(buf, sizeof(buf), "<batch_name>%s</batch_name>\n", batch_name);
     request += string(buf);
     request += "</retire_batch>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -1070,14 +1070,14 @@ int set_expire_time(
     string request;
     char url[1024], buf[256];
     request = "<set_expire_time>\n";
-    sprintf(buf, "<authenticator>%s</authenticator>\n", authenticator);
+    snprintf(buf, sizeof(buf), "<authenticator>%s</authenticator>\n", authenticator);
     request += string(buf);
-    sprintf(buf, "<batch_name>%s</batch_name>\n", batch_name);
+    snprintf(buf, sizeof(buf), "<batch_name>%s</batch_name>\n", batch_name);
     request += string(buf);
-    sprintf(buf, "<expire_time>%f</expire_time>\n", expire_time);
+    snprintf(buf, sizeof(buf), "<expire_time>%f</expire_time>\n", expire_time);
     request += string(buf);
     request += "</set_expire_time>\n";
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);
@@ -1120,7 +1120,7 @@ int ping_server(
     string request;
     char url[1024];
     request = "<ping> </ping>\n";   // the space is needed
-    sprintf(url, "%ssubmit_rpc_handler.php", project_url);
+    snprintf(url, sizeof(url), "%ssubmit_rpc_handler.php", project_url);
     FILE* reply = tmpfile();
     vector<string> x;
     int retval = do_http_post(url, request.c_str(), reply, x);

--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -290,7 +290,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                     );                }
 
                 // Company Name.
-                sprintf(szQuery, "\\StringFileInfo\\%04x%04x\\CompanyName",
+                snprintf(szQuery, sizeof(szQuery), "\\StringFileInfo\\%04x%04x\\CompanyName",
                     lpTranslate[0].wLanguage,
                     lpTranslate[0].wCodePage
                 );
@@ -304,7 +304,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                 }
 
                 // Product Name.
-                sprintf(szQuery, "\\StringFileInfo\\%04x%04x\\ProductName",
+                snprintf(szQuery, sizeof(szQuery), "\\StringFileInfo\\%04x%04x\\ProductName",
                     lpTranslate[0].wLanguage,
                     lpTranslate[0].wCodePage
                 );
@@ -318,7 +318,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                 }
 
                 // File Version.
-                sprintf(szQuery, "\\StringFileInfo\\%04x%04x\\FileVersion",
+                snprintf(szQuery, sizeof(szQuery), "\\StringFileInfo\\%04x%04x\\FileVersion",
                     lpTranslate[0].wLanguage,
                     lpTranslate[0].wCodePage
                 );
@@ -330,7 +330,7 @@ BOOL CALLBACK SymEnumerateModulesProc64(LPCSTR /* ModuleName */, DWORD64 BaseOfD
                 }
 
                 // Product Version.
-                sprintf(szQuery, "\\StringFileInfo\\%04x%04x\\ProductVersion",
+                snprintf(szQuery, sizeof(szQuery), "\\StringFileInfo\\%04x%04x\\ProductVersion",
                     lpTranslate[0].wLanguage,
                     lpTranslate[0].wCodePage
                 );

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -137,41 +137,41 @@ int ndays_to_string (double x, int smallest_timescale, char *buf) {
     seconds = fmod(x*24*60*60, 60);
 
     if (smallest_timescale==4) {
-        sprintf( year_buf, "%.3f yr ", years );
+        snprintf( year_buf, sizeof(year_buf), "%.3f yr ", years );
     } else if (years > 1 && smallest_timescale < 4) {
-        sprintf( year_buf, "%d yr ", (int)years );
+        snprintf( year_buf, sizeof(year_buf), "%d yr ", (int)years );
     } else {
         safe_strcpy( year_buf, "" );
     }
 
     if (smallest_timescale==3) {
-        sprintf( day_buf, "%.2f day%s ", days, (days>1?"s":"") );
+        snprintf( day_buf, sizeof(day_buf), "%.2f day%s ", days, (days>1?"s":"") );
     } else if (days > 1 && smallest_timescale < 3) {
-        sprintf( day_buf, "%d day%s ", (int)days, (days>1?"s":"") );
+        snprintf( day_buf, sizeof(day_buf), "%d day%s ", (int)days, (days>1?"s":"") );
     } else {
         safe_strcpy( day_buf, "" );
     }
 
     if (smallest_timescale==2) {
-        sprintf( hour_buf, "%.2f hr ", hours );
+        snprintf( hour_buf, sizeof(hour_buf), "%.2f hr ", hours );
     } else if (hours > 1 && smallest_timescale < 2) {
-        sprintf( hour_buf, "%d hr ", (int)hours );
+        snprintf( hour_buf, sizeof(hour_buf), "%d hr ", (int)hours );
     } else {
         safe_strcpy( hour_buf, "" );
     }
 
     if (smallest_timescale==1) {
-        sprintf( min_buf, "%.2f min ", minutes );
+        snprintf( min_buf, sizeof(min_buf), "%.2f min ", minutes );
     } else if (minutes > 1 && smallest_timescale < 1) {
-        sprintf( min_buf, "%d min ", (int)minutes );
+        snprintf( min_buf, sizeof(min_buf), "%d min ", (int)minutes );
     } else {
         safe_strcpy( min_buf, "" );
     }
 
     if (smallest_timescale==0) {
-        sprintf( sec_buf, "%.2f sec ", seconds );
+        snprintf( sec_buf, sizeof(sec_buf), "%.2f sec ", seconds );
     } else if (seconds > 1 && smallest_timescale < 0) {
-        sprintf( sec_buf, "%d sec ", (int)seconds );
+        snprintf( sec_buf, sizeof(sec_buf), "%d sec ", (int)seconds );
     } else {
         safe_strcpy( sec_buf, "" );
     }
@@ -207,27 +207,27 @@ void nbytes_to_string(double nbytes, double total_bytes, char* str, int len) {
 
     if (total_bytes != 0) {
         if (total_bytes >= xTera) {
-            sprintf(buf, "%0.2f/%0.2f TB", nbytes/xTera, total_bytes/xTera);
+            snprintf(buf, sizeof(buf), "%0.2f/%0.2f TB", nbytes/xTera, total_bytes/xTera);
         } else if (total_bytes >= xGiga) {
-            sprintf(buf, "%0.2f/%0.2f GB", nbytes/xGiga, total_bytes/xGiga);
+            snprintf(buf, sizeof(buf), "%0.2f/%0.2f GB", nbytes/xGiga, total_bytes/xGiga);
         } else if (total_bytes >= xMega) {
-            sprintf(buf, "%0.2f/%0.2f MB", nbytes/xMega, total_bytes/xMega);
+            snprintf(buf, sizeof(buf), "%0.2f/%0.2f MB", nbytes/xMega, total_bytes/xMega);
         } else if (total_bytes >= xKilo) {
-            sprintf(buf, "%0.2f/%0.2f KB", nbytes/xKilo, total_bytes/xKilo);
+            snprintf(buf, sizeof(buf), "%0.2f/%0.2f KB", nbytes/xKilo, total_bytes/xKilo);
         } else {
-            sprintf(buf, "%0.0f/%0.0f bytes", nbytes, total_bytes);
+            snprintf(buf, sizeof(buf), "%0.0f/%0.0f bytes", nbytes, total_bytes);
         }
     } else {
         if (nbytes >= xTera) {
-            sprintf(buf, "%0.2f TB", nbytes/xTera);
+            snprintf(buf, sizeof(buf), "%0.2f TB", nbytes/xTera);
         } else if (nbytes >= xGiga) {
-            sprintf(buf, "%0.2f GB", nbytes/xGiga);
+            snprintf(buf, sizeof(buf), "%0.2f GB", nbytes/xGiga);
         } else if (nbytes >= xMega) {
-            sprintf(buf, "%0.2f MB", nbytes/xMega);
+            snprintf(buf, sizeof(buf), "%0.2f MB", nbytes/xMega);
         } else if (nbytes >= xKilo) {
-            sprintf(buf, "%0.2f KB", nbytes/xKilo);
+            snprintf(buf, sizeof(buf), "%0.2f KB", nbytes/xKilo);
         } else {
-            sprintf(buf, "%0.0f bytes", nbytes);
+            snprintf(buf, sizeof(buf), "%0.0f bytes", nbytes);
         }
     }
 
@@ -428,7 +428,7 @@ char* precision_time_to_string(double t) {
     struct tm* tm = localtime(&x);
 
     strftime(buf, sizeof(buf)-1, "%Y-%m-%d %H:%M:%S", tm);
-    sprintf(finer, ".%04d", hundreds_of_microseconds);
+    snprintf(finer, sizeof(finer), ".%04d", hundreds_of_microseconds);
     safe_strcat(buf, finer);
     return buf;
 }
@@ -440,25 +440,25 @@ string timediff_format(double diff) {
     int sex = tdiff % 60;
     tdiff /= 60;
     if (!tdiff) {
-        sprintf(buf, "00:00:%02d", sex);
+        snprintf(buf, sizeof(buf), "00:00:%02d", sex);
         return buf;
     }
 
     int min = tdiff % 60;
     tdiff /= 60;
     if (!tdiff) {
-        sprintf(buf, "00:%02d:%02d", min, sex);
+        snprintf(buf, sizeof(buf), "00:%02d:%02d", min, sex);
         return buf;
     }
 
     int hours = tdiff % 24;
     tdiff /= 24;
     if (!tdiff) {
-        sprintf(buf, "%02d:%02d:%02d", hours, min, sex);
+        snprintf(buf, sizeof(buf), "%02d:%02d:%02d", hours, min, sex);
         return buf;
     }
 
-    sprintf(buf, "%d days %02d:%02d:%02d", tdiff, hours, min, sex);
+    snprintf(buf, sizeof(buf), "%d days %02d:%02d:%02d", tdiff, hours, min, sex);
     return buf;
 
 }
@@ -627,7 +627,7 @@ const char* boincerror(int which_error) {
         case ERR_ACCT_REQUIRE_CONSENT: return "This project requires to consent to its terms of use";
     }
     static char buf[128];
-    sprintf(buf, "Error %d", which_error);
+    snprintf(buf, sizeof(buf), "Error %d", which_error);
     return buf;
 }
 

--- a/lib/unix_util.cpp
+++ b/lib/unix_util.cpp
@@ -93,7 +93,7 @@ int setenv(const char *name, const char *value, int overwrite) {
         errno=ENOMEM;
         return -1;
     }
-    sprintf(buf,"%s=%s",name,value);
+    snprintf(buf, sizeof(buf),"%s=%s",name,value);
     rv=putenv(buf);
     // Yes, there is a potential memory leak here.  Some versions of operating
     // systems copy the string into the environment, others make the


### PR DESCRIPTION
Replaces nearly all occurrences of 'sprintf' with 'snprintf' within the sources forming the BOINC client.
Few occurrences are left unchanged as the still return compiler warnings.
