### PR TITLE
Mac: Fix permission errors when running client as a daemon / system service

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -432,7 +432,7 @@ int use_sandbox, int isManager, char* path_to_error, int len
         if (retval)
             return -1041;
         
-        if (sbuf.st_gid != boinc_project_gid)
+        if (sbuf.st_gid != boinc_master_gid)
             return -1042;
 
         if (sbuf.st_uid != 0)   // root

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -587,7 +587,7 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
     isDirectory = S_ISDIR(sbuf.st_mode);
     if ((result == noErr) && (! isDirectory)) {
         // Set owner and group of setprojectgrp application
-        sprintf(buf1, "root:%s", boinc_project_group_name);
+        sprintf(buf1, "root:%s", boinc_master_group_name);
         // chown root:boinc_project "/Library/Application Support/BOINC Data/switcher/setprojectgrp"
         err = DoSudoPosixSpawn(chownPath, buf1, fullpath, NULL, NULL, NULL, NULL);
         if (err)


### PR DESCRIPTION
Fixes #5057 

Fixes a problem changing ownership of project-specific files to boinc_project. This issue occurs only when the Mac client is [set up](https://boinc.berkeley.edu/wiki/Tools_for_Mac_OS_X#Running_BOINC_as_a_daemon_or_system_service) to run as a daemon / system service. This bug was introduced by my commit aecfe8ed15.