### PR TITLE
Mac CI: Don't hard-code the names of targets and build products

### DIFF
--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -160,22 +160,22 @@ fi
 echo ""
 
 if [ "${buildzipapps}" = "1" ]; then
-    if [ ! -a "build/${style}/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
+    if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
 fi
 
 if [ "${builduc2}" = "1" ]; then
-    if [ ! -a "build/${style}/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/${style}/libjpeg.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
+    if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libjpeg.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
 fi
 
 if [ "${buildvboxwrapper}" = "1" ]; then
-    if [ ! -a "build/${style}/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
 fi
 
 if [ "${doclean}" = "clean" ]; then

--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -115,9 +115,9 @@ while [ $# -gt 0 ]; do
     -all ) buildall=1 ; shift 1 ;;
     -lib ) buildlibs=1 ; shift 1 ;;
     -client ) buildclient=1 ; shift 1 ;;
-    -zipapps ) buildzipapps=1 ; buildlibs=1 ; shift 1 ;;
+    -zipapps ) buildzipapps=1 ; shift 1 ;;
     -uc2 ) builduc2=1 ; shift 1 ;;
-    -vboxwrapper ) buildvboxwrapper=1 ; buildlibs=1 ; shift 1 ;;
+    -vboxwrapper ) buildvboxwrapper=1 ; shift 1 ;;
     -target ) shift 1 ; targets="$targets -target $1" ; shift 1 ;;
     -setting ) shift 1 ; name="$1" ;
                 shift 1 ; unset value ; value=("$1");

--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -173,7 +173,7 @@ if [ "${builduc2}" = "1" ]; then
     if [ ! -e "./build/${style}/libboinc_zip.a" ]; then buildzip=1; fi
 fi
 
-if [ "${buildvboxwrapper}" = "1" ]; t
+if [ "${buildvboxwrapper}" = "1" ]; then
     if [ ! -e "./build/${style}/libboinc_api.a" ]; then buildlibs=1; fi
 fi
 

--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -128,46 +128,6 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ "${buildzipapps}" = "1" ]; then
-    if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_zip.a " ]; then buildzip=1; fi
-fi
-
-if [ "${builduc2}" = "1" ]; then
-    if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libjpeg.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_zip.a " ]; then buildzip=1; fi
-fi
-
-if [ "${buildvboxwrapper}" = "1" ]; then
-    if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
-fi
-
-if [ "${doclean}" = "clean" ]; then
-    echo "Clean each target before building"
-fi
-
-if [ "${buildlibs}" = "1" ]; then
-    targets="$targets -target libboinc -target gfx2libboinc -target api_libboinc -target boinc_opencl -target jpeg"
-fi
-
-if [ "${buildclient}" = "1" ]; then
-    targets="$targets -target BOINC_Client -target cmd_boinc"
-fi
-
-if [ "x${targets}" = "x" ] && [ "${buildlibs}" = "0" ] && [ "${buildclient}" = "0" ] && [ "${buildzipapps}" = "0" ] && [ "${builduc2}" = "0" ] && [ "${buildvboxwrapper}" = "0" ]; then
-    buildall=1
-fi
-
-## "-all" overrides "-lib" and "-client" and "-zipaps" and "-uc2" and "-vboxwrapper" since it includes those targets
-if [ "${buildall}" = "1" ]; then
-    targets="-target Build_All"
-fi
-
 version=`uname -r`;
 
 major=`echo $version | sed 's/\([0-9]*\)[.].*/\1/' `;
@@ -198,6 +158,46 @@ else
 fi
 
 echo ""
