### PR TITLE
Increase buffer size

### DIFF
--- a/clientgui/sg_TaskPanel.cpp
+++ b/clientgui/sg_TaskPanel.cpp
@@ -878,7 +878,7 @@ wxString CSimpleTaskPanel::GetStatusString(RESULT* result) {
 void CSimpleTaskPanel::FindSlideShowFiles(TaskSelectionData *selData) {
     RESULT* state_result;
     char proj_dir[1024];
-    char fileName[1024];
+    char fileName[1536];
     char resolvedFileName[1024];
     int j;
     CMainDocument*      pDoc = wxGetApp().GetDocument();


### PR DESCRIPTION
'fileName' size needs to be increased to avoid the warnings below.


```
sg_TaskPanel.cpp: In member function ‘void CSimpleTaskPanel::FindSlideShowFiles(TaskSelectionData*)’:
sg_TaskPanel.cpp:897:53: warning: ‘/slideshow_’ directive output may be truncated writing 11 bytes into a region of size between 1 and 1024 [-Wformat-truncation=]
  897 |             snprintf(fileName, sizeof(fileName), "%s/slideshow_%s_%02d", proj_dir, state_result->app->name, j);
      |                                                     ^~~~~~~~~~~
sg_TaskPanel.cpp:897:50: note: directive argument in the range [0, 98]
  897 |             snprintf(fileName, sizeof(fileName), "%s/slideshow_%s_%02d", proj_dir, state_result->app->name, j);
      |                                                  ^~~~~~~~~~~~~~~~~~~~~~
sg_TaskPanel.cpp:897:21: note: ‘snprintf’ output between 15 and 1293 bytes into a destination of size 1024
  897 |             snprintf(fileName, sizeof(fileName), "%s/slideshow_%s_%02d", proj_dir, state_result->app->name, j);
      |             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
sg_TaskPanel.cpp:909:57: warning: ‘/slideshow_’ directive output may be truncated writing 11 bytes into a region of size between 1 and 1024 [-Wformat-truncation=]
  909 |                 snprintf(fileName, sizeof(fileName), "%s/slideshow_%02d", proj_dir, j);
      |                                                         ^~~~~~~~~~~
sg_TaskPanel.cpp:909:54: note: directive argument in the range [0, 98]
  909 |                 snprintf(fileName, sizeof(fileName), "%s/slideshow_%02d", proj_dir, j);
      |                                                      ^~~~~~~~~~~~~~~~~~~
sg_TaskPanel.cpp:909:25: note: ‘snprintf’ output between 14 and 1037 bytes into a destination of size 1024
  909 |                 snprintf(fileName, sizeof(fileName), "%s/slideshow_%02d", proj_dir, j);
      |                 ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```