### PR TITLE
scheduler: set type of Apple GPUs to "Apple"

### DIFF
--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -140,8 +140,8 @@ int COPROC::parse(XML_PARSER& xp) {
     while (!xp.get_tag()) {
         if (!xp.is_tag) continue;
         if (xp.match_tag("/coproc")) {
-            // the client reports the type of Apple GPUs as the model
-            // (e.g. "Apple M1")
+            // The client reports the type of Apple GPUs as the model
+            // (e.g. "Apple M1").
             // Change it to just "Apple".
             //
             if (strstr(type, "Apple")) {

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -140,6 +140,13 @@ int COPROC::parse(XML_PARSER& xp) {
     while (!xp.get_tag()) {
         if (!xp.is_tag) continue;
         if (xp.match_tag("/coproc")) {
+            // the client reports the type of Apple GPUs as the model
+            // (e.g. "Apple M1")
+            // Change it to just "Apple".
+            //
+            if (strstr(type, "Apple")) {
+                strcpy(type, "Apple");
+            }
             if (!strlen(type)) return ERR_XML_PARSE;
             clear_usage();
             return 0;


### PR DESCRIPTION
When the client reports an OpenCL GPU (other than NVIDIA/AMD/Intel) in a scheduler request, the "type" field is the model name. In the case of Apple GPUs this is "Apple M1" or "Apple M2" (and other models as time goes on).
The type field is used in plan class descriptions.

In the case of Apple the models are (I think) equivalent software-wise, and it would be a nuisance to have to make a new plan class (and app versions) for each model.

So - in the case of Apple GPUs - use "Apple" as the type. The model name is still available (as opencl_prop.name) if needed.

Fixes #5036