### PR TITLE
Added an option to have task details always expanded #4214

### DIFF
--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.kt
@@ -31,6 +31,7 @@ import android.view.ViewGroup
 import android.view.Window
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import edu.berkeley.boinc.adapter.TaskRecyclerViewAdapter
 import edu.berkeley.boinc.databinding.DialogConfirmBinding
@@ -165,7 +166,8 @@ class TasksFragment : Fragment() {
     }
 
     inner class TaskData(var result: Result) {
-        var isExpanded = false
+        var sharedPreferences = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        var isExpanded = sharedPreferences.getBoolean("expandWuData", false)
         var id = result.name
         var nextState = -1
         private var loopCounter = 0

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/TasksFragment.kt
@@ -1,7 +1,7 @@
 /*
  * This file is part of BOINC.
  * http://boinc.berkeley.edu
- * Copyright (C) 2021 University of California
+ * Copyright (C) 2022 University of California
  *
  * BOINC is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License

--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -315,4 +315,5 @@
         I encourage all Mi Fans to download Boinc on their phones, contribute a piece of your power while your phone is not being used.</string>
     <string name="welcome_content_sixth">Last but not least, to my Chinese friends - Happy Chinese New Year! Xin Nian Kuai Le!</string>
     <string name="agree_button">Agree</string>
+    <string name="prefs_expand_wu_data">Always expand task information</string>
 </resources>

--- a/android/BOINC/app/src/main/res/values/configuration.xml
+++ b/android/BOINC/app/src/main/res/values/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   This file is part of BOINC.
   http://boinc.berkeley.edu
-  Copyright (C) 2012 University of California
+  Copyright (C) 2022 University of California
   
   BOINC is free software; you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License

--- a/android/BOINC/app/src/main/res/values/configuration.xml
+++ b/android/BOINC/app/src/main/res/values/configuration.xml
@@ -51,6 +51,7 @@
     <bool name="prefs_power_source_wireless">true</bool>
     <bool name="prefs_stationary_device_mode">false</bool>
     <bool name="prefs_suspend_when_screen_on">true</bool>
+    <bool name="prefs_default_expand_wu_data">false</bool>
     <!-- Monitor behavior -->
     <integer name="status_update_interval_ms">1000</integer>
     <integer name="device_status_update_screen_off_every_X_loop">10

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?><!--
   This file is part of BOINC.
   http://boinc.berkeley.edu
-  Copyright (C) 2021 University of California
+  Copyright (C) 2022 University of California
   
   BOINC is free software; you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -351,5 +351,6 @@
     <string name="welcome_content_sixth">Last but not least, to my Chinese friends - Happy Chinese New Year! Xin Nian Kuai Le!</string>
 
     <string name="agree_button">Agree</string>
+    <string name="prefs_expand_wu_data">Always expand task information</string>
 
 </resources>

--- a/android/BOINC/app/src/main/res/xml/root_preferences.xml
+++ b/android/BOINC/app/src/main/res/xml/root_preferences.xml
@@ -48,6 +48,13 @@
                 app:key="suspendWhenScreenOn"
                 app:title="@string/prefs_suspend_when_screen_on" />
 
+        <CheckBoxPreference
+                app:defaultValue="@bool/prefs_default_expand_wu_data"
+                app:iconSpaceReserved="false"
+                app:isPreferenceVisible="true"
+                app:key="expandWuData"
+                app:title="@string/prefs_expand_wu_data" />
+
         <EditTextPreference
                 app:iconSpaceReserved="false"
                 app:key="deviceName"

--- a/android/BOINC/app/src/main/res/xml/root_preferences.xml
+++ b/android/BOINC/app/src/main/res/xml/root_preferences.xml
@@ -1,7 +1,7 @@
 <!--
   This file is part of BOINC.
   http://boinc.berkeley.edu
-  Copyright (C) 2020 University of California
+  Copyright (C) 2022 University of California
 
   BOINC is free software; you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License


### PR DESCRIPTION
Fixes #4214 

**Description of the Change**

Added an additional shared preference which can be set to automatically expand all tasks details in the task list screen

**Alternate Designs**

N/A

**Release Notes**

Added an option to have task details always expanded
