### PR TITLE
[Client] Correct limit check in throttler thread

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -1254,7 +1254,8 @@ void* throttler(void*) {
     while (1) {
         client_mutex.lock();
         double limit = gstate.current_cpu_usage_limit();
-        if (gstate.tasks_suspended || limit > 99.99) {
+        const double CPU_USAGE_UNLIMITED = 99.99;
+        if (gstate.tasks_suspended || limit >= CPU_USAGE_UNLIMITED) {
             client_mutex.unlock();
 //            ::Sleep((int)(1000*10));  // for Win debugging
             boinc_sleep(10);

--- a/client/app.cpp
+++ b/client/app.cpp
@@ -1254,7 +1254,7 @@ void* throttler(void*) {
     while (1) {
         client_mutex.lock();
         double limit = gstate.current_cpu_usage_limit();
-        if (gstate.tasks_suspended || limit == 0) {
+        if (gstate.tasks_suspended || limit > 99.99) {
             client_mutex.unlock();
 //            ::Sleep((int)(1000*10));  // for Win debugging
             boinc_sleep(10);


### PR DESCRIPTION
Fixes #5072 more

Without this, if the CPU limit is 100%, the throttler thread suspends all tasks, resumes them all 1 s later, then goes to sleep forever (meaning subsequent changes to the limit are never applied)

(Commit 3b1ebfd1b0c3aefd45446d1ec6dacb6d7be4d4c5 changed the ‘nothing to do’ check to `limit == 0` at the same time as implementing `CLIENT_STATE::current_cpu_usage_limit()` which makes that condition impossible)