### PR TITLE
Mac CI: Simplify and generalize logic in the Mac CI build script

### DIFF
--- a/mac_build/buildMacBOINC-CI.sh
+++ b/mac_build/buildMacBOINC-CI.sh
@@ -19,7 +19,7 @@
 #
 #
 # Script to build the different targets in the BOINC xcode project using a
-# combined install directory for all dependencies
+# combined install directory for all dependencies, plus some samples.
 #
 # Usage:
 # ./mac_build/buildMacBOINC-CI.sh [--cache_dir PATH] [--debug] [--clean] [--no_shared_headers]
@@ -27,7 +27,8 @@
 # --cache_dir is the path where the dependencies are installed by 3rdParty/buildMacDependencies.sh.
 # --debug will build the debug Manager (needs debug wxWidgets library in cache_dir).
 # --clean will force a full rebuild.
-# --no_shared_headers will build targets individually instead of in one call of BuildMacBOINC.sh (NOT recommended)
+# --no_shared_headers will build targets individually instead of in one call of
+#   BuildMacBOINC.sh. Provides additional verification & details in build output.
 
 # check working directory because the script needs to be called like: ./mac_build/buildMacBOINC-CI.sh
 if [ ! -d "mac_build" ]; then
@@ -42,14 +43,14 @@ rm -fR ./mac_build/build
 cache_dir="$(pwd)/3rdParty/buildCache/mac"
 style="Deployment"
 config=""
-doclean=""
+doclean="-noclean"
 beautifier="cat" # we need a fallback if xcpretty is not available
 share_paths="yes"
 while [[ $# -gt 0 ]]; do
     key="$1"
     case $key in
         -clean|--clean)
-        doclean="yes"
+        doclean=""
         ;;
         --cache_dir)
         cache_dir="$2"
@@ -75,476 +76,123 @@ if [ $? -eq 0 ]; then
     beautifier="xcpretty"
 fi
 
+rootPath="${PWD}"
+
 cd ./mac_build || exit 1
 retval=0
 
+libSearchPathDbg=""
+if [ "${style}" == "Development" ]; then
+    libSearchPathDbg="./build/Development  ${cache_dir}/lib/debug"
+fi
+
 if [ ${share_paths} = "yes" ]; then
     ## all targets share the same header and library search paths
+    ## Note: this does not build zip apps, upper case or VBoxWrapper projects.
     libSearchPathDbg=""
-    if [ "${style}" == "Development" ]; then
-        libSearchPathDbg="./build/Development  ${cache_dir}/lib/debug"
-    fi
-    source BuildMacBOINC.sh ${config} -all -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "$libSearchPathDbg ${cache_dir}/lib ../lib" | tee xcodebuild_all.log | $beautifier; retval=${PIPESTATUS[0]}
+    source BuildMacBOINC.sh ${config} ${doclean} -all -setting HEADER_SEARCH_PATHS "../clientgui ../lib/** ../api/ ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "$libSearchPathDbg ${cache_dir}/lib ../lib" | tee xcodebuild_all.log | $beautifier; retval=${PIPESTATUS[0]}
     if [ $retval -ne 0 ]; then
-        cd ..; exit 1; fi
+        cd "${rootPath}"; exit 1; fi
     return 0
 fi
 
