### PR TITLE
4946 Fix ClientNotificationTest and readSerialization() deprecations

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/rpc/ProjectRelatedClasses.kt
@@ -141,7 +141,12 @@ data class ProjectInfo(
     private constructor(parcel: Parcel) :
             this(parcel.readString() ?: "", parcel.readString() ?: "", parcel.readString(),
                     parcel.readString(), parcel.readString(), parcel.readString(),
-                    parcel.readSerializable() as ArrayList<String>, parcel.readString(), parcel.readString())
+                    if (VERSION.SDK_INT >= VERSION_CODES.TIRAMISU) {
+                        parcel.readSerializable(null, ArrayList::class.java) as ArrayList<String>
+                    } else {
+                        @Suppress("DEPRECATION")
+                        parcel.readSerializable() as ArrayList<String>
+                    }, parcel.readString(), parcel.readString())
 
     override fun describeContents() = 0
 

--- a/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/ClientNotificationTest.kt
+++ b/android/BOINC/app/src/test/java/edu/berkeley/boinc/client/ClientNotificationTest.kt
@@ -52,8 +52,8 @@ class ClientNotificationTest {
         clientStatus.computingStatus = ClientStatus.COMPUTING_STATUS_NEVER
 
         val notification = clientNotification.buildNotification(clientStatus, true, null)
-        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.get(Notification.EXTRA_TITLE))
-        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.get(Notification.EXTRA_TEXT))
+        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.getString(Notification.EXTRA_TITLE))
+        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.getString(Notification.EXTRA_TEXT))
     }
 
     @Test
@@ -62,8 +62,8 @@ class ClientNotificationTest {
         clientStatus.computingStatus = ClientStatus.COMPUTING_STATUS_IDLE
 
         val notification = clientNotification.buildNotification(clientStatus, true, null)
-        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.get(Notification.EXTRA_TITLE))
-        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.get(Notification.EXTRA_TEXT))
+        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.getString(Notification.EXTRA_TITLE))
+        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.getString(Notification.EXTRA_TEXT))
     }
 
     @Test
@@ -72,8 +72,8 @@ class ClientNotificationTest {
         clientStatus.computingStatus = ClientStatus.COMPUTING_STATUS_SUSPENDED
 
         val notification = clientNotification.buildNotification(clientStatus, true, null)
-        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.get(Notification.EXTRA_TITLE))
-        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.get(Notification.EXTRA_TEXT))
+        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.getString(Notification.EXTRA_TITLE))
+        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.getString(Notification.EXTRA_TEXT))
     }
 
     @Test
@@ -82,8 +82,8 @@ class ClientNotificationTest {
         clientStatus.computingStatus = ClientStatus.COMPUTING_STATUS_COMPUTING
 
         val notification = clientNotification.buildNotification(clientStatus, true, null)
-        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.get(Notification.EXTRA_TITLE))
-        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.get(Notification.EXTRA_TEXT))
+        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.getString(Notification.EXTRA_TITLE))
+        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.getString(Notification.EXTRA_TEXT))
     }
 
     @Test
@@ -92,8 +92,8 @@ class ClientNotificationTest {
         clientStatus.computingStatus = ClientStatus.COMPUTING_STATUS_COMPUTING
 
         val notification = clientNotification.buildNotification(clientStatus, true, listOf())
-        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.get(Notification.EXTRA_TITLE))
-        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.get(Notification.EXTRA_TEXT))
+        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.getString(Notification.EXTRA_TITLE))
+        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.getString(Notification.EXTRA_TEXT))
     }
 
 
@@ -108,8 +108,8 @@ class ClientNotificationTest {
         )
 
         val notification = clientNotification.buildNotification(clientStatus, true, activeTasks)
-        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.get(Notification.EXTRA_TITLE))
-        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.get(Notification.EXTRA_SUB_TEXT))
+        Assert.assertEquals(clientStatus.currentStatusTitle, notification.extras.getString(Notification.EXTRA_TITLE))
+        Assert.assertEquals(clientStatus.currentStatusDescription, notification.extras.getString(Notification.EXTRA_SUB_TEXT))
         Assert.assertEquals(activeTasks.size, notification.number)
         val lines = notification.extras.getCharSequenceArray(Notification.EXTRA_TEXT_LINES)
         Assert.assertNotNull(lines)

--- a/android/BOINC/build.gradle
+++ b/android/BOINC/build.gradle
@@ -14,7 +14,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jacoco:org.jacoco.core:$jacoco_version"
     }


### PR DESCRIPTION
Fixes #4946 - Fixed the deprecations in the unit tests and readSerialization() in ProjectRelatedClasses.kt. I also upgraded gradle to version 7.3.1.