### PR TITLE
Client, Win: include kernel time in non-BOINC CPU usage

### DIFF
--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -124,6 +124,8 @@ void find_children(PROC_MAP& pm) {
 }
 
 // get resource usage of non-BOINC apps
+// NOTE: this is flawed because it doesn't account for short-lived processes.
+// It's not used on Win, Mac, or Linux, which have better ways of getting total CPU usage.
 //
 void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
     procinfo.clear();

--- a/lib/procinfo_win.cpp
+++ b/lib/procinfo_win.cpp
@@ -157,8 +157,12 @@ int procinfo_setup(PROC_MAP& pm) {
 double total_cpu_time() {
     FILETIME i, s, u;
     GetSystemTimes(&i, &s, &u);
-    ULARGE_INTEGER x;
-    x.LowPart = u.dwLowDateTime;
-    x.HighPart = u.dwHighDateTime;
-    return (double)x.QuadPart/1e7;
+    ULARGE_INTEGER ix, sx,ux;
+    ix.LowPart = i.dwLowDateTime;
+    ix.HighPart = i.dwHighDateTime;
+    sx.LowPart = s.dwLowDateTime;
+    sx.HighPart = s.dwHighDateTime;
+    ux.LowPart = u.dwLowDateTime;
+    ux.HighPart = u.dwHighDateTime;
+    return ((double)ux.QuadPart + (double)sx.QuadPart - (double)ix.QuadPart)/1e7;
 }


### PR DESCRIPTION
Fixes #3935