-## This is code that builds each target individually in case the above shared header paths version is giving problems
-## Note: currently this does not build the boinc_zip library
-if [ "${doclean}" = "yes" ]; then
-    ## clean all targets
-    xcodebuild -project boinc.xcodeproj -target Build_All  -configuration ${style} clean | $beautifier; retval=${PIPESTATUS[0]}
-    if [ $retval -ne 0 ]; then cd ..; exit 1; fi
-
-    ## clean boinc_zip which is not included in Build_All
-    xcodebuild -project ../zip/boinc_zip.xcodeproj -target boinc_zip -configuration ${style} clean | $beautifier; retval=${PIPESTATUS[0]}
-    if [ $retval -ne 0 ]; then cd ..; exit 1; fi
+verify_product_archs() {
+cd "${1}"
+if [ $? -ne 0 ]; then
+    cd "${rootPath}"
+    exit 1
 fi
 
-## Target mgr_boinc also builds dependent targets SetVersion and BOINC_Client
-libSearchPathDbg=""
-if [ "${style}" == "Development" ]; then
-    libSearchPathDbg="${cache_dir}/lib/debug"
-fi
-target="mgr_boinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../clientgui ${cache_dir}/include" -setting LIBRARY_SEARCH_PATHS "${libSearchPathDbg} ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a..."
-lipo ./build/${style}/libboinc.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a...done"
-echo "Verifying architecture (x86_64 arm64) of BOINCManager..."
-lipo ./build/${style}/BOINCManager.app/Contents/MacOS/BOINCManager -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of BOINCManager...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of BOINCManager...done"
-echo "Verifying architecture (x86_64 arm64) of SetVersion..."
-lipo ./build/${style}/SetVersion -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of SetVersion...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of SetVersion...done"
-echo "Verifying architecture (x86_64 arm64) of boinc..."
-lipo ./build/${style}/boinc -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinc...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinc...done"
-echo "Verifying architecture (x86_64) of detect_rosetta_cpu..."
-lipo ./build/${style}/detect_rosetta_cpu -verify_arch x86_64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64) of detect_rosetta_cpu...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64) of detect_rosetta_cpu...done"
-echo "Verifying architecture (arm64) of detect_rosetta_cpu..."
-lipo ./build/${style}/detect_rosetta_cpu -verify_arch arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -eq 0 ]; then
-    echo "Verifying architecture (arm64) of detect_rosetta_cpu...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (arm64) of detect_rosetta_cpu...done"
-echo "Building ${target}...done"
+    declare -a files=(*)
+    for (( i = 0; i < ${#files[*]}; ++ i )); do
+        if [[ -z "${files[i]}" ]]; then continue; fi
+        if [[ "${files[i]}" = *dSYM ]]; then continue; fi
+        if [[ "${files[i]}" = detect_rosetta_cpu ]]; then continue; fi
+        fileToCheck="${files[i]}"
+        if [[ -d "$fileToCheck" ]]; then
+            fileToCheck="${files[i]}/Contents/MacOS/${files[i]%.*}"
+        fi
+        echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ..."
+        lipo "${fileToCheck}" -verify_arch x86_64 arm64
+        if [ $? -ne 0 ]; then
+            echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} failed"
+            cd "${rootPath}"; exit 1;
+        fi
+        echo "Verifying architecture (x86_64 arm64) of ${fileToCheck} ...done"
+        echo
+    done
 
-## Target gfx2libboinc also build dependent target jpeg
-target="gfx2libboinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../samples/jpeglib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
+cd "${rootPath}/mac_build"
+if [ $? -ne 0 ]; then
+    cd "${rootPath}"
+    exit 1
 fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a..."
-lipo ./build/${style}/libjpeg.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libjpeg.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a...done"
-echo "Verifying architecture (x86_64 arm64) of libboinc_graphics2.a..."
-lipo ./build/${style}/libboinc_graphics2.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_graphics2.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_graphics2.a...done"
-echo "Building ${target}...done"
+}
 
-target="libboinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a..."
-lipo ./build/${style}/libboinc.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc.a...done"
-echo "Building ${target}...done"
+foundTargets=0
+target="x"
 
-target="api_libboinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_api.a..."
-lipo ./build/${style}/libboinc_api.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_api.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_api.a...done"
-echo "Building ${target}...done"
+## This is code that builds each target individually in the main BOINC Xcode
+## project, plus the zip apps, upper case and VBoxWrapper projects.
+for buildTarget in `xcodebuild -list -project boinc.xcodeproj`
+do
+    if [[ "${target}" = "Build" && "${buildTarget}" = "Configurations:" ]]; then break; fi
+    if [ $foundTargets -eq 1 ]; then
+        if [ "${target}" != "Build_All" ]; then
+            echo "Building ${target}..."
+            source BuildMacBOINC.sh ${config} ${doclean} -target ${target} -setting HEADER_SEARCH_PATHS "../clientgui ../lib/** ../api/ ${cache_dir}/include ../samples/jpeglib ${cache_dir}/include/freetype2" -setting USER_HEADER_SEARCH_PATHS "" -setting LIBRARY_SEARCH_PATHS "${libSearchPathDbg} ${cache_dir}/lib  ../lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+            if [ ${retval} -eq 0 ]; then
+                echo "Building ${target}...success"
+                echo
+            else
+                echo "Building ${target}...failed"
+                cd "${rootPath}"; exit 1;
+            fi
+        fi
+    fi
+    if [ "${target}" = "Targets:" ]; then foundTargets=1; fi
+    target="${buildTarget}"
+done
 
-target="PostInstall"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinc_finish_install..."
-lipo ./build/${style}/BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinc_finish_install...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinc_finish_install...done"
-echo "Verify architecture (x86_64 arm64) of SetVersion..."
-lipo ./build/${style}/SetVersion -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verify architecture (x86_64 arm64) of SetVersion...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verify architecture (x86_64 arm64) of SetVersion...done"
-echo "Verify architecture (x86_64 arm64) of PostInstall..."
-lipo ./build/${style}/PostInstall.app/Contents/MacOS/PostInstall -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verify architecture (x86_64 arm64) of PostInstall...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verify architecture (x86_64 arm64) of PostInstall...done"
-echo "Building ${target}...done"
+## Now verify the architectures of the built products
+verify_product_archs "${rootPath}/mac_build/build/${style}"
 
-target="switcher"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
+echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu..."
+if [[ `lipo "${rootPath}/mac_build/build/${style}/detect_rosetta_cpu" -archs` = "x86_64" ]]; then
+    echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu ...done"
+else
+    echo "Verifying architecture (x86_64 only) of detect_rosetta_cpu failed"
     cd ..; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of switcher..."
-lipo ./build/${style}/switcher -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of switcher...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of switcher...done"
-echo "Building ${target}...done"
-
-target="gfx_switcher"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_switcher..."
-lipo ./build/${style}/gfx_switcher -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of gfx_switcher...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_switcher...done"
-echo "Building ${target}...done"
-
-target="Install_BOINC"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Install_BOINC..."
-lipo ./build/${style}/BOINC\ Installer.app/Contents/MacOS/BOINC\ Installer -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of Install_BOINC...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Install_BOINC...done"
-echo "Building ${target}...done"
-
-libSearchPath=""
-if [ "${style}" == "Development" ]; then
-   libSearchPath="./build/Development"
-fi
-target="ss_app"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting HEADER_SEARCH_PATHS "../api/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "${libSearchPath} ${cache_dir}/lib ../lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a..."
-lipo ./build/${style}/libjpeg.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libjpeg.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libjpeg.a...done"
-echo "Verifying architecture (x86_64 arm64) of boincscr..."
-lipo ./build/${style}/boincscr -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boincscr...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boincscr...done"
-echo "Building ${target}...done"
-
-target="ScreenSaver"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} -setting GCC_ENABLE_OBJC_GC "unsupported" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_cleanup..."
-lipo ./build/${style}/gfx_cleanup -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of gfx_cleanup...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of gfx_cleanup...done"
-echo "Verifying architecture (x86_64 arm64) of BOINCSaver..."
-lipo ./build/${style}/BOINCSaver.saver/Contents/MacOS/BOINCSaver -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of BOINCSaver...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of BOINCSaver...done"
-echo "Building ${target}...done"
-
-target="boinc_opencl"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_opencl.a..."
-lipo ./build/${style}/libboinc_opencl.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_opencl.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_opencl.a...done"
-echo "Building ${target}...done"
-
-target="setprojectgrp"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of setprojectgrp..."
-lipo ./build/${style}/setprojectgrp -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of setprojectgrp...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of setprojectgrp...done"
-echo "Building ${target}...done"
-
-target="cmd_boinc"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinccmd..."
-lipo ./build/${style}/boinccmd -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinccmd...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinccmd...done"
-echo "Building ${target}...done"
-
-target="Uninstaller"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Uninstaller..."
-lipo ./build/${style}/Uninstall\ BOINC.app/Contents/MacOS/Uninstall\ BOINC -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of Uninstaller...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of Uninstaller...done"
-echo "Building ${target}...done"
-
-target="SetUpSecurity"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of SetUpSecurity..."
-lipo ./build/${style}/SetUpSecurity -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of SetUpSecurity...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of SetUpSecurity...done"
-echo "Building ${target}...done"
-
-target="AddRemoveUser"
-echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -target ${target} | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of AddRemoveUser..."
-lipo ./build/${style}/AddRemoveUser -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of AddRemoveUser...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of AddRemoveUser...done"
-echo "Building ${target}...done"
 
 target="zip apps"
 echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -zipapps | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+source BuildMacBOINC.sh ${config} ${doclean} -zipapps | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${rootPath}"; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a..."
