### PR TITLE
[Manager] [Advanced View] Add warning message in preferences for suspension

### DIFF
--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -744,6 +744,7 @@ bool CDlgAdvPreferences::ValidateInput() {
     wxString invMsgLimit10 = _("Number must be between 0 and 10");
     wxString invMsgLimit100 = _("Number must be between 0 and 100");
     wxString invMsgLimit1_100 = _("Number must be between 1 and 100");
+    wxString invMsgIdle = _("Suspend when no mouse or keyboard input needs to be greater than 'in use' mouse or keyboard input.");
     wxString buffer;
     double startTime, endTime;
 
@@ -780,6 +781,31 @@ bool CDlgAdvPreferences::ValidateInput() {
         if (!IsValidFloatValueBetween(buffer, 0, 9999999999999.99)) {
             ShowErrorMessage(invMsgFloat, m_txtNoRecentInput);
             return false;
+        }
+    }
+
+ // It is possible that the computer will not process tasks
+ // if the time for no recent input is nonzero and is less than or
+ // equal to the idle time before computing resumes (ProcIdleFor).
+ // This will check that condition and return an error.
+ //
+    if (m_txtProcIdleFor->IsEnabled() && m_chkNoRecentInput->IsChecked()) {
+        wxString bufferNRI = m_txtNoRecentInput->GetValue();
+        double valueNRI;
+        bufferNRI.ToDouble(&valueNRI);
+        // Since these values will be stored rounded to the hundredth, it should
+        // be evaluated that way.
+        //
+        valueNRI = RoundToHundredths(valueNRI);
+        if (valueNRI > 0) {
+            wxString bufferPIF = m_txtProcIdleFor->GetValue();
+            double valuePIF;
+            bufferPIF.ToDouble(&valuePIF);
+            valuePIF = RoundToHundredths(valuePIF);
+            if (valueNRI <= valuePIF) {
+                ShowErrorMessage(invMsgIdle, m_txtNoRecentInput);
+                return false;
+            }
         }
     }
 

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -784,28 +784,19 @@ bool CDlgAdvPreferences::ValidateInput() {
         }
     }
 
- // It is possible that the computer will not process tasks
- // if the time for no recent input is nonzero and is less than or
- // equal to the idle time before computing resumes (ProcIdleFor).
- // This will check that condition and return an error.
+ // Checks for a condition where no computing could occur if suspended until idle and
+ // suspend after being idle overlap.
  //
     if (m_txtProcIdleFor->IsEnabled() && m_chkNoRecentInput->IsChecked()) {
         wxString bufferNRI = m_txtNoRecentInput->GetValue();
+        wxString bufferPIF = m_txtProcIdleFor->GetValue();
         double valueNRI;
         bufferNRI.ToDouble(&valueNRI);
-        // Since these values will be stored rounded to the hundredth, it should
-        // be evaluated that way.
-        //
-        valueNRI = RoundToHundredths(valueNRI);
-        if (valueNRI > 0) {
-            wxString bufferPIF = m_txtProcIdleFor->GetValue();
-            double valuePIF;
-            bufferPIF.ToDouble(&valuePIF);
-            valuePIF = RoundToHundredths(valuePIF);
-            if (valueNRI <= valuePIF) {
-                ShowErrorMessage(invMsgIdle, m_txtNoRecentInput);
-                return false;
-            }
+        double valuePIF;
+        bufferPIF.ToDouble(&valuePIF);
+        if((valuePIF - valueNRI + 0.005) >=0) {  // 0.005 is included to factor in rounding to nearest hundredth
+            ShowErrorMessage(invMsgIdle, m_txtNoRecentInput);
+            return false;
         }
     }
 


### PR DESCRIPTION


Partially fixes #4939

**Description of the Change**
This commit checks for the condition stated in #4939 when advanced preferences are changed locally.  An error message is created if the condition exists.  The user will have to modify one of the values in order to save their preferences.  The revised error message is:

![image](https://user-images.githubusercontent.com/58096400/194685142-e3fb30e6-05e9-4ebd-97dc-b94103307635.png)


**Alternate Designs**
#4634 was my previous draft.  The conditional logic was slightly different.  I decided this time to validate both values first separately, then check to see if both doubles are "active".  This minimizes additional variables for a condition that is probably rare.

**Release Notes**
Fixed indefinite suspension when suspension times were not set correctly in preferences.
