### PR TITLE
configure.ac: Do not probe for <avxintrin.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -738,7 +738,7 @@ CXXFLAGS="${save_cxxflags} ${sse3_flags}"
 AC_CHECK_HEADERS([intrin.h x86intrin.h pmmintrin.h xmmintrin.h emmintrin.h])
 CXXFLAGS="${save_cxxflags} ${avx_flags}"
 CPPFLAGS="${save_cppflags} ${avx_flags}"
-AC_CHECK_HEADERS([immintrin.h avxintrin.h])
+AC_CHECK_HEADERS([immintrin.h])
 
 AC_CHECK_DECLS([_xgetbv, xgetbv, __xgetbv, cpuid, _cpuid, __cpuid],
     [],[],[[
@@ -747,9 +747,6 @@ AC_CHECK_DECLS([_xgetbv, xgetbv, __xgetbv, cpuid, _cpuid, __cpuid],
 #endif
 #if HAVE_IMMINTRIN_H
 # include <immintrin.h>
-#endif
-#if HAVE_AVXINTRIN_H
-# include <avxintrin.h>
 #endif
 #if HAVE_X86INTRIN_H
 # include <x86intrin.h>


### PR DESCRIPTION
With GCC 12, this header file cannot be included on its own. Doing so fails with #error, but also produces many warnings related to implicit ints and implicit function declarations. This is inconvenient for distributions who are trying to switch to newer C versions (without implicit ints/function declarations), and monitor builds for suspicious warnings related to obsolete C features.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
