### PR TITLE
[Linux][Manager][vcpkg] Fix Linux vcpkg manager compilation

### DIFF
--- a/linux/ci_configure_manager.sh
+++ b/linux/ci_configure_manager.sh
@@ -14,5 +14,5 @@ export VCPKG_DIR="$VCPKG_ROOT/installed/x64-linux"
 linux/update_vcpkg_manager.sh
 
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
-
-./configure --enable-vcpkg --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS=-DwxDEBUG_LEVEL=0 GTK_LIBS="`pkg-config --libs gtk+-3.0 webkit2gtk-4.0 x11 xft xext xi xrender xcursor xfixes xrandr xcomposite xdamage dbus-1` -lresolv"
+export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
+./configure --enable-vcpkg --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS=-DwxDEBUG_LEVEL=0 GTK_LIBS="`pkg-config --libs gtk+-3.0`"


### PR DESCRIPTION
Hello @davidpanderson 
Here is a bug fix of compilation of vcpkg manager in ubuntu.
It not compile correctly with the ld flags, results unable to run the compiled manager under ubuntu 22.04, and maybe other Linux distro / versions.
This is known issue and I test my fix on my wsl2 ubuntu 22.04.
Fix https://github.com/microsoft/vcpkg/issues/25786

I decided to continue contribute and not let ruined for me and the boinc community and let it improve and grow. 

Here some of my contributions to boinc in the recent year:
- Android boinc switch to dark mode along with all icons convert them to graphic vector images.
- Android boinc add tcp ip mode, also lead to remote control on android.
- Refactor Android Monitor to kotlin making it MonitorAsync.
- Add support ARMv6 devices to android.
- Started the wasm direction that can lead boinc web client.
- Started to flutter direction that can lead to prettier and cross platform ui (Desktop, mobile and web). (clientgui).
- Fix Linux skins.


I want to continue contribute, here some of the subjects I can contribute
- Add http2 connection support to servers (world community grid and BOINC Account Manager are support it).
- Compile boinc in snap package
- Compile boinc in flatpack package

Optional directions:
- Add support ipv6 between client and clientgui. (Currently only ipv4 support).
- TLS on android. (One of the requirement to come back google play)
- Split to android apps (One of the requirement to come back google play)
- Continue flutter
- Continue wasm
- Other

I also love to see my ideas such a release android and desktop at once, and be in google summer of code, are implements and grow in the community.

I request take account my professional knowledge, do not add additional conditions for contributions and Vitalii doesn't represent my will and my actions.