-lipo ./build/${style}/libboinc_zip.a -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of libboinc_zip.a...done"
-echo "Verifying architecture (x86_64 arm64) of boinc_zip_test..."
-lipo ../zip/build/${style}/boinc_zip_test -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of boinc_zip_test...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of boinc_zip_test...done"
-echo "Verifying architecture (x86_64 arm64) of testzlibconflict..."
-lipo ../zip/build/${style}/testzlibconflict -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of testzlibconflict...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of testzlibconflict...done"
-echo "Building ${target}...done"
+
+verify_product_archs "${rootPath}/zip/build/${style}"
 
 target="UpperCase2"
 echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -uc2 -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../zip/ ../../clientgui/mac/ ../jpeglib/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+source BuildMacBOINC.sh ${config} ${doclean} -uc2 -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../zip/ ../../clientgui/mac/ ../jpeglib/ ../samples/jpeglib/ ${cache_dir}/include ${cache_dir}/include/freetype2"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${rootPath}"; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin..."
-lipo ../samples/mac_build/build/${style}/UC2_graphics-apple-darwin -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of UC2_graphics-apple-darwin...done"
-echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin..."
-lipo ../samples/mac_build/build/${style}/UC2-apple-darwin -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of UC2-apple-darwin...done"
-echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin..."
-lipo ../samples/mac_build/build/${style}/slide_show-apple-darwin -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of slide_show-apple-darwin...done"
-echo "Building ${target}...done"
+
+verify_product_archs "${rootPath}/samples/mac_build/build/${style}"
 
 target="VBoxWrapper"
 echo "Building ${target}..."
