### PR TITLE
web: fix problems with download page on project sites

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -900,19 +900,23 @@ function current_url() {
 // @param text The text to display on the button
 // @param desc The title of the destination - typically used as a popup
 // @param class The optional CSS class of the button. Defaults to a standard button
+// @params extra Additional text in href tag
 //
 
-function button_text($url, $text, $desc=null, $class="btn-success btn-sm") {
+function button_text($url, $text, $desc=null, $class=null, $extra='') {
     if (!$desc) {
         $desc = $text;
     }
-    return sprintf(' <a href="%s" title="%s" class="btn %s">%s</a>',
-        $url, $desc, $class, $text
+    if (!$class) {
+        $class = "btn-success btn-sm";
+    }
+    return sprintf(' <a href="%s" title="%s" class="btn %s" %s>%s</a>',
+        $url, $desc, $class, $extra, $text
     );
 }
 
-function show_button($url, $text, $desc=null, $class="btn-success btn-sm") {
-    echo button_text($url, $text, $desc, $class);
+function show_button($url, $text, $desc=null, $class=null, $extra=null) {
+    echo button_text($url, $text, $desc, $class, $extra);
 }
 
 // for places with a bunch of buttons, like forum posts

--- a/html/user/download_software.php
+++ b/html/user/download_software.php
@@ -16,20 +16,26 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// Show a page with download links and instructions.
+// Page for downloading the BOINC client, with support for autoattach:
+// https://boinc.berkeley.edu/trac/wiki/SimpleAttach
+// Note: to use autoattach:
+// 1) You need to have the client versions file
+//      run html/ops/get_versions.php
+// 2) Put your project ID (ask DPA if you don't have one)
+//      in config.xml as <project_id>x</project_id>
+//
 // There's a logged-in user.
 //
-// If no project ID, direct user to BOINC web site
-// otherwise...
+// Autoattach case: if project has an ID and client is Win or Mac:
+//    - find latest version for that platform (regular and vbox)
+//    - Create a login token.
+//    - Show download button(s)
+//      The download will be via concierge, using the login token.
+// Otherwise:
+//    - show link to download page on BOINC web site,
+//      and instructions for what to do after that.
 //
-// - get platform from user agent string
-// - find latest version for that platform (regular and vbox)
-// - Create a login token.
-// - Show download button(s)
-//   The download will be via concierge, using the login token.
-//
-// VirtualBox
-//
+// VirtualBox:
 // config.xml entries:
 // <need_vbox/>     This project requires VBox
 // <recommend_vbox> This project can use VBox
@@ -38,11 +44,6 @@
 // For other platforms, direct user to VBox download page
 // before installing BOINC
 //
-// Notes:
-// 1) You need to have the client versions file
-//      run html/ops/get_versions.php
-// 2) Put your project ID in a constant PROJECT_ID
-//    (this all works only for listed projects)
 
 // Can also be called as a web RPC;
 // see https://boinc.berkeley.edu/trac/wiki/WebRpc#download
@@ -97,6 +98,13 @@ function is_windows() {
     if (strstr($user_agent, 'Windows')) {
         return true;
     }
+    return false;
+}
+
+function is_windows_or_mac() {
+    global $user_agent;
+    if (strstr($user_agent, 'Windows')) return true;
+    if (strstr($user_agent, 'Mac')) return true;
     return false;
 }
 
@@ -180,8 +188,7 @@ function show_vbox_info($where) {
         echo "<p>";
         if ($need_vbox) {
             echo tra("This project requires VirtualBox.");
-        }
-        if ($recommend_vbox) {
+        } else if ($recommend_vbox) {
             echo tra("This project recommends VirtualBox.");
         }
         echo " ";
@@ -215,27 +222,41 @@ function direct_to_boinc() {
     global $master_url;
     page_head(tra("Download BOINC"));
     text_start();
-    show_vbox_info("direct");
-    echo sprintf(
-        '<p>%s
-        <p><p>
-        %s
-        <p>
-        ',
-        tra("To download and install BOINC,
+    echo "<p>";
+    echo tra("To download and install BOINC,
             click on the link below and follow the instructions.
-        "),
-        tra("When BOINC first runs it will ask you to select a project.
-            Select %1 from the list,
-            or enter this project's URL: %2",
-            PROJECT,
-            $master_url
-        )
-    );
+    ");
+    echo "<p>";
     show_button(
         "https://boinc.berkeley.edu/download.php",
-        tra("Go to the BOINC download page.")
+        tra("Go to the BOINC download page."),
+        null, null, 'target=_new'
     );
+    show_vbox_info("direct");
+
+    if (parse_bool(get_config(), 'account_manager')) {
+        echo sprintf(
+            "<p><p>%s<p>",
+            tra("When BOINC first runs it will ask you to select a project.
+                Cancel out of this dialog,
+                then select <b>Tools / Use Account Manager</b>
+                to connect BOINC to your %1 account.
+                See <a href=%2>detailed instructions</a>.",
+                PROJECT,
+                'https://boinc.berkeley.edu/wiki/Account_managers'
+            )
+        );
+    } else {
+        echo sprintf(
+            "<p><p>%s<p>",
+            tra("When BOINC first runs it will ask you to select a project.
+                Select '%1' from the list,
+                or enter this project's URL:<p>%2",
+                PROJECT,
+                $master_url
+            )
+        );
+    }
     text_end();
     page_tail();
 }
@@ -245,7 +266,7 @@ function show_download_page($user, $user_agent, $dev) {
 
     // If no project ID, we can't use simplified install
     //
-    if (!$project_id) {
+    if (!$project_id || !is_windows_or_mac()) {
         direct_to_boinc();
         return;
     }


### PR DESCRIPTION
The Linux installers on the BOINC web site (.sh files) have out-of-date binaries, and are not real installers. We shouldn't direct users to them.
But projects and AMs that use auto-attach were directing Linux users to these installers.

This change fixes that.
Linux users are not shown a download button, but are instead directed to https://boinc.berkeley.edu/wiki/Installing_on_Linux which lists various options for installing BOINC on Linux (starting with package managers).

Also: the download page (download_software.php) is also used by account managers (Science United).
In this case, it should show instructions for
adding an account manager, not attaching to a project.

Note: there's an analogous update to download.php on the BOINC web site: if the machine is Linux,
show a link to the Linux instructions rather than a download button.

Fixes #5129