### PR TITLE
Add not-in-use computing prefs

### DIFF
--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -1546,7 +1546,7 @@ void ACTIVE_TASK_SET::get_msgs() {
     last_time = gstate.now;
 
     double et_diff = delta_t;
-    double et_diff_throttle = delta_t * gstate.global_prefs.cpu_usage_limit/100;
+    double et_diff_throttle = delta_t * gstate.current_cpu_usage_limit()/100;
 
     for (i=0; i<active_tasks.size(); i++) {
         atp = active_tasks[i];

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -156,7 +156,7 @@ CLIENT_STATE::CLIENT_STATE()
     redirect_io = false;
     disable_graphics = false;
     cant_write_state_file = false;
-    ncpus = 1;
+    n_usable_cpus = 1;
     benchmarks_running = false;
     client_disk_usage = 0.0;
     total_disk_usage = 0.0;
@@ -202,8 +202,8 @@ void CLIENT_STATE::show_host_info() {
         "Processor: %d %s %s",
         host_info.p_ncpus, host_info.p_vendor, host_info.p_model
     );
-    if (ncpus != host_info.p_ncpus) {
-        msg_printf(NULL, MSG_INFO, "Using %d CPUs", ncpus);
+    if (n_usable_cpus != host_info.p_ncpus) {
+        msg_printf(NULL, MSG_INFO, "Using %d CPUs", n_usable_cpus);
     }
 #if 0
     if (host_info.m_cache > 0) {
@@ -626,7 +626,7 @@ int CLIENT_STATE::init() {
     //
     host_info.p_vm_extensions_disabled = false;
 
-    set_ncpus();
+    set_n_usable_cpus();
     show_host_info();
 
     // this follows parse_state_file() because that's where we read project names
@@ -992,6 +992,8 @@ bool CLIENT_STATE::poll_slow_events() {
 #endif
 
     if (user_active != old_user_active) {
+        set_n_usable_cpus();
+            // if niu_max_ncpus_pct pref is set, # usable CPUs may change
         request_schedule_cpus(user_active?"Not idle":"Idle");
     }
 

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -424,6 +424,7 @@ struct CLIENT_STATE {
         const char* fname = GLOBAL_PREFS_FILE_NAME,
         const char* override_fname = GLOBAL_PREFS_OVERRIDE_FILE
     );
+    void print_global_prefs();
     int save_global_prefs(const char* prefs, char* url, char* sched);
     double available_ram();
     double max_available_ram();
@@ -525,7 +526,7 @@ struct CLIENT_STATE {
         if (!user_active && global_prefs.niu_cpu_usage_limit>=0) {
             x = global_prefs.niu_cpu_usage_limit;
         }
-        if (x < 0.005 || x > 99) {
+        if (x < 0.005 || x > 99.99) {
             x = 100;
         }
         return x;

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -262,9 +262,9 @@ void CLIENT_STATE::start_cpu_benchmarks(bool force) {
     cpu_benchmarks_start = dtime();
 
     benchmark_descs.clear();
-    benchmark_descs.resize(ncpus);
+    benchmark_descs.resize(n_usable_cpus);
 
-    bm_ncpus = ncpus;
+    bm_ncpus = n_usable_cpus;
     benchmarks_running = true;
 
     for (i=0; i<bm_ncpus; i++) {

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -648,53 +648,125 @@ void CLIENT_STATE::read_global_prefs(
         }
     }
 
-    msg_printf(NULL, MSG_INFO, "Preferences:");
-    msg_printf(NULL, MSG_INFO,
-        "   max memory usage when active: %.2f MB",
-        (host_info.m_nbytes*global_prefs.ram_max_used_busy_frac)/MEGA
-    );
-    msg_printf(NULL, MSG_INFO,
-        "   max memory usage when idle: %.2f MB",
-        (host_info.m_nbytes*global_prefs.ram_max_used_idle_frac)/MEGA
-    );
 #ifndef SIM
     get_disk_usages();
-    msg_printf(NULL, MSG_INFO,
-        "   max disk usage: %.2f GB",
-        allowed_disk_usage(total_disk_usage)/GIGA
-    );
 #endif
-    // max_cpus, bandwidth limits may have changed
-    //
     set_n_usable_cpus();
-    if (n_usable_cpus != host_info.p_ncpus) {
-        msg_printf(NULL, MSG_INFO,
-            "   max CPUs used: %d", n_usable_cpus
-        );
-    }
-    if (!global_prefs.run_if_user_active) {
-        msg_printf(NULL, MSG_INFO, "   don't compute while active");
+
 #ifdef ANDROID
-    } else {
-        msg_printf(NULL, MSG_INFO, "   Android: don't compute while active");
-        global_prefs.run_if_user_active = false;
+    global_prefs.run_if_user_active = false;
 #endif
+#ifndef SIM
+    file_xfers->set_bandwidth_limits(true);
+    file_xfers->set_bandwidth_limits(false);
+#endif
+    print_global_prefs();
+    request_schedule_cpus("Prefs update");
+    request_work_fetch("Prefs update");
+#ifndef SIM
+    active_tasks.request_reread_app_info();
+#endif
+}
+
+void CLIENT_STATE::print_global_prefs() {
+    msg_printf(NULL, MSG_INFO, "Preferences:");
+
+    // in use
+    //
+    msg_printf(NULL, MSG_INFO, "   When computer is in use:");
+    msg_printf(NULL, MSG_INFO,
+        "      'In use' means mouse/keyboard in put in last %.1f minutes",
+        global_prefs.idle_time_to_run
+    );
+    if (!global_prefs.run_if_user_active) {
+        msg_printf(NULL, MSG_INFO, "      don't compute");
     }
     if (!global_prefs.run_gpu_if_user_active) {
-        msg_printf(NULL, MSG_INFO, "   don't use GPU while active");
+        msg_printf(NULL, MSG_INFO, "      don't use GPU");
+    }
+    double p = global_prefs.max_ncpus_pct;
+    if (p) {
+        int n = (int)((host_info.p_ncpus * p)/100);
+        msg_printf(NULL, MSG_INFO,
+            "      max CPUs used: %d", n
+        );
+    }
+    if (global_prefs.cpu_usage_limit) {
+        msg_printf(NULL, MSG_INFO,
+            "      Use at most %.0f%% of the CPU time",
+            global_prefs.cpu_usage_limit
+        );
     }
     if (global_prefs.suspend_cpu_usage) {
         msg_printf(NULL, MSG_INFO,
-            "   suspend work if non-BOINC CPU load exceeds %.0f%%",
+            "      suspend work if non-BOINC CPU load exceeds %.0f%%",
             global_prefs.suspend_cpu_usage
+        );
+    }
+    msg_printf(NULL, MSG_INFO,
+        "      max memory usage: %.2f GB",
+        (host_info.m_nbytes*global_prefs.ram_max_used_busy_frac)/GIGA
+    );
+
+    // not in use
+    //
+    msg_printf(NULL, MSG_INFO,
+        "   When computer is not in use (defaults: same as in use)"
+    );
+    p = global_prefs.niu_max_ncpus_pct;
+    if (p) {
+        int n = (int)((host_info.p_ncpus * p)/100);
+        msg_printf(NULL, MSG_INFO,
+            "      max CPUs used: %d", n
+        );
+    }
+    if (global_prefs.niu_cpu_usage_limit) {
+        msg_printf(NULL, MSG_INFO,
+            "      Use at most %.0f%% of the CPU time",
+            global_prefs.niu_cpu_usage_limit
         );
     }
     if (global_prefs.niu_suspend_cpu_usage > 0) {
         msg_printf(NULL, MSG_INFO,
-            "   when idle, suspend work if non-BOINC CPU load exceeds %.0f%%",
+            "      suspend work if non-BOINC CPU load exceeds %.0f%%",
             global_prefs.niu_suspend_cpu_usage
         );
     }
+    msg_printf(NULL, MSG_INFO,
+        "      max memory usage: %.2f GB",
+        (host_info.m_nbytes*global_prefs.ram_max_used_idle_frac)/GIGA
+    );
+    if (global_prefs.suspend_if_no_recent_input > 0) {
+        msg_printf(NULL, MSG_INFO,
+            "      Suspend if no input in last %f minutes",
+            global_prefs.suspend_if_no_recent_input
+        );
+    }
+
+    // general
+    //
+
+    if (!global_prefs.run_on_batteries) {
+        msg_printf(NULL, MSG_INFO,
+            "   Suspend if running on batteries"
+        );
+    }
+    if (global_prefs.leave_apps_in_memory) {
+        msg_printf(NULL, MSG_INFO,
+            "   Leave apps in memory if not running"
+        );
+    }
+    msg_printf(NULL, MSG_INFO,
+        "   Store at least %.2f days of work",
+        global_prefs.work_buf_min_days
+    );
+    msg_printf(NULL, MSG_INFO,
+        "   Store up to an additional %.2f days of work",
+        global_prefs.work_buf_additional_days
+    );
+
+    // network
+    //
     if (global_prefs.max_bytes_sec_down) {
         msg_printf(NULL, MSG_INFO,
             "   max download rate: %.0f bytes/sec",
@@ -707,18 +779,18 @@ void CLIENT_STATE::read_global_prefs(
             global_prefs.max_bytes_sec_up
         );
     }
+
+    // disk
+    //
 #ifndef SIM
-    file_xfers->set_bandwidth_limits(true);
-    file_xfers->set_bandwidth_limits(false);
+    msg_printf(NULL, MSG_INFO,
+        "   max disk usage: %.2f GB",
+        allowed_disk_usage(total_disk_usage)/GIGA
+    );
 #endif
     msg_printf(NULL, MSG_INFO,
         "   (to change preferences, visit a project web site or select Preferences in the Manager)"
     );
-    request_schedule_cpus("Prefs update");
-    request_work_fetch("Prefs update");
-#ifndef SIM
-    active_tasks.request_reread_app_info();
-#endif
 }
 
 int CLIENT_STATE::save_global_prefs(

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -673,72 +673,72 @@ void CLIENT_STATE::print_global_prefs() {
 
     // in use
     //
-    msg_printf(NULL, MSG_INFO, "   When computer is in use:");
+    msg_printf(NULL, MSG_INFO, "-  When computer is in use:");
     msg_printf(NULL, MSG_INFO,
-        "      'In use' means mouse/keyboard in put in last %.1f minutes",
+        "-     'In use' means mouse/keyboard in put in last %.1f minutes",
         global_prefs.idle_time_to_run
     );
     if (!global_prefs.run_if_user_active) {
-        msg_printf(NULL, MSG_INFO, "      don't compute");
+        msg_printf(NULL, MSG_INFO, "-     don't compute");
     }
     if (!global_prefs.run_gpu_if_user_active) {
-        msg_printf(NULL, MSG_INFO, "      don't use GPU");
+        msg_printf(NULL, MSG_INFO, "-     don't use GPU");
     }
     double p = global_prefs.max_ncpus_pct;
     if (p) {
         int n = (int)((host_info.p_ncpus * p)/100);
         msg_printf(NULL, MSG_INFO,
-            "      max CPUs used: %d", n
+            "-     max CPUs used: %d", n
         );
     }
     if (global_prefs.cpu_usage_limit) {
         msg_printf(NULL, MSG_INFO,
-            "      Use at most %.0f%% of the CPU time",
+            "-     Use at most %.0f%% of the CPU time",
             global_prefs.cpu_usage_limit
         );
     }
     if (global_prefs.suspend_cpu_usage) {
         msg_printf(NULL, MSG_INFO,
-            "      suspend work if non-BOINC CPU load exceeds %.0f%%",
+            "-     suspend work if non-BOINC CPU load exceeds %.0f%%",
             global_prefs.suspend_cpu_usage
         );
     }
     msg_printf(NULL, MSG_INFO,
-        "      max memory usage: %.2f GB",
+        "-     max memory usage: %.2f GB",
         (host_info.m_nbytes*global_prefs.ram_max_used_busy_frac)/GIGA
     );
 
     // not in use
     //
     msg_printf(NULL, MSG_INFO,
-        "   When computer is not in use (defaults: same as in use)"
+        "-  When computer is not in use (defaults: same as in use)"
     );
     p = global_prefs.niu_max_ncpus_pct;
     if (p) {
         int n = (int)((host_info.p_ncpus * p)/100);
         msg_printf(NULL, MSG_INFO,
-            "      max CPUs used: %d", n
+            "-     max CPUs used: %d", n
         );
     }
     if (global_prefs.niu_cpu_usage_limit) {
         msg_printf(NULL, MSG_INFO,
-            "      Use at most %.0f%% of the CPU time",
+            "-     Use at most %.0f%% of the CPU time",
             global_prefs.niu_cpu_usage_limit
         );
     }
     if (global_prefs.niu_suspend_cpu_usage > 0) {
         msg_printf(NULL, MSG_INFO,
-            "      suspend work if non-BOINC CPU load exceeds %.0f%%",
+            "-     suspend work if non-BOINC CPU load exceeds %.0f%%",
             global_prefs.niu_suspend_cpu_usage
         );
     }
     msg_printf(NULL, MSG_INFO,
-        "      max memory usage: %.2f GB",
+        "-     max memory usage: %.2f GB",
         (host_info.m_nbytes*global_prefs.ram_max_used_idle_frac)/GIGA
     );
     if (global_prefs.suspend_if_no_recent_input > 0) {
         msg_printf(NULL, MSG_INFO,
-            "      Suspend if no input in last %f minutes",
+            "-     Suspend if no input in last %f minutes",
             global_prefs.suspend_if_no_recent_input
         );
     }
@@ -748,20 +748,20 @@ void CLIENT_STATE::print_global_prefs() {
 
     if (!global_prefs.run_on_batteries) {
         msg_printf(NULL, MSG_INFO,
-            "   Suspend if running on batteries"
+            "-  Suspend if running on batteries"
         );
     }
     if (global_prefs.leave_apps_in_memory) {
         msg_printf(NULL, MSG_INFO,
-            "   Leave apps in memory if not running"
+            "-  Leave apps in memory if not running"
         );
     }
     msg_printf(NULL, MSG_INFO,
-        "   Store at least %.2f days of work",
+        "-  Store at least %.2f days of work",
         global_prefs.work_buf_min_days
     );
     msg_printf(NULL, MSG_INFO,
-        "   Store up to an additional %.2f days of work",
+        "-  Store up to an additional %.2f days of work",
         global_prefs.work_buf_additional_days
     );
 
@@ -769,13 +769,13 @@ void CLIENT_STATE::print_global_prefs() {
     //
     if (global_prefs.max_bytes_sec_down) {
         msg_printf(NULL, MSG_INFO,
-            "   max download rate: %.0f bytes/sec",
+            "-  max download rate: %.0f bytes/sec",
             global_prefs.max_bytes_sec_down
         );
     }
     if (global_prefs.max_bytes_sec_up) {
         msg_printf(NULL, MSG_INFO,
-            "   max upload rate: %.0f bytes/sec",
+            "-  max upload rate: %.0f bytes/sec",
             global_prefs.max_bytes_sec_up
         );
     }
@@ -784,12 +784,12 @@ void CLIENT_STATE::print_global_prefs() {
     //
 #ifndef SIM
     msg_printf(NULL, MSG_INFO,
-        "   max disk usage: %.2f GB",
+        "-  max disk usage: %.2f GB",
         allowed_disk_usage(total_disk_usage)/GIGA
     );
 #endif
     msg_printf(NULL, MSG_INFO,
-        "   (to change preferences, visit a project web site or select Preferences in the Manager)"
+        "-  (to change preferences, visit a project web site or select Preferences in the Manager)"
     );
 }
 

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -711,21 +711,19 @@ void CLIENT_STATE::print_global_prefs() {
     // not in use
     //
     msg_printf(NULL, MSG_INFO,
-        "-  When computer is not in use (defaults: same as in use)"
+        "-  When computer is not in use"
     );
     p = global_prefs.niu_max_ncpus_pct;
-    if (p) {
-        int n = (int)((host_info.p_ncpus * p)/100);
-        msg_printf(NULL, MSG_INFO,
-            "-     max CPUs used: %d", n
-        );
-    }
-    if (global_prefs.niu_cpu_usage_limit) {
-        msg_printf(NULL, MSG_INFO,
-            "-     Use at most %.0f%% of the CPU time",
-            global_prefs.niu_cpu_usage_limit
-        );
-    }
+    int n = (int)((host_info.p_ncpus * p)/100);
+    msg_printf(NULL, MSG_INFO,
+        "-     max CPUs used: %d", n
+    );
+
+    msg_printf(NULL, MSG_INFO,
+        "-     Use at most %.0f%% of the CPU time",
+        global_prefs.niu_cpu_usage_limit
+    );
+
     if (global_prefs.niu_suspend_cpu_usage > 0) {
         msg_printf(NULL, MSG_INFO,
             "-     suspend if non-BOINC CPU load exceeds %.0f%%",

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -673,9 +673,9 @@ void CLIENT_STATE::print_global_prefs() {
 
     // in use
     //
-    msg_printf(NULL, MSG_INFO, "-  When computer is in use:");
+    msg_printf(NULL, MSG_INFO, "-  When computer is in use");
     msg_printf(NULL, MSG_INFO,
-        "-     'In use' means mouse/keyboard in put in last %.1f minutes",
+        "-     'In use' means mouse/keyboard input in last %.1f minutes",
         global_prefs.idle_time_to_run
     );
     if (!global_prefs.run_if_user_active) {
@@ -699,7 +699,7 @@ void CLIENT_STATE::print_global_prefs() {
     }
     if (global_prefs.suspend_cpu_usage) {
         msg_printf(NULL, MSG_INFO,
-            "-     suspend work if non-BOINC CPU load exceeds %.0f%%",
+            "-     suspend if non-BOINC CPU load exceeds %.0f%%",
             global_prefs.suspend_cpu_usage
         );
     }
@@ -728,7 +728,7 @@ void CLIENT_STATE::print_global_prefs() {
     }
     if (global_prefs.niu_suspend_cpu_usage > 0) {
         msg_printf(NULL, MSG_INFO,
-            "-     suspend work if non-BOINC CPU load exceeds %.0f%%",
+            "-     suspend if non-BOINC CPU load exceeds %.0f%%",
             global_prefs.niu_suspend_cpu_usage
         );
     }

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -211,7 +211,7 @@ int CLIENT_STATE::make_scheduler_request(PROJECT* p) {
     // update hardware info, and write host info
     //
     host_info.get_host_info(false);
-    set_ncpus();
+    set_n_usable_cpus();
     host_info.write(mf, !cc_config.suppress_net_info, false);
 
     // get and write disk usage

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -636,7 +636,7 @@ static void handle_reset_host_info(GUI_RPC_CONN& grc) {
     gstate.host_info.get_host_info(true);
     // the amount of RAM or #CPUs may have changed
     //
-    gstate.set_ncpus();
+    gstate.set_n_usable_cpus();
     gstate.request_schedule_cpus("reset_host_info");
     gstate.show_host_info();
     grc.mfout.printf("<success/>\n");
@@ -1331,7 +1331,7 @@ static void handle_read_cc_config(GUI_RPC_CONN& grc) {
     read_config_file(false);
     cc_config.show();
     log_flags.show();
-    gstate.set_ncpus();
+    gstate.set_n_usable_cpus();
     process_gpu_exclusions();
 
     // also reread app_config.xml files
@@ -1349,12 +1349,12 @@ static void handle_get_daily_xfer_history(GUI_RPC_CONN& grc) {
 
 #ifdef __APPLE__
 static void stop_graphics_app(pid_t thePID, 
-                            long iBrandID, 
-                            char current_dir[], 
-                            char switcher_path[], 
-                            string theScreensaverLoginUser, 
-                            GUI_RPC_CONN& grc
-                            ) {
+    long iBrandID, 
+    char current_dir[], 
+    char switcher_path[], 
+    string theScreensaverLoginUser, 
+    GUI_RPC_CONN& grc
+) {
     char* argv[16];
     int argc;
     char screensaverLoginUser[256];
@@ -1365,19 +1365,19 @@ static void stop_graphics_app(pid_t thePID,
         char pidString[10];
         
         snprintf(pidString, sizeof(pidString), "%d", thePID);
-    #if 1
+#if 1
         argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
         argv[1] = saverName[iBrandID];
         argv[2] = "-kill_gfx";
         argv[3] = pidString;
         argc = 4;
-    #else 
+#else 
         argv[0] = const_cast<char*>(SWITCHER_FILE_NAME);
         argv[1] = "/bin/kill";
         argv[2] = "-kill";
         argv[3] = (char *)pidString;
         argc = 4;
-    #endif
+#endif
         if (!theScreensaverLoginUser.empty()) {
             argv[argc++] = "--ScreensaverLoginUser";
             safe_strcpy(screensaverLoginUser, theScreensaverLoginUser.c_str());

--- a/client/rr_sim.cpp
+++ b/client/rr_sim.cpp
@@ -368,7 +368,7 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
                         continue;
                     }
                 } else {
-                    if (rsc_work_fetch[rt].sim_nused >= gstate.ncpus) break;
+                    if (rsc_work_fetch[rt].sim_nused >= gstate.n_usable_cpus) break;
                 }
                 ++rsc_pwf.pending_iter;
             }
@@ -403,7 +403,7 @@ void RR_SIM::pick_jobs_to_run(double reltime) {
 // after the initial assignment of jobs
 //
 static void record_nidle_now() {
-    rsc_work_fetch[0].nidle_now = gstate.ncpus - rsc_work_fetch[0].sim_nused;
+    rsc_work_fetch[0].nidle_now = gstate.n_usable_cpus - rsc_work_fetch[0].sim_nused;
     if (rsc_work_fetch[0].nidle_now < 0) rsc_work_fetch[0].nidle_now = 0;
     for (int i=1; i<coprocs.n_rsc; i++) {
         rsc_work_fetch[i].nidle_now = coprocs.coprocs[i].count - rsc_work_fetch[i].sim_nused;

--- a/client/rrsim_test.cpp
+++ b/client/rrsim_test.cpp
@@ -159,8 +159,8 @@ void PROJECT::set_rrsim_proc_rate(double rrs) {
     // if this project has fewer active results than CPUs,
     // scale up its share to reflect this
     //
-    if (nactive < gstate.ncpus) {
-        x *= ((double)gstate.ncpus)/nactive;
+    if (nactive < gstate.n_usable_cpus) {
+        x *= ((double)gstate.n_usable_cpus)/nactive;
     }
 
     // But its rate on a given CPU can't exceed 1
@@ -424,7 +424,7 @@ int main() {
     gstate.global_prefs.work_buf_min_days = 1;
     gstate.global_prefs.work_buf_additional_days = 1;
     gstate.global_prefs.cpu_scheduling_period_minutes = 60;
-    gstate.ncpus = 1;
+    gstate.n_usable_cpus = 1;
     gstate.now = 0;
 
     p = new PROJECT("project A", 33.);

--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -154,7 +154,7 @@ double gpu_peak_flops() {
 }
 
 double cpu_peak_flops() {
-    return gstate.ncpus * gstate.host_info.p_fpops;
+    return gstate.n_usable_cpus * gstate.host_info.p_fpops;
 }
 
 void print_project_results(FILE* f) {
@@ -600,8 +600,8 @@ bool ACTIVE_TASK_SET::poll() {
     // if CPU is overcommitted, compute cpu_scale
     //
     double cpu_scale = 1;
-    if (cpu_usage > gstate.ncpus) {
-        cpu_scale = (gstate.ncpus - cpu_usage_gpu) / (cpu_usage - cpu_usage_gpu);
+    if (cpu_usage > gstate.n_usable_cpus) {
+        cpu_scale = (gstate.n_usable_cpus - cpu_usage_gpu) / (cpu_usage - cpu_usage_gpu);
     }
 
     double used = 0;

--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -298,8 +298,8 @@ void CLIENT_STATE::get_workload(vector<IP_RESULT>& ip_results) {
         IP_RESULT ipr(rp->name, rp->report_deadline-now, x);
         ip_results.push_back(ipr);
     }
-    //init_ip_results(work_buf_min(), ncpus, ip_results);
-    init_ip_results(0, ncpus, ip_results);
+    //init_ip_results(work_buf_min(), n_usable_ncpus, ip_results);
+    init_ip_results(0, n_usable_cpus, ip_results);
 }
 
 void get_apps_needing_work(PROJECT* p, vector<APP*>& apps) {
@@ -412,7 +412,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
         double et = wup->rsc_fpops_est / rp->avp->flops;
         if (server_uses_workload) {
             IP_RESULT c(rp->name, rp->report_deadline-now, et);
-            if (check_candidate(c, ncpus, ip_results)) {
+            if (check_candidate(c, n_usable_cpus, ip_results)) {
                 ip_results.push_back(c);
             } else {
                 msg_printf(p, MSG_INFO, "job for %s misses deadline sim\n", rp->app->name);
@@ -1495,7 +1495,7 @@ void do_client_simulation() {
     clear_backoff();
 
     gstate.log_show_projects();
-    gstate.set_ncpus();
+    gstate.set_n_usable_cpus();
     work_fetch.init();
 
     //set_initial_rec();

--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -1077,7 +1077,7 @@ void WORK_FETCH::set_initial_work_request(PROJECT* p) {
 // called once, at client startup
 //
 void WORK_FETCH::init() {
-    rsc_work_fetch[0].init(0, gstate.ncpus, 1);
+    rsc_work_fetch[0].init(0, gstate.n_usable_cpus, 1);
     double cpu_flops = gstate.host_info.p_fpops;
 
     // use 20% as a rough estimate of GPU efficiency
@@ -1127,7 +1127,7 @@ void CLIENT_STATE::compute_nuploading_results() {
             rp->project->nuploading_results++;
         }
     }
-    int n = gstate.ncpus;
+    int n = gstate.n_usable_cpus;
     for (int j=1; j<coprocs.n_rsc; j++) {
         if (coprocs.coprocs[j].count > n) {
             n = coprocs.coprocs[j].count;

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -672,6 +672,7 @@ void CDlgAdvPreferences::UpdateControlStates() {
     if (m_chkProcInUse->IsChecked()) m_chkGPUProcInUse->SetValue(true);
 
     m_txtMaxLoad->Enable(m_chkMaxLoad->IsChecked());
+    m_txtMaxLoadNotInUse->Enable(m_chkMaxLoadNotInUse->IsChecked());
 
     // ######### disk and memory usage page
     m_txtDiskMaxSpace->Enable(m_chkDiskMaxSpace->IsChecked());
@@ -1066,7 +1067,9 @@ void CDlgAdvPreferences::OnHandleCommandEvent(wxCommandEvent& ev) {
     case ID_CHKMAXLOAD:
         DisplayValue(defaultPrefs.suspend_cpu_usage, m_txtMaxLoad, m_chkMaxLoad);
         break;
-
+    case ID_CHKMAXLOADNOTINUSE:
+        DisplayValue(defaultPrefs.niu_suspend_cpu_usage, m_txtMaxLoadNotInUse, m_chkMaxLoadNotInUse);
+        break;
     // network usage page
     case ID_CHKNETDOWNLOADRATE:
         DisplayValue((defaultPrefs.max_bytes_sec_down / 1024), m_txtNetDownloadRate, m_chkNetDownloadRate);

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -337,7 +337,9 @@ void CDlgAdvPreferences::ReadPreferenceSettings() {
         m_txtProcIdleFor->Disable();
     }
 
+    m_chkNoRecentInput->SetValue(prefs.suspend_if_no_recent_input > 0.0);
     DisplayValue(prefs.suspend_if_no_recent_input, m_txtNoRecentInput);
+
     m_chkMaxLoad->SetValue(prefs.suspend_cpu_usage > 0.0);
     DisplayValue(prefs.suspend_cpu_usage, m_txtMaxLoad, m_chkMaxLoad);
     m_chkMaxLoadNotInUse->SetValue(prefs.niu_suspend_cpu_usage > 0.0);
@@ -479,9 +481,13 @@ bool CDlgAdvPreferences::SavePreferencesSettings() {
         mask.idle_time_to_run=true;
     }
 
-    m_txtNoRecentInput->GetValue().ToDouble(&td);
-    prefs.suspend_if_no_recent_input = RoundToHundredths(td);
-       mask.suspend_if_no_recent_input = true;
+    if (m_chkNoRecentInput->IsChecked()) {
+        m_txtNoRecentInput->GetValue().ToDouble(&td);
+        prefs.suspend_if_no_recent_input = RoundToHundredths(td);
+    } else {
+        prefs.suspend_if_no_recent_input = 0;
+    }
+    mask.suspend_if_no_recent_input = true;
 
     if (m_chkMaxLoad->IsChecked()) {
         m_txtMaxLoad->GetValue().ToDouble(&td);
@@ -673,6 +679,7 @@ void CDlgAdvPreferences::UpdateControlStates() {
 
     m_txtMaxLoad->Enable(m_chkMaxLoad->IsChecked());
     m_txtMaxLoadNotInUse->Enable(m_chkMaxLoadNotInUse->IsChecked());
+    m_txtNoRecentInput->Enable(m_chkNoRecentInput->IsChecked());
 
     // ######### disk and memory usage page
     m_txtDiskMaxSpace->Enable(m_chkDiskMaxSpace->IsChecked());
@@ -737,10 +744,12 @@ bool CDlgAdvPreferences::ValidateInput() {
         }
     }
 
-    buffer = m_txtNoRecentInput->GetValue();
-    if (!IsValidFloatValueBetween(buffer, 0, 9999999999999.99)) {
-        ShowErrorMessage(invMsgFloat, m_txtNoRecentInput);
-        return false;
+    if (m_chkNoRecentInput->IsChecked()) {
+        buffer = m_txtNoRecentInput->GetValue();
+        if (!IsValidFloatValueBetween(buffer, 0, 9999999999999.99)) {
+            ShowErrorMessage(invMsgFloat, m_txtNoRecentInput);
+            return false;
+        }
     }
 
     if (m_chkMaxLoad->IsChecked()) {
@@ -750,6 +759,7 @@ bool CDlgAdvPreferences::ValidateInput() {
             return false;
         }
     }
+
     if (m_chkMaxLoadNotInUse->IsChecked()) {
         buffer = m_txtMaxLoadNotInUse->GetValue();
         if(!IsValidFloatValueBetween(buffer, 1.0, 100.0)) {
@@ -1069,6 +1079,9 @@ void CDlgAdvPreferences::OnHandleCommandEvent(wxCommandEvent& ev) {
         break;
     case ID_CHKMAXLOADNOTINUSE:
         DisplayValue(defaultPrefs.niu_suspend_cpu_usage, m_txtMaxLoadNotInUse, m_chkMaxLoadNotInUse);
+        break;
+    case ID_CHKNORECENTINPUT:
+        DisplayValue(defaultPrefs.suspend_if_no_recent_input, m_txtNoRecentInput, m_chkNoRecentInput);
         break;
     // network usage page
     case ID_CHKNETDOWNLOADRATE:

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -338,7 +338,7 @@ void CDlgAdvPreferences::ReadPreferenceSettings() {
     }
 
     m_chkNoRecentInput->SetValue(prefs.suspend_if_no_recent_input > 0.0);
-    DisplayValue(prefs.suspend_if_no_recent_input, m_txtNoRecentInput);
+    DisplayValue(prefs.suspend_if_no_recent_input, m_txtNoRecentInput, m_chkNoRecentInput);
 
     m_chkMaxLoad->SetValue(prefs.suspend_cpu_usage > 0.0);
     DisplayValue(prefs.suspend_cpu_usage, m_txtMaxLoad, m_chkMaxLoad);

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -292,11 +292,11 @@ void CDlgAdvPreferences::EnableDisableInUseItem(wxTextCtrl* textCtrl, bool doEna
 void CDlgAdvPreferences::EnableDisableInUseItems() {
     bool doEnable = !(m_chkProcInUse->IsChecked());
     EnableDisableInUseItem(m_txtProcUseProcessors, doEnable, 
-                            defaultPrefs.max_ncpus_pct > 0.0 ? defaultPrefs.max_ncpus_pct : 100.0);
-    EnableDisableInUseItem(m_txtProcUseCPUTime, doEnable, defaultPrefs.cpu_usage_limit);
+                            prefs.max_ncpus_pct > 0.0 ? prefs.max_ncpus_pct : 100.0);
+    EnableDisableInUseItem(m_txtProcUseCPUTime, doEnable, prefs.cpu_usage_limit);
     m_chkMaxLoad->Enable(doEnable);
-    EnableDisableInUseItem(m_txtMaxLoad, doEnable && m_chkMaxLoad->IsChecked(), defaultPrefs.suspend_cpu_usage);
-    EnableDisableInUseItem(m_txtMemoryMaxInUse, doEnable, defaultPrefs.ram_max_used_busy_frac*100.0);
+    EnableDisableInUseItem(m_txtMaxLoad, doEnable && m_chkMaxLoad->IsChecked(), prefs.suspend_cpu_usage);
+    EnableDisableInUseItem(m_txtMemoryMaxInUse, doEnable, prefs.ram_max_used_busy_frac*100.0);
 }
 
 // read preferences from core client and initialize control values
@@ -748,10 +748,12 @@ bool CDlgAdvPreferences::ValidateInput() {
     double startTime, endTime;
 
     // ######### proc usage page
-    buffer = m_txtProcUseProcessors->GetValue();
-    if(!IsValidFloatValueBetween(buffer, 0.0, 100.0)) {
-        ShowErrorMessage(invMsgLimit100, m_txtProcUseProcessors);
-        return false;
+    if (m_txtProcUseProcessors->IsEnabled()) {
+        buffer = m_txtProcUseProcessors->GetValue();
+        if(!IsValidFloatValueBetween(buffer, 0.0, 100.0)) {
+            ShowErrorMessage(invMsgLimit100, m_txtProcUseProcessors);
+            return false;
+        }
     }
     buffer = m_txtProcUseProcessorsNotInUse->GetValue();
     if(!IsValidFloatValueBetween(buffer, 0.0, 100.0)) {
@@ -879,10 +881,12 @@ bool CDlgAdvPreferences::ValidateInput() {
         }
     }
 
-    buffer = m_txtMemoryMaxInUse->GetValue();
-    if(!IsValidFloatValueBetween(buffer, 1.0, 100.0)) {
-        ShowErrorMessage(invMsgLimit1_100, m_txtMemoryMaxInUse);
-        return false;
+    if(m_txtMemoryMaxInUse->IsEnabled()) {
+        buffer = m_txtMemoryMaxInUse->GetValue();
+        if(!IsValidFloatValueBetween(buffer, 1.0, 100.0)) {
+            ShowErrorMessage(invMsgLimit1_100, m_txtMemoryMaxInUse);
+            return false;
+        }
     }
 
     buffer = m_txtMemoryMaxOnIdle->GetValue();

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -327,12 +327,14 @@ void CDlgAdvPreferences::ReadPreferenceSettings() {
     // 0 means "no restriction" but we don't use a checkbox here
     if (prefs.max_ncpus_pct == 0.0) prefs.max_ncpus_pct = 100.0;
     DisplayValue(prefs.max_ncpus_pct, m_txtProcUseProcessors);
+    if (prefs.niu_max_ncpus_pct == 0.0) prefs.niu_max_ncpus_pct = 100.0;
     DisplayValue(prefs.niu_max_ncpus_pct, m_txtProcUseProcessorsNotInUse);
 
     // cpu limit
     // 0 means "no restriction" but we don't use a checkbox here
     if (prefs.cpu_usage_limit == 0.0) prefs.cpu_usage_limit = 100.0;
     DisplayValue(prefs.cpu_usage_limit, m_txtProcUseCPUTime);
+    if (prefs.niu_cpu_usage_limit == 0.0) prefs.niu_cpu_usage_limit = 100.0;
     DisplayValue(prefs.niu_cpu_usage_limit, m_txtProcUseCPUTimeNotInUse);
 
     // on batteries

--- a/clientgui/DlgAdvPreferences.h
+++ b/clientgui/DlgAdvPreferences.h
@@ -59,6 +59,8 @@ public:
     void OnHelp(wxCommandEvent& event);
     void OnClear(wxCommandEvent& event);
     void DisplayValue(double value, wxTextCtrl* textCtrl, wxCheckBox* checkBox=NULL);
+    void EnableDisableInUseItem(wxTextCtrl* textCtrl, bool doEnable, double value);
+    void EnableDisableInUseItems();
     bool OKToShow() { return m_bOKToShow; }
 private:
     GLOBAL_PREFS      prefs;

--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -341,15 +341,15 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     //
     wxString MemoryMaxInUseTT = wxEmptyString;
     MemoryMaxInUseTT.Printf(_("Limit the memory used by %s when you're using the computer."), pSkinAdvanced->GetApplicationShortName().c_str());
-    wxStaticText* staticText50 = new wxStaticText(box, ID_DEFAULT, _("When computer is in use, use at most"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText* staticText50 = new wxStaticText(box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0 );
     textCtrlSize = getTextCtrlSize(wxT("100.00"));
     m_txtMemoryMaxInUse = new wxTextCtrl( box, ID_TXTMEMORYMAXINUSE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
     /*xgettext:no-c-format*/
-    wxStaticText* staticText51 = new wxStaticText( box, ID_DEFAULT, _("%"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText* staticText51 = new wxStaticText( box, ID_DEFAULT, _("% of memory"), wxDefaultPosition, wxDefaultSize, 0 );
     addNewRowToSizer(box_sizer, MemoryMaxInUseTT, staticText50, m_txtMemoryMaxInUse, staticText51);
 
     processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
-    processorTabSizer->Add(box, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE );
+    processorTabSizer->Add(box_sizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE );
 
     // ------------ Not-in-use box --------------
     //
@@ -361,32 +361,51 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     // max # CPUs
     //
     /*xgettext:no-c-format*/
-    m_txtProcUseProcessorsNotInUse = new wxTextCtrl(box, ID_TXTPROCUSEPROCESSORSNOTINUSE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
-    addNewRowToSizer(box_sizer, MaxCPUPctTT, staticText20, m_txtProcUseProcessorsNotInUse, staticText21);
+    wxString MaxCPUPctTTniu(_("Keep some CPUs free for other applications. Example: 75% means use 6 cores on an 8-core CPU."));
+    wxStaticText* staticText20niu = new wxStaticText(
+        box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0
+    );
+    m_txtProcUseProcessorsNotInUse = new wxTextCtrl(box, ID_TXTPROCUSEPROCESSORSNOTINUSE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT);
+    /*xgettext:no-c-format*/
+    wxStaticText* staticText21niu = new wxStaticText(box, ID_DEFAULT, _("% of the CPUs"), wxDefaultPosition, wxDefaultSize, 0);
+    addNewRowToSizer(box_sizer, MaxCPUPctTTniu, staticText20niu, m_txtProcUseProcessorsNotInUse, staticText21niu);
 
     // CPU throttling
     //
-    m_txtProcUseCPUTimeNotInUse = new wxTextCtrl(box, ID_TXTPROCUSECPUTIMENOTINUSE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
-    addNewRowToSizer(box_sizer, MaxCPUTimeTT, staticText22, m_txtProcUseCPUTimeNotInUse, staticText23);
+    wxString MaxCPUTimeTTniu(_("Suspend/resume computing every few seconds to reduce CPU temperature and energy usage. Example: 75% means compute for 3 seconds, wait for 1 second, and repeat."));
+    wxStaticText* staticText22niu = new wxStaticText(
+        box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0
+    );
+    m_txtProcUseCPUTimeNotInUse = new wxTextCtrl(box, ID_TXTPROCUSECPUTIMENOTINUSE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT);
+    /*xgettext:no-c-format*/
+    wxStaticText* staticText23niu = new wxStaticText(box, ID_DEFAULT, _("% of CPU time"), wxDefaultPosition, wxDefaultSize, 0);
+    addNewRowToSizer(box_sizer, MaxCPUTimeTTniu, staticText22niu, m_txtProcUseCPUTimeNotInUse, staticText23niu);
 
     // max CPU load
     //
+
+    wxString MaxLoadCheckBoxTextniu = wxEmptyString;
+    MaxLoadCheckBoxTextniu.Printf(_("Suspend when non-BOINC CPU usage is above"));
+    wxString MaxLoadTTniu(_("Suspend computing when your computer is busy running other programs."));
     m_chkMaxLoadNotInUse = new wxCheckBox(
-        box, ID_CHKMAXLOADNOTINUSE, MaxLoadCheckBoxText, wxDefaultPosition, wxDefaultSize, 0
+        box, ID_CHKMAXLOADNOTINUSE, MaxLoadCheckBoxTextniu, wxDefaultPosition, wxDefaultSize, 0
     );
     m_txtMaxLoadNotInUse = new wxTextCtrl(
         box, ID_TXTMAXLOADNOTINUSE, wxEmptyString, wxDefaultPosition, getTextCtrlSize(wxT("100.00")), wxTE_RIGHT
     );
-    addNewRowToSizer(box_sizer, MaxLoadTT, m_chkMaxLoadNotInUse, m_txtMaxLoadNotInUse, staticText26);
+    wxStaticText* staticText26niu = new wxStaticText(box, ID_DEFAULT, wxT("%"),
+        wxDefaultPosition, wxDefaultSize, 0
+    );
+    addNewRowToSizer(box_sizer, MaxLoadTTniu, m_chkMaxLoadNotInUse, m_txtMaxLoadNotInUse, staticText26niu);
 
     // max memory when not in use
     //
     wxString MemoryMaxOnIdleTT = wxEmptyString;
     MemoryMaxOnIdleTT.Printf(_("Limit the memory used by %s when you're not using the computer."), pSkinAdvanced->GetApplicationShortName().c_str());
-    wxStaticText* staticText52 = new wxStaticText( box, ID_DEFAULT, _("When computer is not in use, use at most"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText* staticText52 = new wxStaticText( box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0 );
     m_txtMemoryMaxOnIdle = new wxTextCtrl( box, ID_TXTMEMORYMAXONIDLE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
     /*xgettext:no-c-format*/
-    wxStaticText* staticText53 = new wxStaticText( box, ID_DEFAULT, _("%"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText* staticText53 = new wxStaticText( box, ID_DEFAULT, _("% of memory"), wxDefaultPosition, wxDefaultSize, 0 );
     addNewRowToSizer(box_sizer, MemoryMaxOnIdleTT, staticText52, m_txtMemoryMaxOnIdle, staticText53);
 
     // suspend after idle time
@@ -407,10 +426,6 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     );
     addNewRowToSizer(box_sizer, NoRecentInputTT, staticText27, m_txtNoRecentInput, staticText28);
 
-    box_sizer->Add(
-        new wxStaticText(box, ID_DEFAULT, _("To suspend by time of day, see the \"Daily Schedules\" section."), wxDefaultPosition, wxDefaultSize, 0),
-        0, wxALL, 5
-    );
 
     processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
     processorTabSizer->Add(box_sizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE);
@@ -470,6 +485,12 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     );
     addNewRowToSizer(box_sizer, DiskWriteToDiskTT, staticText46, m_txtDiskWriteToDisk, staticText47);
 
+    // leave non-GPU tasks in memory while suspended
+//
+    m_chkMemoryWhileSuspended = new wxCheckBox(box, ID_CHKMEMORYWHILESUSPENDED, _("Leave non-GPU tasks in memory while suspended"), wxDefaultPosition, wxDefaultSize, 0);
+    m_chkMemoryWhileSuspended->SetToolTip(_("If checked, suspended tasks stay in memory, and resume with no work lost. If unchecked, suspended tasks are removed from memory, and resume from their last checkpoint."));
+    box_sizer->Add(m_chkMemoryWhileSuspended, 0, wxALL, 5);
+
     // work buffer min
     //
     wxString NetConnectIntervalTT(_("Store at least enough tasks to keep the computer busy for this long."));
@@ -511,6 +532,11 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     );
     addNewRowToSizer(box_sizer, NetAdditionalDaysTT, staticText331, m_txtNetAdditionalDays, staticText341);
 
+    box_sizer->Add(
+        new wxStaticText(box, ID_DEFAULT, _("To suspend by time of day, see the \"Daily Schedules\" section."), wxDefaultPosition, wxDefaultSize, 0),
+        0, wxALL, 5
+    );
+
     box_sizer->AddSpacer(1); // Ensure staticText22 is fully visible on Mac
 
     processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
@@ -535,7 +561,7 @@ wxPanel* CDlgAdvPreferencesBase::createNetworkTab(wxNotebook* notebook) {
 
     wxBoxSizer* networkTabSizer = new wxBoxSizer( wxVERTICAL );
 
-    wxStaticBox* box = new wxStaticBox( networkTab, -1, _("Usage limits") );
+    wxStaticBox* box = new wxStaticBox( networkTab, -1, _("Network usage") );
     wxStaticBoxSizer* box_sizer = new wxStaticBoxSizer(box, wxVERTICAL);
     makeStaticBoxLabelItalic(box);
 
@@ -612,8 +638,7 @@ wxPanel* CDlgAdvPreferencesBase::createNetworkTab(wxNotebook* notebook) {
     return networkTab;
 }
 
-wxPanel* CDlgAdvPreferencesBase::createDiskAndMemoryTab(wxNotebook* notebook)
-{
+wxPanel* CDlgAdvPreferencesBase::createDiskAndMemoryTab(wxNotebook* notebook) {
     CSkinAdvanced*      pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     wxASSERT(pSkinAdvanced);
 
@@ -624,15 +649,9 @@ wxPanel* CDlgAdvPreferencesBase::createDiskAndMemoryTab(wxNotebook* notebook)
 
     wxBoxSizer* diskAndMemoryTabSizer = new wxBoxSizer( wxVERTICAL );
 
-    wxStaticBox* diskUsageStaticBox = new wxStaticBox( diskMemoryTab, -1, _("Disk") );
+    wxStaticBox* diskUsageStaticBox = new wxStaticBox( diskMemoryTab, -1, _("Disk usage") );
     wxStaticBoxSizer* diskUsageBoxSizer = new wxStaticBoxSizer( diskUsageStaticBox, wxVERTICAL );
     makeStaticBoxLabelItalic(diskUsageStaticBox);
-
-    wxString MostRestrictiveText = wxEmptyString;
-    MostRestrictiveText.Printf(_("%s will use the most restrictive of these settings:"), pSkinAdvanced->GetApplicationShortName().c_str());
-    diskUsageBoxSizer->Add(new wxStaticText( diskUsageStaticBox, -1, MostRestrictiveText, wxDefaultPosition, wxDefaultSize, 0),
-        0, wxALL, 5
-    );
 
     // total disk usage
     //
@@ -665,34 +684,24 @@ wxPanel* CDlgAdvPreferencesBase::createDiskAndMemoryTab(wxNotebook* notebook)
     wxStaticText* staticText45 = new wxStaticText( diskUsageStaticBox, ID_DEFAULT, _("% of total"), wxDefaultPosition, wxDefaultSize, 0 );
     addNewRowToSizer(diskUsageBoxSizer, DiskMaxOfTotalTT, m_chkDiskMaxOfTotal, m_txtDiskMaxOfTotal, staticText45);
 
-    diskAndMemoryTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
-    diskAndMemoryTabSizer->Add( diskUsageBoxSizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE );
-
-    wxStaticBox* memoryUsageStaticBox = new wxStaticBox( diskMemoryTab, -1, _("Memory") );
-    wxStaticBoxSizer* memoryUsageBoxSizer = new wxStaticBoxSizer( memoryUsageStaticBox, wxVERTICAL );
-    makeStaticBoxLabelItalic(memoryUsageStaticBox);
-
-    // leave non-GPU tasks in memory while suspended
+    wxString MostRestrictiveText = wxEmptyString;
+    MostRestrictiveText.Printf(_("%s will use the most restrictive of the above settings"), pSkinAdvanced->GetApplicationShortName().c_str());
+    diskUsageBoxSizer->Add(new wxStaticText(diskUsageStaticBox, -1, MostRestrictiveText, wxDefaultPosition, wxDefaultSize, 0),
+        0, wxALL, 5
+    ); 
+ 
+    // swap space limit
     //
-    m_chkMemoryWhileSuspended = new wxCheckBox( memoryUsageStaticBox, ID_CHKMEMORYWHILESUSPENDED, _("Leave non-GPU tasks in memory while suspended"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_chkMemoryWhileSuspended->SetToolTip( _("If checked, suspended tasks stay in memory, and resume with no work lost. If unchecked, suspended tasks are removed from memory, and resume from their last checkpoint.") );
-    memoryUsageBoxSizer->Add(m_chkMemoryWhileSuspended, 0, wxALL, 5 );
-
     wxString DiskMaxSwapTT = wxEmptyString;
     DiskMaxSwapTT.Printf(_("Limit the swap space (page file) used by %s."), pSkinAdvanced->GetApplicationShortName().c_str());
-
-    wxStaticText* staticText48 = new wxStaticText( memoryUsageStaticBox, ID_DEFAULT, _("Page/swap file: use at most"), wxDefaultPosition, wxDefaultSize, 0 );
-
-    m_txtDiskMaxSwap = new wxTextCtrl( memoryUsageStaticBox, ID_TXTDISKWRITETODISK, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
-
+    wxStaticText* staticText48 = new wxStaticText(diskUsageStaticBox, ID_DEFAULT, _("Page/swap file: use at most"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_txtDiskMaxSwap = new wxTextCtrl(diskUsageStaticBox, ID_TXTDISKWRITETODISK, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
     /*xgettext:no-c-format*/
-    wxStaticText* staticText49 = new wxStaticText( memoryUsageStaticBox, ID_DEFAULT, _("%"), wxDefaultPosition, wxDefaultSize, 0 );
+    wxStaticText* staticText49 = new wxStaticText(diskUsageStaticBox, ID_DEFAULT, _("%"), wxDefaultPosition, wxDefaultSize, 0 );
+    addNewRowToSizer(diskUsageBoxSizer, DiskMaxSwapTT, staticText48, m_txtDiskMaxSwap, staticText49);
 
-    addNewRowToSizer(memoryUsageBoxSizer, DiskMaxSwapTT, staticText48, m_txtDiskMaxSwap, staticText49);
-
-    diskAndMemoryTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
-    diskAndMemoryTabSizer->Add( memoryUsageBoxSizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE );
-    diskAndMemoryTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
+    diskAndMemoryTabSizer->AddSpacer(STATICBOXVERTICALSPACER);
+    diskAndMemoryTabSizer->Add(diskUsageBoxSizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE);
 
     diskMemoryTab->SetSizer( diskAndMemoryTabSizer );
     diskMemoryTab->Layout();

--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -331,8 +331,9 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     m_txtMaxLoad = new wxTextCtrl(
         box, ID_TXTMAXLOAD, wxEmptyString, wxDefaultPosition, getTextCtrlSize(wxT("100.00")), wxTE_RIGHT
     );
+    wxString load_tt(_("Suspend computing when your computer is busy running other programs."));
     addNewRowToSizer(box_sizer,
-        wxString (_("Suspend computing when your computer is busy running other programs.")),
+        load_tt,
         m_chkMaxLoad, m_txtMaxLoad,
         new wxStaticText(box, ID_DEFAULT, wxT("%"), wxDefaultPosition, wxDefaultSize, 0)
     );

--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -383,10 +383,8 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
 
     // max CPU load
     //
-
     wxString MaxLoadCheckBoxTextniu = wxEmptyString;
     MaxLoadCheckBoxTextniu.Printf(_("Suspend when non-BOINC CPU usage is above"));
-    wxString MaxLoadTTniu(_("Suspend computing when your computer is busy running other programs."));
     m_chkMaxLoadNotInUse = new wxCheckBox(
         box, ID_CHKMAXLOADNOTINUSE, MaxLoadCheckBoxTextniu, wxDefaultPosition, wxDefaultSize, 0
     );
@@ -396,6 +394,7 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     wxStaticText* staticText26niu = new wxStaticText(box, ID_DEFAULT, wxT("%"),
         wxDefaultPosition, wxDefaultSize, 0
     );
+    wxString MaxLoadTTniu(_("Suspend computing when your computer is busy running other programs."));
     addNewRowToSizer(box_sizer, MaxLoadTTniu, m_chkMaxLoadNotInUse, m_txtMaxLoadNotInUse, staticText26niu);
 
     // max memory when not in use
@@ -410,7 +409,11 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
 
     // suspend after idle time
     //
-    wxString NoRecentInputTT(_("This allows some computers to enter low-power mode when not in use."));
+    wxString str0 = wxEmptyString;
+    str0.Printf(_("Suspend when non-BOINC CPU usage is above"));
+    m_chkNoRecentInput = new wxCheckBox(
+        box, ID_CHKNORECENTINPUT, str0, wxDefaultPosition, wxDefaultSize, 0
+    );
     wxStaticText* staticText27 = new wxStaticText(
         box, ID_DEFAULT,
         _("Suspend when no mouse/keyboard input in last"),
@@ -424,8 +427,8 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     m_txtNoRecentInput = new wxTextCtrl(
         box, ID_TXTNORECENTINPUT, wxEmptyString, wxDefaultPosition, getTextCtrlSize(wxT("999.99")), wxTE_RIGHT
     );
+    wxString NoRecentInputTT(_("This allows some computers to enter low-power mode when not in use."));
     addNewRowToSizer(box_sizer, NoRecentInputTT, staticText27, m_txtNoRecentInput, staticText28);
-
 
     processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
     processorTabSizer->Add(box_sizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE);

--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -154,9 +154,9 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
     iImageIndex = pImageList->Add(wxBitmap(xfer_xpm));
     m_Notebook->AddPage( m_panelNetwork, _("Network"), true, iImageIndex );
 
-    m_panelDiskAndMemory = createDiskAndMemoryTab(m_Notebook);
+    m_panelDisk = createDiskTab(m_Notebook);
     iImageIndex = pImageList->Add(wxBitmap(usage_xpm));
-    m_Notebook->AddPage( m_panelDiskAndMemory, _("Disk"), true, iImageIndex );
+    m_Notebook->AddPage( m_panelDisk, _("Disk"), true, iImageIndex );
 
     m_panelDailySchedules = createDailySchedulesTab(m_Notebook);
     iImageIndex = pImageList->Add(wxBitmap(clock_xpm));
@@ -323,19 +323,19 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
 
     // max CPU load
     //
-    wxString MaxLoadCheckBoxText = wxEmptyString;
-    MaxLoadCheckBoxText.Printf(_("Suspend when non-BOINC CPU usage is above"));
-    wxString MaxLoadTT(_("Suspend computing when your computer is busy running other programs."));
     m_chkMaxLoad = new wxCheckBox(
-        box, ID_CHKMAXLOAD, MaxLoadCheckBoxText, wxDefaultPosition, wxDefaultSize, 0
+        box, ID_CHKMAXLOAD,
+        wxString(_("Suspend when non-BOINC CPU usage is above")),
+        wxDefaultPosition, wxDefaultSize, 0
     );
     m_txtMaxLoad = new wxTextCtrl(
         box, ID_TXTMAXLOAD, wxEmptyString, wxDefaultPosition, getTextCtrlSize(wxT("100.00")), wxTE_RIGHT
     );
-    wxStaticText* staticText26 = new wxStaticText( box, ID_DEFAULT, wxT("%"),
-        wxDefaultPosition, wxDefaultSize, 0
+    addNewRowToSizer(box_sizer,
+        wxString (_("Suspend computing when your computer is busy running other programs.")),
+        m_chkMaxLoad, m_txtMaxLoad,
+        new wxStaticText(box, ID_DEFAULT, wxT("%"), wxDefaultPosition, wxDefaultSize, 0)
     );
-    addNewRowToSizer(box_sizer, MaxLoadTT, m_chkMaxLoad, m_txtMaxLoad, staticText26);
 
     // max memory while in use
     //
@@ -410,14 +410,9 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     // suspend after idle time
     //
     wxString str0 = wxEmptyString;
-    str0.Printf(_("Suspend when non-BOINC CPU usage is above"));
+    str0.Printf(_("Suspend when no mouse/keyboard input in last"));
     m_chkNoRecentInput = new wxCheckBox(
         box, ID_CHKNORECENTINPUT, str0, wxDefaultPosition, wxDefaultSize, 0
-    );
-    wxStaticText* staticText27 = new wxStaticText(
-        box, ID_DEFAULT,
-        _("Suspend when no mouse/keyboard input in last"),
-        wxDefaultPosition, wxDefaultSize, 0
     );
     wxStaticText* staticText28 = new wxStaticText(
         box, ID_DEFAULT,
@@ -428,7 +423,7 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
         box, ID_TXTNORECENTINPUT, wxEmptyString, wxDefaultPosition, getTextCtrlSize(wxT("999.99")), wxTE_RIGHT
     );
     wxString NoRecentInputTT(_("This allows some computers to enter low-power mode when not in use."));
-    addNewRowToSizer(box_sizer, NoRecentInputTT, staticText27, m_txtNoRecentInput, staticText28);
+    addNewRowToSizer(box_sizer, NoRecentInputTT, m_chkNoRecentInput, m_txtNoRecentInput, staticText28);
 
     processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
     processorTabSizer->Add(box_sizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE);
@@ -641,7 +636,7 @@ wxPanel* CDlgAdvPreferencesBase::createNetworkTab(wxNotebook* notebook) {
     return networkTab;
 }
 
-wxPanel* CDlgAdvPreferencesBase::createDiskAndMemoryTab(wxNotebook* notebook) {
+wxPanel* CDlgAdvPreferencesBase::createDiskTab(wxNotebook* notebook) {
     CSkinAdvanced*      pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     wxASSERT(pSkinAdvanced);
 
@@ -650,7 +645,7 @@ wxPanel* CDlgAdvPreferencesBase::createDiskAndMemoryTab(wxNotebook* notebook) {
     wxPanel* diskMemoryTab = new wxPanel( notebook, ID_TABPAGE_DISK, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
     diskMemoryTab->SetExtraStyle( wxWS_EX_VALIDATE_RECURSIVELY );
 
-    wxBoxSizer* diskAndMemoryTabSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer* diskTabSizer = new wxBoxSizer( wxVERTICAL );
 
     wxStaticBox* diskUsageStaticBox = new wxStaticBox( diskMemoryTab, -1, _("Disk usage") );
     wxStaticBoxSizer* diskUsageBoxSizer = new wxStaticBoxSizer( diskUsageStaticBox, wxVERTICAL );
@@ -703,12 +698,12 @@ wxPanel* CDlgAdvPreferencesBase::createDiskAndMemoryTab(wxNotebook* notebook) {
     wxStaticText* staticText49 = new wxStaticText(diskUsageStaticBox, ID_DEFAULT, _("%"), wxDefaultPosition, wxDefaultSize, 0 );
     addNewRowToSizer(diskUsageBoxSizer, DiskMaxSwapTT, staticText48, m_txtDiskMaxSwap, staticText49);
 
-    diskAndMemoryTabSizer->AddSpacer(STATICBOXVERTICALSPACER);
-    diskAndMemoryTabSizer->Add(diskUsageBoxSizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE);
+    diskTabSizer->AddSpacer(STATICBOXVERTICALSPACER);
+    diskTabSizer->Add(diskUsageBoxSizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE);
 
-    diskMemoryTab->SetSizer( diskAndMemoryTabSizer );
+    diskMemoryTab->SetSizer( diskTabSizer );
     diskMemoryTab->Layout();
-    diskAndMemoryTabSizer->Fit( diskMemoryTab );
+    diskTabSizer->Fit( diskMemoryTab );
 
     return diskMemoryTab;
 }

--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -85,15 +85,16 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
         if (m_bUsingLocalPrefs) {
             legendSizer->Add(
                 new wxStaticText( topControlsStaticBox, ID_DEFAULT,
-                            _("Using local preferences.\n"
-                            "Click \"Use web prefs\" to use web-based preferences from"
-                            ), wxDefaultPosition, wxDefaultSize, 0 ),
+                    _("Using local prefs.")
+                    + "  "
+                    +_("Click to use web prefs from"),
+                    wxDefaultPosition, wxDefaultSize, 0 ),
                 0, wxALL, 1
             );
         } else {
             legendSizer->Add(
                 new wxStaticText( topControlsStaticBox, ID_DEFAULT,
-                            _("Using web-based preferences from"),
+                            _("Using web prefs from"),
                             wxDefaultPosition, wxDefaultSize, 0 ),
                 0, wxALL, 1
             );
@@ -110,7 +111,7 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
         if (!m_bUsingLocalPrefs) {
             legendSizer->Add(
                 new wxStaticText( topControlsStaticBox, ID_DEFAULT,
-                     _("Set values and click Save to use local preferences instead."),
+                     _("Set values and click Save to use local prefs instead."),
                      wxDefaultPosition, wxDefaultSize, 0 ),
                 0, wxALL, 1
             );
@@ -201,42 +202,71 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
     this->SetSizer( dialogSizer );
 }
 
+#define PAD0    1
+#define PAD1    3
+
+// this version lets you attach different tooltips to different items
+//
+void CDlgAdvPreferencesBase::add_row_to_sizer2(wxSizer* toSizer,
+    wxWindow* item1, wxString& tt1,
+    wxWindow* item2, wxString& tt2,
+    wxWindow* item3, wxString& tt3,
+    wxWindow* item4, wxString& tt4,
+    wxWindow* item5, wxString& tt5
+) {
+    wxBoxSizer* rowSizer = new wxBoxSizer(wxHORIZONTAL);
+
+    rowSizer->Add(item1, 0, wxALL, PAD1);
+    item1->SetToolTip(tt1);
+    rowSizer->Add(item2, 0, wxALL, PAD0);
+    item2->SetToolTip(tt2);
+    rowSizer->Add(item3, 0, wxALL, PAD1);
+    item3->SetToolTip(tt3);
+    rowSizer->Add(item4, 0, wxALL, PAD0);
+    item4->SetToolTip(tt4);
+    rowSizer->Add(item5, 0, wxALL, PAD1);
+    item5->SetToolTip(tt5);
+
+    toSizer->Add(rowSizer, 0, 0, 1);
+}
+
 void CDlgAdvPreferencesBase::addNewRowToSizer(
-                wxSizer* toSizer, wxString& toolTipText,
-                wxWindow* first, wxWindow* second, wxWindow* third,
-                wxWindow* fourth, wxWindow* fifth)
-{
-    wxBoxSizer* rowSizer = new wxBoxSizer( wxHORIZONTAL );
+    wxSizer* toSizer, wxString& toolTipText,
+    wxWindow* first, wxWindow* second, wxWindow* third,
+    wxWindow* fourth, wxWindow* fifth
+) {
+    wxBoxSizer* rowSizer = new wxBoxSizer(wxHORIZONTAL);
 
 #ifdef __WXMSW__
     // MSW adds space to the right of checkbox label
     if (first->IsKindOf(CLASSINFO(wxCheckBox))) {
-        rowSizer->Add(first, 0, wxTOP | wxBOTTOM |wxLEFT, 5 );
+        rowSizer->Add(first, 0, wxTOP | wxBOTTOM |wxLEFT, PAD1 );
     } else
 #endif
-        rowSizer->Add(first, 0, wxALL, 5 );
+        rowSizer->Add(first, 0, wxALL, PAD1 );
+
+    // the last arg is padding.  Less for text fields, to make things line up
 
     first->SetToolTip(toolTipText);
 
-    rowSizer->Add(second, 0, wxALL, 2 );
+    rowSizer->Add(second, 0, wxALL, PAD0 );
     second->SetToolTip(toolTipText);
 
-    rowSizer->Add(third, 0, wxALL, 5 );
+    rowSizer->Add(third, 0, wxALL, PAD1);
     third->SetToolTip(toolTipText);
 
     if (fourth) {
-        rowSizer->Add(fourth, 0, wxALL, 2 );
+        rowSizer->Add(fourth, 0, wxALL, PAD0);
         fourth->SetToolTip(toolTipText);
     }
 
     if (fifth) {
-        rowSizer->Add(fifth, 0, wxALL, 5 );
+        rowSizer->Add(fifth, 0, wxALL, PAD1);
         fifth->SetToolTip(toolTipText);
     }
 
     toSizer->Add( rowSizer, 0, 0, 1 );
 }
-
 
 wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     CSkinAdvanced*      pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
@@ -260,8 +290,8 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     wxString ProcIdleForTT(_("This determines when the computer is considered 'in use'."));
     wxStaticText* staticText24 = new wxStaticText(
         box, ID_DEFAULT,
-        // context: 'In use' means mouse/keyboard input in last ___ minutes
-        _("'In use' means mouse/keyboard input in last"),
+        // context: 'In use' means mouse or keyboard input in last ___ minutes
+        _("'In use' means mouse or keyboard input in last"),
         wxDefaultPosition, wxDefaultSize, 0
     );
     m_txtProcIdleFor = new wxTextCtrl(
@@ -269,7 +299,7 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     );
     wxStaticText* staticText25 = new wxStaticText(
         box, ID_DEFAULT,
-        // context: 'In use' means mouse/keyboard input in last ___ minutes
+        // context: 'In use' means mouse or keyboard input in last ___ minutes
         _("minutes"),
         wxDefaultPosition, wxDefaultSize, 0
     );
@@ -297,29 +327,29 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     );
     box_sizer->Add( m_chkGPUProcInUse, 0, wxALL, 5 );
 
-    // max # CPUs
+    // max # CPUs and throttling
     //
-    /*xgettext:no-c-format*/
-    wxString MaxCPUPctTT(_("Keep some CPUs free for other applications. Example: 75% means use 6 cores on an 8-core CPU."));
     wxStaticText* staticText20 = new wxStaticText(
         box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0
     );
     m_txtProcUseProcessors = new wxTextCtrl(box, ID_TXTPROCUSEPROCESSORS, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
-    /*xgettext:no-c-format*/
-    wxStaticText* staticText21 = new wxStaticText(box, ID_DEFAULT, _("% of the CPUs"), wxDefaultPosition, wxDefaultSize, 0 );
-    addNewRowToSizer(box_sizer, MaxCPUPctTT, staticText20, m_txtProcUseProcessors, staticText21);
-
-    // CPU throttling
-    //
-    /*xgettext:no-c-format*/
-    wxString MaxCPUTimeTT(_("Suspend/resume computing every few seconds to reduce CPU temperature and energy usage. Example: 75% means compute for 3 seconds, wait for 1 second, and repeat."));
     wxStaticText* staticText22 = new wxStaticText(
-        box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0
+        box, ID_DEFAULT, _("% of the CPUs and at most"), wxDefaultPosition, wxDefaultSize, 0
     );
     m_txtProcUseCPUTime = new wxTextCtrl(box, ID_TXTPROCUSECPUTIME, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT );
     /*xgettext:no-c-format*/
     wxStaticText* staticText23 = new wxStaticText(box, ID_DEFAULT, _("% of CPU time"), wxDefaultPosition, wxDefaultSize, 0 );
-    addNewRowToSizer(box_sizer, MaxCPUTimeTT, staticText22, m_txtProcUseCPUTime, staticText23);
+    /*xgettext:no-c-format*/
+    wxString tt_ncpus(_("Keep some CPUs free for other applications. Example: 75% means use 6 cores on an 8-core CPU."));
+    /*xgettext:no-c-format*/
+    wxString tt_throttle(_("Suspend/resume computing every few seconds to reduce CPU temperature and energy usage. Example: 75% means compute for 3 seconds, wait for 1 second, and repeat."));
+    add_row_to_sizer2(box_sizer,
+        staticText20, tt_ncpus,
+        m_txtProcUseProcessors, tt_ncpus,
+        staticText22, tt_ncpus,
+        m_txtProcUseCPUTime, tt_throttle,
+        staticText23, tt_throttle
+    );
 
     // max CPU load
     //
@@ -359,28 +389,26 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     box_sizer = new wxStaticBoxSizer(box, wxVERTICAL);
     makeStaticBoxLabelItalic(box);
 
-    // max # CPUs
+    // max # CPUs and throttling
     //
-    /*xgettext:no-c-format*/
-    wxString MaxCPUPctTTniu(_("Keep some CPUs free for other applications. Example: 75% means use 6 cores on an 8-core CPU."));
     wxStaticText* staticText20niu = new wxStaticText(
         box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0
     );
     m_txtProcUseProcessorsNotInUse = new wxTextCtrl(box, ID_TXTPROCUSEPROCESSORSNOTINUSE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT);
-    /*xgettext:no-c-format*/
-    wxStaticText* staticText21niu = new wxStaticText(box, ID_DEFAULT, _("% of the CPUs"), wxDefaultPosition, wxDefaultSize, 0);
-    addNewRowToSizer(box_sizer, MaxCPUPctTTniu, staticText20niu, m_txtProcUseProcessorsNotInUse, staticText21niu);
-
-    // CPU throttling
-    //
-    wxString MaxCPUTimeTTniu(_("Suspend/resume computing every few seconds to reduce CPU temperature and energy usage. Example: 75% means compute for 3 seconds, wait for 1 second, and repeat."));
     wxStaticText* staticText22niu = new wxStaticText(
-        box, ID_DEFAULT, _("Use at most"), wxDefaultPosition, wxDefaultSize, 0
+        /*xgettext:no-c-format*/
+        box, ID_DEFAULT, _("% of the CPUs and at most"), wxDefaultPosition, wxDefaultSize, 0
     );
     m_txtProcUseCPUTimeNotInUse = new wxTextCtrl(box, ID_TXTPROCUSECPUTIMENOTINUSE, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT);
     /*xgettext:no-c-format*/
     wxStaticText* staticText23niu = new wxStaticText(box, ID_DEFAULT, _("% of CPU time"), wxDefaultPosition, wxDefaultSize, 0);
-    addNewRowToSizer(box_sizer, MaxCPUTimeTTniu, staticText22niu, m_txtProcUseCPUTimeNotInUse, staticText23niu);
+    add_row_to_sizer2(box_sizer,
+        staticText20niu, tt_ncpus,
+        m_txtProcUseProcessorsNotInUse, tt_ncpus,
+        staticText22niu, tt_ncpus,
+        m_txtProcUseCPUTimeNotInUse, tt_throttle,
+        staticText23niu, tt_throttle
+    );
 
     // max CPU load
     //
@@ -411,7 +439,7 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     // suspend after idle time
     //
     wxString str0 = wxEmptyString;
-    str0.Printf(_("Suspend when no mouse/keyboard input in last"));
+    str0.Printf(_("Suspend when no mouse or keyboard input in last"));
     m_chkNoRecentInput = new wxCheckBox(
         box, ID_CHKNORECENTINPUT, str0, wxDefaultPosition, wxDefaultSize, 0
     );
@@ -490,6 +518,7 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     m_chkMemoryWhileSuspended->SetToolTip(_("If checked, suspended tasks stay in memory, and resume with no work lost. If unchecked, suspended tasks are removed from memory, and resume from their last checkpoint."));
     box_sizer->Add(m_chkMemoryWhileSuspended, 0, wxALL, 5);
 
+#if 0
     // work buffer min
     //
     wxString NetConnectIntervalTT(_("Store at least enough tasks to keep the computer busy for this long."));
@@ -530,17 +559,55 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
         wxDefaultPosition, wxDefaultSize, 0
     );
     addNewRowToSizer(box_sizer, NetAdditionalDaysTT, staticText331, m_txtNetAdditionalDays, staticText341);
+#else
+    // work buffer
+    //
+    wxString tt_min(_("Store at least enough tasks to keep the computer busy for this long."));
+    wxStaticText* staticText30 = new wxStaticText(
+        box, ID_DEFAULT,
+        // context: Store at least ___ days of work
+        _("Store at least"),
+        wxDefaultPosition, wxDefaultSize, 0
+    );
+    m_txtNetConnectInterval = new wxTextCtrl(
+        box, ID_TXTNETCONNECTINTERVAL, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT
+    );
+    wxStaticText* staticText31 = new wxStaticText(
+        box, ID_DEFAULT,
+        // context: Store at least ___ days of work
+        _("days and up to an additional"),
+        wxDefaultPosition, wxDefaultSize, 0
+    );
+    wxString tt_extra(_("Store additional tasks above the minimum level.  Determines how much work is requested when contacting a project."));
+    m_txtNetAdditionalDays = new wxTextCtrl(
+        box, ID_TXTNETADDITIONALDAYS, wxEmptyString, wxDefaultPosition, textCtrlSize, wxTE_RIGHT
+    );
+    wxStaticText* staticText341 = new wxStaticText(
+        box, ID_DEFAULT,
+        // context: Store up to an additional ___ days of work
+        _("days of work"),
+        wxDefaultPosition, wxDefaultSize, 0
+    );
+    add_row_to_sizer2(box_sizer,
+        staticText30, tt_min,
+        m_txtNetConnectInterval, tt_min,
+        staticText31, tt_min,
+        m_txtNetAdditionalDays, tt_extra,
+        staticText341, tt_extra
+    );
+#endif
 
+#if 0
     box_sizer->Add(
         new wxStaticText(box, ID_DEFAULT, _("To suspend by time of day, see the \"Daily Schedules\" section."), wxDefaultPosition, wxDefaultSize, 0),
         0, wxALL, 5
     );
-
+#endif
     box_sizer->AddSpacer(1); // Ensure staticText22 is fully visible on Mac
 
-    processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
+    //processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
     processorTabSizer->Add( box_sizer, 0, wxLEFT | wxRIGHT | wxEXPAND, STATICBOXBORDERSIZE );
-    processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
+    //processorTabSizer->AddSpacer( STATICBOXVERTICALSPACER );
 
     processorTab->SetSizer( processorTabSizer );
     processorTab->Layout();

--- a/clientgui/DlgAdvPreferencesBase.h
+++ b/clientgui/DlgAdvPreferencesBase.h
@@ -39,9 +39,6 @@
 #include <wx/panel.h>
 #include <wx/statbmp.h>
 
-///////////////////////////////////////////////////////////////////////////
-
-
 #define PROC_DAY_OF_WEEK_TOOLTIP_TEXT _("On this day of the week, compute only during these hours.")
 #define NET_DAY_OF_WEEK_TOOLTIP_TEXT _("On this day of the week, transfer files only during these hours.")
 
@@ -145,7 +142,6 @@ enum {
     ID_ADV_PREFS_LAST
 };
 
-
 class CDlgAdvPreferencesBase : public wxDialog {
 protected:
     wxStaticBitmap* m_bmpWarning;
@@ -202,7 +198,7 @@ protected:
 
     // Disk panel
     //
-    wxPanel* m_panelDiskAndMemory;
+    wxPanel* m_panelDisk;
     wxCheckBox* m_chkDiskMaxSpace;
     wxTextCtrl* m_txtDiskMaxSpace;
     wxCheckBox* m_chkDiskLeastFree;
@@ -271,15 +267,19 @@ protected:
     bool m_bUsingLocalPrefs;
 
 public:
-    CDlgAdvPreferencesBase( wxWindow* parent, int id = -1, wxString title = wxT(""), wxPoint pos = wxDefaultPosition, wxSize size = wxDefaultSize, int style = wxDEFAULT_DIALOG_STYLE );
+    CDlgAdvPreferencesBase(
+        wxWindow* parent, int id = -1, wxString title = wxT(""), wxPoint pos = wxDefaultPosition,
+        wxSize size = wxDefaultSize, int style = wxDEFAULT_DIALOG_STYLE
+    );
 
 private:
     void addNewRowToSizer(wxSizer* toSizer, wxString& toolTipText,
-                wxWindow* first, wxWindow* second, wxWindow* third,
-                wxWindow* fourth=NULL, wxWindow* fifth=NULL);
+        wxWindow* first, wxWindow* second, wxWindow* third,
+        wxWindow* fourth=NULL, wxWindow* fifth=NULL
+    );
     wxPanel* createProcessorTab(wxNotebook* notebook);
     wxPanel* createNetworkTab(wxNotebook* notebook);
-    wxPanel* createDiskAndMemoryTab(wxNotebook* notebook);
+    wxPanel* createDiskTab(wxNotebook* notebook);
     wxPanel* createDailySchedulesTab(wxNotebook* notebook);
     wxSize getTextCtrlSize(wxString maxText);
     bool doesLocalPrefsFileExist();

--- a/clientgui/DlgAdvPreferencesBase.h
+++ b/clientgui/DlgAdvPreferencesBase.h
@@ -137,6 +137,7 @@ enum {
     ID_TXTPROCWEDNESDAYSTART,
     ID_TXTPROCWEDNESDAYSTOP,
     ID_CHKGPUPROCINUSE,
+    ID_CHKNORECENTINPUT,
     ID_TXTMAXLOAD,
     ID_TXTMAXLOADNOTINUSE,
     ID_DAILY_XFER_LIMIT_MB,
@@ -171,6 +172,7 @@ protected:
     wxCheckBox* m_chkMaxLoadNotInUse;
     wxTextCtrl* m_txtMaxLoadNotInUse;
     wxTextCtrl* m_txtMemoryMaxOnIdle;
+    wxCheckBox* m_chkNoRecentInput;
     wxTextCtrl* m_txtNoRecentInput;
     // General items
     //
@@ -190,7 +192,7 @@ protected:
     wxCheckBox* m_chkNetUploadRate;
     wxTextCtrl* m_txtNetUploadRate;
 
-    wxCheckBox * m_chk_daily_xfer_limit;
+    wxCheckBox* m_chk_daily_xfer_limit;
     wxTextCtrl* m_txt_daily_xfer_limit_mb;
     wxTextCtrl* m_txt_daily_xfer_period_days;
 

--- a/clientgui/DlgAdvPreferencesBase.h
+++ b/clientgui/DlgAdvPreferencesBase.h
@@ -81,6 +81,7 @@ enum {
     ID_CHKPROCEVERYDAY,
     ID_CHKPROCINUSE,
     ID_CHKMAXLOAD,
+    ID_CHKMAXLOADNOTINUSE,
     ID_CHKPROCONBATTERIES,
     ID_TABPAGE_SCHED,
     ID_TABPAGE_DISK,
@@ -113,6 +114,7 @@ enum {
     ID_TXTNETWEDNESDAYSTART,
     ID_TXTNETWEDNESDAYSTOP,
     ID_TXTPROCUSECPUTIME,
+    ID_TXTPROCUSECPUTIMENOTINUSE,
     ID_TXTPROCEVERYDAYSTART,
     ID_TXTPROCEVERYDAYSTOP,
     ID_TXTPROCFRIDAYSTART,
@@ -131,36 +133,83 @@ enum {
     ID_TXTPROCTUESDAYSTART,
     ID_TXTPROCTUESDAYSTOP,
     ID_TXTPROCUSEPROCESSORS,
+    ID_TXTPROCUSEPROCESSORSNOTINUSE,
     ID_TXTPROCWEDNESDAYSTART,
     ID_TXTPROCWEDNESDAYSTOP,
     ID_CHKGPUPROCINUSE,
     ID_TXTMAXLOAD,
+    ID_TXTMAXLOADNOTINUSE,
     ID_DAILY_XFER_LIMIT_MB,
     ID_DAILY_XFER_PERIOD_DAYS,
     ID_ADV_PREFS_LAST
 };
 
 
-/**
- * Class CDlgAdvPreferencesBase
- */
-class CDlgAdvPreferencesBase : public wxDialog 
-{
+class CDlgAdvPreferencesBase : public wxDialog {
 protected:
     wxStaticBitmap* m_bmpWarning;
     wxButton* m_btnClear;
     wxPanel* m_panelControls;
     wxNotebook* m_Notebook;
+
+    // Computing panel
+    //
+    // In-use items
     wxPanel* m_panelProcessor;
-    wxTextCtrl* m_txtProcUseProcessors;
-    wxTextCtrl* m_txtProcUseCPUTime;
-    wxCheckBox* m_chkProcOnBatteries;
+    wxTextCtrl* m_txtProcIdleFor;
     wxCheckBox* m_chkProcInUse;
     wxCheckBox* m_chkGPUProcInUse;
-    wxTextCtrl* m_txtProcIdleFor;
-    wxTextCtrl* m_txtNoRecentInput;
+    wxTextCtrl* m_txtProcUseProcessors;
+    wxTextCtrl* m_txtProcUseCPUTime;
     wxCheckBox* m_chkMaxLoad;
     wxTextCtrl* m_txtMaxLoad;
+    wxTextCtrl* m_txtMemoryMaxInUse;
+    // Not in Use items
+    //
+    wxTextCtrl* m_txtProcUseProcessorsNotInUse;
+    wxTextCtrl* m_txtProcUseCPUTimeNotInUse;
+    wxCheckBox* m_chkMaxLoadNotInUse;
+    wxTextCtrl* m_txtMaxLoadNotInUse;
+    wxTextCtrl* m_txtMemoryMaxOnIdle;
+    wxTextCtrl* m_txtNoRecentInput;
+    // General items
+    //
+    wxCheckBox* m_chkProcOnBatteries;
+    wxTextCtrl* m_txtProcSwitchEvery;
+    wxTextCtrl* m_txtDiskWriteToDisk;
+    wxCheckBox* m_chkMemoryWhileSuspended;
+    wxTextCtrl* m_txtNetConnectInterval;
+    wxTextCtrl* m_txtNetAdditionalDays;
+    wxTextCtrl* m_txtDiskMaxSwap;
+
+    // Network panel
+    //
+    wxPanel* m_panelNetwork;
+    wxCheckBox* m_chkNetDownloadRate;
+    wxTextCtrl* m_txtNetDownloadRate;
+    wxCheckBox* m_chkNetUploadRate;
+    wxTextCtrl* m_txtNetUploadRate;
+
+    wxCheckBox * m_chk_daily_xfer_limit;
+    wxTextCtrl* m_txt_daily_xfer_limit_mb;
+    wxTextCtrl* m_txt_daily_xfer_period_days;
+
+    wxCheckBox* m_chkNetSkipImageVerification;
+    wxCheckBox* m_chkNetConfirmBeforeConnect;
+    wxCheckBox* m_chkNetDisconnectWhenDone;
+
+    // Disk panel
+    //
+    wxPanel* m_panelDiskAndMemory;
+    wxCheckBox* m_chkDiskMaxSpace;
+    wxTextCtrl* m_txtDiskMaxSpace;
+    wxCheckBox* m_chkDiskLeastFree;
+    wxTextCtrl* m_txtDiskLeastFree;
+    wxCheckBox* m_chkDiskMaxOfTotal;
+    wxTextCtrl* m_txtDiskMaxOfTotal;
+
+    // Daily schedules panel
+    wxPanel* m_panelDailySchedules;
     wxCheckBox* m_chkNetEveryDay;
     wxCheckBox* m_chkProcEveryDay;
     wxTextCtrl* m_txtProcEveryDayStart;
@@ -186,23 +235,7 @@ protected:
     wxCheckBox* m_chkProcSunday;
     wxTextCtrl* m_txtProcSundayStart;
     wxTextCtrl* m_txtProcSundayStop;
-    wxTextCtrl* m_txtProcSwitchEvery;
-    wxTextCtrl* m_txtDiskWriteToDisk;
-    wxPanel* m_panelNetwork;
-    wxCheckBox* m_chkNetDownloadRate;
-    wxTextCtrl* m_txtNetDownloadRate;
-    wxCheckBox* m_chkNetUploadRate;
-    wxTextCtrl* m_txtNetUploadRate;
 
-    wxCheckBox * m_chk_daily_xfer_limit;
-    wxTextCtrl* m_txt_daily_xfer_limit_mb;
-    wxTextCtrl* m_txt_daily_xfer_period_days;
-
-    wxTextCtrl* m_txtNetConnectInterval;
-    wxTextCtrl* m_txtNetAdditionalDays;
-    wxCheckBox* m_chkNetSkipImageVerification;
-    wxCheckBox* m_chkNetConfirmBeforeConnect;
-    wxCheckBox* m_chkNetDisconnectWhenDone;
     wxTextCtrl* m_txtNetEveryDayStart;
     wxTextCtrl* m_txtNetEveryDayStop;
     wxCheckBox* m_chkNetMonday;
@@ -226,18 +259,6 @@ protected:
     wxCheckBox* m_chkNetSunday;
     wxTextCtrl* m_txtNetSundayStart;
     wxTextCtrl* m_txtNetSundayStop;
-    wxPanel* m_panelDiskAndMemory;
-    wxCheckBox* m_chkDiskMaxSpace;
-    wxTextCtrl* m_txtDiskMaxSpace;
-    wxCheckBox* m_chkDiskLeastFree;
-    wxTextCtrl* m_txtDiskLeastFree;
-    wxCheckBox* m_chkDiskMaxOfTotal;
-    wxTextCtrl* m_txtDiskMaxOfTotal;
-    wxTextCtrl* m_txtDiskMaxSwap;
-    wxTextCtrl* m_txtMemoryMaxInUse;
-    wxTextCtrl* m_txtMemoryMaxOnIdle;
-    wxCheckBox* m_chkMemoryWhileSuspended;
-    wxPanel* m_panelDailySchedules;
     
     wxPanel* m_panelButtons;
     wxButton* m_btnOK;

--- a/clientgui/DlgAdvPreferencesBase.h
+++ b/clientgui/DlgAdvPreferencesBase.h
@@ -277,6 +277,14 @@ private:
         wxWindow* first, wxWindow* second, wxWindow* third,
         wxWindow* fourth=NULL, wxWindow* fifth=NULL
     );
+    // variant with separate tooltip per item
+    void add_row_to_sizer2(wxSizer* toSizer,
+        wxWindow* item1, wxString& tt1,
+        wxWindow* item2, wxString& tt2,
+        wxWindow* item3, wxString& tt3,
+        wxWindow* item4, wxString& tt4,
+        wxWindow* item5, wxString& tt5
+    );
     wxPanel* createProcessorTab(wxNotebook* notebook);
     wxPanel* createNetworkTab(wxNotebook* notebook);
     wxPanel* createDiskTab(wxNotebook* notebook);

--- a/html/inc/prefs.inc
+++ b/html/inc/prefs.inc
@@ -1,7 +1,7 @@
 <?php
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2014 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -42,13 +42,32 @@
 include_once("../inc/prefs_util.inc");
 include_once("../inc/translation.inc");
 
-global $cpu_prefs;
+global $in_use_prefs;
+global $not_in_use_prefs;
+global $job_prefs;
 global $disk_prefs;
-global $mem_prefs;
 global $net_prefs;
 
-$cpu_prefs = array(
-    tra("Usage limits"),
+$in_use_prefs = [
+    new PREF_NUM(
+        tra("'In use' means mouse/keyboard input in last"),
+        tra("This determines when the computer is considered 'in use'."),
+        "idle_time_to_run",
+        new NUM_SPEC(tra("minutes"), 1, 9999, 3),
+        true
+    ),
+    new PREF_BOOL(
+        tra("Suspend all computing"),
+        tra("Check this to suspend computing and file transfers when you're using the computer."),
+        "run_if_user_active",
+        true, true
+    ),
+    new PREF_BOOL(
+        tra("Suspend GPU computing"),
+        tra("Check this to suspend GPU computing when you're using the computer."),
+        "run_gpu_if_user_active",
+        false, true
+    ),
     new PREF_NUM(
         tra("Use at most"),
         // xgettext:no-php-format
@@ -65,31 +84,49 @@ $cpu_prefs = array(
         // xgettext:no-php-format
         new NUM_SPEC(tra("% of CPU time"), 1, 100, 100)
     ),
-    tra("When to suspend"),
-    new PREF_BOOL(
-        tra("Suspend when computer is on battery"),
-        tra("Check this to suspend computing on portables when running on battery power."),
-        "run_on_batteries",
-        false, true
-    ),
-    new PREF_BOOL(
-        tra("Suspend when computer is in use"),
-        tra("Check this to suspend computing and file transfers when you're using the computer."),
-        "run_if_user_active",
-        true, true
-    ),
-    new PREF_BOOL(
-        tra("Suspend GPU computing when computer is in use"),
-        tra("Check this to suspend GPU computing when you're using the computer."),
-        "run_gpu_if_user_active",
-        false, true
+    new PREF_OPT_NUM(
+        tra("Suspend when non-BOINC CPU usage is above"),
+        tra("Suspend computing when your computer is busy running other programs."),
+        "suspend_cpu_usage",
+        new NUM_SPEC("%", 0, 100, 25)
     ),
     new PREF_NUM(
-        tra("'In use' means mouse/keyboard input in last"),
-        tra("This determines when the computer is considered 'in use'."),
-        "idle_time_to_run",
-        new NUM_SPEC(tra("minutes"), 1, 9999, 3),
-        true
+        tra("Use at most"),
+        tra("Limit the memory used by BOINC when you're using the computer."),
+        "ram_max_used_busy_pct",
+        // xgettext:no-php-format
+        new NUM_SPEC(tra("% of memory"), 1, 100, 50)
+    ),
+];
+$not_in_use_prefs = [
+    new PREF_NUM(
+        tra("Use at most"),
+        // xgettext:no-php-format
+        tra("Keep some CPUs free for other applications. Example: 75% means use 6 cores on an 8-core CPU."),
+        "niu_max_ncpus_pct",
+        // xgettext:no-php-format
+        new NUM_SPEC(tra("% of the CPUs"), 1, 100, 100)
+    ),
+    new PREF_NUM(
+        tra("Use at most"),
+        // xgettext:no-php-format
+        tra("Suspend/resume computing every few seconds to reduce CPU temperature and energy usage. Example: 75% means compute for 3 seconds, wait for 1 second, and repeat."),
+        "niu_cpu_usage_limit",
+        // xgettext:no-php-format
+        new NUM_SPEC(tra("% of CPU time"), 1, 100, 100)
+    ),
+    new PREF_OPT_NUM(
+        tra("Suspend when non-BOINC CPU usage is above"),
+        tra("Suspend computing when your computer is busy running other programs."),
+        "niu_suspend_cpu_usage",
+        new NUM_SPEC("%", 0, 100, 25)
+    ),
+    new PREF_NUM(
+        tra("Use at most"),
+        tra("Limit the memory used by BOINC when you're not using the computer."),
+        "ram_max_used_idle_pct",
+        // xgettext:no-php-format
+        new NUM_SPEC(tra("% of memory"), 1, 100, 90)
     ),
     new PREF_OPT_NUM(
         tra("Suspend when no mouse/keyboard input in last"),
@@ -97,29 +134,13 @@ $cpu_prefs = array(
         "suspend_if_no_recent_input",
         new NUM_SPEC(tra("minutes"), 0, 9999, 0, 1, 60)
     ),
-    new PREF_OPT_NUM(
-        tra("Suspend when non-BOINC CPU usage is above"),
-        tra("Suspend computing when your computer is busy running other programs."),
-        "suspend_cpu_usage",
-        new NUM_SPEC("%", 0, 100, 25)
-    ),
-    new PREF_HOUR_RANGE(
-        tra("Compute only between"),
-        tra("Compute only during a particular period each day."),
-        "start_hour", "end_hour"
-    ),
-    tra("Other"),
-    new PREF_NUM(
-        tra("Store at least"),
-        tra("Store at least enough tasks to keep the computer busy for this long."),
-        "work_buf_min_days",
-        new NUM_SPEC(tra("days of work"), 0, 10, .1)
-    ),
-    new PREF_NUM(
-        tra("Store up to an additional"),
-        tra("Store additional tasks above the minimum level.  Determines how much work is requested when contacting a project."),
-        "work_buf_additional_days",
-        new NUM_SPEC(tra("days of work"), 0, 10, .5)
+];
+$job_prefs = [
+    new PREF_BOOL(
+        tra("Suspend when computer is on battery"),
+        tra("Check this to suspend computing on portables when running on battery power."),
+        "run_on_batteries",
+        false, true
     ),
     new PREF_NUM(
         tra("Switch between tasks every"),
@@ -133,7 +154,37 @@ $cpu_prefs = array(
         "disk_interval",
         new NUM_SPEC(tra("seconds"), 0, 9999999, 60)
     ),
-);
+    new PREF_BOOL(
+        tra("Leave non-GPU tasks in memory while suspended"),
+        tra("If checked, suspended tasks stay in memory, and resume with no work lost. If unchecked, suspended tasks are removed from memory, and resume from their last checkpoint."),
+        "leave_apps_in_memory",
+        false
+    ),
+    new PREF_NUM(
+        tra("Store at least"),
+        tra("Store at least enough tasks to keep the computer busy for this long."),
+        "work_buf_min_days",
+        new NUM_SPEC(tra("days of work"), 0, 10, .1)
+    ),
+    new PREF_NUM(
+        tra("Store up to an additional"),
+        tra("Store additional tasks above the minimum level.  Determines how much work is requested when contacting a project."),
+        "work_buf_additional_days",
+        new NUM_SPEC(tra("days of work"), 0, 10, .5)
+    ),
+    new PREF_HOUR_RANGE(
+        tra("Compute only between"),
+        tra("Compute only during a particular period each day."),
+        "start_hour", "end_hour"
+    ),
+    new PREF_NUM(
+        tra("Page/swap file: use at most"),
+        tra("Limit the swap space (page file) used by BOINC."),
+        "vm_max_used_pct",
+        // xgettext:no-php-format
+        new NUM_SPEC(tra("%"), 1, 100, 75)
+    ),
+];
 
 $dp = get_disk_space_config();
 
@@ -159,38 +210,7 @@ $disk_prefs = array(
     ),
 );
 
-$mem_prefs = array(
-    new PREF_NUM(
-        tra("When computer is in use, use at most"),
-        tra("Limit the memory used by BOINC when you're using the computer."),
-        "ram_max_used_busy_pct",
-        // xgettext:no-php-format
-        new NUM_SPEC(tra("%"), 1, 100, 50)
-    ),
-    new PREF_NUM(
-        tra("When computer is not in use, use at most"),
-        tra("Limit the memory used by BOINC when you're not using the computer."),
-        "ram_max_used_idle_pct",
-        // xgettext:no-php-format
-        new NUM_SPEC(tra("%"), 1, 100, 90)
-    ),
-    new PREF_BOOL(
-        tra("Leave non-GPU tasks in memory while suspended"),
-        tra("If checked, suspended tasks stay in memory, and resume with no work lost. If unchecked, suspended tasks are removed from memory, and resume from their last checkpoint."),
-        "leave_apps_in_memory",
-        false
-    ),
-    new PREF_NUM(
-        tra("Page/swap file: use at most"),
-        tra("Limit the swap space (page file) used by BOINC."),
-        "vm_max_used_pct",
-        // xgettext:no-php-format
-        new NUM_SPEC(tra("%"), 1, 100, 75)
-    ),
-);
-
 $net_prefs = array(
-    tra("Usage limits"),
     new PREF_OPT_NUM(
         tra("Limit download rate to"),
         tra("Limit the download rate of file transfers."),
@@ -211,13 +231,11 @@ $net_prefs = array(
         new NUM_SPEC(tra("MB every"), 0, 9999999, 0, 1, 10000),
         new NUM_SPEC(tra("days"), 0, 9999999, 0, 1, 30)
     ),
-    tra("When to suspend"),
     new PREF_HOUR_RANGE(
         tra("Transfer files only between"),
         tra("Transfer files only during a particular period each day."),
         "net_start_hour", "net_end_hour"
     ),
-    tra("Other"),
     new PREF_BOOL(
         tra("Skip data verification for image files"),
         tra("Check this only if your Internet provider modifies image files. Skipping verification reduces the security of BOINC."),
@@ -238,10 +256,11 @@ $net_prefs = array(
     ),
 );
 
-define("CPU_LIMIT_DESC", tra("Computing"));
-define("DISK_LIMIT_DESC", tra("Disk"));
-define("MEM_LIMIT_DESC", tra("Memory"));
-define("NETWORK_LIMIT_DESC", tra("Network"));
+define("IN_USE_DESC", tra("When computer is in use"));
+define("NOT_IN_USE_DESC", tra("When computer is not in use"));
+define("JOBS_DESC", tra("Tasks"));
+define("DISK_DESC", tra("Disk"));
+define("NET_DESC", tra("Network"));
 
 // These texts are used in multiple places in prefs_edit.php and add_venue.php
 define("PREFS_FORM_DESC1", tra("These preferences apply to all the BOINC projects in which you participate.")."<br><br>");
@@ -323,13 +342,23 @@ function element_end_global($parser, $name) {
     global $parse_result;
     global $top_parse_result;
     global $venue_name;
-    global $cpu_prefs;
+    global $in_use_prefs;
+    global $not_in_use_prefs;
+    global $job_prefs;
     global $disk_prefs;
-    global $mem_prefs;
     global $net_prefs;
 
-    foreach ($cpu_prefs as $p) {
-        if (is_string($p)) continue;
+    foreach ($in_use_prefs as $p) {
+        if ($p->xml_parse($parse_result, $name, $text)) {
+            return;
+        }
+    }
+    foreach ($not_in_use_prefs as $p) {
+        if ($p->xml_parse($parse_result, $name, $text)) {
+            return;
+        }
+    }
+    foreach ($job_prefs as $p) {
         if ($p->xml_parse($parse_result, $name, $text)) {
             return;
         }
@@ -339,13 +368,7 @@ function element_end_global($parser, $name) {
             return;
         }
     }
-    foreach ($mem_prefs as $p) {
-        if ($p->xml_parse($parse_result, $name, $text)) {
-            return;
-        }
-    }
     foreach ($net_prefs as $p) {
-        if (is_string($p)) continue;
         if ($p->xml_parse($parse_result, $name, $text)) {
             return;
         }
@@ -374,24 +397,26 @@ function char_handler($parser, $x) {
 // state of prefs before parsing; defines prefs for new users
 //
 function default_prefs_global() {
-    global $cpu_prefs;
+    global $in_use_prefs;
+    global $not_in_use_prefs;
+    global $job_prefs;
     global $disk_prefs;
-    global $mem_prefs;
     global $net_prefs;
 
     $p = new StdClass;
-    foreach ($cpu_prefs as $pref) {
-        if (is_string($pref)) continue;
+    foreach ($in_use_prefs as $pref) {
+        $pref->set_default($p);
+    }
+    foreach ($not_in_use_prefs as $pref) {
+        $pref->set_default($p);
+    }
+    foreach ($job_prefs as $pref) {
         $pref->set_default($p);
     }
     foreach ($disk_prefs as $pref) {
         $pref->set_default($p);
     }
-    foreach ($mem_prefs as $pref) {
-        $pref->set_default($p);
-    }
     foreach ($net_prefs as $pref) {
-        if (is_string($pref)) continue;
         $pref->set_default($p);
     }
     return $p;
@@ -414,66 +439,60 @@ function prefs_parse_global($prefs_xml) {
 // Display all venues as columns next to descriptions
 //
 function prefs_show_columns_global($prefs) {
-    global $cpu_prefs;
+    global $in_use_prefs;
+    global $not_in_use_prefs;
+    global $job_prefs;
     global $disk_prefs;
-    global $mem_prefs;
     global $net_prefs;
 
-    row_top(CPU_LIMIT_DESC);
-    foreach ($cpu_prefs as $p) {
-        if (is_string($p)) {
-            group_header($p);
-            continue;
-        }
+    row_top(IN_USE_DESC);
+    foreach ($in_use_prefs as $p) {
         $p->show_cols($prefs);
     }
-    row_top(DISK_LIMIT_DESC);
+    row_top(NOT_IN_USE_DESC);
+    foreach ($not_in_use_prefs as $p) {
+        $p->show_cols($prefs);
+    }
+    row_top(JOBS_DESC);
+    foreach ($job_prefs as $p) {
+        $p->show_cols($prefs);
+    }
+    row_top(DISK_DESC);
     foreach ($disk_prefs as $p) {
         $p->show_cols($prefs);
     }
-    row_top(MEM_LIMIT_DESC);
-    foreach ($mem_prefs as $p) {
-        $p->show_cols($prefs);
-    }
-    row_top(NETWORK_LIMIT_DESC);
+    row_top(NET_DESC);
     foreach ($net_prefs as $p) {
-        if (is_string($p)) {
-            group_header($p);
-            continue;
-        }
         $p->show_cols($prefs);
     }
     row_links("global", $prefs);
 }
 
 function prefs_show_global($prefs) {
-    global $cpu_prefs;
+    global $in_use_prefs;
+    global $not_in_use_prefs;
+    global $job_prefs;
     global $disk_prefs;
-    global $mem_prefs;
     global $net_prefs;
 
-    row1(CPU_LIMIT_DESC);
-    foreach ($cpu_prefs as $p) {
-        if (is_string($p)) {
-            group_header($p);
-            continue;
-        }
+    row1(IN_USE_DESC);
+    foreach ($in_use_prefs as $p) {
         $p->show($prefs);
     }
-    row1(DISK_LIMIT_DESC);
+    row1(NOT_IN_USE_DESC);
+    foreach ($not_in_use_prefs as $p) {
+        $p->show($prefs);
+    }
+    row1(JOBS_DESC);
+    foreach ($job_prefs as $p) {
+        $p->show($prefs);
+    }
+    row1(DISK_DESC);
     foreach ($disk_prefs as $p) {
         $p->show($prefs);
     }
-    row1(MEM_LIMIT_DESC);
-    foreach ($mem_prefs as $p) {
-        $p->show($prefs);
-    }
-    row1(NETWORK_LIMIT_DESC);
+    row1(NET_DESC);
     foreach ($net_prefs as $p) {
-        if (is_string($p)) {
-            group_header($p);
-            continue;
-        }
         $p->show($prefs);
     }
 }
@@ -491,7 +510,7 @@ function prefs_display_venue($prefs, $venue, $subset) {
 
     if ($x) {
         start_table();
-        row_heading(tra("Separate preferences for %1", $venue));
+        row_heading(tra("Separate preferences for %1", $venue), 'bg-info');
         if ($subset == "global") {
             prefs_show_global($x);
         } else {
@@ -604,33 +623,30 @@ function print_prefs_form(
 // Functions to display preference subsets as forms
 //
 function prefs_form_global($user, $prefs, $error=false) {
-    global $cpu_prefs;
+    global $in_use_prefs;
+    global $not_in_use_prefs;
+    global $job_prefs;
     global $disk_prefs;
-    global $mem_prefs;
     global $net_prefs;
 
-    row1(CPU_LIMIT_DESC);
-    foreach ($cpu_prefs as $p) {
-        if (is_string($p)) {
-            group_header($p);
-            continue;
-        }
+    row1(IN_USE_DESC);
+    foreach ($in_use_prefs as $p) {
         $p->show_form_row($prefs, $error);
     }
-    row1(DISK_LIMIT_DESC);
+    row1(NOT_IN_USE_DESC);
+    foreach ($not_in_use_prefs as $p) {
+        $p->show_form_row($prefs, $error);
+    }
+    row1(JOBS_DESC);
+    foreach ($job_prefs as $p) {
+        $p->show_form_row($prefs, $error);
+    }
+    row1(DISK_DESC);
     foreach ($disk_prefs as $p) {
         $p->show_form_row($prefs, $error);
     }
-    row1(MEM_LIMIT_DESC);
-    foreach ($mem_prefs as $p) {
-        $p->show_form_row($prefs, $error);
-    }
-    row1(NETWORK_LIMIT_DESC);
+    row1(NET_DESC);
     foreach ($net_prefs as $p) {
-        if (is_string($p)) {
-            group_header($p);
-            continue;
-        }
         $p->show_form_row($prefs, $error);
     }
 }
@@ -697,24 +713,26 @@ function venue_parse_form(&$user) {
 // returns an object with errorvalues or false in success case
 //
 function prefs_global_parse_form(&$prefs) {
-    global $cpu_prefs;
+    global $in_use_prefs;
+    global $not_in_use_prefs;
+    global $job_prefs;
     global $disk_prefs;
-    global $mem_prefs;
     global $net_prefs;
 
     $error = false;
-    foreach ($cpu_prefs as $p) {
-        if (is_string($p)) continue;
+    foreach ($in_use_prefs as $p) {
+        $p->parse_form($prefs, $error);
+    }
+    foreach ($not_in_use_prefs as $p) {
+        $p->parse_form($prefs, $error);
+    }
+    foreach ($job_prefs as $p) {
         $p->parse_form($prefs, $error);
     }
     foreach ($disk_prefs as $p) {
         $p->parse_form($prefs, $error);
     }
-    foreach ($mem_prefs as $p) {
-        $p->parse_form($prefs, $error);
-    }
     foreach ($net_prefs as $p) {
-        if (is_string($p)) continue;
         $p->parse_form($prefs, $error);
     }
     return $error;
@@ -726,9 +744,10 @@ function prefs_global_parse_form(&$prefs) {
 // convert prefs from structure to XML
 //
 function global_prefs_make_xml($prefs, $primary=true) {
-    global $cpu_prefs;
+    global $in_use_prefs;
+    global $not_in_use_prefs;
+    global $job_prefs;
     global $disk_prefs;
-    global $mem_prefs;
     global $net_prefs;
 
     $xml = "";
@@ -738,18 +757,19 @@ function global_prefs_make_xml($prefs, $primary=true) {
         $xml = $xml."<mod_time>$now</mod_time>\n";
     }
 
-    foreach ($cpu_prefs as $p) {
-        if (is_string($p)) continue;
+    foreach ($in_use_prefs as $p) {
+        $xml .= $p->xml_string($prefs);
+    }
+    foreach ($not_in_use_prefs as $p) {
+        $xml .= $p->xml_string($prefs);
+    }
+    foreach ($job_prefs as $p) {
         $xml .= $p->xml_string($prefs);
     }
     foreach ($disk_prefs as $p) {
         $xml .= $p->xml_string($prefs);
     }
-    foreach ($mem_prefs as $p) {
-        $xml .= $p->xml_string($prefs);
-    }
     foreach ($net_prefs as $p) {
-        if (is_string($p)) continue;
         $xml .= $p->xml_string($prefs);
     }
 

--- a/html/inc/prefs.inc
+++ b/html/inc/prefs.inc
@@ -177,13 +177,6 @@ $job_prefs = [
         tra("Compute only during a particular period each day."),
         "start_hour", "end_hour"
     ),
-    new PREF_NUM(
-        tra("Page/swap file: use at most"),
-        tra("Limit the swap space (page file) used by BOINC."),
-        "vm_max_used_pct",
-        // xgettext:no-php-format
-        new NUM_SPEC(tra("%"), 1, 100, 75)
-    ),
 ];
 
 $dp = get_disk_space_config();
@@ -207,6 +200,13 @@ $disk_prefs = array(
         "disk_max_used_pct",
         // xgettext:no-php-format
         new NUM_SPEC(tra("% of total"), 0, 100, $dp->disk_max_used_pct)
+    ),
+    new PREF_NUM(
+        tra("Page/swap file: use at most"),
+        tra("Limit the swap space (page file) used by BOINC."),
+        "vm_max_used_pct",
+        // xgettext:no-php-format
+        new NUM_SPEC(tra("%"), 1, 100, 75)
     ),
 );
 

--- a/html/inc/prefs.inc
+++ b/html/inc/prefs.inc
@@ -258,7 +258,7 @@ $net_prefs = array(
 
 define("IN_USE_DESC", tra("When computer is in use"));
 define("NOT_IN_USE_DESC", tra("When computer is not in use"));
-define("JOBS_DESC", tra("Tasks"));
+define("JOBS_DESC", tra("General"));
 define("DISK_DESC", tra("Disk"));
 define("NET_DESC", tra("Network"));
 

--- a/html/inc/prefs.inc
+++ b/html/inc/prefs.inc
@@ -100,7 +100,7 @@ $in_use_prefs = [
 ];
 $not_in_use_prefs = [
     new PREF_NUM(
-        tra("Use at most"),
+        tra("Use at most")."<br><font size=-2>Requires BOINC 7.20.3+</font>",
         // xgettext:no-php-format
         tra("Keep some CPUs free for other applications. Example: 75% means use 6 cores on an 8-core CPU."),
         "niu_max_ncpus_pct",
@@ -108,7 +108,7 @@ $not_in_use_prefs = [
         new NUM_SPEC(tra("% of the CPUs"), 1, 100, 100)
     ),
     new PREF_NUM(
-        tra("Use at most"),
+        tra("Use at most") ."<br><font size=-2>Requires BOINC 7.20.3+</font>",
         // xgettext:no-php-format
         tra("Suspend/resume computing every few seconds to reduce CPU temperature and energy usage. Example: 75% means compute for 3 seconds, wait for 1 second, and repeat."),
         "niu_cpu_usage_limit",
@@ -116,7 +116,7 @@ $not_in_use_prefs = [
         new NUM_SPEC(tra("% of CPU time"), 1, 100, 100)
     ),
     new PREF_OPT_NUM(
-        tra("Suspend when non-BOINC CPU usage is above"),
+        tra("Suspend when non-BOINC CPU usage is above")."<br><font size=-2>Requires BOINC 7.20.3+</font>",
         tra("Suspend computing when your computer is busy running other programs."),
         "niu_suspend_cpu_usage",
         new NUM_SPEC("%", 0, 100, 25)

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -397,6 +397,17 @@ int GLOBAL_PREFS::parse_override(
             if (net_times.start_hour == net_times.end_hour) {
                 mask.net_start_hour = mask.net_end_hour = false;
             }
+            // if not-in-use prefs weren't specified, use in-use counterpart
+            //
+            if (!mask.niu_max_ncpus_pct) {
+                niu_max_ncpus_pct = max_ncpus_pct;
+            }
+            if (!mask.niu_cpu_usage_limit) {
+                niu_cpu_usage_limit = cpu_usage_limit;
+            }
+            if (!mask.niu_suspend_cpu_usage) {
+                niu_suspend_cpu_usage = suspend_cpu_usage;
+            }
             return 0;
         }
         if (in_venue) {

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -238,9 +238,9 @@ void GLOBAL_PREFS::defaults() {
 #else
     network_wifi_only = false;
 #endif
-    niu_max_ncpus_pct = -1;     // -1 means unspecified, use max_ncpus_pct
-    niu_cpu_usage_limit = -1;
-    niu_suspend_cpu_usage = -1;
+    niu_max_ncpus_pct = 100;
+    niu_cpu_usage_limit = 100;
+    niu_suspend_cpu_usage = 50;
     ram_max_used_busy_frac = 0.5;
 #ifdef ANDROID
     ram_max_used_idle_frac = 0.5;

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -255,7 +255,7 @@ void GLOBAL_PREFS::defaults() {
 #else
     suspend_cpu_usage = 25;
 #endif
-    suspend_if_no_recent_input = 0;
+    suspend_if_no_recent_input = 60;
     vm_max_used_frac = 0.75;
     work_buf_additional_days = 0.5;
     work_buf_min_days = 0.1;

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -537,7 +537,7 @@ int GLOBAL_PREFS::parse_override(
             continue;
         }
         if (xp.parse_double("niu_max_ncpus_pct", niu_max_ncpus_pct)) {
-            if (niu_max_ncpus_pct < 0) niu_max_ncpus_pct = 0;
+            if (niu_max_ncpus_pct <= 0) niu_max_ncpus_pct = 100;
             if (niu_max_ncpus_pct > 100) niu_max_ncpus_pct = 100;
             mask.niu_max_ncpus_pct = true;
             continue;
@@ -604,10 +604,10 @@ int GLOBAL_PREFS::parse_override(
             continue;
         }
         if (xp.parse_double("niu_cpu_usage_limit", dtemp)) {
-            if (dtemp > 0 && dtemp <= 100) {
-                niu_cpu_usage_limit = dtemp;
-                mask.niu_cpu_usage_limit = true;
-            }
+            if (dtemp <= 0) dtemp = 100;
+            if (dtemp > 100) dtemp = 100;
+            niu_cpu_usage_limit = dtemp;
+            mask.niu_cpu_usage_limit = true;
             continue;
         }
         if (xp.parse_double("daily_xfer_limit_mb", dtemp)) {

--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -59,6 +59,9 @@ struct GLOBAL_PREFS_MASK {
     bool net_end_hour;
     bool net_start_hour;
     bool network_wifi_only;
+    bool niu_cpu_usage_limit;
+    bool niu_max_ncpus_pct;
+    bool niu_suspend_cpu_usage;
     bool ram_max_used_busy_frac;
     bool ram_max_used_idle_frac;
     bool run_if_user_active;
@@ -143,8 +146,8 @@ struct TIME_PREFS : public TIME_SPAN {
 struct GLOBAL_PREFS {
     double mod_time;
 
-    double battery_charge_min_pct;
-    double battery_max_temperature;
+    double battery_charge_min_pct;      // Android
+    double battery_max_temperature;     // Android
     bool confirm_before_connecting;
     double cpu_scheduling_period_minutes;
         // length of a time slice.
@@ -172,6 +175,9 @@ struct GLOBAL_PREFS {
         // not on public cell networks.
         // CAUTION: this only applies to file transfers.
         // scheduler RPCs are made regardless of this preference.
+    double niu_cpu_usage_limit;
+    double niu_max_ncpus_pct;
+    double niu_suspend_cpu_usage;
     double ram_max_used_busy_frac;
     double ram_max_used_idle_frac;
     bool run_gpu_if_user_active;


### PR DESCRIPTION
Fixes #41 (!)
Previously there were single prefs for
- % of CPUs
- % of CPU time
- suspend if non-BOINC CPU load above X
These applied whether or not the computer was in use.
This PR adds separate prefs for when the computer is not in use.
It includes both web-based and Manager interfaces for editing them.
Backwards compatible; if the new prefs are not specified, it uses the old ones for both cases.