### PR TITLE
Mac: compute non-BOINC CPU usage in a more accurate way

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -486,7 +486,7 @@ void ACTIVE_TASK_SET::get_memory_usage() {
         }
     }
 
-#if defined(__linux__) || defined(_WIN32)
+#if defined(__linux__) || defined(_WIN32) || defined(__APPLE__)
     // compute non_boinc_cpu_usage
     // Improved version for systems where we can get total CPU (Win, Linux)
     //

--- a/client/app.cpp
+++ b/client/app.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/lib/procinfo_mac.cpp
+++ b/lib/procinfo_mac.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2020 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -185,7 +185,7 @@ double total_cpu_time() {
     static double scale;
     uint64_t totalUserTime = 0;
 
-    if (!first) {
+    if (first) {
         first = false;
         long hz = sysconf(_SC_CLK_TCK);
         scale = 1./hz;

--- a/lib/procinfo_mac.cpp
+++ b/lib/procinfo_mac.cpp
@@ -178,13 +178,15 @@ int procinfo_setup(PROC_MAP& pm) {
 // };
 //
 double total_cpu_time() {
-    static natural_t processorCount = 0;
+    static bool first = true;
+    natural_t processorCount = 0;
     processor_cpu_load_info_t cpuLoad;
     mach_msg_type_number_t processorMsgCount;
     static double scale;
     uint64_t totalUserTime = 0;
 
-    if (processorCount == 0) {
+    if (!first) {
+        first = false;
         long hz = sysconf(_SC_CLK_TCK);
         scale = 1./hz;
     }

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License


### PR DESCRIPTION
Fixes #4327, #4328

**Description of the Change**
Implement #4859 for Macintosh computers
