### PR TITLE
Mac: Fixes for MacOS 13 and Xcode 14

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -433,10 +433,10 @@ int use_sandbox, int isManager, char* path_to_error, int len
         if (sbuf.st_gid != boinc_project_gid)
             return -1042;
 
-        if (sbuf.st_uid != boinc_master_uid)
+        if (sbuf.st_uid != 0)   // root
             return -1043;
 
-        if ((sbuf.st_mode & 07777) != 02500)
+        if ((sbuf.st_mode & 07777) != 04050)
             return -1044;
 
 #ifdef __APPLE__

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1864,7 +1864,7 @@ GUI_RPC gui_rpcs[] = {
     GUI_RPC("project_reset", handle_project_reset,                  true,   true,   false),
     GUI_RPC("project_update", handle_project_update,                true,   true,   false),
     GUI_RPC("retry_file_transfer", handle_retry_file_transfer,      true,   true,   false),
-    GUI_RPC("run_graphics_app", handle_run_graphics_app,            true,   true,   false),
+    GUI_RPC("run_graphics_app", handle_run_graphics_app,            false,   false,   false),
 };
 
 // return nonzero only if we need to close the connection

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1378,11 +1378,21 @@ static void stop_graphics_app(pid_t thePID,
         argv[3] = (char *)pidString;
         argc = 4;
 #endif
-        if (!theScreensaverLoginUser.empty()) {
-            argv[argc++] = "--ScreensaverLoginUser";
-            safe_strcpy(screensaverLoginUser, theScreensaverLoginUser.c_str());
-            argv[argc++] = screensaverLoginUser;
+        // Graphics apps run by Manager write files in slot directory
+        // as logged in user, not boinc_master. This ugly hack uses 
+        // setprojectgrp to fix all ownerships in this slot directory.
+        // To fix all ownerships in the slot directory, invoke the 
+        // run_graphics_app RPC with operation "stop", slot number 
+        // for the operand and empty string for screensaverLoginUser
+        // after the graphics app stops.
+        if (theScreensaverLoginUser.empty()) {
+            fix_slot_owners(thePID);    // Manager passes slot # instead of PID
+            return;
         }
+        
+        argv[argc++] = "--ScreensaverLoginUser";
+        safe_strcpy(screensaverLoginUser, theScreensaverLoginUser.c_str());
+        argv[argc++] = screensaverLoginUser;
         argv[argc] = 0;
 
         retval = run_program(
@@ -1391,6 +1401,7 @@ static void stop_graphics_app(pid_t thePID,
         );
     } else {
         retval = kill_program(thePID);
+        
     }
     if (retval) {
         grc.mfout.printf("<error>attempt to kill graphics app failed</error>\n");
@@ -1448,7 +1459,17 @@ static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
         if (grc.xp.parse_string("ScreensaverLoginUser", theScreensaverLoginUser)) continue;
     }
     
-    if (stop || test) {
+    if (stop) {
+        if (theScreensaverLoginUser.empty() ){
+             if (thePID < 0) {
+                 grc.mfout.printf("<error>missing or invalid slot number</error>\n");
+            }
+        } else {
+            if (thePID < 1) {
+                grc.mfout.printf("<error>missing or invalid process id</error>\n");
+            }
+        }
+    } else if (test) {
         if (thePID < 1) {
             grc.mfout.printf("<error>missing or invalid process id</error>\n");
             return;

--- a/client/sandbox.h
+++ b/client/sandbox.h
@@ -17,6 +17,7 @@
 
 extern int kill_via_switcher(int pid);
 extern int get_project_gid();
+extern int fix_slot_owners(const int slot);
 extern int set_to_project_group(const char* path);
 extern int switcher_exec(const char* util_filename, const char* cmdline);
 extern int client_clean_out_dir(

--- a/client/setprojectgrp.cpp
+++ b/client/setprojectgrp.cpp
@@ -19,28 +19,54 @@
 //
 // When run as
 // setprojectgrp Path
-// sets group of file at Path to boinc_project
+// sets file at Path to user boinc_master and group boinc_project
 //
 // setprojectgrp runs setuid boinc_master and setgid boinc_project
 
 #include <unistd.h>
 #include <grp.h>
+#include <pwd.h>	// getpwuid
 #include <cstdio>
 #include <cerrno>
 #if HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
 
+#define VERBOSE 0
+
+#if VERBOSE
+#include <cstring>
+#include <time.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+static void print_to_log_file(const char *format, ...);
+#ifdef __cplusplus
+}
+static void strip_cr(char *buf);
+#endif
+#endif
+
 int main(int argc, char** argv) {
-    gid_t       project_gid;
+    passwd      *pw;
+    group       *grp;
+    uid_t       master_uid = 0;
+    gid_t       project_gid = 0;
     int         retval = 0;
     struct stat sbuf;
-    
-    project_gid = getegid();
 
-#if 0           // For debugging
-    fprintf(stderr, "setprojectgrp argc=%d, arg[1]= %s, boinc_project gid = %d\n", argc, argv[1], project_gid);
-    fflush(stderr);
+    pw = getpwnam("boinc_master");
+    if (pw) master_uid = pw->pw_uid;
+
+    grp = getgrnam("boinc_project");
+    if (grp) project_gid = grp->gr_gid;
+
+#if VERBOSE
+    print_to_log_file("setprojectgrp: current uid=%d, current euid=%d, current gid=%d, current egid=%d\n", getuid(), geteuid(), getgid(), getegid());
+    print_to_log_file("setprojectgrp: argc=%d, arg[1]= %s, boinc_project gid = %d\n", argc, argv[1], project_gid);
 #endif
 
     // chown() doesn't change ownership of symbolic links; it follows the link and 
@@ -54,10 +80,61 @@ int main(int argc, char** argv) {
     //
     if (lstat(argv[1], &sbuf) == 0) {
         if (!S_ISLNK(sbuf.st_mode)) {
-            retval = chown(argv[1], (uid_t)-1, project_gid);
+            retval = chown(argv[1], master_uid, project_gid);
+//            retval = chown(argv[1], -1, project_gid);
+#if VERBOSE
             if (retval)
-                fprintf(stderr, "chown(%s, -1, %d) failed: errno=%d\n", argv[1], project_gid, errno);
+                print_to_log_file("setprojectgrp: chown(%s, %d, %d) failed: errno=%d %s\n", argv[1], master_uid, project_gid, errno, strerror(errno));
+        else
+                print_to_log_file("setprojectgrp: chown(%s, %d, %d) succeeded: errno=%d\n", argv[1], master_uid, project_gid, errno);
+#endif
         }
     }
     return retval;
 }
+
+
+#if VERBOSE
+
+static void print_to_log_file(const char *format, ...) {
+    FILE *f;
+    va_list args;
+    char buf[256];
+    time_t t;
+    
+    f = fopen("/Users/Shared/test_log_gfx_switcher.txt", "a");
+    if (!f) return;
+
+//  freopen(buf, "a", stdout);
+//  freopen(buf, "a", stderr);
+
+    time(&t);
+    strlcpy(buf, asctime(localtime(&t)), sizeof(buf));
+    strip_cr(buf);
+
+    fputs(buf, f);
+    fputs("   ", f);
+
+    va_start(args, format);
+    vfprintf(f, format, args);
+    va_end(args);
+    
+    fputs("\n", f);
+    fflush(f);
+    fclose(f);
+    chmod("/Users/Shared/test_log_gfx_switcher.txt", 0666);
+}
+
+static void strip_cr(char *buf)
+{
+    char *theCR;
+
+    theCR = strrchr(buf, '\n');
+    if (theCR)
+        *theCR = '\0';
+    theCR = strrchr(buf, '\r');
+    if (theCR)
+        *theCR = '\0';
+}
+#endif
+

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -38,6 +38,24 @@
 #include "mac_spawn.h"
 #endif
 
+#define VERBOSE 0
+
+#if VERBOSE
+#include <cstring>
+#include <time.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+static void print_to_log_file(const char *format, ...);
+#ifdef __cplusplus
+}
+static void strip_cr(char *buf);
+#endif
+#endif
+
 using std::strcpy;
 
 int main(int /*argc*/, char** argv) {
@@ -62,21 +80,21 @@ int main(int /*argc*/, char** argv) {
     strcpy(boinc_project_group_name, "boinc_project");
     strcpy(boinc_master_user_name, "boinc_master");
 
-#if 0           // For debugging only
-    fprintf(stderr, "\n\nEntered switcher with euid %d, egid %d, uid %d and gid %d\n", geteuid(), getegid(), getuid(), getgid());       
+#if VERBOSE     // For debugging only
+    print_to_log_file("\n\nEntered switcher with euid %d, egid %d, uid %d and gid %d\n", geteuid(), getegid(), getuid(), getgid());       
     getcwd( current_dir, sizeof(current_dir));
-    fprintf(stderr, "current directory = %s\n", current_dir);
+    print_to_log_file("current directory = %s\n", current_dir);
     fflush(stderr);
     
     i = 0;
     while(argv[i]) {
-        fprintf(stderr, "switcher arg %d: %s\n", i, argv[i]);
+        print_to_log_file("switcher arg %d: %s\n", i, argv[i]);
         fflush(stderr);
         ++i;
     }
 #endif
 
-#if 0       // For debugging only
+#if VERBOSE      // For debugging only
     // Allow debugging without running as user or group boinc_project
     pw = getpwuid(getuid());
     if (pw) {
@@ -85,7 +103,7 @@ int main(int /*argc*/, char** argv) {
     }
     grp = getgrgid(getgid());
     if (grp) {
-        strcpy(boinc_project_group_name, grp->gr_gid);
+        strcpy(boinc_project_group_name, grp->gr_name);
     }
 
 #endif
@@ -226,8 +244,8 @@ int main(int /*argc*/, char** argv) {
             }
         }
         safe_strcat(cmd, "\'");
-#if 0       // For debugging only
-        fprintf(stderr, "About to call Posix Spawn (%s)\n", cmd);
+#if VERBOSE      // For debugging only
+        print_to_log_file("About to call Posix Spawn (%s)\n", cmd);
         fflush(stderr);
 #endif
         if (launching_gfx) {
@@ -243,7 +261,56 @@ int main(int /*argc*/, char** argv) {
     if (retval == -1) {
         // If we got here execv failed
         fprintf(stderr, "Process creation (%s) failed: %s (errno = %d)\n", argv[1], strerror(errno), retval);
+ #if VERBOSE
+        print_to_log_file("Process creation (%s) failed: %s (errno = %d)\n", argv[1], strerror(errno), retval);
+ #endif
     }
 
     return retval;
 }
+
+
+#if VERBOSE
+
+static void print_to_log_file(const char *format, ...) {
+    FILE *f;
+    va_list args;
+    char buf[256];
+    time_t t;
+    
+    f = fopen("/Users/Shared/test_log_gfx_switcher.txt", "a");
+    if (!f) return;
+
+//  freopen(buf, "a", stdout);
+//  freopen(buf, "a", stderr);
+
+    time(&t);
+    strlcpy(buf, asctime(localtime(&t)), sizeof(buf));
+    strip_cr(buf);
+
+    fputs(buf, f);
+    fputs("   ", f);
+
+    va_start(args, format);
+    vfprintf(f, format, args);
+    va_end(args);
+    
+    fputs("\n", f);
+    fflush(f);
+    fclose(f);
+    chmod("/Users/Shared/test_log_gfx_switcher.txt", 0666);
+}
+
+static void strip_cr(char *buf)
+{
+    char *theCR;
+
+    theCR = strrchr(buf, '\n');
+    if (theCR)
+        *theCR = '\0';
+    theCR = strrchr(buf, '\r');
+    if (theCR)
+        *theCR = '\0';
+}
+#endif
+

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -25,6 +25,8 @@
 #include "error_numbers.h"
 #include "str_replace.h"
 #include "util.h"
+#include "BOINCGUIApp.h"
+#include "MainDocument.h"
 
 #ifdef __WXMAC__
 #include "mac_util.h"
@@ -33,8 +35,6 @@
 #include "proc_control.h"
 #endif
 
-#include "BOINCGUIApp.h"
-#include "MainDocument.h"
 #include "BOINCBaseFrame.h"
 #include "AdvancedFrame.h"
 #include "BOINCClientManager.h"
@@ -1630,8 +1630,20 @@ RUNNING_GFX_APP* CMainDocument::GetRunningGraphicsApp(RESULT* rp) {
             }
 
             // Graphics app is still running but the slot now has a different task
+#ifdef __APPLE__
+            // For some graphics apps (including Einstein), we must explicitly delete both
+            // our forked process and its child graphics app, or the other will remain. A
+            // race condition can occur because of the time it takes for our forked process
+            // to launch the graphics app, so we periodically poll for the child's PID until
+            // it is available. If we don't have it yet, we defer killing our forked process. 
+            if (GetGFXPIDFromForkedPID(&(*gfx_app_iter))) { 
+                KillGraphicsApp((*gfx_app_iter).gfx_pid);
+                KillGraphicsApp((*gfx_app_iter).pid);
+           }
+#else
             KillGraphicsApp((*gfx_app_iter).pid);
-        }
+#endif
+       }
 
         // Either the graphics app had already exited or we just killed it
         (*gfx_app_iter).name.clear();
@@ -1672,7 +1684,19 @@ void CMainDocument::KillInactiveGraphicsApps() {
         }
 
         if (!bStillRunning) {
+#ifdef __APPLE__
+            // For some graphics apps (including Einstein), we must explicitly delete both
+            // our forked process and its child graphics app, or the other will remain. A
+            // race condition can occur because of the time it takes for our forked process
+            // to launch the graphics app, so we periodically poll for the child's PID until
+            // it is available. If we don't have it yet, we defer killing our forked process. 
+            if (GetGFXPIDFromForkedPID(&(*gfx_app_iter))) { 
+                KillGraphicsApp((*gfx_app_iter).gfx_pid);
+                KillGraphicsApp((*gfx_app_iter).pid);
+           }
+#else
             KillGraphicsApp((*gfx_app_iter).pid);
+#endif
             gfx_app_iter = m_running_gfx_apps.erase(gfx_app_iter);
         } else {
             gfx_app_iter++;
@@ -1690,6 +1714,18 @@ void CMainDocument::KillAllRunningGraphicsApps()
     n = m_running_gfx_apps.size();
     for (i=0; i<n; i++) {
         gfx_app_iter = m_running_gfx_apps.begin();
+#ifdef __APPLE__
+        // For some graphics apps (including Einstein), we must explicitly delete both
+        // our forked process and its child graphics app, or the other will remain. A
+        // race condition can occur because of the time it takes for our forked process
+        // to launch the graphics app, so we periodically poll for the child's PID until
+        // it is available. If we don't have it yet, we defer killing our forked process. 
+        if (!GetGFXPIDFromForkedPID(&(*gfx_app_iter))) {
+            continue;
+        }
+        KillGraphicsApp((*gfx_app_iter).gfx_pid);
+#endif
+
         KillGraphicsApp((*gfx_app_iter).pid);
         (*gfx_app_iter).name.clear();
         (*gfx_app_iter).project_url.clear();
@@ -1704,34 +1740,43 @@ void CMainDocument::KillGraphicsApp(HANDLE pid) {
 }
 #else
 void CMainDocument::KillGraphicsApp(int pid) {
-    char* argv[6];
-    char currentDir[1024];
-    char thePIDbuf[20];
-    int id;
-
-
-    if (g_use_sandbox) {
-        snprintf(thePIDbuf, sizeof(thePIDbuf), "%d", pid);
-        argv[0] = "switcher";
-        argv[1] = "/bin/kill";
-        argv[2] =  "kill";
-        argv[3] = "-KILL";
-        argv[4] = thePIDbuf;
-        argv[5] = 0;
-
-        run_program(
-            getcwd(currentDir, sizeof(currentDir)),
-            "./switcher/switcher",
-            5,
-            argv,
-            0,
-            id
-        );
-    } else {
-        kill_program(pid);
-    }
+    // As of MacOS 13.0 Ventura IOSurface cannot be used to share graphics
+    // between apps unless they are running as the same user, so we no
+    // longer run the graphics apps as user boinc_master.
+    kill_program(pid);
 }
 #endif
+
+
+#ifdef __APPLE__
+// For some graphics apps (including Einstein), we must explicitly delete both
+// our forked process and its child graphics app, or the other will remain. A
+// race condition can occur because of the time it takes for our forked process
+// to launch the graphics app, so we periodically call this method to poll for
+// the child's PID until it is available.. 
+//
+int CMainDocument::GetGFXPIDFromForkedPID(RUNNING_GFX_APP* gfx_app) {
+    char buf[256];
+
+    if (gfx_app->gfx_pid) return gfx_app->gfx_pid;    // We already found it
+    
+    // The graphics app is the child of our forked process. Get its PID
+    FILE *fp = (FILE*)popen("ps -xoppid,pid","r");
+    fgets(buf, sizeof(buf), fp);    // Skip the header line
+    int parent, child;
+    
+    // Find the process whose parent is our forked process
+    while (fscanf(fp, "%d %d\n", &parent, &child) == 2) {
+        if (parent == gfx_app->pid) {
+            gfx_app->gfx_pid = child;
+            break;
+        }
+    }
+    pclose(fp);
+    return gfx_app->gfx_pid;
+}
+#endif
+
 
 int CMainDocument::WorkShowGraphics(RESULT* rp) {
     int iRetVal = 0;
@@ -1750,61 +1795,89 @@ int CMainDocument::WorkShowGraphics(RESULT* rp) {
 #ifdef __WXMSW__
         HANDLE   id;
 #else
-        int      id;
+        int      id = 0;
 #endif
 
         // See if we are already running the graphics application for this task
         previous_gfx_app = GetRunningGraphicsApp(rp);
 
         if (previous_gfx_app) {
-            // If graphics app is already running, the button has changed to
-            // "Stop graphics", so we end the graphics app.
-            //
-            KillGraphicsApp(previous_gfx_app->pid); // User clicked on "Stop graphics" button
+#ifdef __APPLE__
+            if (g_use_sandbox) {
+                // If graphics app is already running, the button has changed to
+                // "Stop graphics", so we end the graphics app.
+                //
+                // For some graphics apps (including Einstein), we must explicitly delete both
+                // our forked process and its child graphics app, or the other will remain. A
+                // race condition can occur because of the time it takes for our forked process
+                // to launch the graphics app, so we periodically poll for the child's PID until
+                // it is available. If we don't have it yet, then defer responding to the "Stop 
+                // graphics" button.
+                if (GetGFXPIDFromForkedPID(previous_gfx_app)) {
+                    KillGraphicsApp(previous_gfx_app->pid); // User clicked on "Stop graphics" button
+                    KillGraphicsApp(previous_gfx_app->gfx_pid);
+                }
+            } else {
+                KillGraphicsApp(previous_gfx_app->pid); // User clicked on "Stop graphics" button
+            }
+#else
+        // On other platforms, don't launch a second instance if graphics app is already running
+#endif
             return 0;
         }
 
-#ifndef __WXMSW__
-        char* argv[4];
-
-        argv[0] = "switcher";
-        // For unknown reasons on Macs, the graphics application
-        // exits with "RegisterProcess failed (error = -50)" unless
-        // we pass its full path twice in the argument list to execv.
-        //
-        argv[1] = (char *)rp->graphics_exec_path;
-        argv[2] = (char *)rp->graphics_exec_path;
-        argv[3] = 0;
-
-        if (g_use_sandbox) {
-            iRetVal = run_program(
-                rp->slot_path,
-                "../../switcher/switcher",
-                3,
-                argv,
-                0,
-                id
-            );
-        } else {
-            iRetVal = run_program(
-                rp->slot_path,
-                rp->graphics_exec_path,
-                1,
-                &argv[2],
-                0,
-                id
-            );
-        }
-#else
-        // If graphics app is already running, don't launch a second instance
-        //
-        if (previous_gfx_app) return 0;
 
         char* argv[2] = {
             rp->graphics_exec_path,
             NULL
         };
 
+#ifndef __WXMSW__
+        if (g_use_sandbox) {    // Used only by Mac
+            int pid = fork();
+            char path[MAXPATHLEN];
+            char cmd[2048];
+            
+            // As of MacOS 13.0 Ventura IOSurface cannot be used to share graphics
+            // between apps unless they are running as the same user, so we no
+            // longer run the graphics apps as user boinc_master. To replace the
+            // security that was provided by running as a different user, we use
+            // sandbox-exec() to launch the graphics apps. Note that sandbox-exec()
+            // is marked deprecated because it is an Apple private API so the syntax
+            // of the security specifications is subject to change without notice.
+            // But it is used widely in Apple's software, and the security profile
+            // elements we use are very unlikely to change.
+            if (pid == 0) {
+                // For unknown reasons, the graphics application exits with 
+                // "RegisterProcess failed (error = -50)" unless we pass its 
+                // full path twice in the argument list to execv.
+                strlcpy(cmd, "sandbox-exec -f \"", sizeof(cmd));
+                getPathToThisApp(path, sizeof(path));
+                strlcat(cmd, path, sizeof(cmd)); // path to this executable
+                strlcat(cmd, "/Contents/Resources/mac_restrict_access.sb\" \"", sizeof(cmd)); // path to sandboxing profile
+                strlcat(cmd, rp->graphics_exec_path, sizeof(cmd)); // path to graphics app
+                strlcat(cmd, "\"", sizeof(cmd)); // path to sandboxing profile
+                chdir(rp->slot_path);
+                iRetVal = callPosixSpawn(cmd);
+                
+                exit(0);
+            }
+            id = pid;
+            // The graphics app is the child of our forked process. Get its PID
+            gfx_app.pid = id;
+            gfx_app.gfx_pid = 0;    // Initialize GetGFXPIDFromForkedPID()
+            gfx_app.gfx_pid = GetGFXPIDFromForkedPID(&gfx_app);
+        } else {    // !g_use_sandbox
+            iRetVal = run_program(
+                rp->slot_path,
+                rp->graphics_exec_path,
+                1,
+                argv,
+                0,
+                id
+            );
+        }
+#else
         iRetVal = run_program(
             rp->slot_path,
             rp->graphics_exec_path,

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -253,6 +253,7 @@ public:
 #endif
 #ifdef __APPLE__
     int                         GetGFXPIDFromForkedPID(RUNNING_GFX_APP* gfx_app);
+    int                         fix_slot_file_owners(int slot);
 #endif
 
     //

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -35,6 +35,9 @@ typedef struct {
     HANDLE pid;
 #else
     int pid;
+#ifdef __APPLE__
+    int gfx_pid;  // Used only on Mac
+#endif
 #endif
 } RUNNING_GFX_APP;
 
@@ -247,6 +250,9 @@ public:
     void                        KillGraphicsApp(HANDLE pid);
 #else
     void                        KillGraphicsApp(int tpid);
+#endif
+#ifdef __APPLE__
+    int                         GetGFXPIDFromForkedPID(RUNNING_GFX_APP* gfx_app);
 #endif
 
     //

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -587,8 +587,8 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
     isDirectory = S_ISDIR(sbuf.st_mode);
     if ((result == noErr) && (! isDirectory)) {
         // Set owner and group of setprojectgrp application
-        sprintf(buf1, "%s:%s", boinc_master_user_name, boinc_project_group_name);
-        // chown boinc_master:boinc_project "/Library/Application Support/BOINC Data/switcher/setprojectgrp"
+        sprintf(buf1, "root:%s", boinc_project_group_name);
+        // chown root:boinc_project "/Library/Application Support/BOINC Data/switcher/setprojectgrp"
         err = DoSudoPosixSpawn(chownPath, buf1, fullpath, NULL, NULL, NULL, NULL);
         if (err)
             return err;
@@ -597,7 +597,7 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
         // chmod u=rx,g=s,o= "/Library/Application Support/BOINC Data/switcher/setprojectgrp"
         // 02500 = S_ISGID | S_IRUSR | S_IXUSR
         // Set setgid-on-execution plus read and execute permission for user only
-        err = DoSudoPosixSpawn(chmodPath, "u=rx,g=s,o=", fullpath, NULL, NULL, NULL, NULL);
+        err = DoSudoPosixSpawn(chmodPath, "u=s,g=rx,o=", fullpath, NULL, NULL, NULL, NULL);
         if (err)
             return err;
     }       // setprojectgrp application

--- a/clientscr/res/BOINCSaver.xib
+++ b/clientscr/res/BOINCSaver.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment version="101003" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <deployment version="101304" identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>

--- a/clientscr/res/mac_restrict_access.sb
+++ b/clientscr/res/mac_restrict_access.sb
@@ -1,0 +1,8 @@
+(version 1)
+(allow default)
+(deny file-read* (subpath "/Users") (subpath "/Volumes") (subpath "/private") (subpath "/etc") (subpath "/cores") (subpath "/opt") (subpath "/dev") (subpath "/var"))
+(deny file-write* (subpath "/Users") (subpath "/Volumes") (subpath "/private") (subpath "/etc") (subpath "/cores") (subpath "/opt") (subpath "/dev") (subpath "/var"))
+(deny file-read* (subpath "/Library/Application Support") )
+(deny file-write* (subpath "/Library/Application Support") )
+(allow file-write* (subpath "/Library/Application Support/BOINC Data") (subpath "/private/tmp") )
+(allow file-read* (subpath "/Library/Application Support/BOINC Data") (subpath "/private/tmp") )

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -276,6 +276,9 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
                 break;
             }
         }
+        if (! graphics_application) {
+            return -1;
+        }
         // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
         // Inform our helper app what we launched 
         fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
@@ -401,6 +404,7 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
     // We have tested this on OS 10.13 High Sierra and it works there, too
     //
     int thePID = -1;
+    graphics_application = 0;
     retval = rpc->run_graphics_app("runfullscreen", thePID, gUserName);
     for (int i=0; i<800; i++) {
         boinc_sleep(0.01);      // Wait 8 seconds max
@@ -408,6 +412,9 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
             graphics_application = *pid_from_shmem;
             break;
         }
+    }
+    if (! graphics_application) {
+        return -1;
     }
     // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
     // Inform our helper app what we launched 
@@ -954,11 +961,6 @@ bool CScreensaver::HasProcessExited(pid_t pid, int &exitCode) {
     // whether that app is still running. If we sent an RPC to the client 
     // asking the client to launch a graphics app via switcher, we must 
     // send another RPC to the client to call waitpid() for that app.
-    //
-    // As of MacOS 13.0 Ventura IOSurface cannot be used to share graphics
-    // between apps unless they are running as the same user, so we no
-    // longer run the graphics apps as user boinc_master, so we might be 
-    // able to just call waitpid directly now.
     //
     if (pid_from_shmem) {
         //fprintf(stderr, "screensaver HasProcessExited got pid_from_shmem = %d\n", *pid_from_shmem);

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -98,6 +98,7 @@ RESULT* graphics_app_result_ptr = NULL;
 
 #ifdef __APPLE__
 pid_t* pid_from_shmem = NULL;
+bool canAccessProjectGFXApps = true; 
 #endif
 
 bool CScreensaver::is_same_task(RESULT* taska, RESULT* taskb) {
@@ -223,6 +224,26 @@ bool CScreensaver::isIncompatible(char *appPath) {
     return false;
 }
 
+static Boolean IsUserMemberOfGroup(const char *userName, const char *groupName) {
+    group               *grp;
+    short               i = 0;
+    char                *p;
+
+    grp = getgrnam(groupName);
+    if (!grp) {
+        printf("getgrnam(%s) failed\n", groupName);
+        fflush(stdout);
+        return false;  // Group not found
+    }
+
+    while ((p = grp->gr_mem[i]) != NULL) {  // Step through all users in group groupName
+        if (strcmp(p, userName) == 0) {
+            return true;
+        }
+        ++i;
+    }
+    return false;
+}
 #endif
 
 
@@ -234,53 +255,31 @@ int CScreensaver::launch_screensaver(RESULT* rp, GFXAPP_ID& graphics_application
     if (strlen(rp->graphics_exec_path)) {
         // V6 Graphics
 #ifdef __APPLE__
-        if (gIsCatalina) {
-            // As of OS 10.15 (Catalina) screensavers can no longer:
-            //  - launch apps that run setuid or setgid
-            //  - launch apps downloaded from the Internet which have not been 
-            //    specifically approved by the  user via Gatekeeper.
-            // So instead of launching graphics apps via gfx_switcher, we send an 
-            // RPC to the client asking the client to launch them via gfx_switcher.
-            // See comments in gfx_switcher.cpp for a more detailed explanation.
-            // We have tested this on OS 10.13 High Sierra and it works there, too
-            //
-            retval = rpc->run_graphics_app("runfullscreen", rp->slot, gUserName);
-            for (int i=0; i<800; i++) {
-                boinc_sleep(0.01);      // Wait 8 seconds max
-                if (*pid_from_shmem != 0) {
-                    graphics_application = *pid_from_shmem;
-                    break;
-                }
+        // As of OS 10.15 (Catalina) screensavers can no longer:
+        //  - launch apps that run setuid or setgid
+        //  - launch apps downloaded from the Internet which have not been 
+        //    specifically approved by the  user via Gatekeeper.
+        // So instead of launching graphics apps via gfx_switcher, we send an 
+        // RPC to the client asking the client to launch them via gfx_switcher.
+        // See comments in gfx_switcher.cpp for a more detailed explanation.
+        // We have tested this on OS 10.13 High Sierra and it works there, too
+        //
+        // As of MacOS 13.0 Ventura IOSurface cannot be used to share graphics
+        // between apps unless they are running as the same user, so we no
+        // longer run the graphics apps as user boinc_master.
+        //
+        retval = rpc->run_graphics_app("runfullscreen", rp->slot, gUserName);
+        for (int i=0; i<800; i++) {
+            boinc_sleep(0.01);      // Wait 8 seconds max
+            if (*pid_from_shmem != 0) {
+                graphics_application = *pid_from_shmem;
+                break;
             }
-            // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
-            // Inform our helper app what we launched 
-            fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
-            fflush(m_gfx_Cleanup_IPC);
-        } else {
-            // For sandbox security, use gfx_switcher to launch gfx app 
-            // as user boinc_project and group boinc_project.
-            //
-            // For unknown reasons, the graphics application exits with 
-            // "RegisterProcess failed (error = -50)" unless we pass its 
-            // full path twice in the argument list to execv.
-            char* argv[5];
-            argv[0] = "gfx_Switcher";
-            argv[1] = "-launch_gfx";
-            argv[2] = strrchr(rp->slot_path, '/');
-            if (*argv[2]) argv[2]++;    // Point to the slot number in ascii
-            
-            argv[3] = "--fullscreen";
-            argv[4] = 0;
-
-           retval = run_program(
-                rp->slot_path,
-                m_gfx_Switcher_Path,
-                4,
-                argv,
-                0,
-                graphics_application
-            );
-    }
+        }
+        // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
+        // Inform our helper app what we launched 
+        fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
+        fflush(m_gfx_Cleanup_IPC);
     
     if (graphics_application) {
         launchedGfxApp(rp->graphics_exec_path, graphics_application, rp->slot);
@@ -313,91 +312,44 @@ int CScreensaver::terminate_v6_screensaver(GFXAPP_ID& graphics_application, RESU
 #ifdef __APPLE__
     pid_t thePID;
     
-    if (gIsCatalina) {
-        // As of OS 10.15 (Catalina) screensavers can no longer launch apps
-        // that run setuid or setgid. So instead of killing graphics apps 
-        // via gfx_switcher, we send an RPC to the client asking the client 
-        // to kill them via switcher.
-        // We have tested this on OS 10.13 High Sierra and it works there, too
-        //
-        int ignore;
+    // As of OS 10.15 (Catalina) screensavers can no longer launch apps
+    // that run setuid or setgid. So instead of killing graphics apps 
+    // via gfx_switcher, we send an RPC to the client asking the client 
+    // to kill them via switcher.
+    // We have tested this on OS 10.13 High Sierra and it works there, too
+    //
+    // As of MacOS 13.0 Ventura IOSurface cannot be used to share graphics
+    // between apps unless they are running as the same user, so we no
+    // longer run the graphics apps as user boinc_master, so we might be 
+    // able to just call kill_program(graphics_application).
+    //
+    int ignore;
 
-        if (graphics_application == 0) return 0;
+    if (graphics_application == 0) return 0;
 
-        // MUTEX may help prevent crashes when terminating an older gfx app which
-        // we were displaying using CGWindowListCreateImage under OS X >= 10.13
-        // Also prevents reentry when called from our other thread
-        pthread_mutex_lock(&saver_mutex);
+    // MUTEX may help prevent crashes when terminating an older gfx app which
+    // we were displaying using CGWindowListCreateImage under OS X >= 10.13
+    // Also prevents reentry when called from our other thread
+    pthread_mutex_lock(&saver_mutex);
 
-        thePID = graphics_application;
-        // fprintf(stderr, "stopping pid %d\n", thePID);
-        retval = rpc->run_graphics_app("stop", thePID, gUserName);
-        //kill_program(graphics_application);
+    thePID = graphics_application;
+    // fprintf(stderr, "stopping pid %d\n", thePID);
+    retval = rpc->run_graphics_app("stop", thePID, gUserName);
+    //kill_program(graphics_application);
 
-        // Inform our helper app that we have stopped current graphics app 
-        fprintf(m_gfx_Cleanup_IPC, "0\n");
-        fflush(m_gfx_Cleanup_IPC);
+    // Inform our helper app that we have stopped current graphics app 
+    fprintf(m_gfx_Cleanup_IPC, "0\n");
+    fflush(m_gfx_Cleanup_IPC);
 
-        launchedGfxApp("", 0, -1);
+    launchedGfxApp("", 0, -1);
 
-        for (i=0; i<200; i++) {
-            boinc_sleep(0.01);      // Wait 2 seconds max
-            if (HasProcessExited(graphics_application, ignore)) {
-                break;
-            }
+    for (i=0; i<200; i++) {
+        boinc_sleep(0.01);      // Wait 2 seconds max
+        if (HasProcessExited(graphics_application, ignore)) {
+            break;
         }
-        pthread_mutex_unlock(&saver_mutex);
-    
-    } else {
-        // Under sandbox security, use gfx_switcher to kill default gfx app 
-        // as user boinc_master and group boinc_master (for default gfx app)
-        // or user boinc_project and group boinc_project (for project gfx 
-        // apps.) The man page for kill() says the user ID of the process 
-        // sending the signal must match that of the target process, though 
-        // in practice that seems not to be true on the Mac.
-        
-        char current_dir[PATH_MAX];
-        char gfx_pid[16];
-        
-        if (graphics_application == 0) return 0;
-        
-        // MUTEX may help prevent crashes when terminating an older gfx app which
-        // we were displaying using CGWindowListCreateImage under OS X >= 10.13
-        // Also prevents reentry when called from our other thread
-        pthread_mutex_lock(&saver_mutex);
-
-        sprintf(gfx_pid, "%d", graphics_application);
-        getcwd( current_dir, sizeof(current_dir));
-
-        char* argv[4];
-        argv[0] = "gfx_switcher";
-        argv[1] = "-kill_gfx";
-        argv[2] = gfx_pid;
-        argv[3] = 0;
-
-        retval = run_program(
-            current_dir,
-            m_gfx_Switcher_Path,
-            3,
-            argv,
-            0,
-            thePID
-        );
-
-        if (graphics_application) {
-            launchedGfxApp("", 0, -1);
-        }
-        
-        for (i=0; i<200; i++) {
-            boinc_sleep(0.01);      // Wait 2 seconds max
-            // Prevent gfx_switcher from becoming a zombie
-            if (waitpid(thePID, 0, WNOHANG) == thePID) {
-                break;
-            }
-        }
-        pthread_mutex_unlock(&saver_mutex);
     }
-    
+    pthread_mutex_unlock(&saver_mutex);    
 #endif
 
 #ifdef _WIN32
@@ -437,60 +389,30 @@ int CScreensaver::terminate_screensaver(GFXAPP_ID& graphics_application, RESULT*
 //
 int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics_application) {
     int retval = 0;
-    int num_args;
     
 #ifdef __APPLE__
-    if (gIsCatalina) {
-        // As of OS 10.15 (Catalina) screensavers can no longer:
-        //  - launch apps that run setuid or setgid
-        //  - launch apps downloaded from the Internet which have not been 
-        //    specifically approved by the  user via Gatekeeper.
-        // So instead of launching graphics apps via gfx_switcher, we send an 
-        // RPC to the client asking the client to launch them via gfx_switcher.
-        // See comments in gfx_switcher.cpp for a more detailed explanation.
-        // We have tested this on OS 10.13 High Sierra and it works there, too
-        //
-        int thePID = -1;
-        retval = rpc->run_graphics_app("runfullscreen", thePID, gUserName);
-        for (int i=0; i<800; i++) {
-            boinc_sleep(0.01);      // Wait 8 seconds max
-            if (*pid_from_shmem != 0) {
-                graphics_application = *pid_from_shmem;
-                break;
-            }
+    // As of OS 10.15 (Catalina) screensavers can no longer:
+    //  - launch apps that run setuid or setgid
+    //  - launch apps downloaded from the Internet which have not been 
+    //    specifically approved by the  user via Gatekeeper.
+    // So instead of launching graphics apps via gfx_switcher, we send an 
+    // RPC to the client asking the client to launch them via gfx_switcher.
+    // See comments in gfx_switcher.cpp for a more detailed explanation.
+    // We have tested this on OS 10.13 High Sierra and it works there, too
+    //
+    int thePID = -1;
+    retval = rpc->run_graphics_app("runfullscreen", thePID, gUserName);
+    for (int i=0; i<800; i++) {
+        boinc_sleep(0.01);      // Wait 8 seconds max
+        if (*pid_from_shmem != 0) {
+            graphics_application = *pid_from_shmem;
+            break;
         }
-        // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
-        // Inform our helper app what we launched 
-        fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
-        fflush(m_gfx_Cleanup_IPC);
-    } else {
-        // For sandbox security, use gfx_switcher to launch default 
-        // gfx app as user boinc_master and group boinc_master.
-        char* argv[6];
-
-        argv[0] = "gfx_switcher";
-        argv[1] = "-default_gfx";
-        argv[2] = THE_DEFAULT_SS_EXECUTABLE;    // Will be changed by gfx_switcher
-        argv[3] = "--fullscreen";
-        argv[4] = 0;
-        argv[5] = 0;
-        if (!m_bConnected) {
-            BOINCTRACE(_T("launch_default_screensaver using --retry_connect argument\n"));
-            argv[4] = "--retry_connect";
-            num_args = 5;
-        } else {
-            num_args = 4;
-        }
-
-        retval = run_program(
-            dir_path,
-            m_gfx_Switcher_Path,
-            num_args,
-            argv,
-            0,
-            graphics_application
-        );
     }
+    // fprintf(stderr, "launch_screensaver got pid %d\n", graphics_application);
+    // Inform our helper app what we launched 
+    fprintf(m_gfx_Cleanup_IPC, "%d\n", graphics_application);
+    fflush(m_gfx_Cleanup_IPC);
     
     if (graphics_application) {
         launchedGfxApp("boincscr", graphics_application, -1);
@@ -501,6 +423,7 @@ int CScreensaver::launch_default_screensaver(char *dir_path, GFXAPP_ID& graphics
 #else
     char* argv[4];
     char full_path[1024];
+    int num_args;
 
     strlcpy(full_path, dir_path, sizeof(full_path));
     strlcat(full_path, PATH_SEPARATOR, sizeof(full_path));
@@ -599,20 +522,22 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
 #ifdef __APPLE__
     m_vIncompatibleGfxApps.clear();
     default_ss_dir_path = "/Library/Application Support/BOINC Data";
-    if (gIsCatalina) {
-        char shmem_name[MAXPATHLEN];
-        snprintf(shmem_name, sizeof(shmem_name), "/tmp/boinc_ss_%s", gUserName);
-        retval = create_shmem_mmap(shmem_name, sizeof(int), (void**)&pid_from_shmem);
-        // make sure user/group RW permissions are set, but not other.
-        //
-        if (retval == 0) {
-            chmod(shmem_name, 0666);
-            retval = attach_shmem_mmap(shmem_name, (void**)&pid_from_shmem);
-        }
-        if (retval == 0) {
-            *pid_from_shmem = 0;
-        }
+    char shmem_name[MAXPATHLEN];
+    snprintf(shmem_name, sizeof(shmem_name), "/tmp/boinc_ss_%s", gUserName);
+    retval = create_shmem_mmap(shmem_name, sizeof(int), (void**)&pid_from_shmem);
+    // make sure user/group RW permissions are set, but not other.
+    //
+    if (retval == 0) {
+        chmod(shmem_name, 0666);
+        retval = attach_shmem_mmap(shmem_name, (void**)&pid_from_shmem);
     }
+    if (retval == 0) {
+        *pid_from_shmem = 0;
+    }
+    
+    if (!IsUserMemberOfGroup(gUserName, "boinc_master")) canAccessProjectGFXApps = false;
+    if (!IsUserMemberOfGroup(gUserName, "boinc_project")) canAccessProjectGFXApps = false;
+    if (!canAccessProjectGFXApps) m_bShow_default_ss_first = true;
 #else
     default_ss_dir_path = (char*)m_strBOINCInstallDirectory.c_str();
 #endif
@@ -759,6 +684,20 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
             }
         }
         
+#ifdef __APPLE__
+        // If user is not a member of both group bonc_master and group boinc_project, then
+        // it can't access the project graphics apps (via slots and projects directories.)
+        if (!canAccessProjectGFXApps) {
+             if (!m_bDefault_gfx_running) {
+                if (m_bDefault_ss_exists) {
+                    switch_to_default_gfx = true;
+                } else {
+                    SetError(TRUE, m_hrError);          // No GFX App is running: show moving BOINC logo
+                }
+            }
+        }
+#endif
+       
         if (switch_to_default_gfx) {
             if (m_bScience_gfx_running) {
                 if (m_hGraphicsApplication || previous_result_ptr) {
@@ -874,7 +813,15 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
                     graphics_app_result_ptr = get_random_graphics_app(results, previous_result_ptr);
                     previous_result_ptr = NULL;
                 }
-                
+
+#ifdef __APPLE__
+                // If user is not a member of both group bonc_master and group boinc_project, then
+                // it can't access the project graphics apps (via slots and projects directories.)
+                if (!canAccessProjectGFXApps) {
+                    graphics_app_result_ptr = NULL;
+                }
+#endif
+
                 if (graphics_app_result_ptr) {
                     if (m_bDefault_gfx_running) {
                         terminate_default_screensaver(m_hGraphicsApplication);
@@ -1003,28 +950,21 @@ BOOL CScreensaver::HasProcessExited(HANDLE pid_handle, int &exitCode) {
 }
 #else
 bool CScreensaver::HasProcessExited(pid_t pid, int &exitCode) {
-    int status;
-    pid_t p;
-    
-    if (gIsCatalina) {
-        // Only the process which launched an app can use waitpid() to test 
-        // whether that app is still running. If we sent an RPC to the client 
-        // asking the client to launch a graphics app via switcher, we must 
-        // send another RPC to the client to call waitpid() for that app.
-        //
-        if (pid_from_shmem) {
-            //fprintf(stderr, "screensaver HasProcessExited got pid_from_shmem = %d\n", *pid_from_shmem);
-            if (*pid_from_shmem != 0) return false;
-        }
-        return true;
+    // Only the process which launched an app can use waitpid() to test 
+    // whether that app is still running. If we sent an RPC to the client 
+    // asking the client to launch a graphics app via switcher, we must 
+    // send another RPC to the client to call waitpid() for that app.
+    //
+    // As of MacOS 13.0 Ventura IOSurface cannot be used to share graphics
+    // between apps unless they are running as the same user, so we no
+    // longer run the graphics apps as user boinc_master, so we might be 
+    // able to just call waitpid directly now.
+    //
+    if (pid_from_shmem) {
+        //fprintf(stderr, "screensaver HasProcessExited got pid_from_shmem = %d\n", *pid_from_shmem);
+        if (*pid_from_shmem != 0) return false;
     }
-    
-    p = waitpid(pid, &status, WNOHANG);
-    exitCode = WEXITSTATUS(status);
-    if (p == pid) return true;     // process has exited
-    if (p == -1) return true;      // PID doesn't exist
-    exitCode = 0;
-    return false;
+    return true;
 }
 #endif
 

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1971,6 +1971,11 @@ int RPC_CLIENT::run_benchmarks() {
 // operand is slot number (for run or runfullscreen) or pid (for stop)
 // if slot = -1, start the default screensaver
 // screensaverLoginUser is the login name of the user running the screensaver
+//         
+// Graphics apps run by Manager write files in slot directory as logged
+// in user, not boinc_master. To tell BOINC client to fix all ownerships
+// in the slot directory, use operation "stop", slot number for operand 
+// and empty string for screensaverLoginUser after the graphics app stops.
 //
 int RPC_CLIENT::run_graphics_app(
     const char *operation, int& operand, const char *screensaverLoginUser

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -64,8 +64,9 @@
 
 # Updated 1/28/10 for BOINC version 6.8.20, 6.10.30 and 6.11.1
 # Updated 10/24/11 for OS 10.7.2 Lion
-# Last updated 3/3/12 to create users and groups with IDs > 500 
+# Updated 3/3/12 to create users and groups with IDs > 500 
 # and to create RealName key with empty string as value (for users)
+# Updated 11/8/22 revised setprojectgrp wonership & permissions for MacOS 13
 #
 # WARNING: do not use this script with versions of BOINC older 
 # than 6.8.20 and 6.10.30
@@ -257,7 +258,7 @@ set_perm switcher/AppStats root boinc_master 4550
 fi
 
 set_perm switcher/switcher root boinc_master 04050
-set_perm switcher/setprojectgrp boinc_master boinc_project 2500
+set_perm switcher/setprojectgrp root boinc_project 04050
 set_perm switcher boinc_master boinc_master 0550
 
 if [ -d locale ] ; then

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -192,6 +192,7 @@
 		DD531BC60C193D3800742E50 /* MacInstaller.icns in Resources */ = {isa = PBXBuildFile; fileRef = DD531BC50C193D3800742E50 /* MacInstaller.icns */; };
 		DD531BC80C193D5200742E50 /* MacUninstaller.icns in Resources */ = {isa = PBXBuildFile; fileRef = DD531BC70C193D5200742E50 /* MacUninstaller.icns */; };
 		DD55AF6D1916248200259439 /* coproc_sched.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD55AF6B1916248200259439 /* coproc_sched.cpp */; };
+		DD57E7922913D08E00E857CA /* mac_restrict_access.sb in Resources */ = {isa = PBXBuildFile; fileRef = DD57E7912913D08E00E857CA /* mac_restrict_access.sb */; };
 		DD5BF77D0D4F3D0C00EDF980 /* mac_icon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6381450870DB78007A2F8E /* mac_icon.cpp */; };
 		DD5F6550236064E4009ED2A2 /* gui_rpc_client.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD81C5CC07C5D7D90098A04D /* gui_rpc_client.cpp */; };
 		DD5F6551236064E4009ED2A2 /* gui_rpc_client_ops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD73E34E08A0694000656EB1 /* gui_rpc_client_ops.cpp */; };
@@ -582,6 +583,7 @@
 		DDFE84E70B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFE84E30B60CD66009B43D9 /* DlgAdvPreferencesBase.cpp */; };
 		DDFF2AE90A53D599002BC19D /* setprojectgrp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDFF2AE80A53D599002BC19D /* setprojectgrp.cpp */; };
 		DDFF2EAB245BA6A300347B89 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
+		DDFF50582917D08F0050D03C /* mac_restrict_access.sb in Resources */ = {isa = PBXBuildFile; fileRef = DD57E7912913D08E00E857CA /* mac_restrict_access.sb */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1023,6 +1025,7 @@
 		DD531BC70C193D5200742E50 /* MacUninstaller.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = MacUninstaller.icns; path = ../clientgui/res/MacUninstaller.icns; sourceTree = SOURCE_ROOT; };
 		DD55AF6B1916248200259439 /* coproc_sched.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = coproc_sched.cpp; sourceTree = "<group>"; };
 		DD55AF6C1916248200259439 /* coproc_sched.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = coproc_sched.h; sourceTree = "<group>"; };
+		DD57E7912913D08E00E857CA /* mac_restrict_access.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = mac_restrict_access.sb; path = ../clientscr/res/mac_restrict_access.sb; sourceTree = "<group>"; };
 		DD58C41808F3343F00C1DF66 /* AccountInfoPage.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = AccountInfoPage.cpp; path = ../clientgui/AccountInfoPage.cpp; sourceTree = SOURCE_ROOT; };
 		DD58C41908F3343F00C1DF66 /* AccountInfoPage.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = AccountInfoPage.h; path = ../clientgui/AccountInfoPage.h; sourceTree = SOURCE_ROOT; };
 		DD58C41C08F3343F00C1DF66 /* AccountManagerInfoPage.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = AccountManagerInfoPage.cpp; path = ../clientgui/AccountManagerInfoPage.cpp; sourceTree = SOURCE_ROOT; };
@@ -1652,6 +1655,7 @@
 				DD957E59181B908800ECA34E /* thumbnail.png */,
 				DD957E5A181B908800ECA34E /* thumbnail@2x.png */,
 				DDBC6CA40D5D458700564C49 /* boinc_ss_logo.png */,
+				DD57E7912913D08E00E857CA /* mac_restrict_access.sb */,
 				DDF3028907CCCE2C00701169 /* BOINCMgr.icns */,
 				DD35BF3927E3601800F1BBFC /* BOINCSaver.xib */,
 				DD531BC50C193D3800742E50 /* MacInstaller.icns */,
@@ -2715,6 +2719,7 @@
 			files = (
 				DD3E14DB0A774397007E0084 /* boinc in Resources */,
 				DDB0805E2163019F00520B63 /* InfoPlist.strings in Resources */,
+				DDFF50582917D08F0050D03C /* mac_restrict_access.sb in Resources */,
 				DD3E14DC0A774397007E0084 /* BOINCMgr.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2738,6 +2743,7 @@
 				DD818295245ED4110076E5D0 /* boinc_ss_helper.sh in Resources */,
 				DD35BF3A27E3601800F1BBFC /* BOINCSaver.xib in Resources */,
 				DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */,
+				DD57E7922913D08E00E857CA /* mac_restrict_access.sb in Resources */,
 				DDBC6CA50D5D458700564C49 /* boinc_ss_logo.png in Resources */,
 				DD957E5B181B908800ECA34E /* thumbnail.png in Resources */,
 				DD957E5C181B908800ECA34E /* thumbnail@2x.png in Resources */,
@@ -2774,6 +2780,7 @@
 		};
 		DD1B90070A954C9A00FF5591 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2802,6 +2809,7 @@
 		};
 		DD3B67F6140CFFA20088683F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2815,6 +2823,7 @@
 		};
 		DD3E15390A774397007E0084 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2828,6 +2837,7 @@
 		};
 		DD5E20A7140CE808000FADAA /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2842,6 +2852,7 @@
 		};
 		DD5E20A8140CE842000FADAA /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2851,10 +2862,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"CONFIGURATION = ${CONFIGURATION}\"\n# echo \"PRODUCT_NAME = ${PRODUCT_NAME}\"\nmkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" -nt \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n        strip -S \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    fi\nfi";
+			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"CONFIGURATION = ${CONFIGURATION}\"\n# echo \"PRODUCT_NAME = ${PRODUCT_NAME}\"\nmkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" -nt \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n        strip -S \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    fi\nfi\n";
 		};
 		DD5FD5990A0233D60093C19F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2885,6 +2897,7 @@
 		};
 		DD818296245EDA220076E5D0 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2902,6 +2915,7 @@
 		};
 		DD81C827144D90FC000BE61A /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2941,6 +2955,7 @@
 		};
 		DDC8FB2B1F6D398700BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2954,6 +2969,7 @@
 		};
 		DDC8FB2C1F6D39B800BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2967,6 +2983,7 @@
 		};
 		DDF9B764245C12AA00587EBE /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2984,6 +3001,7 @@
 		};
 		DDF9EC07144EB255005D6144 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2997,6 +3015,7 @@
 		};
 		DDFE33E224EA9AC300F5C838 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -3014,6 +3033,7 @@
 		};
 		DDFE33E324EA9ADC00F5C838 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -3967,7 +3987,7 @@
 					"-D_THREAD_SAFE",
 					"-D__WXMAC__",
 					"-D_DEBUG",
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101000",
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
 				"OTHER_CFLAGS[arch=arm64]" = (
@@ -3979,7 +3999,7 @@
 					"-D_THREAD_SAFE",
 					"-D__WXMAC__",
 					"-D_DEBUG",
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101000",
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
 				"OTHER_CFLAGS[arch=x86_64]" = (
@@ -3991,7 +4011,7 @@
 					"-D_THREAD_SAFE",
 					"-D__WXMAC__",
 					"-D_DEBUG",
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101000",
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
@@ -4047,7 +4067,7 @@
 					"-DSANDBOX",
 					"-D_NDEBUG",
 					"-DBUILDING_MANAGER",
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101000",
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
 				"OTHER_CFLAGS[arch=arm64]" = (
@@ -4061,7 +4081,7 @@
 					"-DSANDBOX",
 					"-D_NDEBUG",
 					"-DBUILDING_MANAGER",
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101000",
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
 				"OTHER_CFLAGS[arch=x86_64]" = (
@@ -4075,7 +4095,7 @@
 					"-DSANDBOX",
 					"-D_NDEBUG",
 					"-DBUILDING_MANAGER",
-					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101000",
+					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
 				OTHER_CPLUSPLUSFLAGS = "$(OTHER_CFLAGS)";
@@ -4135,6 +4155,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -4194,6 +4215,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_NS_ASSERTIONS = NO;
@@ -4478,7 +4500,11 @@
 				);
 				PRODUCT_NAME = boinc;
 				STRIP_INSTALLED_PRODUCT = NO;
-				USER_HEADER_SEARCH_PATHS = "../../curl-7.79.1/include ../../openssl-3.0.0/include ../lib/**";
+				USER_HEADER_SEARCH_PATHS = (
+					"../../curl-7.79.1/include",
+					"../../openssl-3.0.0/include",
+					"../lib/**",
+				);
 				WARNING_CFLAGS = (
 					"-Wmost",
 					"-Wno-four-char-constants",
@@ -4554,11 +4580,12 @@
 				GCC_FAST_MATH = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				"GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]" = NO;
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
 				HEADER_SEARCH_PATHS = "../lib/**";
 				LIBRARY_STYLE = STATIC;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_CFLAGS = (
 					"-D_THREAD_SAFE",
 					"-DNDEBUG",
@@ -4668,7 +4695,11 @@
 				);
 				PRODUCT_NAME = boinc;
 				STRIP_INSTALLED_PRODUCT = NO;
-				USER_HEADER_SEARCH_PATHS = "../../curl-7.79.1/include ../../openssl-3.0.0/include ../lib/**";
+				USER_HEADER_SEARCH_PATHS = (
+					"../../curl-7.79.1/include",
+					"../../openssl-3.0.0/include",
+					"../lib/**",
+				);
 				WARNING_CFLAGS = (
 					"-Wmost",
 					"-Wno-four-char-constants",
@@ -4744,11 +4775,12 @@
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_SYMBOLS_PRIVATE_EXTERN = YES;
+				"GCC_WARN_64_TO_32_BIT_CONVERSION[arch=*64]" = NO;
 				GCC_WARN_ABOUT_DEPRECATED_FUNCTIONS = NO;
 				GCC_WARN_TYPECHECK_CALLS_TO_PRINTF = NO;
 				HEADER_SEARCH_PATHS = "../lib/**";
 				LIBRARY_STYLE = STATIC;
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				OTHER_CFLAGS = (
 					"-D_THREAD_SAFE",
 					"-D_DEBUG",

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -59,7 +59,8 @@ int callPosixSpawn(const char *cmd);
 long GetBrandID(char *path);
 static void FixLaunchServicesDataBase(void);
 static Boolean IsUserActive(const char *userName);
-static char * PersistentFGets(char *buf, size_t buflen, FILE *f);void print_to_log_file(const char *format, ...);
+static char * PersistentFGets(char *buf, size_t buflen, FILE *f);
+void print_to_log_file(const char *format, ...);
 void strip_cr(char *buf);
 
 int main(int argc, const char * argv[]) {


### PR DESCRIPTION
Fixes BOINC screensaver and Manager "Show Graphics" button functionality to work with MacOS 13 Ventura. This also required a different implementation of security to prevent access to user's files in the unlikely case of  malevolent or buggy project graphics apps.

As of MacOS 13.0 Ventura IOSurface cannot be used to share graphics between apps unless they are running as the same user, so  the screensaver can no longer run the graphics apps as user boinc_master or user boinc_project. Similarly, project graphics no longer work if run as user boinc_master or user boinc_project when run from the Manager's _Show Graphics_ button, though I don't fully understand why.

As a result, they now must be run as the logged in user, creating a potential security risk. I have implemented a technique to block access to the user's files and other sensitive directories based on an API that Apple uses extensively but has marked deprecated because it is an Apple private API. Apple warns it has deprecated the API because the syntax used to specify the access restrictions one passes to this API is subject to change without notice. But the syntax has remained unchanged for many years, this API is used widely in Apple's software, and the security profile elements we use are quite basic and so are very unlikely to change. I can find no other way to provide this security.
