### PR TITLE
libboinc: fix include order

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     name: ${{ matrix.type }}-build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         type: [libs, client, apps, libs-vcpkg, client-vcpkg, apps-vcpkg, libs-cmake, libs-arm64, apps-arm64, manager-with-webview-vcpkg, server, manager-with-webview, manager-without-webview, unit-test, integration-test]

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -18,11 +18,6 @@
 #if defined(_WIN32)
 #include "boinc_win.h"
 #else
-#ifdef _USING_FCGI_
-#include "boinc_fcgi.h"
-#else
-#include <cstdio>
-#endif
 #include <cstring>
 #include <cstdlib>
 #include <cmath>
@@ -47,6 +42,14 @@
 #include "parse.h"
 #include "str_replace.h"
 #include "util.h"
+
+#if !defined(_WIN32)
+#ifdef _USING_FCGI_
+#include "boinc_fcgi.h"
+#else
+#include <cstdio>
+#endif
+#endif
 
 #include "coproc.h"
 

--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -26,11 +26,6 @@
 
 #if !defined(_WIN32) || defined(__CYGWIN32__)
 #include "config.h"
-#ifdef _USING_FCGI_
-#include "boinc_fcgi.h"
-#else
-#include <cstdio>
-#endif
 #include <fcntl.h>
 #include <cerrno>
 #include <sys/stat.h>
@@ -70,6 +65,14 @@
 #include "str_util.h"
 #include "str_replace.h"
 #include "error_numbers.h"
+
+#if !defined(_WIN32) || defined(__CYGWIN32__)
+#ifdef _USING_FCGI_
+#include "boinc_fcgi.h"
+#else
+#include <cstdio>
+#endif
+#endif
 
 #include "filesys.h"
 


### PR DESCRIPTION
Compilation fails if "filesys.h" is included after "boinc_fcgi.h".

I don't know what's the reason but here's error message:

```
In file included from /usr/include/features.h:490,
                 from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:27,
                 from /usr/include/fcgi_stdio.h:18,
                 from boinc_fcgi.h:19,
                 from coproc.cpp:22:
/usr/include/wchar.h:582:24: error: 'malloc' attribute argument 1 is ambiguous
  582 |   __attribute_malloc__ __attr_dealloc_fclose;
      |                        ^~~~~~~~~~~~~~~~~~~~~
/usr/include/wchar.h:582:24: note: use a cast to the expected type to disambiguate
```