### PR TITLE
client: when using a dynamic AM and checking for idle devices, include CPU

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -1124,11 +1124,10 @@ bool ACCT_MGR_INFO::poll() {
     }
 
     // it's possible that the set of projects given us by the AM
-    // is starting a resources
-    // e.g. they don't currently have jobs, or they're down.
-    //
-    // See if some resource is starved with the current set of projects,
-    // and if so possibly do a "starved" RPC asking for different projects
+    // is starving a resources
+    // e.g. those projects don't currently have jobs, or are down.
+    // In that case contact the AM, asking for other projects.
+    // Do this with exponential backoff to avoid overloading the AM
 
     // do this check once a minute
     //
@@ -1144,6 +1143,10 @@ bool ACCT_MGR_INFO::poll() {
                 "[work_fetch] Using AM and some device idle"
             );
         }
+
+        // "first_starved" is the time when starvation began.
+        // Let 10 min pass before contacting the AM
+        // (e.g. in case a scheduler request fails for some reason)
 
         if (first_starved == 0) {
             first_starved = gstate.now;

--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -1136,11 +1136,10 @@ bool ACCT_MGR_INFO::poll() {
         return false;
     }
     idle_timer = 0;
-    get_nidle();
-    if (any_resource_idle()) {
+    if (n_idle_resources()>0) {
         if (log_flags.work_fetch_debug) {
             msg_printf(NULL, MSG_INFO,
-                "[work_fetch] Using AM and some device idle"
+                "[work_fetch] Using dynamic AM and some device is idle"
             );
         }
 

--- a/client/rr_sim.cpp
+++ b/client/rr_sim.cpp
@@ -698,15 +698,14 @@ void rr_simulation(const char* why) {
     rr_sim.simulate();
 }
 
-// Compute the number of idle instances of each resource
+// Compute the number resources with > 0 idle instance
 // Put results in global state (rsc_work_fetch)
-// This is used from the account manager logic,
+// This is called from the account manager logic,
 // to decide if we need to get new projects from the AM.
-// ?? why not use RR sim result?
 //
-void get_nidle() {
+int n_idle_resources() {
     int nidle_rsc = coprocs.n_rsc;
-    for (int i=1; i<coprocs.n_rsc; i++) {
+    for (int i=0; i<coprocs.n_rsc; i++) {
         rsc_work_fetch[i].nidle_now = coprocs.coprocs[i].count;
     }
     for (unsigned int i=0; i<gstate.results.size(); i++) {
@@ -738,13 +737,5 @@ void get_nidle() {
             break;
         }
     }
-}
-
-bool any_resource_idle() {
-    for (int i=1; i<coprocs.n_rsc; i++) {
-        if (rsc_work_fetch[i].nidle_now > 0) {
-            return true;
-        }
-    }
-    return false;
+    return nidle_rsc;
 }

--- a/client/rr_sim.h
+++ b/client/rr_sim.h
@@ -20,7 +20,6 @@
 
 extern void rr_simulation(const char* why);
 extern void print_deadline_misses();
-extern void get_nidle();
-extern bool any_resource_idle();
+extern int n_idle_resources();
 
 #endif


### PR DESCRIPTION
Fixes a problem where, no hosts with no GPUs  Science United would attach to projects with no jobs, and the client would fail to reconnect to SU to get other projects.