### PR TITLE
client: close file descriptors if Curl initialization fails.

### DIFF
--- a/client/http_curl.h
+++ b/client/http_curl.h
@@ -76,8 +76,6 @@ public:
         // a pointer to a form item for POST
     struct curl_httppost *pcurlFormEnd;
         // a pointer to a form item for POST
-    unsigned char* pByte;
-        // pointer to bytes for reading via libcurl_read function
 
     // request message stuff
     //
@@ -148,7 +146,7 @@ public:
     void init(PROJECT*);
     int get_ip_addr(int &ip_addr);
     void close_socket();
-    void close_file();
+    void close_files();
     void update_speed();
     void set_speed_limit(bool is_upload, double bytes_sec);
     void handle_messages(CURLMsg*);


### PR DESCRIPTION
    HTTP_OP::libcurl_exec() opens input and/or output files.
    In the normal case these eventually are closed in handle_messages()
    when the HTTP op finishes.
    But if the call to curl_multi_add_handle() returns an error
    (which I believe happens on a connect failure, e.g. if the project is down)
    then we need to close the files.
    We weren't doing this, possibly leading to running out of file descriptors.

Fixes #4914 (possibly)