### PR TITLE
Avoid character conversion

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -605,9 +605,7 @@ namespace vboxmanage {
                     //
 
                     type_line = output;
-                    transform(type_line.cbegin(), type_line.cend(),
-                        type_line.begin(), [](unsigned char c) { return tolower(c); });
-                    type_start = type_line.find("\ntype: ") + 1;
+                    type_start = type_line.find("\nType: ") + 1;
                     type_end   = type_line.find("\n", type_start) - type_start;
                     type_line  = type_line.substr(type_start, type_end);
 


### PR DESCRIPTION
Avoid possibly unsafe character conversion 'tolower'. Instead, rely on the output of vboxmanage.
Should be fine as long as the virtualbox developers keep their outputs stable. If not, all tests against their messages would need a revision.

Fixes #4993