+
+if [ "${buildzipapps}" = "1" ]; then
+    if [ ! -a "build/${style}/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
+fi
+
+if [ "${builduc2}" = "1" ]; then
+    if [ ! -a "build/${style}/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/${style}/libjpeg.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
+fi
+
+if [ "${buildvboxwrapper}" = "1" ]; then
+    if [ ! -a "build/${style}/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+fi
+
+if [ "${doclean}" = "clean" ]; then
+    echo "Clean each target before building"
+fi
+
+if [ "${buildlibs}" = "1" ]; then
+    targets="$targets -target libboinc -target gfx2libboinc -target api_libboinc -target boinc_opencl -target jpeg"
+fi
+
+if [ "${buildclient}" = "1" ]; then
+    targets="$targets -target BOINC_Client -target cmd_boinc"
+fi
+
+if [ "x${targets}" = "x" ] && [ "${buildlibs}" = "0" ] && [ "${buildclient}" = "0" ] && [ "${buildzipapps}" = "0" ] && [ "${builduc2}" = "0" ] && [ "${buildvboxwrapper}" = "0" ]; then
+    buildall=1
+fi
+
+## "-all" overrides "-lib" and "-client" and "-zipaps" and "-uc2" and "-vboxwrapper" since it includes those targets
+if [ "${buildall}" = "1" ]; then
+    targets="-target Build_All"
+fi
 
 SDKPATH=`xcodebuild -version -sdk macosx Path`
 result=0

--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -159,6 +159,11 @@ fi
 
 echo ""
 
+## for testing only:
+echo "style is " ${style}
+ls -al "./build/${style}"
+echo "before tests, buildlibs = " ${buildlibs}
+
 if [ "${buildzipapps}" = "1" ]; then
     if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
     if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
@@ -177,6 +182,9 @@ if [ "${buildvboxwrapper}" = "1" ]; then
     if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
     if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
 fi
+
+## for testing only:
+echo "after tests, buildlibs = " ${buildlibs}
 
 if [ "${doclean}" = "clean" ]; then
     echo "Clean each target before building"

--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -159,32 +159,23 @@ fi
 
 echo ""
 
-## for testing only:
-echo "style is " ${style}
-ls -al "./build/${style}"
-echo "before tests, buildlibs = " ${buildlibs}
-
 if [ "${buildzipapps}" = "1" ]; then
-    if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -e "./build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
+    if [ ! -e "./build/${style}/libboinc.a" ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_api.a" ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_zip.a" ]; then buildzip=1; fi
 fi
 
 if [ "${builduc2}" = "1" ]; then
-    if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -e "./build/${style}/libjpeg.a " ]; then buildlibs=1; fi
-    if [ ! -e "./build/${style}/libboinc_zip.a " ]; then buildzip=1; fi
+    if [ ! -e "./build/${style}/libboinc.a" ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_api.a" ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_api.a" ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libjpeg.a" ]; then buildlibs=1; fi
+    if [ ! -e "./build/${style}/libboinc_zip.a" ]; then buildzip=1; fi
 fi
 
-if [ "${buildvboxwrapper}" = "1" ]; then
-    if [ ! -e "./build/${style}/libboinc.a " ]; then buildlibs=1; fi
-    if [ ! -e "./build/${style}/libboinc_api.a " ]; then buildlibs=1; fi
+if [ "${buildvboxwrapper}" = "1" ]; t
+    if [ ! -e "./build/${style}/libboinc_api.a" ]; then buildlibs=1; fi
 fi
-
-## for testing only:
-echo "after tests, buildlibs = " ${buildlibs}
 
 if [ "${doclean}" = "clean" ]; then
     echo "Clean each target before building"

--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -37,6 +37,7 @@
 # Updated 5/19/21 for compatibility with zsh
 # Updated 7/12/22 result is moved out of eval string to get correct status on CI if build fails
 # Updated 2/14/23 refactoring made to build zip apps (-zipapps), uc2 samples (-uc2) and vboxwrapper (-vboxwrapper)
+# Updated 3/12/23 Don't unnecessary rebuild libraries for uc2, zip apps or vboxwrapper
 #
 ## This script requires OS 10.8 or later
 #
@@ -115,7 +116,7 @@ while [ $# -gt 0 ]; do
     -lib ) buildlibs=1 ; shift 1 ;;
     -client ) buildclient=1 ; shift 1 ;;
     -zipapps ) buildzipapps=1 ; buildlibs=1 ; shift 1 ;;
-    -uc2 ) builduc2=1 ; buildlibs=1 ; shift 1 ;;
+    -uc2 ) builduc2=1 ; shift 1 ;;
     -vboxwrapper ) buildvboxwrapper=1 ; buildlibs=1 ; shift 1 ;;
     -target ) shift 1 ; targets="$targets -target $1" ; shift 1 ;;
     -setting ) shift 1 ; name="$1" ;
