### PR TITLE
[Manager] Freeze view when modifying columns

### DIFF
--- a/clientgui/BOINCListCtrl.cpp
+++ b/clientgui/BOINCListCtrl.cpp
@@ -349,11 +349,12 @@ void CBOINCListCtrl::SetListColumnOrder(wxArrayString& orderArray) {
     CBOINCBaseView* pView = (CBOINCBaseView*)GetParent();
     wxASSERT(wxDynamicCast(pView, CBOINCBaseView));
 
+    // Manager will crash if the scroll bar is not at the left-most position on the
+    // current view if columns are modified.
+    //
+    pView->Freeze();
     pView->m_iColumnIndexToColumnID.Clear();
-    for (i=colCount-1; i>=0; --i) {
-        DeleteColumn(i);
-    }
-
+    DeleteAllColumns();
     stdCount = pView->m_aStdColNameOrder->GetCount();
 
     pView->m_iColumnIDToColumnIndex.Clear();
@@ -412,6 +413,7 @@ void CBOINCListCtrl::SetListColumnOrder(wxArrayString& orderArray) {
         SetColumnsOrder(aOrder);
     }
 #endif
+    pView->Thaw();
 }
 
 


### PR DESCRIPTION
Fixes #4888

**Description of the Change**
Implements a freeze and thaw of the active view window when adding or removing columns.

Also unrelated, but wxWidgets has a remove all columns function.  I've added this to replace the iterative remove column function.

**Alternate Designs**
N/A

**Release Notes**
Fixed crash when removing columns when horizontal scroll bar is not at left-most position
