### PR TITLE
Fix compile errors caused by missing header file

### DIFF
--- a/samples/vboxwrapper/vboxlogging.cpp
+++ b/samples/vboxwrapper/vboxlogging.cpp
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdarg.h> 
 #include <cmath>
+#include <ctime>
 #include <string>
 #include <unistd.h>
 #endif


### PR DESCRIPTION
After a system upgrade to the recent Tumbleweed version a few days ago making vboxwrapper fails with the errors below.
As suggested by the make output adding `#include <ctime>` solves the problem.
That's weird since "vboxlogging.cpp" hasn't changed for years.

```
vboxlogging.cpp: In function 'int vboxlog_msg(const char*, ...)':
vboxlogging.cpp:39:15: error: aggregate 'tm tm' has incomplete type and cannot be defined
   39 |     struct tm tm;
      |               ^~
vboxlogging.cpp:44:16: error: 'time' was not declared in this scope
   44 |     time_t x = time(0);
      |                ^~~~
vboxlogging.cpp:33:1: note: 'time' is defined in header '<ctime>'; did you forget to '#include <ctime>'?
   32 | #include "vboxlogging.h"
  +++ |+#include <ctime>
   33 | 
vboxlogging.cpp:51:5: error: 'localtime_r' was not declared in this scope; did you mean 'locale_t'?
   51 |     localtime_r(&x, &tm);
      |     ^~~~~~~~~~~
      |     locale_t
vboxlogging.cpp:54:5: error: 'strftime' was not declared in this scope
   54 |     strftime(buf, sizeof(buf)-1, "%Y-%m-%d %H:%M:%S", &tm);
      |     ^~~~~~~~
vboxlogging.cpp:54:5: note: 'strftime' is defined in header '<ctime>'; did you forget to '#include <ctime>'?
ln -s `g++ -print-file-name=libstdc++.a`
make: *** [Makefile:62: vboxlogging.o] Error 1
make: *** Waiting for unfinished jobs....
```