@@ -125,6 +126,24 @@ while [ $# -gt 0 ]; do
     * ) echo "usage:" ; echo "cd {path}/mac_build/" ; echo "source BuildMacBOINC.sh [-dev] [-noclean] [-libstdc++] [-all] [-lib] [-client] [-zipapps] [-uc2] [-vboxwrapper] [-target targetName] [-setting name value] [-help]" ; return 1 ;;
   esac
 done
+
+if [ "${buildzipapps}" = "1" ]; then
+    if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_zip.a " ]; then buildlibs=1; fi
+fi
+
+if [ "${builduc2}" = "1" ]; then
+    if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_zip.a " ]; then buildlibs=1; fi
+fi
+
+if [ "${buildvboxwrapper}" = "1" ]; then
+    if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
+fi
 
 if [ "${doclean}" = "clean" ]; then
     echo "Clean each target before building"

--- a/mac_build/BuildMacBOINC.sh
+++ b/mac_build/BuildMacBOINC.sh
@@ -101,6 +101,7 @@ uselibcplusplus=""
 buildall=0
 buildlibs=0
 buildclient=0
+buildzip=0
 buildzipapps=0
 builduc2=0
 buildvboxwrapper=0
@@ -130,14 +131,15 @@ done
 if [ "${buildzipapps}" = "1" ]; then
     if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
     if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_zip.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_zip.a " ]; then buildzip=1; fi
 fi
 
 if [ "${builduc2}" = "1" ]; then
     if [ ! -a "build/style/libboinc.a " ]; then buildlibs=1; fi
     if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
     if [ ! -a "build/style/libboinc_api.a " ]; then buildlibs=1; fi
-    if [ ! -a "build/style/libboinc_zip.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libjpeg.a " ]; then buildlibs=1; fi
+    if [ ! -a "build/style/libboinc_zip.a " ]; then buildzip=1; fi
 fi
 
 if [ "${buildvboxwrapper}" = "1" ]; then
@@ -221,6 +223,10 @@ fi
 if [ $result -eq 0 ]; then
     # build libboinc_zip.a for -all or -lib or -zipapps
     if [ "${buildall}" = "1" ] || [ "${buildlibs}" = "1" ] || [ "${buildzipapps}" = "1" ]; then
+        buildzip=1
+    fi
+    
+    if [ "${buildzip}" = "1" ]; then
         eval "xcodebuild -project ../zip/boinc_zip.xcodeproj -target boinc_zip -configuration ${style} -sdk \"${SDKPATH}\" ${doclean} build  ${uselibcplusplus} ${theSettings}"
         result=$?
     fi

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -158,7 +158,7 @@ done
 verify_product_archs "${rootPath}/mac_build/build/${style}"
 
 echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu..."
-if [[ `lipo "${rootPath}/mac_build/build/${style}/detect_rosetta_cpu -archs` = "x86_64" ]]; then
+if [[ `lipo "${rootPath}/mac_build/build/${style}/detect_rosetta_cpu" -archs` = "x86_64" ]]; then
     echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu ...done"
 else
     echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu failed"

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -158,7 +158,7 @@ done
 verify_product_archs "${rootPath}/mac_build/build/${style}"
 
 echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu..."
-if [[ `lipo detect_rosetta_cpu -archs` = "x86_64" ]]; then
+if [[ `lipo "${rootPath}/mac_build/build/${style}/detect_rosetta_cpu -archs` = "x86_64" ]]; then
     echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu ...done"
 else
     echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu failed"

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -217,7 +217,7 @@ if [ ${retval} -ne 0 ]; then
     cd "${savedPath}"; exit 1;
 fi
 
-cd "./samples/vboxwrapper/build/${style}"
+cd "../samples/vboxwrapper/build/${style}"
 if [ $? -ne 0 ]; then
     cd "${savedPath}"
     exit 1

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -195,4 +195,7 @@ fi
 
 verify_product_archs "${rootPath}/samples/vboxwrapper/build/${style}"
 
+## for testing only:
+force an error to try to create a log
+
 cd "${rootPath}"

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -196,6 +196,3 @@ fi
 verify_product_archs "${rootPath}/samples/vboxwrapper/build/${style}"
 
 cd "${rootPath}"
