### PR TITLE
[Manager] Convert ProcessorTab in Preferences dialog from wxPanel to wxScrolledWindow to show all content on small screens (e.g. 1024x768).

### DIFF
--- a/clientgui/DlgAdvPreferencesBase.cpp
+++ b/clientgui/DlgAdvPreferencesBase.cpp
@@ -200,6 +200,7 @@ CDlgAdvPreferencesBase::CDlgAdvPreferencesBase( wxWindow* parent, int id, wxStri
 
     dialogSizer->Fit( this );
     this->SetSizer( dialogSizer );
+    m_panelProcessor->SetVirtualSize(notebookSizer->GetMinSize());
 }
 
 #define PAD0    1
@@ -268,14 +269,14 @@ void CDlgAdvPreferencesBase::addNewRowToSizer(
     toSizer->Add( rowSizer, 0, 0, 1 );
 }
 
-wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
+wxScrolledWindow* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
     CSkinAdvanced*      pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     wxASSERT(pSkinAdvanced);
 
     wxSize textCtrlSize = getTextCtrlSize(wxT("999.99"));
 
-    wxPanel* processorTab = new wxPanel( notebook, ID_TABPAGE_PROC, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL );
-    processorTab->SetExtraStyle( wxWS_EX_VALIDATE_RECURSIVELY );
+    wxScrolledWindow* processorTab = new wxScrolledWindow( notebook, ID_TABPAGE_PROC, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL|wxVSCROLL );
+    processorTab->SetScrollRate(0, 5);
 
     wxBoxSizer* processorTabSizer = new wxBoxSizer( wxVERTICAL );
 
@@ -612,7 +613,6 @@ wxPanel* CDlgAdvPreferencesBase::createProcessorTab(wxNotebook* notebook) {
 
     processorTab->SetSizer( processorTabSizer );
     processorTab->Layout();
-    processorTabSizer->Fit( processorTab );
 
     return processorTab;
 }
@@ -1203,4 +1203,3 @@ void CDlgAdvPreferencesBase::makeStaticBoxLabelItalic(wxStaticBox* staticBox) {
     staticBox->SetOwnFont(myFont);
 #endif
 }
-

--- a/clientgui/DlgAdvPreferencesBase.h
+++ b/clientgui/DlgAdvPreferencesBase.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2015 University of California
+// Copyright (C) 2022 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -35,7 +35,7 @@
 #endif
 
 #include <wx/button.h>
-#include <wx/notebook.h> 
+#include <wx/notebook.h>
 #include <wx/panel.h>
 #include <wx/statbmp.h>
 
@@ -151,8 +151,8 @@ protected:
 
     // Computing panel
     //
+    wxScrolledWindow* m_panelProcessor;
     // In-use items
-    wxPanel* m_panelProcessor;
     wxTextCtrl* m_txtProcIdleFor;
     wxCheckBox* m_chkProcInUse;
     wxCheckBox* m_chkGPUProcInUse;
@@ -257,12 +257,12 @@ protected:
     wxCheckBox* m_chkNetSunday;
     wxTextCtrl* m_txtNetSundayStart;
     wxTextCtrl* m_txtNetSundayStop;
-    
+
     wxPanel* m_panelButtons;
     wxButton* m_btnOK;
     wxButton* m_btnCancel;
     wxButton* m_btnHelp;
-    
+
     wxString *web_prefs_url;
     bool m_bUsingLocalPrefs;
 
@@ -285,7 +285,7 @@ private:
         wxWindow* item4, wxString& tt4,
         wxWindow* item5, wxString& tt5
     );
-    wxPanel* createProcessorTab(wxNotebook* notebook);
+    wxScrolledWindow* createProcessorTab(wxNotebook* notebook);
     wxPanel* createNetworkTab(wxNotebook* notebook);
     wxPanel* createDiskTab(wxNotebook* notebook);
     wxPanel* createDailySchedulesTab(wxNotebook* notebook);


### PR DESCRIPTION
This fixes #1872.

Signed-off-by: Vitalii Koshura <lestat.de.lionkur@gmail.com>
