### PR TITLE
client: don't change user CPID if detach from oldest project

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -767,7 +767,7 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
                     "Attaching to %s", acct.url.c_str()
                 );
                 gstate.add_project(
-                    acct.url.c_str(), acct.authenticator.c_str(), "", true
+                    acct.url.c_str(), acct.authenticator.c_str(), "", "", true
                 );
                 pp = gstate.lookup_project(acct.url.c_str());
                 if (pp) {

--- a/client/acct_setup.cpp
+++ b/client/acct_setup.cpp
@@ -458,7 +458,7 @@ void LOOKUP_LOGIN_TOKEN_OP::handle_reply(int http_op_retval) {
         msg_printf(NULL, MSG_INFO, "Attaching to project %s", pli->name.c_str());
         gstate.add_project(
             pli->master_url.c_str(), authenticator.c_str(),
-            pli->name.c_str(), false
+            pli->name.c_str(), "", false
         );
         PROJECT *p = gstate.lookup_project(pli->master_url.c_str());
         if (p) {

--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -592,7 +592,7 @@ int main(int argc, char** argv) {
         safe_strcpy(url, next_arg(argc, argv, i));
         canonicalize_master_url(url, sizeof(url));
         char* auth = next_arg(argc, argv, i);
-        retval = rpc.project_attach(url, auth, "");
+        retval = rpc.project_attach(url, auth, "", "");
         show_alerts(rpc);
     } else if (!strcmp(cmd, "--file_transfer")) {
         FILE_TRANSFER ft;

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -757,10 +757,14 @@ int CLIENT_STATE::init() {
     process_autologin(true);
     acct_mgr_info.init();
     project_init.init();
+
     // if project_init.xml specifies an account, attach
     //
     if (strlen(project_init.url) && strlen(project_init.account_key)) {
-        add_project(project_init.url, project_init.account_key, project_init.name, false);
+        add_project(
+            project_init.url, project_init.account_key, project_init.name, "",
+            false
+        );
         project_init.remove();
     }
 

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -347,7 +347,8 @@ struct CLIENT_STATE {
 // --------------- cs_account.cpp:
     int add_project(
         const char* master_url, const char* authenticator,
-        const char* project_name, bool attached_via_acct_mgr
+        const char* project_name, const char* email_addr,
+        bool attached_via_acct_mgr
     );
 
     int parse_account_files();

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -15,9 +15,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// Structures representing jobs, files, etc.
+//
 // If you change anything, make sure you also change:
-// client_types.C         (to write and parse it)
-// client_state.C  (to cross-link objects)
+// client_types.cpp (to write and parse it)
+// client_state.cpp (to cross-link objects)
 //
 
 #ifndef BOINC_CLIENT_TYPES_H
@@ -441,6 +443,33 @@ struct RUN_MODE {
 struct PLATFORM {
     std::string name;
 };
+
+// the oldest CPID for a given email hash
+//
+struct USER_CPID {
+    char email_hash[MD5_LEN];
+    char cpid[MD5_LEN];
+    double time;
+    inline void clear() {
+        strcpy(email_hash, "");
+        strcpy(cpid, "");
+        time = 0;
+    }
+    int parse(XML_PARSER&);
+    int write(MIOFILE&);
+};
+
+// a list of the above
+//
+struct USER_CPIDS {
+    std::vector<USER_CPID> cpids;
+    int parse(XML_PARSER&);
+    int write(MIOFILE&);
+    USER_CPID *lookup(const char* email_hash);
+    void init_from_projects();
+};
+
+extern USER_CPIDS user_cpids;
 
 extern int parse_project_files(XML_PARSER&, std::vector<FILE_REF>&);
 

--- a/client/cs_account.cpp
+++ b/client/cs_account.cpp
@@ -33,6 +33,7 @@
 
 #include "error_numbers.h"
 #include "filesys.h"
+#include "md5_file.h"
 #include "parse.h"
 #include "str_replace.h"
 #include "str_util.h"
@@ -502,6 +503,7 @@ int PROJECT::write_statistics_file() {
 
 int CLIENT_STATE::add_project(
     const char* master_url, const char* _auth, const char* project_name,
+    const char* email_addr,
     bool attached_via_acct_mgr
 ) {
     char path[MAXPATHLEN], canonical_master_url[256], auth[256];
@@ -588,6 +590,16 @@ int CLIENT_STATE::add_project(
     projects.push_back(project);
     sort_projects_by_name();
     project->sched_rpc_pending = RPC_REASON_INIT;
+
+    // compute email addr hash
+    //
+    if (strlen(email_addr)) {
+        md5_block(
+            (unsigned char*)email_addr,
+            strlen(email_addr),
+            project->email_hash
+        );
+    }
     set_client_state_dirty("Add project");
     return 0;
 }

--- a/client/cs_cmdline.cpp
+++ b/client/cs_cmdline.cpp
@@ -381,7 +381,7 @@ void CLIENT_STATE::do_cmdline_actions() {
 
     if (strlen(attach_project_url)) {
         canonicalize_master_url(attach_project_url, sizeof(attach_project_url));
-        add_project(attach_project_url, attach_project_auth, "", false);
+        add_project(attach_project_url, attach_project_auth, "", "", false);
     }
 }
 

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -511,6 +511,10 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
         if (xp.parse_string("client_version_check_url", client_version_check_url)) {
             continue;
         }
+        if (xp.match_tag("user_cpids")) {
+            user_cpids.parse(xp);
+            continue;
+        }
 #ifdef ENABLE_AUTO_UPDATE
         if (xp.match_tag("auto_update")) {
             if (!project) {
@@ -554,6 +558,13 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
             }
         }
     }
+
+    // this should happen once, on client update
+    //
+    if (user_cpids.cpids.empty()) {
+        user_cpids.init_from_projects();
+    }
+
     return 0;
 }
 
@@ -813,6 +824,7 @@ int CLIENT_STATE::write_state(MIOFILE& f) {
     if (strlen(main_host_venue)) {
         f.printf("<host_venue>%s</host_venue>\n", main_host_venue);
     }
+    user_cpids.write(f);
     f.printf("</client_state>\n");
     return 0;
 }

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -869,7 +869,7 @@ void handle_create_account_poll(GUI_RPC_CONN& grc) {
 }
 
 static void handle_project_attach(GUI_RPC_CONN& grc) {
-    string url, authenticator, project_name;
+    string url, authenticator, project_name, email_addr;
     bool use_config_file = false;
     bool already_attached = false;
     unsigned int i;
@@ -880,6 +880,7 @@ static void handle_project_attach(GUI_RPC_CONN& grc) {
         if (grc.xp.parse_string("project_url", url)) continue;
         if (grc.xp.parse_string("authenticator", authenticator)) continue;
         if (grc.xp.parse_string("project_name", project_name)) continue;
+        if (grc.xp.parse_string("email_addr", email_addr)) continue;
     }
 
     // Get URL/auth from project_init.xml?
@@ -930,7 +931,7 @@ static void handle_project_attach(GUI_RPC_CONN& grc) {
     //
     gstate.project_attach.messages.clear();
     gstate.project_attach.error_num = gstate.add_project(
-        url.c_str(), authenticator.c_str(), project_name.c_str(), false
+        url.c_str(), authenticator.c_str(), project_name.c_str(), email_addr.c_str(), false
     );
 
     // if project_init.xml refers to this project,

--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -380,7 +380,8 @@ int RPCThread::ProcessRPCRequest() {
         retval = (m_pDoc->rpcClient).project_attach(
             (const char*)(current_request->arg1), 
             (const char*)(current_request->arg2), 
-            (const char*)(current_request->arg3)
+            (const char*)(current_request->arg3),
+            (const char*)(current_request->arg4)
         );
         break;
     case RPC_PROJECT_ATTACH_FROM_FILE:

--- a/clientgui/AsyncRPC.h
+++ b/clientgui/AsyncRPC.h
@@ -304,8 +304,12 @@ public:
     int create_account_poll(ACCOUNT_OUT& arg1)
             { return RPC_Wait(RPC_CREATE_ACCOUNT_POLL, (void*)&arg1); }
     int project_attach(
-        const char* url, const char* auth, const char* project_name 
-    )       { return RPC_Wait(RPC_PROJECT_ATTACH, (void*)url, (void*)auth, (void*)project_name); }
+        const char* url, const char* auth, const char* project_name, const char* email_addr
+    ) {
+        return RPC_Wait(
+            RPC_PROJECT_ATTACH, (void*)url, (void*)auth, (void*)project_name, (void*)email_addr
+        );
+    }
     int project_attach_from_file()
             { return RPC_Wait(RPC_PROJECT_ATTACH_FROM_FILE); }
     int project_attach_poll(PROJECT_ATTACH_REPLY& arg1)

--- a/clientgui/ProjectProcessingPage.cpp
+++ b/clientgui/ProjectProcessingPage.cpp
@@ -559,7 +559,8 @@ void CProjectProcessingPage::OnStateChange( CProjectProcessingPageEvent& WXUNUSE
                             pDoc->rpc.project_attach(
                                 master_url.c_str(),
                                 ao->authenticator.c_str(),
-                                pWA->project_config.name.c_str()
+                                pWA->project_config.name.c_str(),
+                                ai->email_addr.c_str()
                             );
                         }
                     }

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -738,7 +738,8 @@ struct RPC_CLIENT {
     int create_account(ACCOUNT_IN&);
     int create_account_poll(ACCOUNT_OUT&);
     int project_attach(
-        const char* url, const char* auth, const char* project_name
+        const char* url, const char* auth, const char* project_name,
+        const char* email_addr  // optional - pass empty string if unknown
     );
     int project_attach_from_file();
     int project_attach_poll(PROJECT_ATTACH_REPLY&);

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1825,7 +1825,7 @@ int RPC_CLIENT::project_attach_from_file() {
 }
 
 int RPC_CLIENT::project_attach(
-    const char* url, const char* auth, const char* name
+    const char* url, const char* auth, const char* name, const char* email_addr
 ) {
     int retval;
     SET_LOCALE sl;
@@ -1837,8 +1837,9 @@ int RPC_CLIENT::project_attach(
         "  <project_url>%s</project_url>\n"
         "  <authenticator>%s</authenticator>\n"
         "  <project_name>%s</project_name>\n"
+        "  <email_addr>%s</email_addr>\n"
         "</project_attach>\n",
-        url, auth, name
+        url, auth, name, email_addr
     );
     buf[sizeof(buf)-1] = 0;
 


### PR DESCRIPTION
 - Maintain a map from email hash to the oldest user CPID and its time.
        This doesn't change if that project is detached.

 - Write/parse write this in client_state.xml

- Update it when handling a scheduler reply

- Use it when sending a scheduler request

 - If, on startup, the map is empty, populate it from PROJECT data.
        This should happen only once, when update to this version

Fixes #5177