### PR TITLE
changes systemd flag ProtectSystem from strict to full

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -7,7 +7,7 @@ After=vboxdrv.service network-online.target
 [Service]
 Type=simple
 ProtectHome=true
-ProtectSystem=strict
+ProtectSystem=full
 ProtectControlGroups=true
 ReadWritePaths=-/var/lib/boinc -/etc/boinc-client
 Nice=10


### PR DESCRIPTION
Fixes issue [3355](https://github.com/BOINC/boinc/issues/3355).
Below I am copying the description originally available at https://github.com/BOINC/boinc/issues/3355#issuecomment-1264751840


**Description of the Change**
Before this change, BOINC working units that make use of Virtualbox could not properly run on Linux, like the ones from LHC@home.
To fix this problem I used the default boinc-client systemd unit file, and just replaced
```
ProtectSystem=strict
```
with
```
ProtectSystem=full
```

Before such change, I made many different attempts, while having the old value `ProtectSystem=strict`

- adding file `/etc/tmpfiles.d/boinc-vbox.conf` containing `d /tmp/.vbox-boinc-ipc 700 boinc boinc - -`
- adding `-/tmp/.vbox-boinc-ipc` in `ReadWritePaths`

but they all failed.

I also had to set SELinux to `permissive` mode in order to be able to successfully run VBox based working units. Of course this is outside what concerns BOINC code base, but it worth to be mentioned.

**INFORMATIONS ABOUT THE TEST ENVIRONMENT**

**System environment**
```
Fedora 36
systemd 250.8
Linux kernel 5.18.18
SELinux on permissive mode
BOINC 7.20.2
VirtualBox 6.1.38 and its following kernel modules: vboxnetadp, vboxnetflt, vboxdrv, vboxnetadp, vboxnetflt
```

**systemd unit file content**
```
[Unit]
Description=Berkeley Open Infrastructure Network Computing Client
Documentation=man:boinc(1)
Wants=vboxdrv.service
After=vboxdrv.service network-online.target

[Service]
Type=simple
ProtectHome=true
ProtectSystem=full
ProtectControlGroups=true
ReadWritePaths=-/var/lib/boinc -/etc/boinc-client
Nice=10
User=boinc
WorkingDirectory=/var/lib/boinc
ExecStart=/usr/bin/boinc
ExecStop=/usr/bin/boinccmd --quit
ExecReload=/usr/bin/boinccmd --read_cc_config
ExecStopPost=/bin/rm -f lockfile
IOSchedulingClass=idle

[Install]
WantedBy=multi-user.target
```

To ensure reliability of the tests, after each systemd unit file change, and/or creation or removal of `/etc/tmpfiles.d/boinc-vbox.conf`, I always have done the following:

1. erased all current/pending working units
2. blocked LHC@home from requesting new working units
3. systemctl daemon-reload
4. systemd restart boinc-client

Each test was running at least for 10 minutes, which I empirically found out to be the threshold for a working unit to fail or not. 

I also completed a CMS@home and ATLAS@home working unit
https://lhcathome.cern.ch/lhcathome/result.php?resultid=366519312
https://lhcathome.cern.ch/lhcathome/result.php?resultid=366555838

Best regards