### PR TITLE
Fix pragma warning

### DIFF
--- a/clientgui/DlgDiagnosticLogFlags.cpp
+++ b/clientgui/DlgDiagnosticLogFlags.cpp
@@ -16,7 +16,7 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 //
 #if defined(__GNUG__) && !defined(__APPLE__)
-#pragma implementation "DlgDiagnosticLogFlags.cpp"
+#pragma implementation "DlgDiagnosticLogFlags.h"
 #endif
 
 #include "stdwx.h"

--- a/clientgui/DlgHiddenColumns.cpp
+++ b/clientgui/DlgHiddenColumns.cpp
@@ -16,7 +16,7 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 //
 #if defined(__GNUG__) && !defined(__APPLE__)
-#pragma implementation "DlgHiddenColumns.cpp"
+#pragma implementation "DlgHiddenColumns.h"
 #endif
 
 #include "stdwx.h"


### PR DESCRIPTION
Not sure, but shouldn't the file reference point to the header file instead of the cpp file?

```
DlgDiagnosticLogFlags.cpp:19:24: warning: ‘#pragma implementation’ for ‘DlgDiagnosticLogFlags.cpp’ appears after file is included
   19 | #pragma implementation "DlgDiagnosticLogFlags.cpp"
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```
