### PR TITLE
client and server: increase p_features size from 1024 to 8192.

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -527,7 +527,7 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
 
     host.m_cache=-1;
     safe_strcpy(features, "");
-    while (fgets(buf, 1024, f)) {
+    while (fgets(buf, sizeof(buf), f)) {
         strip_whitespace(buf);
         if (
                 /* there might be conflicts if we dont #ifdef */

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -485,7 +485,7 @@ static void parse_meminfo_linux(HOST_INFO& host) {
 // See http://people.nl.linux.org/~hch/cpuinfo/ for some examples.
 //
 static void parse_cpuinfo_linux(HOST_INFO& host) {
-    char buf[1024], features[P_FEATURES_SIZE], model_buf[1024];
+    char buf[P_FEATURES_SIZE], features[P_FEATURES_SIZE], model_buf[1024];
     bool vendor_found=false, model_found=false;
     bool cache_found=false, features_found=false;
     bool model_hack=false, vendor_hack=false;
@@ -762,7 +762,7 @@ void use_cpuid(HOST_INFO& host) {
     u_int cpu_id;
     char vendor[13];
     int hasMMX, hasSSE, hasSSE2, hasSSE3, has3DNow, has3DNowExt, hasAVX;
-    char capabilities[256];
+    char capabilities[P_FEATURES_SIZE];
 
     hasMMX = hasSSE = hasSSE2 = hasSSE3 = has3DNow = has3DNowExt = hasAVX = 0;
     do_cpuid(0x0, p);
@@ -1075,7 +1075,7 @@ static void get_cpu_info_haiku(HOST_INFO& host) {
 
     int32 found = 0;
     int32 i;
-    char buf[12];
+    char buf[256];
 
     for (i = 0; i < 32; i++) {
         if ((cpuInfo.eax_1.features & (1UL << i)) && kFeatures[i] != NULL) {

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -24,6 +24,7 @@
 #include "opencl_boinc.h"
 #include "parse.h"
 #include "wslinfo.h"
+#include "hostinfo.h"
 
 // Sizes of text buffers in memory, corresponding to database BLOBs.
 // The following is for regular blobs, 64KB

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -50,7 +50,7 @@ const char file_redhatrelease[] = "/etc/redhat-release";
 
 // if you add fields, update clear_host_info()
 
-#define P_FEATURES_SIZE 1024
+#define P_FEATURES_SIZE 8192
 
 class HOST_INFO {
 public:

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -1286,12 +1286,14 @@ int main() {
     }
 
     for (unsigned int i=0; i<pcs.classes.size(); i++) {
-        bool b = pcs.check(sreq, pcs.classes[i].name, hu);
+        WORKUNIT wu;
+        wu.id = 100;
+        wu.batch = 100;
+        bool b = pcs.check(sreq, pcs.classes[i].name, hu, &wu);
         if (b) {
             printf("%s: check succeeded\n", pcs.classes[i].name);
-            printf("\tncudas: %f\n\tnatis: %f\n\tgpu_ram: %fMB\n\tavg_ncpus: %f\n\tprojected_flops: %fG\n\tpeak_flops: %fG\n",
-                hu.ncudas,
-                hu.natis,
+            printf("\tgpu_usage: %f\n\tgpu_ram: %fMB\n\tavg_ncpus: %f\n\tprojected_flops: %fG\n\tpeak_flops: %fG\n",
+                hu.gpu_usage,
                 hu.gpu_ram/1e6,
                 hu.avg_ncpus,
                 hu.projected_flops/1e9,


### PR DESCRIPTION
1024 wasn't enough for some CPUs.
This caused some hosts to not get sse3 app versions, for example.

Note: ideally we'd change this to std::string.
But that would have disrupted the code that populates it (hostinfo_unix.cpp, hostinfo_win.cpp).
Easier/safer to do it this way.

Fixes #5122