### PR TITLE
[Manager] Sort requests to suspend/resume/abort multiple tasks

### DIFF
--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -1561,7 +1561,7 @@ int CMainDocument::GetWorkCount() {
 }
 
 
-int CMainDocument::WorkSuspend(char* url, char* name) {
+int CMainDocument::WorkSuspend(const char* url, const char* name) {
     int iRetVal = 0;
 
     RESULT* pStateResult = state.lookup_result(url, name);
@@ -1575,7 +1575,7 @@ int CMainDocument::WorkSuspend(char* url, char* name) {
 }
 
 
-int CMainDocument::WorkResume(char* url, char* name) {
+int CMainDocument::WorkResume(const char* url, const char* name) {
     int iRetVal = 0;
 
     RESULT* pStateResult = state.lookup_result(url, name);
@@ -1984,7 +1984,7 @@ int CMainDocument::WorkShowVMConsole(RESULT* res) {
 }
 
 
-int CMainDocument::WorkAbort(char* url, char* name) {
+int CMainDocument::WorkAbort(const char* url, const char* name) {
     int iRetVal = 0;
 
     RESULT* pStateResult = state.lookup_result(url, name);

--- a/clientgui/MainDocument.h
+++ b/clientgui/MainDocument.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -279,11 +279,11 @@ public:
 
     int                         GetWorkCount();
 
-    int                         WorkSuspend(char* url, char* name);
-    int                         WorkResume(char* url, char* name);
+    int                         WorkSuspend(const char* url, const char* name);
+    int                         WorkResume(const char* url, const char* name);
     int                         WorkShowGraphics(RESULT* result);
     int                         WorkShowVMConsole(RESULT* result);
-    int                         WorkAbort(char* url, char* name);
+    int                         WorkAbort(const char* url, const char* name);
     CC_STATE*                   GetState() { return &state; };
 
 

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -529,10 +529,10 @@ void CViewWork::OnWorkSuspend( wxCommandEvent& WXUNUSED(event) ) {
     // the two makes no difference. If somehow we do end up with entries in both,
     // sending the resume requests first gives the client a more up-to-date picture
     // before the suspensions cause it to go looking for tasks that are ready to run.
-    for (RESULT* result : results_to_resume) {
+    for (const RESULT* result : results_to_resume) {
         pDoc->WorkResume(result->project_url, result->name);
     }
-    for (RESULT* result : results_to_suspend) {
+    for (const RESULT* result : results_to_suspend) {
         pDoc->WorkSuspend(result->project_url, result->name);
     }
 
@@ -677,7 +677,7 @@ void CViewWork::OnWorkAbort( wxCommandEvent& WXUNUSED(event) ) {
     // See longer explanation in OnWorkSuspend()
     std::stable_sort(results_to_abort.begin(), results_to_abort.end(), sort_order_not_started);
 
-    for (RESULT* result : results_to_abort) {
+    for (const RESULT* result : results_to_abort) {
         pDoc->WorkAbort(result->project_url, result->name);
     }
 

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -529,13 +529,11 @@ void CViewWork::OnWorkSuspend( wxCommandEvent& WXUNUSED(event) ) {
     // the two makes no difference. If somehow we do end up with entries in both,
     // sending the resume requests first gives the client a more up-to-date picture
     // before the suspensions cause it to go looking for tasks that are ready to run.
-    for (std::vector<RESULT*>::iterator resultIt = results_to_resume.begin();
-         resultIt != results_to_resume.end(); ++resultIt) {
-        pDoc->WorkResume((*resultIt)->project_url, (*resultIt)->name);
+    for (RESULT* result : results_to_resume) {
+        pDoc->WorkResume(result->project_url, result->name);
     }
-    for (std::vector<RESULT*>::iterator resultIt = results_to_suspend.begin();
-         resultIt != results_to_suspend.end(); ++resultIt) {
-        pDoc->WorkSuspend((*resultIt)->project_url, (*resultIt)->name);
+    for (RESULT* result : results_to_suspend) {
+        pDoc->WorkSuspend(result->project_url, result->name);
     }
 
     UpdateSelection();
@@ -679,9 +677,8 @@ void CViewWork::OnWorkAbort( wxCommandEvent& WXUNUSED(event) ) {
     // See longer explanation in OnWorkSuspend()
     std::stable_sort(results_to_abort.begin(), results_to_abort.end(), sort_order_not_started);
 
-    for (std::vector<RESULT*>::iterator resultIt = results_to_abort.begin();
-         resultIt != results_to_abort.end(); ++resultIt) {
-        pDoc->WorkAbort((*resultIt)->project_url, (*resultIt)->name);
+    for (RESULT* result : results_to_abort) {
+        pDoc->WorkAbort(result->project_url, result->name);
     }
 
     UpdateSelection();

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -311,6 +311,13 @@ struct RESULT {
     int parse(XML_PARSER&);
     void print();
     void clear();
+
+    bool is_not_started() const {
+        if (state >= RESULT_COMPUTE_ERROR) return false;
+        if (ready_to_report) return false;
+        if (active_task) return false;
+        return true;
+    }
 };
 
 struct FILE_TRANSFER {


### PR DESCRIPTION
Resolves #1024 by making the Manager smarter when suspending/​resuming/​aborting multiple tasks at once.

When suspending or aborting multiple tasks, the requests are sorted to prevent the situation where as soon as a running task is stopped, a slot becomes free and the client immediately starts the next ready task, not knowing that the user wants to suspend/​abort that one as well.

When resuming multiple tasks, the ordering is reversed to favour resuming tasks that have already started over those that have not.