### PR TITLE
[Client][Manager] Support http2 connection, show IP and http version on manager

### DIFF
--- a/3rdParty/vcpkg_ports/configs/client/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/client/vcpkg.json
@@ -4,7 +4,7 @@
     [
         {
           "name": "curl",
-          "features": ["openssl"],
+          "features": ["openssl", "http2"],
           "default-features": false
         }
     ]   

--- a/3rdParty/vcpkg_ports/configs/libs/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/libs/vcpkg.json
@@ -4,7 +4,7 @@
     [
         {
           "name": "curl",
-          "features": ["openssl"],
+          "features": ["openssl", "http2"],
           "default-features": false
         }
     ]   

--- a/3rdParty/vcpkg_ports/configs/libs/windows/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/libs/windows/vcpkg.json
@@ -4,7 +4,7 @@
     [
         {
           "name": "curl",
-          "features": ["schannel"],
+          "features": ["schannel", "http2"],
           "default-features": false
         },
         "openssl"

--- a/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
@@ -5,7 +5,7 @@
         "ftgl",
         {
           "name": "curl",
-          "features": ["openssl"],
+          "features": ["openssl", "http2"],
           "default-features": false
         },
         {

--- a/3rdParty/vcpkg_ports/configs/msbuild/ARM64/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/msbuild/ARM64/vcpkg.json
@@ -4,7 +4,7 @@
     [
       {
         "name": "curl",
-        "features": ["schannel"],
+        "features": ["schannel", "http2"],
         "default-features": false
       },
       "openssl",

--- a/3rdParty/vcpkg_ports/configs/msbuild/x64/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/msbuild/x64/vcpkg.json
@@ -4,7 +4,7 @@
     [
         {
           "name": "curl",
-          "features": ["schannel"],
+          "features": ["schannel", "http2"],
           "default-features": false
         },
         "openssl",

--- a/client/http_curl.h
+++ b/client/http_curl.h
@@ -60,6 +60,8 @@ public:
     char m_url[1024];  
     char m_curl_user_credentials[1024];
         // string needed for proxy username/password
+    char m_http_version[100];
+    char m_ip_version[5];
 
     int content_length;
     unsigned int trace_id;
@@ -148,6 +150,7 @@ public:
     void close_socket();
     void close_files();
     void update_speed();
+    void update_http_ip_version();
     void set_speed_limit(bool is_upload, double bytes_sec);
     void handle_messages(CURLMsg*);
 

--- a/client/pers_file_xfer.cpp
+++ b/client/pers_file_xfer.cpp
@@ -451,12 +451,16 @@ int PERS_FILE_XFER::write(MIOFILE& fout) {
             "        <file_offset>%f</file_offset>\n"
             "        <xfer_speed>%f</xfer_speed>\n"
             "        <url>%s</url>\n"
+            "        <http_version>%s</http_version>\n"
+            "        <ip_version>%s</ip_version>\n"
             "    </file_xfer>\n",
             estimated_xfer_time_remaining(),
             fxp->bytes_xferred,
             fxp->file_offset,
             fxp->xfer_speed,
-            fxp->m_url
+            fxp->m_url,
+            fxp->m_http_version,
+            fxp->m_ip_version
         );
     }
     return 0;

--- a/clientgui/ViewTransfers.h
+++ b/clientgui/ViewTransfers.h
@@ -46,6 +46,8 @@ public:
     wxString m_strTime;
     wxString m_strTimeToCompletion;
     wxString m_strSpeed;
+    wxString m_strHttpVersion;
+    wxString m_strIpVersion;
 };
 
 
@@ -102,6 +104,8 @@ protected:
     wxInt32                 FormatSpeed( double fBuffer, wxString& strBuffer ) const;
     void                    GetDocStatus(wxInt32 item, wxString& strBuffer) const;
     void                    GetDocProjectURL(wxInt32 item, wxString& strBuffer) const;
+    void                    GetDocHTTPVersion(wxInt32 item, wxString& strBuffer) const;
+    void                    GetDocIPVersion(wxInt32 item, wxString& strBuffer) const;
 
     virtual double          GetProgressValue(long item);
     virtual wxString        GetProgressText( long item);

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -336,6 +336,8 @@ struct FILE_TRANSFER {
     std::string hostname;
     double project_backoff;
     PROJECT* project;
+    std::string http_version;
+    std::string ip_version;
 
     FILE_TRANSFER();
 

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -790,6 +790,8 @@ int FILE_TRANSFER::parse(XML_PARSER& xp) {
         if (xp.parse_double("xfer_speed", xfer_speed)) continue;
         if (xp.parse_string("hostname", hostname)) continue;
         if (xp.parse_double("project_backoff", project_backoff)) continue;
+        if (xp.parse_string("http_version", http_version)) continue;
+        if (xp.parse_string("ip_version", ip_version)) continue;
     }
     return ERR_XML_PARSE;
 }
@@ -817,6 +819,8 @@ void FILE_TRANSFER::clear() {
     hostname.clear();
     project = NULL;
     project_backoff = 0;
+    http_version.clear();
+    ip_version.clear();
 }
 
 MESSAGE::MESSAGE() {

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -210,6 +210,8 @@ void FILE_TRANSFER::print() {
     if (xfer_active) printf("   estimated_xfer_time_remaining: %f\n", estimated_xfer_time_remaining);
     printf("   bytes_xferred: %f\n", bytes_xferred);
     printf("   xfer_speed: %f\n", xfer_speed);
+    printf("   http_version: %s\n", http_version.c_str());
+    printf("   ip_version: %s\n", ip_version.c_str());
 }
 
 void MESSAGE::print() {

--- a/linux/ci_configure_manager.sh
+++ b/linux/ci_configure_manager.sh
@@ -15,4 +15,4 @@ linux/update_vcpkg_manager.sh
 
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
-./configure --enable-vcpkg --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS=-DwxDEBUG_LEVEL=0 GTK_LIBS="`pkg-config --libs gtk+-3.0`"
+./configure --enable-vcpkg --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config GTK_LIBS="`pkg-config --libs gtk+-3.0`"

--- a/win_build/boinc_cli.vcxproj
+++ b/win_build/boinc_cli.vcxproj
@@ -140,7 +140,7 @@
       <AdditionalIncludeDirectories>../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;nvapi.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;Iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;nghttp2.lib;nvapi.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;Iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/debug/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -190,7 +190,7 @@
       <AdditionalIncludeDirectories>../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;Iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;nghttp2.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;Iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/debug/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -239,7 +239,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;nvapi.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;nghttp2.lib;nvapi.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -289,7 +289,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;nghttp2.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;iphlpapi.lib;kernel32.lib;user32.lib;advapi32.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/win_build/crypt_prog.vcxproj
+++ b/win_build/crypt_prog.vcxproj
@@ -140,7 +140,7 @@
       <AdditionalIncludeDirectories>../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libcrypto.lib;libssl.lib;libcurl-d.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/debug/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -187,7 +187,7 @@
       <AdditionalIncludeDirectories>../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libcrypto.lib;libssl.lib;libcurl-d.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/debug/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -233,7 +233,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libcrypto.lib;libssl.lib;libcurl.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;libcrypto.lib;libssl.lib;libcurl.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -280,7 +280,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>libcrypto.lib;libssl.lib;libcurl.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;libcrypto.lib;libssl.lib;libcurl.lib;wsock32.lib;wininet.lib;winmm.lib;libboinc.lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalLibraryDirectories>$(VcpkgInstalledDir)/lib;../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;../../;$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/win_build/sim.vcxproj
+++ b/win_build/sim.vcxproj
@@ -133,7 +133,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -181,7 +181,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlibd.lib;libcrypto.lib;libssl.lib;libcurl-d.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
@@ -230,7 +230,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>
@@ -280,7 +280,7 @@
       <AdditionalIncludeDirectories>..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
+      <AdditionalDependencies>nghttp2.lib;kernel32.lib;user32.lib;advapi32.lib;wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;zlib.lib;libcrypto.lib;libssl.lib;libcurl.lib;%(AdditionalDependencies);Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib</AdditionalDependencies>
       <ShowProgress>NotSet</ShowProgress>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <IgnoreAllDefaultLibraries>false</IgnoreAllDefaultLibraries>


### PR DESCRIPTION
Add support http2 connection. Client can connect to the server and account manager in http2.
Show IP and http version on manager.

Currently World Community Grid and Boinc Account Manager are support http2. 

Test it on windows 11 and wsl2 ubuntu 22.04.

![image](https://user-images.githubusercontent.com/7043539/191987354-270c0de9-9d4c-42e1-8876-f5e1eb956988.png)

![image](https://user-images.githubusercontent.com/7043539/191987986-f1cfacfe-2410-4089-8d42-398387ef942b.png)

![image](https://user-images.githubusercontent.com/7043539/191988770-bae6f092-aa92-4a56-83b6-4a84f4467220.png)

wsl2 ubuntu 22.04:
![image](https://user-images.githubusercontent.com/7043539/221891787-47db478d-3406-40d0-b938-3b8d2c6825ef.png)

