### PR TITLE
client: don't send "web prefs" in scheduler requests.

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -161,23 +161,6 @@ int CLIENT_STATE::make_scheduler_request(PROJECT* p) {
     global_prefs.write(mf);
     fprintf(f, "</working_global_preferences>\n");
 
-    // send master global preferences if present and not host-specific
-    //
-    if (!global_prefs.host_specific && boinc_file_exists(GLOBAL_PREFS_FILE_NAME)) {
-        FILE* fprefs = fopen(GLOBAL_PREFS_FILE_NAME, "r");
-        if (fprefs) {
-            copy_stream(fprefs, f);
-            fclose(fprefs);
-        }
-        PROJECT* pp = lookup_project(global_prefs.source_project);
-        if (pp && strlen(pp->email_hash)) {
-            fprintf(f,
-                "<global_prefs_source_email_hash>%s</global_prefs_source_email_hash>\n",
-                pp->email_hash
-            );
-        }
-    }
-
     // Of the projects with same email hash as this one,
     // send the oldest cross-project ID.
     // Use project URL as tie-breaker.


### PR DESCRIPTION
This was originally done to propagate prefs between projects.
When you edit prefs on project A, they propagate to project B and you can edit them there too.
But this doesn't make sense - and can lead to undesirable behavior - when projects
have different prefs-editing web code.
And it's not a particularly useful feature.
If you're using web prefs, the Manager tells you what project they came from.
You can go there to edit them.

Note: we still send working prefs,, which are used for scheduler decisions.