-
-## for testing only:
-exit 1  ## force an error to try to create a log

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -195,7 +195,7 @@ fi
 
 verify_product_archs "${rootPath}/samples/vboxwrapper/build/${style}"
 
-## for testing only:
-force an error to try to create a log
-
 cd "${rootPath}"
+
+## for testing only:
+exit 1  ## force an error to try to create a log

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -19,7 +19,7 @@
 #
 #
 # Script to build the different targets in the BOINC xcode project using a
-# combined install directory for all dependencies
+# combined install directory for all dependencies, plus some samples.
 #
 # Usage:
 # ./mac_build/buildMacBOINC-CI.sh [--cache_dir PATH] [--debug] [--clean] [--no_shared_headers]
@@ -27,7 +27,8 @@
 # --cache_dir is the path where the dependencies are installed by 3rdParty/buildMacDependencies.sh.
 # --debug will build the debug Manager (needs debug wxWidgets library in cache_dir).
 # --clean will force a full rebuild.
-# --no_shared_headers will build targets individually instead of in one call of BuildMacBOINC.sh (NOT recommended)
+# --no_shared_headers will build targets individually instead of in one call of
+#   BuildMacBOINC.sh. Provides additional verification & details in build output.
 
 # check working directory because the script needs to be called like: ./mac_build/buildMacBOINC-CI.sh
 if [ ! -d "mac_build" ]; then
@@ -42,14 +43,14 @@ rm -fR ./mac_build/build
 cache_dir="$(pwd)/3rdParty/buildCache/mac"
 style="Deployment"
 config=""
-doclean=""
+doclean="-noclean"
 beautifier="cat" # we need a fallback if xcpretty is not available
 share_paths="yes"
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
         -clean|--clean)
-        doclean="yes"
+        doclean=""
         ;;
         --cache_dir)
         cache_dir="$2"
@@ -75,408 +76,104 @@ if [ $? -eq 0 ]; then
     beautifier="xcpretty"
 fi
 
+savedPath="${PWD}"
+
 cd ./mac_build || exit 1
 retval=0
 
+libSearchPathDbg=""
+if [ "${style}" == "Development" ]; then
+    libSearchPathDbg="./build/Development  ${cache_dir}/lib/debug"
+fi
+
 if [ ${share_paths} = "yes" ]; then
     ## all targets share the same header and library search paths
+    ## Note: this does not build zip apps, upper case or VBoxWrapper projects.
     libSearchPathDbg=""
-    if [ "${style}" == "Development" ]; then
-        libSearchPathDbg="./build/Development  ${cache_dir}/lib/debug"
-    fi
-    source BuildMacBOINC.sh ${config} -all -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "$libSearchPathDbg ${cache_dir}/lib ../lib" | tee xcodebuild_all.log | $beautifier; retval=${PIPESTATUS[0]}
+    source BuildMacBOINC.sh ${config} ${doclean} -all -setting HEADER_SEARCH_PATHS "../clientgui ../lib/** ../api/ ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "$libSearchPathDbg ${cache_dir}/lib ../lib" | tee xcodebuild_all.log | $beautifier; retval=${PIPESTATUS[0]}
     if [ $retval -ne 0 ]; then
-        cd ..; exit 1; fi
+        cd "${savedPath}"; exit 1; fi
     return 0
 fi
 
-## This is code that builds each target individually in case the above shared header paths version is giving problems
-## Note: currently this does not build the boinc_zip library
-if [ "${doclean}" = "yes" ]; then
-    ## clean all targets
-    xcodebuild -project boinc.xcodeproj -target Build_All  -configuration ${style} clean | $beautifier; retval=${PIPESTATUS[0]}
-    if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+foundTargets=0
+target="x"
 
