### PR TITLE
Fix some compile warnings on Win (VS 2022).

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -1023,17 +1023,16 @@ int boinc_wu_cpu_time(double& cpu_t) {
 // Suspend this job.
 // Can be called from either timer or worker thread.
 //
-#ifdef VERBOSE
 static int suspend_activities(bool called_from_worker) {
+#ifdef VERBOSE
     char log_buf[256];
     fprintf(stderr, "%s suspend_activities() called from %s\n",
         boinc_msg_prefix(log_buf, sizeof(log_buf)),
         called_from_worker?"worker thread":"timer thread"
     );
-#else
-static int suspend_activities(bool) {
 #endif
 #ifdef _WIN32
+    (void) called_from_worker;  // suppress warning
     static vector<int> pids;
     if (options.multi_thread) {
         if (pids.size() == 0) {

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -1023,13 +1023,15 @@ int boinc_wu_cpu_time(double& cpu_t) {
 // Suspend this job.
 // Can be called from either timer or worker thread.
 //
-static int suspend_activities(bool called_from_worker) {
 #ifdef VERBOSE
+static int suspend_activities(bool called_from_worker) {
     char log_buf[256];
     fprintf(stderr, "%s suspend_activities() called from %s\n",
         boinc_msg_prefix(log_buf, sizeof(log_buf)),
         called_from_worker?"worker thread":"timer thread"
     );
+#else
+static int suspend_activities(bool) {
 #endif
 #ifdef _WIN32
     static vector<int> pids;

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1628,7 +1628,9 @@ bool CLIENT_STATE::garbage_collect_always() {
             }
             rp->output_files[i].file_info->ref_cnt++;
         }
-#ifndef SIM
+#ifdef SIM
+        (void)found_error;
+#else
         if (found_error) {
             // check for process still running; this can happen
             // e.g. if an intermediate upload fails

--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -402,13 +402,13 @@ int FILE_INFO::parse(XML_PARSER& xp) {
             retval = pfxp->parse(xp);
 #ifdef SIM
             delete pfxp;
-            continue;
-#endif
+#else
             if (!retval) {
                 pers_file_xfer = pfxp;
             } else {
                 delete pfxp;
             }
+#endif
             continue;
         }
         if (xp.match_tag("file_xfer")) {

--- a/client/cs_notice.cpp
+++ b/client/cs_notice.cpp
@@ -319,7 +319,9 @@ void NOTICES::unkeep(const char* url) {
             ++i;
         }
     }
-#ifndef SIM
+#ifdef SIM
+    (void)removed_something;
+#else
     if (removed_something) {
         gstate.gui_rpcs.set_notice_refresh();
     }
@@ -404,7 +406,9 @@ bool NOTICES::remove_dups(NOTICE& n) {
             ++i;
         }
     }
-#ifndef SIM
+#ifdef SIM
+    (void)removed_something;
+#else
     if (removed_something) {
         gstate.gui_rpcs.set_notice_refresh();
     }

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -472,7 +472,7 @@ int get_os_information(
     }
 
 
-    snprintf_s( szVersion, sizeof(szVersion), ", (%.2u.%.2u.%.4u.%.2u)",
+    snprintf( szVersion, sizeof(szVersion), ", (%.2u.%.2u.%.4u.%.2u)",
         osvi.dwMajorVersion, osvi.dwMinorVersion, (osvi.dwBuildNumber & 0xFFFF), 0
     );
 

--- a/client/project.h
+++ b/client/project.h
@@ -364,7 +364,7 @@ struct PROJECT : PROJ_AM {
 
 #ifdef SIM
     RANDOM_PROCESS available;
-    int index;
+    int proj_index; // order among projects; used for color coding
     int result_index;
     double idle_time;
     double idle_time_sumsq;

--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -810,7 +810,7 @@ void show_project_colors() {
         PROJECT* p = gstate.projects[i];
         fprintf(html_out,
             "<tr><td bgcolor=%s><font color=ffffff>%s</font></td><td>%.0f</td></tr>\n",
-            colors[p->index%NCOLORS], p->project_name, p->resource_share
+            colors[p->proj_index%NCOLORS], p->project_name, p->resource_share
         );
     }
     fprintf(html_out, "</table>\n");
@@ -865,7 +865,7 @@ void show_resource(int rsc_type) {
         }
         fprintf(html_out, "<tr valign=top><td>%.2f</td><td bgcolor=%s><font color=#ffffff>%s%s</font></td><td>%.0f</td>%s</tr>\n",
             ninst,
-            colors[p->index%NCOLORS],
+            colors[p->proj_index%NCOLORS],
             rp->edf_scheduled?"*":"",
             rp->name,
             rp->sim_flops_left/1e9,
@@ -887,7 +887,7 @@ void show_resource(int rsc_type) {
         job_count(p, rsc_type, in_progress, done);
         if (in_progress || done) {
             fprintf(html_out, "<td bgcolor=%s><font color=#ffffff>%s</font></td><td>%d</td><td>%d</td><td>%.3f</td></tr>\n",
-                colors[p->index%NCOLORS], p->project_name, in_progress, done,
+                colors[p->proj_index%NCOLORS], p->project_name, in_progress, done,
                 p->pwf.rec
             );
             found = true;
@@ -1489,7 +1489,7 @@ void do_client_simulation() {
 
     int j=0;
     for (unsigned int i=0; i<gstate.projects.size(); i++) {
-        gstate.projects[i]->index = j++;
+        gstate.projects[i]->proj_index = j++;
     }
 
     clear_backoff();

--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -252,21 +252,24 @@ void make_job(
 void CLIENT_STATE::handle_completed_results(PROJECT* p) {
     char buf[256];
     vector<RESULT*>::iterator result_iter;
+    int n;
 
     result_iter = results.begin();
     while (result_iter != results.end()) {
         RESULT* rp = *result_iter;
         if (rp->project == p && rp->ready_to_report) {
             if (gstate.now > rp->report_deadline) {
-                snprintf(buf, sizeof(buf), "result %s reported; "
+                n = snprintf(buf, sizeof(buf), "result %s reported; "
                     "<font color=#cc0000>MISSED DEADLINE by %f</font><br>\n",
                     rp->name, gstate.now - rp->report_deadline
                 );
+                (void)n;
             } else {
-                snprintf(buf, sizeof(buf), "result %s reported; "
+                n = snprintf(buf, sizeof(buf), "result %s reported; "
                     "<font color=#00cc00>MADE DEADLINE</font><br>\n",
                     rp->name
                 );
+                (void)n;
             }
             PROJECT* spp = rp->project;
             if (gstate.now > rp->report_deadline) {
@@ -344,6 +347,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
     char buf[256], buf2[256];
     vector<IP_RESULT> ip_results;
     vector<RESULT*> new_results;
+    int n;
 
     bool avail;
     if (p->last_rpc_time) {
@@ -354,7 +358,8 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
     }
     p->last_rpc_time = now;
     if (!avail) {
-        snprintf(buf, sizeof(buf), "RPC to %s skipped - project down<br>", p->project_name);
+        n = snprintf(buf, sizeof(buf), "RPC to %s skipped - project down<br>", p->project_name);
+        (void)n;
         html_msg += buf;
         msg_printf(p, MSG_INFO, "RPC skipped: project down");
         gstate.scheduler_op->project_rpc_backoff(p, "project down");
@@ -389,7 +394,8 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
     }
 
     work_fetch.request_string(buf2, sizeof(buf2));
-    snprintf(buf, sizeof(buf), "RPC to %s: %s<br>", p->project_name, buf2);
+    n = snprintf(buf, sizeof(buf), "RPC to %s: %s<br>", p->project_name, buf2);
+    (void)n;
     html_msg += buf;
 
     msg_printf(p, MSG_INFO, "RPC: %s", buf2);
@@ -561,6 +567,7 @@ bool ACTIVE_TASK_SET::poll() {
         diff = 0;
     }
     PROJECT* p;
+    int n;
 
     for (i=0; i<gstate.projects.size(); i++) {
         p = gstate.projects[i];
@@ -629,7 +636,8 @@ bool ACTIVE_TASK_SET::poll() {
             rp->ready_to_report = true;
             gstate.request_schedule_cpus("job finished");
             gstate.request_work_fetch("job finished");
-            snprintf(buf, sizeof(buf), "result %s finished<br>", rp->name);
+            n = snprintf(buf, sizeof(buf), "result %s finished<br>", rp->name);
+            (void)n;
             html_msg += buf;
             action = true;
         }

--- a/client/sim.cpp
+++ b/client/sim.cpp
@@ -347,8 +347,8 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
 
     bool avail;
     if (p->last_rpc_time) {
-        double delta = now - p->last_rpc_time;
-        avail = p->available.sample(delta);
+        double dt = now - p->last_rpc_time;
+        avail = p->available.sample(dt);
     } else {
         avail = p->available.sample(0);
     }
@@ -402,12 +402,12 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
 
     bool sent_something = false;
     while (!existing_jobs_only) {
-        vector<APP*> apps;
-        get_apps_needing_work(p, apps);
-        if (apps.empty()) break;
+        vector<APP*> wapps;
+        get_apps_needing_work(p, wapps);
+        if (wapps.empty()) break;
         RESULT* rp = new RESULT;
         WORKUNIT* wup = new WORKUNIT;
-        make_job(p, wup, rp, apps);
+        make_job(p, wup, rp, wapps);
 
         double et = wup->rsc_fpops_est / rp->avp->flops;
         if (server_uses_workload) {
@@ -453,7 +453,7 @@ bool CLIENT_STATE::simulate_rpc(PROJECT* p) {
 
     njobs += (int)new_results.size();
     msg_printf(0, MSG_INFO, "Got %lu tasks", new_results.size());
-    snprintf(buf, sizeof(buf), "got %lu tasks<br>", new_results.size());
+    snprintf(buf, sizeof(buf), "got %zu tasks<br>", new_results.size());
     html_msg += buf;
 
     SCHEDULER_REPLY sr;

--- a/lib/boinc_stdio.h
+++ b/lib/boinc_stdio.h
@@ -76,7 +76,11 @@ namespace boinc {
 #ifdef _USING_FCGI_
         return FCGI_fileno(f);
 #else
+#ifdef _WIN32
+        return ::_fileno(f);
+#else
         return ::fileno(f);
+#endif
 #endif
     }
 

--- a/lib/boinc_win.h
+++ b/lib/boinc_win.h
@@ -27,7 +27,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(disable: 4996)  // deprecated function names
-#pragma warning(disable: 4127)  // constant conditional expression
+//#pragma warning(disable: 4127)  // constant conditional expression
 #pragma warning(disable: 4244)  // conversion from int to char
 #define chdir       _chdir
 #define finite      _finite
@@ -38,10 +38,6 @@
 #define stricmp     _stricmp
 #define strtime     _strtime
 #define unlink      _unlink
-#define snprintf_s  _snprintf_s
-#if _MSC_VER < 1900
-#define snprintf    _snprintf
-#endif
 #endif
 
 #ifdef __MINGW32__

--- a/lib/str_replace.h
+++ b/lib/str_replace.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -54,13 +54,6 @@ inline int strcasecmp(const char* s1, const char* s2) {
     if (*s2) return -1;
     return 0;
 }
-#endif
-
-#ifdef _WIN32
-#define snprintf _snprintf
-    // Yucky!  _snprintf() is not the same as snprintf();
-    // it doesn't null-terminate if buffer is too small.
-    // This is a workaround until we switch to VS2015, which has sprintf()
 #endif
 
 #endif

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -158,8 +158,8 @@ int create_result(
     result.random = lrand48();
 
     result.priority += priority_increase;
-    sprintf(result.name, "%s_%s", wu.name, result_name_suffix);
-    sprintf(base_outfile_name, "%s_r%ld_", result.name, lrand48());
+    snprintf(result.name, sizeof(result.name), "%s_%s", wu.name, result_name_suffix);
+    snprintf(base_outfile_name, sizeof(base_outfile_name), "%s_r%ld_", result.name, lrand48());
     retval = read_filename(
         result_template_filename, result_template, sizeof(result_template)
     );

--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -99,9 +99,9 @@ void usage() {
 
 bool arg(char** argv, int i, const char* name) {
     char buf[256];
-    sprintf(buf, "-%s", name);
+    snprintf(buf, sizeof(buf), "-%s", name);
     if (!strcmp(argv[i], buf)) return true;
-    sprintf(buf, "--%s", name);
+    snprintf(buf, sizeof(buf), "--%s", name);
     if (!strcmp(argv[i], buf)) return true;
     return false;
 }
@@ -368,13 +368,13 @@ int main(int argc, char** argv) {
         usage();
     }
     if (!strlen(jd.wu.name)) {
-        sprintf(jd.wu.name, "%s_%d_%f", app.name, getpid(), dtime());
+        snprintf(jd.wu.name, sizeof(jd.wu.name), "%s_%d_%f", app.name, getpid(), dtime());
     }
     if (!strlen(jd.wu_template_file)) {
-        sprintf(jd.wu_template_file, "templates/%s_in", app.name);
+        snprintf(jd.wu_template_file, sizeof(jd.wu_template_file), "templates/%s_in", app.name);
     }
     if (!strlen(jd.result_template_file)) {
-        sprintf(jd.result_template_file, "templates/%s_out", app.name);
+        snprintf(jd.result_template_file, sizeof(jd.result_template_file), "templates/%s_out", app.name);
     }
 
     retval = config.parse_file(config_dir);
@@ -397,7 +397,7 @@ int main(int argc, char** argv) {
         exit(1);
     }
     boinc_db.set_isolation_level(READ_UNCOMMITTED);
-    sprintf(buf, "where name='%s'", app.name);
+    snprintf(buf, sizeof(buf), "where name='%s'", app.name);
     retval = app.lookup(buf);
     if (retval) {
         fprintf(stderr, "create_work: app not found\n");
@@ -446,7 +446,7 @@ int main(int argc, char** argv) {
                 jd2.parse_cmdline(_argc, _argv);
                     // get info from stdin line
                 if (!strlen(jd2.wu.name)) {
-                    sprintf(jd2.wu.name, "%s_%d", jd.wu.name, j);
+                    snprintf(jd2.wu.name, sizeof(jd2.wu.name), "%s_%d", jd.wu.name, j);
                 }
                 if (strlen(jd2.wu_template_file)) {
                     get_wu_template(jd2);
@@ -470,7 +470,7 @@ int main(int argc, char** argv) {
                 _argc = parse_command_line(buf, _argv);
                 jd2.parse_cmdline(_argc, _argv);
                 if (!strlen(jd2.wu.name)) {
-                    sprintf(jd2.wu.name, "%s_%d", jd.wu.name, j);
+                    snprintf(jd2.wu.name, sizeof(jd2.wu.name), "%s_%d", jd.wu.name, j);
                 }
                 // if the stdin line specified assignment,
                 // create the job individually


### PR DESCRIPTION
Remove outdated stuff (e.g. VS has snprintf() now).

I'd like to have a clean build (no warnings) on both VS and gcc. Currently VS has a bunch of printf code warnings in diagnostics.cpp, diagnostics_win.cpp, and stackwalker_win.cpp. These should be easy to fix.
gcc has a bunch of sprintf buffer-size warnings, not easy to fix. There are lots of warnings in zip (to be fixed with vcpkg?) and in old graphics code.