### PR TITLE
Mac: upgrade tp wxWidgets 3.1.6

### DIFF
--- a/clientgui/BOINCTaskBar.cpp
+++ b/clientgui/BOINCTaskBar.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -410,13 +410,22 @@ wxMenu *CTaskBarIcon::CreatePopupMenu() {
 // 16x16 icon for the menubar, while the Dock needs a 128x128 icon.
 // Rather than using an entire separate icon, overlay the Dock icon with a badge
 // so we don't need additional Snooze and Disconnected icons for branding.
-bool CTaskBarIcon::SetIcon(const wxIcon& icon, const wxString& ) {
+#if wxCHECK_VERSION(3,1,6)
+bool CTaskBarIcon::SetIcon(const wxBitmapBundle& newIcon, const wxString& )
+#else
+bool CTaskBarIcon::SetIcon(const wxIcon& icon, const wxString& )
+#endif
+{
     wxImage macIcon;
 #if wxDEBUG_LEVEL
     int err = noErr;
 #endif
     int w, h, x, y;
 
+#if wxCHECK_VERSION(3,1,6)
+    wxIcon icon = newIcon.GetIcon(wxDefaultSize);
+#endif
+    
     if (m_iconType != wxTBI_DOCK) {
         if (wxGetApp().GetBOINCMGRHideMenuBarIcon()) {
             RemoveIcon();
@@ -481,7 +490,7 @@ bool CTaskBarIcon::SetIcon(const wxIcon& icon, const wxString& ) {
     return true;
 }
 
-#endif  // ! __WXMAC__
+#endif  // __WXMAC__
 
 
 void CTaskBarIcon::DisplayContextMenu() {

--- a/clientgui/BOINCTaskBar.h
+++ b/clientgui/BOINCTaskBar.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -81,7 +81,11 @@ private:
 
 public:
     wxMenu *CreatePopupMenu();
+#if wxCHECK_VERSION(3,1,6)
+    bool SetIcon(const wxBitmapBundle& icon, const wxString& message = wxEmptyString);
+#else
     bool SetIcon(const wxIcon& icon, const wxString& message = wxEmptyString);
+#endif
 
 #define BALLOONTYPE_INFO 0
     bool IsBalloonsSupported();
@@ -92,7 +96,7 @@ public:
         const wxString message = wxEmptyString,
         unsigned int iconballoon = BALLOONTYPE_INFO
     );
-#endif
+#endif  // __WXMAC__
 
     wxIcon          m_iconTaskBarNormal;
     wxIcon          m_iconTaskBarDisconnected;

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -66,7 +66,8 @@
 # Updated 10/24/11 for OS 10.7.2 Lion
 # Updated 3/3/12 to create users and groups with IDs > 500 
 # and to create RealName key with empty string as value (for users)
-# Updated 11/8/22 revised setprojectgrp wonership & permissions for MacOS 13
+# Updated 11/8/22 revised setprojectgrp ownership & permissions for MacOS 13
+# Updated 4/6/23 revised setprojectgrp ownership to match PR #5061
 #
 # WARNING: do not use this script with versions of BOINC older 
 # than 7.20.4
@@ -258,7 +259,7 @@ set_perm switcher/AppStats root boinc_master 4550
 fi
 
 set_perm switcher/switcher root boinc_master 04050
-set_perm switcher/setprojectgrp root boinc_project 04050
+set_perm switcher/setprojectgrp root boinc_master 04050
 set_perm switcher boinc_master boinc_master 0550
 
 if [ -d locale ] ; then

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -3980,13 +3980,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ../clientgui/mac/MacGUI.pch;
 				HEADER_SEARCH_PATHS = (
-					"../../wxWidgets-3.1.5/include",
-					"../../wxWidgets-3.1.5/build/osx/setup/cocoa/include",
+					"../../wxWidgets-3.1.6/include",
+					"../../wxWidgets-3.1.6/build/osx/setup/cocoa/include",
 					../clientgui,
 					"../lib/**",
 				);
 				INFOPLIST_FILE = Info.plist;
-				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.1.5/build/osx/build/Debug";
+				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.1.6/build/osx/build/Debug";
 				OTHER_CFLAGS = (
 					"-DHAVE_CONFIG_H",
 					"-D_FILE_OFFSET_BITS=64",
@@ -4058,13 +4058,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ../clientgui/mac/MacGUI.pch;
 				HEADER_SEARCH_PATHS = (
-					"../../wxWidgets-3.1.5/include",
-					"../../wxWidgets-3.1.5/build/osx/setup/cocoa/include",
+					"../../wxWidgets-3.1.6/include",
+					"../../wxWidgets-3.1.6/build/osx/setup/cocoa/include",
 					../clientgui,
 					"../lib/**",
 				);
 				INFOPLIST_FILE = Info.plist;
-				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.1.5/build/osx/build/Release";
+				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.1.6/build/osx/build/Release";
 				OTHER_CFLAGS = (
 					"-DHAVE_CONFIG_H",
 					"-D_FILE_OFFSET_BITS=64",

--- a/mac_build/buildWxMac.sh
+++ b/mac_build/buildWxMac.sh
@@ -18,7 +18,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 #
 #
-# Script to build the wxMac-3.1.0 wxCocoa library for BOINC
+# Script to build the wxMac-3.1.6 wxCocoa library for BOINC
 #
 # by Charlie Fenton    7/21/06
 # Updated for wx-Mac 2.8.10 and Unicode 4/17/09
@@ -44,11 +44,12 @@
 # Updated 9/30/21 for wxCocoa 3.1.5
 # Updated 10/18/21 to add -Werror=unguarded-availability compiler flag
 # Updated 2/6/23 changed MACOSX_DEPLOYMENT_TARGET to 10.13
+# Updated 4/6/23 for wxCocoa 3.1.6 and for args now accepted by patch utility
 #
 ## This script requires OS 10.6 or later
 ##
-## In Terminal, CD to the wxWidgets-3.1.0 directory.
-##    cd [path]/wxWidgets-3.1.0/
+## In Terminal, CD to the wxWidgets-3.1.6 directory.
+##    cd [path]/wxWidgets-3.1.6/
 ## then run this script:
 ##    source [ path_to_this_script ] [ -clean ] [ -nodebug ] [--prefix PATH]
 ##
@@ -82,11 +83,11 @@ echo ""
 ##
 ## We patch 4 files to accomplish this.
 ##
-# Patch wxWidgets-3.1.5/include/wx/osx/choice.h
+# Patch wxWidgets-3.1.6/include/wx/osx/choice.h
 if [ ! -f include/wx/osx/choice.h.orig ]; then
     cat >> /tmp/choice_h_diff << ENDOFFILE
---- include/wx/osx/choice.h    2021-04-12 15:23:58.000000000 -0700
-+++ include/wx/osx/choice_patched.h    2021-09-29 23:47:19.000000000 -0700
+--- include/wx/osx/choice.h
++++ include/wx/osx/choice_patched.h
 @@ -73,6 +73,7 @@
      virtual int FindString(const wxString& s, bool bCase = false) const wxOVERRIDE;
      virtual wxString GetString(unsigned int n) const wxOVERRIDE;
@@ -96,7 +97,7 @@ if [ ! -f include/wx/osx/choice.h.orig ]; then
 
      virtual bool OSXHandleClicked(double timestampsec) wxOVERRIDE;
 ENDOFFILE
-    patch -bfi /tmp/choice_h_diff include/wx/osx/choice.h
+    patch -b -f -i /tmp/choice_h_diff include/wx/osx/choice.h
     rm -f /tmp/choice_h_diff
 else
     echo "include/wx/osx/choice.h already patched"
@@ -104,12 +105,12 @@ fi
 
 echo ""
 
-# Patch wxWidgets-3.1.5/src/osx/choice_osx.cpp
+# Patch wxWidgets-3.1.6/src/osx/choice_osx.cpp
 if [ ! -f src/osx/choice_osx.cpp.orig ]; then
     cat >> /tmp/choice_osx_cpp_diff << ENDOFFILE
 --- src/osx/choice_osx.cpp    2021-04-12 15:23:58.000000000 -0700
 +++ src/osx/choice_osx_patched.cpp    2021-09-30 00:26:06.000000000 -0700
-@@ -212,6 +212,13 @@
+@@ -217,6 +217,13 @@
      return m_strings[n] ;
  }
 
@@ -124,7 +125,7 @@ if [ ! -f src/osx/choice_osx.cpp.orig ]; then
  // client data
  // ----------------------------------------------------------------------------
 ENDOFFILE
-    patch -bfi /tmp/choice_osx_cpp_diff src/osx/choice_osx.cpp
+    patch -b -f -i /tmp/choice_osx_cpp_diff src/osx/choice_osx.cpp
     rm -f /tmp/choice_osx_cpp_diff
 else
     echo "src/osx/choice_osx.cpp already patched"
@@ -132,12 +133,12 @@ fi
 
 echo ""
 
-# Patch wxWidgets-3.1.5/include/wx/osx/core/private.h
+# Patch wxWidgets-3.1.6/include/wx/osx/core/private.h
 if [ ! -f include/wx/osx/core/private.h.orig ]; then
     cat >> /tmp/private_h_cpp_diff << ENDOFFILE
 --- include/wx/osx/core/private.h    2021-04-12 15:23:58.000000000 -0700
 +++ include/wx/osx/core/private_patched.h    2021-09-30 01:11:28.000000000 -0700
-@@ -809,6 +809,8 @@
+@@ -821,6 +821,8 @@
      }
 
      virtual void SetItem(int pos, const wxString& item) = 0;
@@ -147,7 +148,7 @@ if [ ! -f include/wx/osx/core/private.h.orig ]; then
 
 
 ENDOFFILE
-    patch -bfi /tmp/private_h_cpp_diff include/wx/osx/core/private.h
+    patch -b -f -i /tmp/private_h_cpp_diff include/wx/osx/core/private.h
     rm -f /tmp/private_h_cpp_diff
 else
     echo "include/wx/osx/core/private.h already patched"
@@ -155,26 +156,29 @@ fi
 
 echo ""
 
-# Patch wxWidgets-3.1.5/src/osx/cocoa/choice.mm
+# Patch wxWidgets-3.1.6/src/osx/cocoa/choice.mm
 if [ ! -f src/osx/cocoa/choice.mm.orig ]; then
     cat >> /tmp/choice_mm_diff << ENDOFFILE
 --- src/osx/cocoa/choice.mm    2021-09-28 22:52:32.000000000 -0700
 +++ src/osx/cocoa/choice_patched.mm    2021-09-30 01:08:32.000000000 -0700
-@@ -130,6 +130,12 @@
+@@ -130,6 +130,15 @@
          m_popUpMenu->FindItemByPosition( pos )->SetItemLabel( s ) ;
      }
 
-+    void SetItemBitmap(unsigned int n, const wxBitmap& bitmap)
++    void SetItemBitmap(unsigned int n, const wxBitmap& bitmap) wxOVERRIDE
 +    {
-+        if ( bitmap.Ok() )
-+            m_popUpMenu->FindItemByPosition( n )->SetBitmap( bitmap ); ;
++        if ( bitmap.Ok() ) {
++            wxMenuItem *item = m_popUpMenu->FindItemByPosition( n );
++            item->SetBitmap( bitmap );
++            item->UpdateItemBitmap();
++        }
 +    }
 +
  private:
      wxMenu* m_popUpMenu;
  };
 ENDOFFILE
-    patch -bfi /tmp/choice_mm_diff src/osx/cocoa/choice.mm
+    patch -b -f -i /tmp/choice_mm_diff src/osx/cocoa/choice.mm
     rm -f /tmp/choice_mm_diff
 else
     echo "src/osx/cocoa/choice.mm already patched"
@@ -273,7 +277,7 @@ else
     ## systems supported by BOINC.
 
     set -o pipefail
-     xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Release $doclean build ARCHS="\$(ARCHS_STANDARD)" ONLY_ACTIVE_ARCH="NO" MACOSX_DEPLOYMENT_TARGET="10.13" GCC_C_LANGUAE_STANDARD="compiler-default" CLANG_CXX_LANGUAGE_SANDARD="c++0x" CLANG_CXX_LIBRARY="libc++" OTHER_CFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DPNG_ARM_NEON_OPT=0 -DNDEBUG -fvisibility=hidden -include unistd.h" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DPNG_ARM_NEON_OPT=0 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER NO_CXX11_REGEX WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=$?
+     xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Release $doclean build ARCHS="\$(ARCHS_STANDARD)" ONLY_ACTIVE_ARCH="NO" MACOSX_DEPLOYMENT_TARGET="10.13" GCC_C_LANGUAE_STANDARD="compiler-default" CLANG_CXX_LANGUAGE_STANDARD="compiler-default" CLANG_CXX_LIBRARY="libc++" OTHER_CFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DPNG_ARM_NEON_OPT=0 -DNDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DwxDEBUG_LEVEL=0 -DPNG_ARM_NEON_OPT=0 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="\$(GCC_PREPROCESSOR_DEFINITIONS) wxUSE_UNICODE_UTF8=1  wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=$?
     if [ ${retval} -ne 0 ]; then return 1; fi
     if [ "x${lprefix}" != "x" ]; then
         # copy library and headers to $lprefix
@@ -329,7 +333,7 @@ else
     ## $(ARCHS_STANDARD) builds Universal Binary (x86_64 & arm64) library under
     ## Xcode versions that can, otherwise it builds only the X86_64 library.
     set -o pipefail
-   xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Debug build ARCHS="\$(ARCHS_STANDARD)" ONLY_ACTIVE_ARCH="NO" MACOSX_DEPLOYMENT_TARGET="10.13" GCC_C_LANGUAE_STANDARD="compiler-default" CLANG_CXX_LANGUAGE_SANDARD="c++0x" CLANG_CXX_LIBRARY="libc++" OTHER_CFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DPNG_ARM_NEON_OPT=0 -DDEBUG -fvisibility=hidden -include unistd.h" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DPNG_ARM_NEON_OPT=0 -DDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="WXBUILDING __WXOSX_COCOA__ __WX__ wxUSE_BASE=1 _FILE_OFFSET_BITS=64 _LARGE_FILES MACOS_CLASSIC __WXMAC_XCODE__=1 SCI_LEXER NO_CXX11_REGEX WX_PRECOMP=1 wxUSE_UNICODE_UTF8=1 wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=$?
+   xcodebuild -project build/osx/wxcocoa.xcodeproj -target static -configuration Debug build ARCHS="\$(ARCHS_STANDARD)" ONLY_ACTIVE_ARCH="NO" MACOSX_DEPLOYMENT_TARGET="10.13" GCC_C_LANGUAE_STANDARD="compiler-default" CLANG_CXX_LANGUAGE_STANDARD="compiler-default" CLANG_CXX_LIBRARY="libc++" OTHER_CFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1  -DPNG_ARM_NEON_OPT=0 -DDEBUG -fvisibility=hidden" OTHER_CPLUSPLUSFLAGS="-Wall -Wundef -Werror=unguarded-availability -fno-strict-aliasing -fno-common -DHAVE_LOCALTIME_R=1 -DHAVE_GMTIME_R=1 -DwxUSE_UNICODE=1 -DPNG_ARM_NEON_OPT=0 -DDEBUG -fvisibility=hidden -fvisibility-inlines-hidden" GCC_PREPROCESSOR_DEFINITIONS="\$(GCC_PREPROCESSOR_DEFINITIONS) wxUSE_UNICODE_UTF8=1  wxUSE_UNICODE_WCHAR=0 __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES=1" | $beautifier; retval=$?
     if [ ${retval} -ne 0 ]; then return 1; fi
     if [ "x${lprefix}" != "x" ]; then
         # copy debug library to $PREFIX

--- a/mac_build/buildc-ares.sh
+++ b/mac_build/buildc-ares.sh
@@ -35,6 +35,7 @@
 # Updated 5/18/21 for compatibility with zsh
 # Updated 10/18/21 for building c-ares 1.17.2
 # Updated 2/6/23 changed MAC_OS_X_VERSION_MAX_ALLOWED to 101300 and MAC_OS_X_VERSION_MIN_REQUIRED to 101300 and MACOSX_DEPLOYMENT_TARGET to 10.13
+# Updated 4/5/23 to set mmacosx-version-min, arm64-apple-macos10.10 to 10.13 
 
 #
 ## This script requires OS 10.8 or later
@@ -53,32 +54,6 @@
 ## if --prefix is given as absolute path the library is installed into there
 ## use -q or --quiet to redirect build output to /dev/null instead of /dev/stdout
 ##
-
-function patch_ares_config() {
-    # Patch src/lib/ares_config.h to not use clock_gettime(), which is
-    # defined in OS 10.12 SDK but was not available before OS 10.12.
-    # If building with an older SDK, this patch will fail because
-    # config has already set our desired value.
-    rm -f src/lib/ares_config.h.orig
-    rm -f /tmp/ares_config_h_diff
-    cat >> /tmp/ares_config_h_diff << ENDOFFILE
---- src/lib/ares_config_orig.h    2018-01-25 04:15:37.000000000 -0800
-+++ src/lib/ares_config.h    2018-02-22 01:30:57.000000000 -0800
-@@ -74,7 +74,7 @@
- #define HAVE_BOOL_T 1
-
- /* Define to 1 if you have the clock_gettime function and monotonic timer. */
--#define HAVE_CLOCK_GETTIME_MONOTONIC 1
-+/* #undef HAVE_CLOCK_GETTIME_MONOTONIC */
-
- /* Define to 1 if you have the closesocket function. */
- /* #undef HAVE_CLOSESOCKET */
-ENDOFFILE
-
-    patch -bfi /tmp/ares_config_h_diff src/lib/ares_config.h
-    rm -f /tmp/ares_config_h_diff
-    rm -f src/lib/ares_config.h.rej
-}
 
 doclean=""
 stdout_target="/dev/stdout"
@@ -173,15 +148,13 @@ fi
 ## there is an unguarded API not available in our Deployment Target. This
 ## helps ensure c-ares won't try to use unavailable APIs on older Mac
 ## systems supported by BOINC.
-## It also causes configure to reject any such APIs for which it tests;
-## this actually makes the call to the patch_ares_config function
-## redundant, but it does no harm to leave it in.
+## It also causes configure to reject any such APIs for which it tests.
 #
 export CC="${GCCPATH}";export CXX="${GPPPATH}"
 export CPPFLAGS=""
 export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64"
-export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -arch x86_64 -mmacosx-version-min=10.10 -stdlib=libc++"
-export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -mmacosx-version-min=10.10 -arch x86_64"
+export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -arch x86_64 -mmacosx-version-min=10.13 -stdlib=libc++"
+export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -mmacosx-version-min=10.13 -arch x86_64"
 export SDKROOT="${SDKPATH}"
 export MACOSX_DEPLOYMENT_TARGET=10.13
 export MAC_OS_X_VERSION_MAX_ALLOWED=101300
@@ -190,7 +163,6 @@ export MAC_OS_X_VERSION_MIN_REQUIRED=101300
 ./configure --prefix=${lprefix} --enable-shared=NO --host=x86_64
 if [ $? -ne 0 ]; then return 1; fi
 
-patch_ares_config
 
 if [ "${doclean}" = "yes" ]; then
     make clean
@@ -208,8 +180,8 @@ if [ $GCC_can_build_arm64 = "yes" ]; then
     export CC="${GCCPATH}";export CXX="${GPPPATH}"
     export CPPFLAGS=""
     export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,arm64"
-    export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -target arm64-apple-macos10.10 -mmacosx-version-min=10.10 -stdlib=libc++"
-    export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -mmacosx-version-min=10.10 -target arm64-apple-macos10.10"
+    export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -target arm64-apple-macos10.13 -mmacosx-version-min=10.13 -stdlib=libc++"
+    export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -mmacosx-version-min=10.13 -target arm64-apple-macos10.13"
     export SDKROOT="${SDKPATH}"
     export MACOSX_DEPLOYMENT_TARGET=10.13
     export MAC_OS_X_VERSION_MAX_ALLOWED=101300
@@ -221,8 +193,6 @@ if [ $GCC_can_build_arm64 = "yes" ]; then
         echo "c-ares: x86_64 build succeeded but could not build for arm64."
         echo "              ******"
     else
-
-        patch_ares_config
 
         # save x86_64 header and lib for later use
         # c-ares configure creates a different ares_build.h file for each architecture

--- a/mac_build/buildcurl.sh
+++ b/mac_build/buildcurl.sh
@@ -43,6 +43,7 @@
 #   instead of ca-bundle.crt)
 # Updated 11/16/21 for curl 7.79.1
 # Updated 2/6/23 changed MAC_OS_X_VERSION_MAX_ALLOWED to 101300 and MAC_OS_X_VERSION_MIN_REQUIRED to 101300 and MACOSX_DEPLOYMENT_TARGET to 10.13
+# Updated 4/5/23 for args now accepted by patch utility; set mmacosx-version-min=10.13
 #
 ## Curl's configure and make set the "-Werror=partial-availability" compiler flag,
 ## which generates an error if there is an API not available in our Deployment
@@ -88,27 +89,8 @@ function patch_curl_config {
  /* Define to 1 if you have the clock_gettime function and monotonic timer. */
 ENDOFFILE
 
-    patch -fi /tmp/curl_config_h_diff1 lib/curl_config.h
+    patch -b -f -i /tmp/curl_config_h_diff1 lib/curl_config.h
     rm -f /tmp/curl_config_h_diff1
-    rm -f lib/curl_config.h.rej
-
-    # Patch curl_config.h to not use clock_gettime(), which is
-    # defined in OS 10.12 SDK but was not available before OS 10.12.
-    rm -f /tmp/curl_config_h_diff2
-    cat >> /tmp/curl_config_h_diff2 << ENDOFFILE
---- lib/curl_config.h    2018-02-22 04:21:52.000000000 -0800
-+++ lib/curl_config2.h.in    2018-02-22 04:30:21.000000000 -0800
-@@ -171,5 +171,5 @@
-
- /* Define to 1 if you have the clock_gettime function and monotonic timer. */
--#define HAVE_CLOCK_GETTIME_MONOTONIC 1
-+/* #undef HAVE_CLOCK_GETTIME_MONOTONIC */
-
- /* Define to 1 if you have the closesocket function. */
-ENDOFFILE
-
-    patch -fi /tmp/curl_config_h_diff2 lib/curl_config.h
-    rm -f /tmp/curl_config_h_diff2
     rm -f lib/curl_config.h.rej
 }
 
@@ -221,9 +203,9 @@ export MAC_OS_X_VERSION_MAX_ALLOWED=101300
 export MAC_OS_X_VERSION_MIN_REQUIRED=101300
 
 export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64"
-export CPPFLAGS="-isysroot ${SDKPATH} -arch x86_64 -mmacosx-version-min=10.10 -stdlib=libc++"
-export CXXFLAGS="-isysroot ${SDKPATH} -arch x86_64 -mmacosx-version-min=10.10 -stdlib=libc++"
-export CFLAGS="-isysroot ${SDKPATH} -mmacosx-version-min=10.10 -arch x86_64"
+export CPPFLAGS="-isysroot ${SDKPATH} -arch x86_64 -mmacosx-version-min=10.13 -stdlib=libc++"
+export CXXFLAGS="-isysroot ${SDKPATH} -arch x86_64 -mmacosx-version-min=10.13 -stdlib=libc++"
+export CFLAGS="-isysroot ${SDKPATH} -mmacosx-version-min=10.13 -arch x86_64"
 
 if [ "x${lprefix}" != "x" ]; then
     PKG_CONFIG_PATH="${lprefix}/lib/pkgconfig" ./configure --prefix=${lprefix} --enable-ares --disable-shared --with-secure-transport --without-libidn --without-libidn2 --without-nghttp2 --without-ngtcp2 --without-nghttp3 --without-quiche --host=x86_64-apple-darwin
@@ -273,9 +255,9 @@ fi
 if [ $GCC_can_build_arm64 = "yes" ]; then
 
 export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,arm64"
-export CPPFLAGS="-isysroot ${SDKPATH} -target arm64-apple-macos -mmacosx-version-min=10.10 -stdlib=libc++"
-export CXXFLAGS="-isysroot ${SDKPATH} -target arm64-apple-macos -mmacosx-version-min=10.10 -stdlib=libc++"
-export CFLAGS="-isysroot ${SDKPATH} -mmacosx-version-min=10.10 -target arm64-apple-macos"
+export CPPFLAGS="-isysroot ${SDKPATH} -target arm64-apple-macos -mmacosx-version-min=10.13 -stdlib=libc++"
+export CXXFLAGS="-isysroot ${SDKPATH} -target arm64-apple-macos -mmacosx-version-min=10.13 -stdlib=libc++"
+export CFLAGS="-isysroot ${SDKPATH} -mmacosx-version-min=10.13 -target arm64-apple-macos"
 
 # c-ares configure creates a different ares_build.h file for each architecture
 # for a sanity check on size of long and socklen_t. But these are  identical for

--- a/mac_build/buildopenssl.sh
+++ b/mac_build/buildopenssl.sh
@@ -39,6 +39,7 @@
 # Updated 5/18/21 for compatibility with zsh
 # Updated 10/18/21 for building OpenSSL 3.0.0
 # Updated 2/6/23 changed MAC_OS_X_VERSION_MAX_ALLOWED to 101300 and MAC_OS_X_VERSION_MIN_REQUIRED to 101300 and MACOSX_DEPLOYMENT_TARGET to 10.13
+# Updated 4/5/23 for args now accepted by patch utility; set mmacosx-version-min=10.13
 #
 ## Building OpenSSL 3.0 requires Xcode 10.2 or later
 #
@@ -192,7 +193,7 @@ if [[ $major -lt 10  || ($major -eq 10 && $minor -lt 2 ) ]]; then
  *STDOUT=*OUT;
 ENDOFFILE
 
-    patch -bfi /tmp/rsaz-avx512_pl_diff crypto/bn/asm/rsaz-avx512.pl
+    patch -b -f -i /tmp/rsaz-avx512_pl_diff crypto/bn/asm/rsaz-avx512.pl
     rm -f /tmp/rsaz-avx512_pl_diff
     rm -f crypto/bn/asm/rsaz-avx512.pl.rej
 else
@@ -208,8 +209,8 @@ echo ""
 export CC="${GCCPATH}";export CXX="${GPPPATH}"
 export CPPFLAGS=""
 export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,x86_64"
-export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -arch x86_64 -mmacosx-version-min=10.10 -stdlib=libc++ -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
-export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -arch x86_64 -mmacosx-version-min=10.10 -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
+export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -arch x86_64 -mmacosx-version-min=10.13 -stdlib=libc++ -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
+export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -arch x86_64 -mmacosx-version-min=10.13 -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
 export SDKROOT="${SDKPATH}"
 export MACOSX_DEPLOYMENT_TARGET=10.13
 export LIBRARY_PATH="${SDKPATH}/usr/lib"
@@ -235,9 +236,9 @@ if [ $GCC_can_build_arm64 = "yes" ]; then
 
     export CC="${GCCPATH}";export CXX="${GPPPATH}"
     export LDFLAGS="-Wl,-syslibroot,${SDKPATH},-arch,arm64"
-    export CPPFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -target arm64-apple-macos -mmacosx-version-min=10.10 -stdlib=libc++ -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
-    export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -target arm64-apple-macos -mmacosx-version-min=10.10 -stdlib=libc++ -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
-    export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -mmacosx-version-min=10.10 -target arm64-apple-macos -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
+    export CPPFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -target arm64-apple-macos -mmacosx-version-min=10.13 -stdlib=libc++ -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
+    export CXXFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -target arm64-apple-macos -mmacosx-version-min=10.13 -stdlib=libc++ -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
+    export CFLAGS="-isysroot ${SDKPATH} -Werror=unguarded-availability -mmacosx-version-min=10.13 -target arm64-apple-macos -DMAC_OS_X_VERSION_MAX_ALLOWED=101300 -DMAC_OS_X_VERSION_MIN_REQUIRED=101300"
     export SDKROOT="${SDKPATH}"
     export MACOSX_DEPLOYMENT_TARGET=10.13
     export LIBRARY_PATH="${SDKPATH}/usr/lib"

--- a/mac_build/dependencyNames.sh
+++ b/mac_build/dependencyNames.sh
@@ -49,9 +49,9 @@ curlDirName="curl-7.79.1"
 curlFileName="curl-7.79.1.tar.gz"
 curlURL="https://curl.se/download/curl-7.79.1.tar.gz"
 
-wxWidgetsDirName="wxWidgets-3.1.5"
-wxWidgetsFileName="wxWidgets-3.1.5.tar.bz2"
-wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2"
+wxWidgetsDirName="wxWidgets-3.1.6"
+wxWidgetsFileName="wxWidgets-3.1.6.tar.bz2"
+wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxWidgets-3.1.6.tar.bz2"
 
 freetypeDirName="freetype-2.11.0"
 freetypeFileName="freetype-2.11.0.tar.gz"

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -516,12 +516,14 @@ static OSStatus DeleteOurBundlesFromDirectory(CFStringRef bundleID, char *extens
     DIR                     *dirp;
     dirent                  *dp;
     CFStringRef             urlStringRef = NULL;
-    int                     index;
     CFStringRef             thisID = NULL;
     CFBundleRef             thisBundle = NULL;
     CFURLRef                bundleURLRef = NULL;
     char                    myRmCommand[MAXPATHLEN+10], *p;
     int                     pathOffset;
+#if TESTING
+    int                     index = -1;
+#endif
 
     dirp = opendir(dirPath);
     if (dirp == NULL) {      // Should never happen
@@ -529,10 +531,10 @@ static OSStatus DeleteOurBundlesFromDirectory(CFStringRef bundleID, char *extens
         return -1;
     }
     
-    index = -1;
     while (true) {
+#if TESTING
         index++;
-        
+#endif        
         dp = readdir(dirp);
         if (dp == NULL)
             break;                  // End of list


### PR DESCRIPTION
PR #5176 requires wxWidgets 3.1.6. This PR:
 * Updates the Mac Xcode project, source files and build scripts for wxWidgets 3.1.6 and Xcode 14.3.
 * Fixes dependency build scripts for changes in the way the patch utility expects its arguments.
 * Changes missed OS 10.10 references in build scripts to OS 10.13 for consistency and completeness.
 * Fixes a compiler warning.
