### PR TITLE
client, Win: add a cc_config.xml option <no_rdp_check>.

### DIFF
--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -269,6 +269,7 @@ bool gpus_usable = true;
 //
 bool check_coprocs_usable() {
 #ifdef _WIN32
+    if (cc_config.no_rdp_check) return false;
     unsigned int i;
     bool new_usable = !is_remote_desktop();
     if (gpus_usable) {

--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -265,6 +265,9 @@ void CC_CONFIG::show() {
     if (no_priority_change) {
         msg_printf(NULL, MSG_INFO, "Config: run apps at regular priority");
     }
+    if (no_rdp_check) {
+        msg_printf(NULL, MSG_INFO, "Config: allow GPU apps when using remote desktop");
+    }
     if (report_results_immediately) {
         msg_printf(NULL, MSG_INFO, "Config: report completed tasks immediately");
     }
@@ -428,6 +431,7 @@ int CC_CONFIG::parse_options_client(XML_PARSER& xp) {
         if (xp.parse_bool("no_info_fetch", no_info_fetch)) continue;
         if (xp.parse_bool("no_opencl", no_opencl)) continue;
         if (xp.parse_bool("no_priority_change", no_priority_change)) continue;
+        if (xp.parse_bool("no_rdp_check", no_rdp_check)) continue;
         if (xp.parse_bool("os_random_only", os_random_only)) continue;
         if (xp.parse_int("process_priority", process_priority)) continue;
         if (xp.parse_int("process_priority_special", process_priority_special)) continue;

--- a/client/sandbox.cpp
+++ b/client/sandbox.cpp
@@ -218,8 +218,8 @@ int get_project_gid() {
 // Graphics button) now write files in their slot directory as
 // the logged in user, not boinc_master. This ugly hack uses 
 // setprojectgrp to fix all ownerships in this slot directory.
-int fix_slot_owners(const int slot){
 #ifdef __APPLE__
+int fix_slot_owners(const int slot){
     char relative_path[100];
     char full_path[MAXPATHLEN];
     
@@ -228,9 +228,13 @@ int fix_slot_owners(const int slot){
         realpath(relative_path, full_path);
         fix_owners_in_directory(full_path);
     }
-#endif
     return 0;
 }
+#else
+int fix_slot_owners(const int){
+    return 0;
+}
+#endif
 
 int fix_owners_in_directory(char* dir_path) {
     char item_path[MAXPATHLEN];

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -209,7 +209,6 @@ void CC_CONFIG::defaults() {
     disallow_attach = false;
     dont_check_file_sizes = false;
     dont_contact_ref_site = false;
-    lower_client_priority = false;
     dont_suspend_nci = false;
     dont_use_vbox = false;
     dont_use_wsl = false;
@@ -228,6 +227,8 @@ void CC_CONFIG::defaults() {
     for (int i=1; i<NPROC_TYPES; i++) {
         ignore_gpu_instance[i].clear();
     }
+    ignore_tty.clear();
+    lower_client_priority = false;
     max_event_log_lines = DEFAULT_MAX_EVENT_LOG_LINES;
     max_file_xfers = 8;
     max_file_xfers_per_project = 2;
@@ -240,6 +241,7 @@ void CC_CONFIG::defaults() {
     no_info_fetch = false;
     no_opencl = false;
     no_priority_change = false;
+    no_rdp_check = false;
     os_random_only = false;
     process_priority = CONFIG_PRIORITY_UNSPECIFIED;
     process_priority_special = CONFIG_PRIORITY_UNSPECIFIED;
@@ -262,7 +264,6 @@ void CC_CONFIG::defaults() {
     use_certs = false;
     use_certs_only = false;
     vbox_window = false;
-    ignore_tty.clear();
 }
 
 int EXCLUDE_GPU::parse(XML_PARSER& xp) {
@@ -403,6 +404,7 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
         if (xp.parse_bool("no_info_fetch", no_info_fetch)) continue;
         if (xp.parse_bool("no_opencl", no_opencl)) continue;
         if (xp.parse_bool("no_priority_change", no_priority_change)) continue;
+        if (xp.parse_bool("no_rdp_check", no_rdp_check)) continue;
         if (xp.parse_bool("os_random_only", os_random_only)) continue;
         if (xp.parse_int("process_priority", process_priority)) continue;
         if (xp.parse_int("process_priority_special", process_priority_special)) continue;
@@ -637,6 +639,7 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         "        <no_info_fetch>%d</no_info_fetch>\n"
         "        <no_opencl>%d</no_opencl>\n"
         "        <no_priority_change>%d</no_priority_change>\n"
+        "        <no_rpd_check>%d</no_rpd_check>\n"
         "        <os_random_only>%d</os_random_only>\n"
         "        <process_priority>%d</process_priority>\n"
         "        <process_priority_special>%d</process_priority_special>\n",
@@ -652,6 +655,7 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         no_info_fetch,
         no_opencl,
         no_priority_change,
+        no_rdp_check,
         os_random_only,
         process_priority,
         process_priority_special

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -143,8 +143,14 @@ struct EXCLUDE_GPU {
 };
 
 // if you add anything here, add it to
-// defaults(), parse_options(), parse_options_client(), write(),
-// and possibly show()
+// lib/cc_config.cpp:
+//      defaults()
+//      parse_options()
+//      write()
+// client/log_flags.cpp:
+//      parse_options_client()
+//      possibly show()
+// the web doc: https://boinc.berkeley.edu/wiki/Client_configuration
 //
 struct CC_CONFIG {
     bool abort_jobs_on_exit;
@@ -153,6 +159,7 @@ struct CC_CONFIG {
     bool allow_remote_gui_rpc;
     std::vector<std::string> alt_platforms;
     COPROCS config_coprocs;
+    std::string device_name;
     bool disallow_attach;
     bool dont_check_file_sizes;
     bool dont_contact_ref_site;
@@ -169,9 +176,10 @@ struct CC_CONFIG {
     bool fetch_on_update;
     std::string force_auth;
     bool http_1_0;
-    int http_transfer_timeout_bps;
     int http_transfer_timeout;
+    int http_transfer_timeout_bps;
     std::vector<int> ignore_gpu_instance[NPROC_TYPES];
+    std::vector<std::string> ignore_tty;
     bool lower_client_priority;
     int max_event_log_lines;
     int max_file_xfers;
@@ -185,6 +193,7 @@ struct CC_CONFIG {
     bool no_info_fetch;
     bool no_opencl;
     bool no_priority_change;
+    bool no_rdp_check;
     bool os_random_only;
     int process_priority;       // values in common_defs.h
     int process_priority_special;
@@ -193,8 +202,8 @@ struct CC_CONFIG {
     bool report_results_immediately;
     bool run_apps_manually;
     int save_stats_days;
-    bool skip_cpu_benchmarks;
     bool simple_gui_only;
+    bool skip_cpu_benchmarks;
     double start_delay;
     bool stderr_head;
     bool suppress_net_info;
@@ -204,8 +213,6 @@ struct CC_CONFIG {
     bool use_certs_only;
         // overrides use_certs
     bool vbox_window;
-    std::vector<std::string> ignore_tty;
-    std::string device_name;
 
     CC_CONFIG();
     void defaults();


### PR DESCRIPTION
If set, it skips the check to see if Remote Desktop Protocol (RDP) is in use, allowing GPU apps to run while using RDP.
This should be done only if you have configured RDP as described here: https://knowledge.civilgeo.com/knowledge-base/enabling-gpu-rendering-for-microsoft-remote-desktop/

Fixes #5143