### PR TITLE
Fix most of the deprecations introduced by API level 33

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/BOINCActivity.kt
@@ -27,11 +27,13 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.ServiceConnection
 import android.content.pm.PackageManager
+import android.content.pm.PackageManager.PackageInfoFlags
 import android.content.res.Configuration
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.os.IBinder
 import android.os.RemoteException
-import android.util.Log
 import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
@@ -277,8 +279,13 @@ class BOINCActivity : AppCompatActivity() {
                     val returnB = dialog.findViewById<Button>(R.id.returnB)
                     val tvVersion = dialog.findViewById<TextView>(R.id.version)
                     try {
-                        tvVersion.text = getString(R.string.about_version,
-                                packageManager.getPackageInfo(packageName, 0).versionName)
+                        val packageInfo = if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                            packageManager.getPackageInfo(packageName, PackageInfoFlags.of(0))
+                        } else {
+                            @Suppress("DEPRECATION")
+                            packageManager.getPackageInfo(packageName, 0)
+                        }
+                        tvVersion.text = getString(R.string.about_version, packageInfo.versionName)
                     } catch (e: PackageManager.NameNotFoundException) {
                             Logging.logWarning(Logging.Category.USER_ACTION, "version name not found.")
                     }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/BatchProcessingActivity.kt
@@ -26,6 +26,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -75,6 +76,19 @@ class BatchProcessingActivity : AppCompatActivity() {
         })
         adaptHintHeader()
         doBindService()
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (binding.hintContainer.currentItem == 0) {
+                    // If the user is currently looking at the first step, allow the system to handle the
+                    // Back button. This calls finish() on this activity and pops the back stack.
+                    finish()
+                } else {
+                    // Otherwise, select the previous step.
+                    binding.hintContainer.currentItem--
+                }
+            }
+        })
     }
 
     override fun onDestroy() {
@@ -82,17 +96,6 @@ class BatchProcessingActivity : AppCompatActivity() {
 
         super.onDestroy()
         doUnbindService()
-    }
-
-    override fun onBackPressed() {
-        if (binding.hintContainer.currentItem == 0) {
-            // If the user is currently looking at the first step, allow the system to handle the
-            // Back button. This calls finish() on this activity and pops the back stack.
-            super.onBackPressed()
-        } else {
-            // Otherwise, select the previous step.
-            binding.hintContainer.currentItem--
-        }
     }
 
     // triggered by continue button

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectInfoFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/attach/ProjectInfoFragment.kt
@@ -19,6 +19,8 @@
 package edu.berkeley.boinc.attach
 
 import android.app.Dialog
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -43,7 +45,12 @@ class ProjectInfoFragment : DialogFragment() {
         _binding = AttachProjectInfoLayoutBinding.inflate(inflater, container, false)
 
         // get data
-        val info: ProjectInfo? = requireArguments().getParcelable("info")
+        val info: ProjectInfo? = if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+            requireArguments().getParcelable("info", ProjectInfo::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            requireArguments().getParcelable("info")
+        }
         if (info == null) {
             Logging.logError(Logging.Category.GUI_VIEW, "ProjectInfoFragment info is null, return.")
 

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.kt
@@ -18,6 +18,8 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.core.os.ParcelCompat.readBoolean
@@ -114,7 +116,13 @@ data class Project(
                     attachedViaAcctMgr = readBoolean(parcel), detachWhenDone = readBoolean(parcel),
                     ended = readBoolean(parcel), trickleUpPending = readBoolean(parcel),
                     noCPUPref = readBoolean(parcel), noCUDAPref = readBoolean(parcel), noATIPref = readBoolean(parcel),
-                    guiURLs = arrayListOf<GuiUrl?>().apply { parcel.readList(this as MutableList<*>, GuiUrl::class.java.classLoader) })
+                    guiURLs = arrayListOf<GuiUrl?>().apply { if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                        parcel.readList(this as MutableList<GuiUrl>, GuiUrl::class.java.classLoader, GuiUrl::class.java)
+                    } else {
+                        @Suppress("DEPRECATION")
+                        parcel.readList(this as MutableList<*>, GuiUrl::class.java.classLoader)
+                    }
+                    })
 
     override fun equals(other: Any?): Boolean {
         if (this === other) {

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/Project.kt
@@ -117,7 +117,7 @@ data class Project(
                     ended = readBoolean(parcel), trickleUpPending = readBoolean(parcel),
                     noCPUPref = readBoolean(parcel), noCUDAPref = readBoolean(parcel), noATIPref = readBoolean(parcel),
                     guiURLs = arrayListOf<GuiUrl?>().apply { if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
-                        parcel.readList(this as MutableList<GuiUrl>, GuiUrl::class.java.classLoader, GuiUrl::class.java)
+                        parcel.readList(this as MutableList<GuiUrl?>, GuiUrl::class.java.classLoader, GuiUrl::class.java)
                     } else {
                         @Suppress("DEPRECATION")
                         parcel.readList(this as MutableList<*>, GuiUrl::class.java.classLoader)

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
@@ -53,7 +53,7 @@ data class ProjectConfig(
                     parcel.readInt(), parcel.readInt(), parcel.readString() ?: "") {
         platforms = arrayListOf<PlatformInfo?>().apply {
             if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
-                parcel.readList(this as MutableList<PlatformInfo>, PlatformInfo::class.java.classLoader, PlatformInfo::class.java)
+                parcel.readList(this as MutableList<PlatformInfo?>, PlatformInfo::class.java.classLoader, PlatformInfo::class.java)
             } else {
                 @Suppress("DEPRECATION")
                 parcel.readList(this as MutableList<*>, PlatformInfo::class.java.classLoader)

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
@@ -18,6 +18,8 @@
  */
 package edu.berkeley.boinc.rpc
 
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.core.os.ParcelCompat.readBoolean
@@ -50,7 +52,12 @@ data class ProjectConfig(
                     parcel.readString() ?: "", parcel.readString() ?: "",
                     parcel.readInt(), parcel.readInt(), parcel.readString() ?: "") {
         platforms = arrayListOf<PlatformInfo?>().apply {
-            parcel.readList(this as MutableList<*>, PlatformInfo::class.java.classLoader)
+            if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                parcel.readList(this as MutableList<PlatformInfo>, PlatformInfo::class.java.classLoader, PlatformInfo::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                parcel.readList(this as MutableList<*>, PlatformInfo::class.java.classLoader)
+            }
         }
         termsOfUse = parcel.readString()
 


### PR DESCRIPTION
Fixes most of the deprecations that were caused by updating the API to v33 (Tiramisu). However, the last deprecation of issue #4946 (readSerializable() in ProjectRelatedClasses.kt) is not fixed within this PR. It needs some more work.
I tested the changes with API 30 and API 33 and the app seems to work.