-    ## clean boinc_zip which is not included in Build_All
-    xcodebuild -project ../zip/boinc_zip.xcodeproj -target boinc_zip -configuration ${style} clean | $beautifier; retval=${PIPESTATUS[0]}
-    if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+## This is code that builds each target individually in the main BOINC Xcode
+## project, plus the zip apps, upper case and VBoxWrapper projects.
+for buildTarget in `xcodebuild -list -project boinc.xcodeproj`
+do
+    if [[ "${target}" = "Build" && "${buildTarget}" = "Configurations:" ]]; then break; fi
+    if [ $foundTargets -eq 1 ]; then
+        if [ "${target}" != "Build_All" ]; then
+            echo "Building ${target}..."
+            source BuildMacBOINC.sh ${config} ${doclean} -target ${target} -setting HEADER_SEARCH_PATHS "../clientgui ../lib/** ../api/ ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "${libSearchPathDbg} ${cache_dir}/lib  ../lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+            if [ ${retval} -eq 0 ]; then
+                echo "Building ${target}...success"
+                echo
+            else
+                echo "Building ${target}...failed"
+                cd "${savedPath}"; exit 1;
+            fi
+        fi
+    fi
+    if [ "${target}" = "Targets:" ]; then foundTargets=1; fi
+    target="${buildTarget}"
+done
+
+## Now verify the architectures of the built products
+cd "./build/${style}"
+if [ $? -ne 0 ]; then
+    cd "${savedPath}"
+    exit 1
 fi
 