-source BuildMacBOINC.sh ${config} -noclean -vboxwrapper -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../clientgui/mac/ ../samples/jpeglib ${cache_dir}/include"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
+source BuildMacBOINC.sh ${config} ${doclean} -vboxwrapper -setting HEADER_SEARCH_PATHS "../../ ../../api/ ../../lib/ ../../clientgui/mac/ ../samples/jpeglib ${cache_dir}/include"  -setting LIBRARY_SEARCH_PATHS "../../mac_build/build/Deployment ${cache_dir}/lib" | tee xcodebuild_${target}.log | $beautifier; retval=${PIPESTATUS[0]}
 if [ ${retval} -ne 0 ]; then
     echo "Building ${target}...failed"
-    cd ..; exit 1;
+    cd "${rootPath}"; exit 1;
 fi
-echo "Verifying architecture (x86_64 arm64) of vboxwrapper..."
-lipo ../samples/vboxwrapper/build/${style}/vboxwrapper -verify_arch x86_64 arm64 | $beautifier; retval=${PIPESTATUS[0]}
-if [ ${retval} -ne 0 ]; then
-    echo "Verifying architecture (x86_64 arm64) of vboxwrapper...failed"
-    echo "Building ${target}...failed"
-    cd ..; exit 1;
-fi
-echo "Verifying architecture (x86_64 arm64) of vboxwrapper...done"
-echo "Building ${target}...done"
 
-cd ..
+verify_product_archs "${rootPath}/samples/vboxwrapper/build/${style}"
+
+cd "${rootPath}"


### PR DESCRIPTION
Mac CI: 
Don't hard-code the names of targets and built executables in the Mac CI build script.
Don't unnecessary rebuild libraries for the _Zip Apps_, _UpperCase2_ or _VBoxWrapper_ projects.
Simplify and generalize the logic in the Mac CI build script.

The script _buildMacBOINC-CI.sh_ hard coded each of the targets and resulting executables for the main BOINC Xcode project. When I modified the _boinc_finish_install_ target in PR #5125 to build a full application bundle instead of a command-line style executable, this hard coding caused the CI builds to fail. I wasted many hours trying to fix the failure in my code before I realized it was due to a problem in the _buildMacBOINC-CI.sh_ script and not in my code.

This PR generalizes the _buildMacBOINC-CI.sh_ script to automatically determine the targets and build products, while also shortening and simplifying it. It also fixes some bugs in this script which prevented cleaning the _Zip Apps_, _UpperCase2_ and _VBoxWrapper_ projects before building them.

The _buildMacBOINC.sh_ script (called multiple times from the _buildMacBOINC-CI.sh_ script) unnecessarily rebuilt the BOINC libraries when building the _Zip Apps_, _UpperCase2_ and _VBoxWrapper_ projects, even if they had already been built. This PR adds code to build the BOINC libraries for these projects only when they don't already exist. It also consolidates and simplifies logic in the _buildMacBOINC-CI.sh_ and _buildMacBOINC.sh_ build scripts.