### PR TITLE
Client:  Update cpu/gpu resources when app_config is re-read

### DIFF
--- a/client/client_state.h
+++ b/client/client_state.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2020 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -442,7 +442,7 @@ struct CLIENT_STATE {
         // - task is completed or fails
         // - tasks are killed
         // - an RPC completes
-        // - project suspend/detch/attach/reset GUI RPC
+        // - project suspend/detach/attach/reset GUI RPC
         // - result suspend/abort GUI RPC
     int make_scheduler_request(PROJECT*);
     int handle_scheduler_reply(PROJECT*, char* scheduler_url);
@@ -465,7 +465,7 @@ struct CLIENT_STATE {
     int parse_app_info(PROJECT*, FILE*);
     int write_state_gui(MIOFILE&);
     int write_file_transfers_gui(MIOFILE&);
-    int write_tasks_gui(MIOFILE&, bool);
+    int write_tasks_gui(MIOFILE&, bool active_only, bool ac_updated = false);
     void sort_results();
     void sort_projects_by_name();
 

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -567,7 +567,9 @@ void CLIENT_STATE::sort_results() {
     unsigned int i;
     for (i=0; i<results.size(); i++) {
         RESULT* rp = results[i];
-        rp->name_md5 = md5_string(string(rp->name));
+        if (rp) {
+            rp->name_md5 = md5_string(string(rp->name));
+        }
     }
     std::sort(
         results.begin(),
@@ -576,7 +578,9 @@ void CLIENT_STATE::sort_results() {
     );
     for (i=0; i<results.size(); i++) {
         RESULT* rp = results[i];
-        rp->index = i;
+        if (rp) {
+            rp->index = i;
+        }
     }
 }
 
@@ -1047,18 +1051,22 @@ int CLIENT_STATE::write_state_gui(MIOFILE& f) {
     return 0;
 }
 
-int CLIENT_STATE::write_tasks_gui(MIOFILE& f, bool active_only) {
+int CLIENT_STATE::write_tasks_gui(MIOFILE& f, bool active_only, bool ac_updated) {
     unsigned int i;
 
     if (active_only) {
         for (i=0; i<active_tasks.active_tasks.size(); i++) {
             RESULT* rp = active_tasks.active_tasks[i]->result;
-            rp->write_gui(f);
+            if (rp) {
+                rp->write_gui(f, ac_updated);
+            }
         }
     } else {
         for (i=0; i<results.size(); i++) {
             RESULT* rp = results[i];
-            rp->write_gui(f);
+            if (rp) {
+                rp->write_gui(f, ac_updated);
+            }
         }
     }
     return 0;

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -533,13 +533,13 @@ static void handle_file_transfer_op(GUI_RPC_CONN& grc, const char* op) {
         grc.mfout.printf("<error>Missing filename</error>\n");
         return;
     }
-    
+
     FILE_INFO* f = gstate.lookup_file_info(p, filename.c_str());
     if (!f) {
         grc.mfout.printf("<error>No such file</error>\n");
         return;
     }
-    
+
     PERS_FILE_XFER* pfx = f->pers_file_xfer;
     if (!pfx) {
         grc.mfout.printf("<error>No such transfer waiting</error>\n");
@@ -762,7 +762,7 @@ static void handle_get_project_init_status(GUI_RPC_CONN& grc) {
         if (urls_match(p->master_url, gstate.project_init.url)) { 
             gstate.project_init.remove(); 
             break; 
-        } 
+        }
     }
 
     grc.mfout.printf(
@@ -914,40 +914,40 @@ static void handle_project_attach(GUI_RPC_CONN& grc) {
 	// or vice versa
 	// also clear last '/' character if present
 
-	const string http = "http://";
-	const string https = "https://";
+    const string http = "http://";
+    const string https = "https://";
 
-	string new_project_url = url;
-	size_t pos = new_project_url.find(http);
-	if (pos != string::npos) {
-		new_project_url.erase(pos, http.length());
-	}
-	else if ((pos = new_project_url.find(https)) != string::npos) {
-		new_project_url.erase(pos, https.length());
-	}
-	if (new_project_url.length() >= 1 && new_project_url[new_project_url.length() - 1] == '/') {
-		new_project_url.erase(new_project_url.length() - 1, 1);
+    string new_project_url = url;
+    size_t pos = new_project_url.find(http);
+    if (pos != string::npos) {
+        new_project_url.erase(pos, http.length());
+    }
+    else if ((pos = new_project_url.find(https)) != string::npos) {
+        new_project_url.erase(pos, https.length());
+    }
+    if (new_project_url.length() >= 1 && new_project_url[new_project_url.length() - 1] == '/') {
+        new_project_url.erase(new_project_url.length() - 1, 1);
 	}
 
     for (i=0; i<gstate.projects.size(); i++) {
         PROJECT* p = gstate.projects[i];
-		string project_url = p->master_url;
+        string project_url = p->master_url;
 
-		pos = project_url.find(http);
-		if (pos != string::npos) {
-			project_url.erase(pos, http.length());
-		}
-		else if ((pos = project_url.find(https)) != string::npos) {
-			project_url.erase(pos, https.length());
-		}
-		if (project_url.length() >= 1 && project_url[project_url.length() - 1] == '/') {
-			project_url.erase(project_url.length() - 1, 1);
-		}
+        pos = project_url.find(http);
+        if (pos != string::npos) {
+            project_url.erase(pos, http.length());
+        }
+        else if ((pos = project_url.find(https)) != string::npos) {
+            project_url.erase(pos, https.length());
+        }
+        if (project_url.length() >= 1 && project_url[project_url.length() - 1] == '/') {
+            project_url.erase(project_url.length() - 1, 1);
+        }
 
-		if (new_project_url == project_url) {
-			already_attached = true;
-			break;
-		}
+        if (new_project_url == project_url) {
+            already_attached = true;
+            break;
+        }
     }
 
     if (already_attached) {
@@ -1059,7 +1059,7 @@ static void handle_acct_mgr_rpc(GUI_RPC_CONN& grc) {
             safe_strcpy(ami.login_name, name.c_str());
             safe_strcpy(ami.password_hash, password_hash.c_str());
             safe_strcpy(ami.authenticator, authenticator.c_str());
-       }
+        }
     }
 
     if (bad_arg) {
@@ -1337,7 +1337,7 @@ static void handle_read_cc_config(GUI_RPC_CONN& grc) {
     // also reread app_config.xml files
     //
     check_app_config();
-
+    gstate.write_tasks_gui(grc.mfout, false, true);
     gstate.request_schedule_cpus("Core client configuration");
     gstate.request_work_fetch("Core client configuration");
     set_no_rsc_config();

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2012 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -352,7 +352,7 @@ static const char* cpu_string(double ncpus) {
     return (ncpus==1)?"CPU":"CPUs";
 }
 
-int RESULT::write_gui(MIOFILE& out) {
+int RESULT::write_gui(MIOFILE& out, bool check_resources) {
     out.printf(
         "<result>\n"
         "    <name>%s</name>\n"
@@ -404,9 +404,7 @@ int RESULT::write_gui(MIOFILE& out) {
     if (atp) {
         atp->write_gui(out);
     }
-    if (!strlen(resources)) {
-        // only need to compute this string once
-        //
+    if (!strlen(resources) || check_resources) { // update resource string only when zero or when app_config is updated.
         if (avp->gpu_usage.rsc_type) {
             if (avp->gpu_usage.usage == 1) {
                 snprintf(resources, sizeof(resources),
@@ -441,7 +439,8 @@ int RESULT::write_gui(MIOFILE& out) {
             safe_strcpy(resources, " ");
         }
     }
-    if (strlen(resources)>1) {
+    // update app version resources
+    if (strlen(resources)>1) { 
         char buf[256];
         safe_strcpy(buf, "");
         if (atp && atp->scheduler_state == CPU_SCHED_SCHEDULED) {

--- a/client/result.h
+++ b/client/result.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2012 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -103,7 +103,7 @@ struct RESULT {
     int parse_state(XML_PARSER&);
     int parse_name(XML_PARSER&, const char* end_tag);
     int write(MIOFILE&, bool to_server);
-    int write_gui(MIOFILE&);
+    int write_gui(MIOFILE&, bool check_resources = false);
     bool is_upload_done();    // files uploaded?
     void clear_uploaded_flags();
     FILE_REF* lookup_file(FILE_INFO*);


### PR DESCRIPTION
Fixes #1903

**Description of the Change**
When the app_config is re-read, the CPU/GPU resources will be updated in the Manager and boinccmd without requiring BOINC to restart.

Edit:  Changes are made in the client.  The CPU/GPU string stored in "resources" is printed only once.  If there is a string present, the client was not reprinting the resources if they changed.  This PR now passes a bool for the case when app_config is re-read so the resources can be reprinted.  No changes were made to the Manager.

Also note that if app_config is removed, the CPU/GPU resources do not change.  The client doesn't update these currently, it needs information from the server to provide default CPU/GPU usage.

**Alternate Designs**
None.

**Release Notes**
CPU/GPU usage in Manager displays correctly immediately when app_config is re-read.
