### PR TITLE
[Wrapper] Add logging of child process PID, plus minor fixes for Windows

### DIFF
--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -836,6 +836,7 @@ int TASK::run(int argct, char** argvt) {
     if (env_vars) delete [] env_vars;
     pid_handle = process_info.hProcess;
     pid = process_info.dwProcessId;
+    CloseHandle(process_info.hThread);
 #else
     int retval;
     char* argv[256];
@@ -956,6 +957,7 @@ bool TASK::poll(int& status) {
                 boinc_msg_prefix(buf, sizeof(buf)),
                 application.c_str(), final_cpu_time
             );
+            CloseHandle(pid_handle);
             return true;
         }
     }

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -921,6 +921,11 @@ int TASK::run(int argct, char** argvt) {
         exit(ERR_EXEC);
     }  // pid = 0 i.e. child proc of the fork
 #endif
+
+    fprintf(stderr, "%s wrapper: created child process %d\n",
+        boinc_msg_prefix(buf, sizeof(buf)), (int)pid
+    );
+
     suspended = false;
     elapsed_time = 0;
     return 0;

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -778,7 +778,8 @@ int TASK::run(int argct, char** argvt) {
         boinc_resolve_filename_s(stdout_filename.c_str(), stdout_path);
         startup_info.hStdOutput = win_fopen(stdout_path.c_str(), "a");
     } else {
-        startup_info.hStdOutput = (HANDLE)_get_osfhandle(_fileno(stdout));
+        // Redirecting child stdout to wrapper stderr here is not a typo
+        startup_info.hStdOutput = (HANDLE)_get_osfhandle(_fileno(stderr));
     }
     if (stdin_filename != "") {
         boinc_resolve_filename_s(stdin_filename.c_str(), stdin_path);

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -778,7 +778,7 @@ int TASK::run(int argct, char** argvt) {
         boinc_resolve_filename_s(stdout_filename.c_str(), stdout_path);
         startup_info.hStdOutput = win_fopen(stdout_path.c_str(), "a");
     } else {
-        startup_info.hStdOutput = (HANDLE)_get_osfhandle(_fileno(stderr));
+        startup_info.hStdOutput = (HANDLE)_get_osfhandle(_fileno(stdout));
     }
     if (stdin_filename != "") {
         boinc_resolve_filename_s(stdin_filename.c_str(), stdin_path);


### PR DESCRIPTION
Logging the child process PID is useful on Windows, where we otherwise have to go rummaging in undocumented internals to find process parent-child relationships