### PR TITLE
Add Android ARM64 to default platform list (tools/project.xml).

### DIFF
--- a/tools/project.xml
+++ b/tools/project.xml
@@ -45,7 +45,11 @@
     </platform>
     <platform>
         <name>arm-android-linux-gnu</name>
-        <user_friendly_name>Android running on ARM</user_friendly_name>
+        <user_friendly_name>Android running on ARM armeabi-v7a</user_friendly_name>
+    </platform>
+    <platform>
+        <name>aarch64-android-linux-gnu</name>
+        <user_friendly_name>Android running on ARM 64-bit arm64-v8a</user_friendly_name>
     </platform>
     <platform>
         <name>arm-unknown-linux-gnu</name>

--- a/tools/project.xml
+++ b/tools/project.xml
@@ -64,8 +64,8 @@
         <user_friendly_name>Android running on Intel x86 compatible</user_friendly_name>
     </platform>
     <platform>
-        <name>arm-unknown-linux-gnu</name>
-        <user_friendly_name>Linux running on ARM</user_friendly_name>
+        <name>arm-unknown-linux-gnueabihf</name>
+        <user_friendly_name>Linux running on ARM, hardware FP</user_friendly_name>
     </platform>
     <platform>
         <name>aarch64-unknown-linux-gnu</name>

--- a/tools/project.xml
+++ b/tools/project.xml
@@ -28,6 +28,10 @@
         <user_friendly_name>Intel 64-bit Mac OS 10.5 or later</user_friendly_name>
     </platform>
     <platform>
+        <name>arm64-apple-darwin</name>
+        <user_friendly_name>Mac OS running on ARM</user_friendly_name>
+    </platform>
+    <platform>
         <name>sparc-sun-solaris2.7</name>
         <user_friendly_name>Solaris 2.7 running on a SPARC-compatible CPU</user_friendly_name>
     </platform>
@@ -50,6 +54,14 @@
     <platform>
         <name>aarch64-android-linux-gnu</name>
         <user_friendly_name>Android running on ARM 64-bit arm64-v8a</user_friendly_name>
+    </platform>
+    <platform>
+        <name>x86_64-android-linux-gnu</name>
+        <user_friendly_name>Android running on Intel x64 compatible</user_friendly_name>
+    </platform>
+    <platform>
+        <name>x86-android-linux-gnu</name>
+        <user_friendly_name>Android running on Intel x86 compatible</user_friendly_name>
     </platform>
     <platform>
         <name>arm-unknown-linux-gnu</name>


### PR DESCRIPTION
Note: there's some inconsistency between this list and https://boinc.berkeley.edu/trac/wiki/BoincPlatforms