-## Target mgr_boinc also builds dependent targets SetVersion and BOINC_Client
-libSearchPathDbg=""
-if [ "${style}" == "Development" ]; then
-    libSearchPathDbg="${cache_dir}/lib/debug"
-fi
-target="mgr_boinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include" -setting LIBRARY_SEARCH_PATHS "${libSearchPathDbg} ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a..."
-lipo ./build/${style}/libboinc.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a...done"
-echo "Verifying architecture (x86_64 arm64) of BOINCManager..."
-lipo ./build/${style}/BOINCManager.app/Contents/MacOS/BOINCManager -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of BOINCManager...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of BOINCManager...done"
-echo "Verifying architecture (x86_64 arm64) of SetVersion..."
-lipo ./build/${style}/SetVersion -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of SetVersion...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of SetVersion...done"
-echo "Verifying architecture (x86_64 arm64) of boinc..."
-lipo ./build/${style}/boinc -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinc...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinc...done"
-echo "Verifying architecture (x86_64) of detect_rosetta_cpu..."
-lipo ./build/${style}/detect_rosetta_cpu -verify_arch x86_64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64) of detect_rosetta_cpu...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64) of detect_rosetta_cpu...done"
-echo "Verifying architecture (arm64) of detect_rosetta_cpu..."
-lipo ./build/${style}/detect_rosetta_cpu -verify_arch arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -eq 0 ]; then
-    echo "Verifying architecture (arm64) of detect_rosetta_cpu...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (arm64) of detect_rosetta_cpu...done"
-echo "Building ${target}...done"
+declare -a files=(*)
+for (( i = 0; i < ${#files[*]}; ++ i )); do
+    if [[ -z "${files[i]}" ]]; then continue; fi
+    if [[ "${files[i]}" = *dSYM ]]; then continue; fi
+    if [[ "${files[i]}" = detect_rosetta_cpu ]]; then continue; fi
+    fileToCheck="${files[i]}"
+    if [[ -d "$fileToCheck" ]]; then
+        fileToCheck="${files[i]}/Contents/MacOS/${files[i]%.*}"
+    fi
+    echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ..."
+    lipo "${fileToCheck}" -verify_arch x86_64 arm64
+    if [ $? -ne 0 ]; then
+        echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} failed"
+        cd "${savedPath}"; exit 1;
+    fi
+    echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ...done"
+    echo
+done
 
-## Target gfx2libboinc also build dependent target jpeg
-target="gfx2libboinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../samples/jpeglib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
+echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu..."
+if [[ `lipo detect_rosetta_cpu -archs` = "x86_64" ]]; then
+    echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu ...done"
+else
+    echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu failed"
     cd ..; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a..."
-lipo ./build/${style}/libjpeg.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libjpeg.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a...done"
-echo "Verifying architecture (x86_64 arm64) of libboinc_graphics2.a..."
-lipo ./build/${style}/libboinc_graphics2.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_graphics2.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_graphics2.a...done"
-echo "Building ${target}...done"
 
-target="libboinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
+cd "${savedPath}/mac_build"
+if [ $? -ne 0 ]; then
+    cd "${savedPath}"
+    exit 1
 fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a..."
-lipo ./build/${style}/libboinc.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a...done"
-echo "Building ${target}...done"
-
-target="api_libboinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_api.a..."
-lipo ./build/${style}/libboinc_api.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_api.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_api.a...done"
-echo "Building ${target}...done"
-
-target="PostInstall"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinc_finish_install..."
-lipo ./build/${style}/BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinc_finish_install...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinc_finish_install...done"
-echo "Verify architecture (x86_64 arm64) of SetVersion..."
-lipo ./build/${style}/SetVersion -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verify architecture (x86_64 arm64) of SetVersion...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verify architecture (x86_64 arm64) of SetVersion...done"
-echo "Verify architecture (x86_64 arm64) of PostInstall..."
-lipo ./build/${style}/PostInstall.app/Contents/MacOS/PostInstall -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verify architecture (x86_64 arm64) of PostInstall...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verify architecture (x86_64 arm64) of PostInstall...done"
-echo "Building ${target}...done"
-
-target="switcher"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of switcher..."
-lipo ./build/${style}/switcher -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of switcher...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of switcher...done"
-echo "Building ${target}...done"
-
-target="gfx_switcher"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_switcher..."
-lipo ./build/${style}/gfx_switcher -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of gfx_switcher...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_switcher...done"
-echo "Building ${target}...done"
-
-target="Install_BOINC"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Install_BOINC..."
-lipo ./build/${style}/BOINC\ Installer.app/Contents/MacOS/BOINC\ Installer -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of Install_BOINC...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Install_BOINC...done"
-echo "Building ${target}...done"
-
-libSearchPath=""
-if [ "${style}" == "Development" ]; then
-   libSearchPath="./build/Development"
-fi
-target="ss_app"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../api/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "${libSearchPath} ${cache_dir}/lib ../lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a..."
-lipo ./build/${style}/libjpeg.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libjpeg.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a...done"
-echo "Verifying architecture (x86_64 arm64) of boincscr..."
-lipo ./build/${style}/boincscr -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boincscr...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boincscr...done"
-echo "Building ${target}...done"
-
-target="ScreenSaver"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting GCC_ENABLE_OBJC_GC "unsupported" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_cleanup..."
-lipo ./build/${style}/gfx_cleanup -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of gfx_cleanup...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_cleanup...done"
-echo "Verifying architecture (x86_64 arm64) of BOINCSaver..."
-lipo ./build/${style}/BOINCSaver.saver/Contents/MacOS/BOINCSaver -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of BOINCSaver...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of BOINCSaver...done"
-echo "Building ${target}...done"
-
-target="boinc_opencl"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_opencl.a..."
-lipo ./build/${style}/libboinc_opencl.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_opencl.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_opencl.a...done"
-echo "Building ${target}...done"
-
-target="setprojectgrp"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of setprojectgrp..."
-lipo ./build/${style}/setprojectgrp -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of setprojectgrp...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of setprojectgrp...done"
-echo "Building ${target}...done"
-
-target="cmd_boinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinccmd..."
-lipo ./build/${style}/boinccmd -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinccmd...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinccmd...done"
-echo "Building ${target}...done"
-
-target="Uninstaller"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Uninstaller..."
-lipo ./build/${style}/Uninstall\ BOINC.app/Contents/MacOS/Uninstall\ BOINC -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of Uninstaller...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Uninstaller...done"
-echo "Building ${target}...done"
-
-target="SetUpSecurity"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of SetUpSecurity..."
-lipo ./build/${style}/SetUpSecurity -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of SetUpSecurity...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of SetUpSecurity...done"
-echo "Building ${target}...done"
-
-target="AddRemoveUser"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of AddRemoveUser..."
-lipo ./build/${style}/AddRemoveUser -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of AddRemoveUser...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of AddRemoveUser...done"
-echo "Building ${target}...done"
 
 target="zip apps"
 echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -zipapps | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+source BuildMacBOINC.sh ${config} ${doclean} -zipapps | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a..."
 lipo ./build/${style}/libboinc_zip.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a...failed"
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a...done"
 echo "Verifying architecture (x86_64 arm64) of boinc_zip_test..."
@@ -484,7 +181,7 @@ lipo ../zip/build/${style}/boinc_zip_test -verify_arch x86_64 arm64 | $beautifie
 if [ ${retval} -ne 0 ]; then
     echo "Verifying architecture (x86_64 arm64) of boinc_zip_test...failed"
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of boinc_zip_test...done"
 echo "Verifying architecture (x86_64 arm64) of testzlibconflict..."
@@ -492,24 +189,24 @@ lipo ../zip/build/${style}/testzlibconflict -verify_arch x86_64 arm64 | $beautif
 if [ ${retval} -ne 0 ]; then
     echo "Verifying architecture (x86_64 arm64) of testzlibconflict...failed"
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of testzlibconflict...done"
 echo "Building ${target}...done"
 
 target="UpperCase2"
 echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -uc2 -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../zip/ ../../clientgui/mac/ ../jpeglib/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+source BuildMacBOINC.sh ${config} ${doclean} -uc2 -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../zip/ ../../clientgui/mac/ ../jpeglib/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin..."
 lipo ../samples/mac_build/build/${style}/UC2_graphics-apple-darwin -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin...failed"
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin...done"
 echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin..."
@@ -517,7 +214,7 @@ lipo ../samples/mac_build/build/${style}/UC2-apple-darwin -verify_arch x86_64 ar
 if [ ${retval} -ne 0 ]; then
     echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin...failed"
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin...done"
 echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin..."
@@ -525,26 +222,26 @@ lipo ../samples/mac_build/build/${style}/slide_show-apple-darwin -verify_arch x8
 if [ ${retval} -ne 0 ]; then
     echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin...failed"
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin...done"
 echo "Building ${target}...done"
 
 target="VBoxWrapper"
 echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -vboxwrapper -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../clientgui/mac/ ../samples/jpeglib ${cache_dir}/include"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+source BuildMacBOINC.sh ${config} ${doclean} -vboxwrapper -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../clientgui/mac/ ../samples/jpeglib ${cache_dir}/include"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of vboxwrapper..."
 lipo ../samples/vboxwrapper/build/${style}/vboxwrapper -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Verifying architecture (x86_64 arm64) of vboxwrapper...failed"
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${savedPath}"; exit 1;
 fi
 echo "Verifying architecture (x86_64 arm64) of vboxwrapper...done"
 echo "Building ${target}...done"
 
-cd ..
+cd "${savedPath}"

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -96,6 +96,27 @@ if [ ${share_paths} = "yes" ]; then
     return 0
 fi
 
+verify_product_archs() {
+    declare -a files=(*)
+    for (( i = 0; i < ${#files[*]}; ++ i )); do
+        if [[ -z "${files[i]}" ]]; then continue; fi
+        if [[ "${files[i]}" = *dSYM ]]; then continue; fi
+        if [[ "${files[i]}" = detect_rosetta_cpu ]]; then continue; fi
+        fileToCheck="${files[i]}"
+        if [[ -d "$fileToCheck" ]]; then
+            fileToCheck="${files[i]}/Contents/MacOS/${files[i]%.*}"
+        fi
+        echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ..."
+        lipo "${fileToCheck}" -verify_arch x86_64 arm64
+        if [ $? -ne 0 ]; then
+            echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} failed"
+            cd "${savedPath}"; exit 1;
+        fi
+        echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ...done"
+        echo
+    done
+}
+
 foundTargets=0
 target="x"
 
@@ -128,24 +149,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-declare -a files=(*)
-for (( i = 0; i < ${#files[*]}; ++ i )); do
-    if [[ -z "${files[i]}" ]]; then continue; fi
-    if [[ "${files[i]}" = *dSYM ]]; then continue; fi
-    if [[ "${files[i]}" = detect_rosetta_cpu ]]; then continue; fi
-    fileToCheck="${files[i]}"
-    if [[ -d "$fileToCheck" ]]; then
-        fileToCheck="${files[i]}/Contents/MacOS/${files[i]%.*}"
-    fi
-    echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ..."
-    lipo "${fileToCheck}" -verify_arch x86_64 arm64
-    if [ $? -ne 0 ]; then
-        echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} failed"
-        cd "${savedPath}"; exit 1;
-    fi
-    echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ...done"
-    echo
-done
+verify_product_archs
 
 echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu..."
 if [[ `lipo detect_rosetta_cpu -archs` = "x86_64" ]]; then
@@ -168,31 +172,20 @@ if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
     cd "${savedPath}"; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a..."
-lipo ./build/${style}/libboinc_zip.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a...failed"
-    echo "Building ${target}...failed"
-    cd "${savedPath}"; exit 1;
+
+cd "./build/${style}"
+if [ $? -ne 0 ]; then
+    cd "${savedPath}"
+    exit 1
 fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a...done"
-echo "Verifying architecture (x86_64 arm64) of boinc_zip_test..."
-lipo ../zip/build/${style}/boinc_zip_test -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinc_zip_test...failed"
-    echo "Building ${target}...failed"
-    cd "${savedPath}"; exit 1;
+
+verify_product_archs
+
+cd "${savedPath}/mac_build"
+if [ $? -ne 0 ]; then
+    cd "${savedPath}"
+    exit 1
 fi
-echo "Verifying architecture (x86_64 arm64) of boinc_zip_test...done"
-echo "Verifying architecture (x86_64 arm64) of testzlibconflict..."
-lipo ../zip/build/${style}/testzlibconflict -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of testzlibconflict...failed"
-    echo "Building ${target}...failed"
-    cd "${savedPath}"; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of testzlibconflict...done"
-echo "Building ${target}...done"
 
 target="UpperCase2"
 echo "Building ${target}..."
@@ -201,31 +194,20 @@ if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
     cd "${savedPath}"; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin..."
-lipo ../samples/mac_build/build/${style}/UC2_graphics-apple-darwin -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin...failed"
-    echo "Building ${target}...failed"
-    cd "${savedPath}"; exit 1;
+
+cd "../samples/mac_build/build/${style}"
+if [ $? -ne 0 ]; then
+    cd "${savedPath}"
+    exit 1
 fi
-echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin...done"
-echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin..."
-lipo ../samples/mac_build/build/${style}/UC2-apple-darwin -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin...failed"
-    echo "Building ${target}...failed"
-    cd "${savedPath}"; exit 1;
+
+verify_product_archs
+
+cd "${savedPath}/mac_build"
+if [ $? -ne 0 ]; then
+    cd "${savedPath}"
+    exit 1
 fi
-echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin...done"
-echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin..."
-lipo ../samples/mac_build/build/${style}/slide_show-apple-darwin -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin...failed"
-    echo "Building ${target}...failed"
-    cd "${savedPath}"; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin...done"
-echo "Building ${target}...done"
 
 target="VBoxWrapper"
 echo "Building ${target}..."
@@ -234,14 +216,13 @@ if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
     cd "${savedPath}"; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of vboxwrapper..."
-lipo ../samples/vboxwrapper/build/${style}/vboxwrapper -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of vboxwrapper...failed"
-    echo "Building ${target}...failed"
-    cd "${savedPath}"; exit 1;
+
+cd "./samples/vboxwrapper/build/${style}"
+if [ $? -ne 0 ]; then
+    cd "${savedPath}"
+    exit 1
 fi
-echo "Verifying architecture (x86_64 arm64) of vboxwrapper...done"
-echo "Building ${target}...done"
+
+verify_product_archs
 
 cd "${savedPath}"

--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -173,7 +173,7 @@ if [ ${retval} -ne 0 ]; then
     cd "${savedPath}"; exit 1;
 fi
 
-cd "./build/${style}"
+cd "../zip/build/${style}"
 if [ $? -ne 0 ]; then
     cd "${savedPath}"
     exit 1


### PR DESCRIPTION
Don't hard-code the names of targets and build products in the Mac CI build script

The script buildMacBOINC-CI.sh hard coded each of the targets and resulting executables for the main BOINC Xcode project. When I modified the boinc_finish_install target in PR https://github.com/BOINC/boinc/pull/5125 to build a full application bundle instead of a common-line style executable, this hard coding caused the CI builds to fail. I wasted many hours trying to fix the failure in my code before I realized it was due to a problem in the buildMacBOINC-CI.sh script and not in my code.

This PR generalizes the script to automatically determine the targets and build products, while also shortening and simplifying it. It also fixes some bugs in the script which prevented cleaning the zip apps, UpperCase2 and VBoxWrapper projects before building them.