### PR TITLE
Manager: don't clear in-use prefs when disable in-use computing

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -687,7 +687,7 @@ int CLIENT_STATE::handle_scheduler_reply(
         // BAM! currently has mixed http, https; trim off
         char* p = strchr(global_prefs.source_project, '/');
         char* q = strchr(gstate.acct_mgr_info.master_url, '/');
-        if (gstate.acct_mgr_info.using_am() && p && q && !strcmp(p, q)) {
+        if (!global_prefs.override_file_present && gstate.acct_mgr_info.using_am() && p && q && !strcmp(p, q)) {
             if (log_flags.sched_op_debug) {
                 msg_printf(project, MSG_INFO,
                     "[sched_op] ignoring prefs from project; using prefs from AM"

--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -277,26 +277,23 @@ void CDlgAdvPreferences::DisplayValue(double value, wxTextCtrl* textCtrl, wxChec
     textCtrl->Enable();
 }
 
-void CDlgAdvPreferences::EnableDisableInUseItem(wxTextCtrl* textCtrl, bool doEnable, double value) {
+void CDlgAdvPreferences::EnableDisableInUseItem(wxTextCtrl* textCtrl, bool doEnable) {
     if (doEnable) {
         if (! textCtrl->IsEnabled()) {
             textCtrl->Enable();
-            DisplayValue(value, textCtrl);
         }
     } else {
-        textCtrl->Clear();
         textCtrl->Disable();
     }
 }
 
 void CDlgAdvPreferences::EnableDisableInUseItems() {
     bool doEnable = !(m_chkProcInUse->IsChecked());
-    EnableDisableInUseItem(m_txtProcUseProcessors, doEnable, 
-                            prefs.max_ncpus_pct > 0.0 ? prefs.max_ncpus_pct : 100.0);
-    EnableDisableInUseItem(m_txtProcUseCPUTime, doEnable, prefs.cpu_usage_limit);
+    EnableDisableInUseItem(m_txtProcUseProcessors, doEnable);
+    EnableDisableInUseItem(m_txtProcUseCPUTime, doEnable);
     m_chkMaxLoad->Enable(doEnable);
-    EnableDisableInUseItem(m_txtMaxLoad, doEnable && m_chkMaxLoad->IsChecked(), prefs.suspend_cpu_usage);
-    EnableDisableInUseItem(m_txtMemoryMaxInUse, doEnable, prefs.ram_max_used_busy_frac*100.0);
+    EnableDisableInUseItem(m_txtMaxLoad, doEnable && m_chkMaxLoad->IsChecked());
+    EnableDisableInUseItem(m_txtMemoryMaxInUse, doEnable);
 }
 
 // read preferences from core client and initialize control values
@@ -475,33 +472,30 @@ bool CDlgAdvPreferences::SavePreferencesSettings() {
     mask.clear();
 
     // ######### proc usage page
-    if (m_txtProcUseProcessors->IsEnabled()) {
-        m_txtProcUseProcessors->GetValue().ToDouble(&td);
-        prefs.max_ncpus_pct = RoundToHundredths(td);
-        mask.max_ncpus_pct=true;
-    }
+    m_txtProcUseProcessors->GetValue().ToDouble(&td);
+    prefs.max_ncpus_pct = RoundToHundredths(td);
+    mask.max_ncpus_pct=true;
     m_txtProcUseProcessorsNotInUse->GetValue().ToDouble(&td);
     prefs.niu_max_ncpus_pct = RoundToHundredths(td);
     mask.niu_max_ncpus_pct=true;
     
-    if (m_txtProcUseCPUTime->IsEnabled()) {
-        m_txtProcUseCPUTime->GetValue().ToDouble(&td);
-        prefs.cpu_usage_limit=RoundToHundredths(td);
-        mask.cpu_usage_limit=true;
-    }
+    m_txtProcUseCPUTime->GetValue().ToDouble(&td);
+    prefs.cpu_usage_limit=RoundToHundredths(td);
+    mask.cpu_usage_limit=true;
+
     m_txtProcUseCPUTimeNotInUse->GetValue().ToDouble(&td);
     prefs.niu_cpu_usage_limit = RoundToHundredths(td);
     mask.niu_cpu_usage_limit = true;
 
     prefs.run_on_batteries = ! (m_chkProcOnBatteries->GetValue());
     mask.run_on_batteries=true;
-    //
+
     prefs.run_if_user_active = (! m_chkProcInUse->GetValue());
     mask.run_if_user_active=true;
 
     prefs.run_gpu_if_user_active = (! m_chkGPUProcInUse->GetValue());
     mask.run_gpu_if_user_active=true;
-    //
+
     if(m_txtProcIdleFor->IsEnabled()) {
         m_txtProcIdleFor->GetValue().ToDouble(&td);
         prefs.idle_time_to_run=RoundToHundredths(td);
@@ -620,13 +614,11 @@ bool CDlgAdvPreferences::SavePreferencesSettings() {
     }
     mask.disk_max_used_pct=true;
     //Memory
-    if (m_txtMemoryMaxInUse->IsEnabled()) {
-        m_txtMemoryMaxInUse->GetValue().ToDouble(&td);
-        td = RoundToHundredths(td);
-        td = td / 100.0;
-        prefs.ram_max_used_busy_frac=td;
-        mask.ram_max_used_busy_frac=true;
-    }
+    m_txtMemoryMaxInUse->GetValue().ToDouble(&td);
+    td = RoundToHundredths(td);
+    td = td / 100.0;
+    prefs.ram_max_used_busy_frac=td;
+    mask.ram_max_used_busy_frac=true;
     //
     m_txtMemoryMaxOnIdle->GetValue().ToDouble(&td);
     td = RoundToHundredths(td);

--- a/clientgui/DlgAdvPreferences.h
+++ b/clientgui/DlgAdvPreferences.h
@@ -59,7 +59,7 @@ public:
     void OnHelp(wxCommandEvent& event);
     void OnClear(wxCommandEvent& event);
     void DisplayValue(double value, wxTextCtrl* textCtrl, wxCheckBox* checkBox=NULL);
-    void EnableDisableInUseItem(wxTextCtrl* textCtrl, bool doEnable, double value);
+    void EnableDisableInUseItem(wxTextCtrl* textCtrl, bool doEnable);
     void EnableDisableInUseItems();
     bool OKToShow() { return m_bOKToShow; }
 private:


### PR DESCRIPTION
In-use prefs:
- cpu_usage_limit
- max_ncpus_pct
- ram_max_used_busy_frac
- suspend_cpu_usage
Don't clear their values when in-use computing is disabled, and write them to the override file.
That way if the user enables in-use computing again, they'll see the values they had set before.

Fixes some of Charlie's comments in #5072