### PR TITLE
[Windows] Favor `_beginthreadex()` over `CreateThread()`

### DIFF
--- a/api/graphics_impl.cpp
+++ b/api/graphics_impl.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -64,9 +64,9 @@ pthread_t graphics_thread;
 #endif
 
 #ifdef _WIN32
-DWORD WINAPI foobar(LPVOID) {
+static unsigned int WINAPI thread_proc(void*) {
 #else
-void* foobar(void*) {
+static void* thread_proc(void*) {
 #endif
     g_bmsp->start_timer_thread_hook();
     worker_main();
@@ -97,12 +97,12 @@ static int start_worker_thread(
         NULL      // object not named
     );
 
-    DWORD threadId;
+    unsigned int threadId;
 
     // Create and start worker thread
     //
-    worker_thread_handle = CreateThread(
-        NULL, 0, foobar, 0, CREATE_SUSPENDED, &threadId
+    worker_thread_handle = (HANDLE)_beginthreadex(
+        NULL, 0, thread_proc, 0, CREATE_SUSPENDED, &threadId
     );
     ResumeThread(worker_thread_handle);
 
@@ -146,7 +146,7 @@ static int start_worker_thread(
         );
     }
 
-    retval = pthread_create(&worker_thread, &worker_thread_attr, foobar, 0);
+    retval = pthread_create(&worker_thread, &worker_thread_attr, thread_proc, 0);
     if (retval) return ERR_THREAD;
     pthread_attr_destroy( &worker_thread_attr );
 

--- a/client/app.cpp
+++ b/client/app.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -1242,7 +1242,7 @@ void ACTIVE_TASK::set_task_state(int val, const char* where) {
 
 #ifndef SIM
 #ifdef _WIN32
-DWORD WINAPI throttler(LPVOID) {
+unsigned int WINAPI throttler(void*) {
 #else
 void* throttler(void*) {
 #endif

--- a/client/app.h
+++ b/client/app.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2020 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -346,7 +346,7 @@ extern double non_boinc_cpu_usage;
 extern void run_test_app();
 
 #ifdef _WIN32
-extern DWORD WINAPI throttler(void*);
+extern unsigned int WINAPI throttler(void*);
 #else
 extern void* throttler(void*);
 #endif

--- a/client/sysmon_win.cpp
+++ b/client/sysmon_win.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -224,7 +224,7 @@ static LRESULT CALLBACK WindowsMonitorSystemPowerWndProc(
 }
 
 // Create a thread to monitor system events
-static DWORD WINAPI WindowsMonitorSystemPowerThread( LPVOID  ) {
+static unsigned int WINAPI WindowsMonitorSystemPowerThread(void*) {
     WNDCLASS wc;
     MSG msg;
 
@@ -384,7 +384,7 @@ static void windows_detect_autoproxy_settings() {
     }
 }
 
-static DWORD WINAPI WindowsMonitorSystemProxyThread( LPVOID  ) {
+static unsigned int WINAPI WindowsMonitorSystemProxyThread(void*) {
 
     // Initialize diagnostics framework for this thread
     //
@@ -424,7 +424,7 @@ int initialize_system_monitor(int /*argc*/, char** /*argv*/) {
 
     // Create a thread to receive system power events.
     //
-    g_hWindowsMonitorSystemPowerThread = CreateThread(
+    g_hWindowsMonitorSystemPowerThread = (HANDLE)_beginthreadex(
         NULL,
         0,
         WindowsMonitorSystemPowerThread,
@@ -440,7 +440,7 @@ int initialize_system_monitor(int /*argc*/, char** /*argv*/) {
     // Create a thread to handle proxy auto-detection.
     //
     if (!cc_config.proxy_info.no_autodetect) {
-        g_hWindowsMonitorSystemProxyThread = CreateThread(
+        g_hWindowsMonitorSystemProxyThread = (HANDLE)_beginthreadex(
             NULL,
             0,
             WindowsMonitorSystemProxyThread,

--- a/client/thread.cpp
+++ b/client/thread.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2011 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -19,11 +19,18 @@
 #include <boinc_win.h>
 #endif
 
+#include "error_numbers.h"
+
 #include "thread.h"
 
 #ifdef _WIN32
-int THREAD::run(LPTHREAD_START_ROUTINE func, void* _arg) {
-    CreateThread(NULL, 0, func, this, 0, NULL);
+int THREAD::run(_beginthreadex_proc_type func, void* _arg) {
+    HANDLE hThread = (HANDLE)_beginthreadex(
+        NULL, 0, func, this, 0, NULL);
+    if (!hThread) {
+        return ERR_THREAD;
+    }
+    CloseHandle(hThread);
 #else
 int THREAD::run(void*(*func)(void*), void* _arg) {
     pthread_t id;

--- a/client/thread.h
+++ b/client/thread.h
@@ -19,6 +19,7 @@
 #define BOINC_THREAD_H
 
 #ifdef _WIN32
+#include <process.h>
 #else
 #include <pthread.h>
 #endif
@@ -27,7 +28,7 @@ struct THREAD {
     void* arg;
     bool quit_flag;
 #ifdef _WIN32
-    int run(LPTHREAD_START_ROUTINE, void*);
+    int run(_beginthreadex_proc_type, void*);
 #else
     int run(void*(*func)(void*), void*);
 #endif

--- a/clientscr/screensaver_win.cpp
+++ b/clientscr/screensaver_win.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -819,17 +819,17 @@ BOOL CScreensaver::GetTextForError(
 // Create the thread that is used to monitor input activity.
 //
 BOOL CScreensaver::CreateInputActivityThread() {
-    DWORD dwThreadID = 0;
+    unsigned int tid = 0;
 
     BOINCTRACE(_T("CScreensaver::CreateInputActivityThread Start\n"));
 
-    m_hInputActivityThread = CreateThread(
+    m_hInputActivityThread = (HANDLE)_beginthreadex(
         NULL,                        // default security attributes 
         0,                           // use default stack size  
         InputActivityProcStub,       // thread function 
         NULL,                        // argument to thread function 
         0,                           // use default creation flags 
-        &dwThreadID );               // returns the thread identifier 
+        &tid );                      // returns the thread identifier
  
    if (m_hInputActivityThread == NULL) {
     	BOINCTRACE(_T("CScreensaver::CreateInputActivityThread: Failed to create input activity thread '%d'\n"), GetLastError());
@@ -852,6 +852,8 @@ BOOL CScreensaver::DestroyInputActivityThread() {
     	BOINCTRACE(_T("CScreensaver::DestroyInputActivityThread: Failed to terminate input activity thread '%d'\n"), GetLastError());
         return FALSE;
     }
+    CloseHandle(m_hInputActivityThread);
+    m_hInputActivityThread = NULL;
 
     return TRUE;
 }
@@ -862,7 +864,7 @@ BOOL CScreensaver::DestroyInputActivityThread() {
 // This function forwards to InputActivityProc, which has access to the
 //   "this" pointer.
 //
-DWORD WINAPI CScreensaver::InputActivityProcStub(LPVOID UNUSED(lpParam)) {
+unsigned int WINAPI CScreensaver::InputActivityProcStub(void* UNUSED(lpParam)) {
     return gspScreensaver->InputActivityProc();
 }
 
@@ -924,15 +926,15 @@ DWORD WINAPI CScreensaver::InputActivityProc() {
 // Create the thread that is used to promote the graphics window.
 //
 BOOL CScreensaver::CreateGraphicsWindowPromotionThread() {
-    DWORD dwThreadID = 0;
+    unsigned int tid = 0;
     BOINCTRACE(_T("CScreensaver::CreateGraphicsWindowPromotionThread Start\n"));
-    m_hGraphicsWindowPromotionThread = CreateThread(
+    m_hGraphicsWindowPromotionThread = (HANDLE)_beginthreadex(
         NULL,                        // default security attributes 
         0,                           // use default stack size  
         GraphicsWindowPromotionProcStub,       // thread function 
         NULL,                        // argument to thread function 
         0,                           // use default creation flags 
-        &dwThreadID );               // returns the thread identifier 
+        &tid );                      // returns the thread identifier
  
    if (m_hGraphicsWindowPromotionThread == NULL) {
     	BOINCTRACE(_T("CScreensaver::CreateGraphicsWindowPromotionThread: Failed to create graphics window promotion thread '%d'\n"), GetLastError());
@@ -953,6 +955,8 @@ BOOL CScreensaver::DestroyGraphicsWindowPromotionThread() {
     	BOINCTRACE(_T("CScreensaver::DestroyGraphicsWindowPromotionThread: Failed to terminate graphics window promotion thread '%d'\n"), GetLastError());
         return FALSE;
     }
+    CloseHandle(m_hGraphicsWindowPromotionThread);
+    m_hGraphicsWindowPromotionThread = NULL;
 
     return TRUE;
 }
@@ -963,7 +967,7 @@ BOOL CScreensaver::DestroyGraphicsWindowPromotionThread() {
 // This function forwards to GraphicsWindowPromotionProc, which has access to the
 //   "this" pointer.
 //
-DWORD WINAPI CScreensaver::GraphicsWindowPromotionProcStub(LPVOID UNUSED(lpParam)) {
+unsigned int WINAPI CScreensaver::GraphicsWindowPromotionProcStub(void* UNUSED(lpParam)) {
     return gspScreensaver->GraphicsWindowPromotionProc();
 }
 
@@ -1044,17 +1048,17 @@ DWORD WINAPI CScreensaver::GraphicsWindowPromotionProc() {
 // Create the thread that is used to talk to the daemon.
 //
 BOOL CScreensaver::CreateDataManagementThread() {
-    DWORD dwThreadID = 0;
+    unsigned int tid = 0;
 
     BOINCTRACE(_T("CScreensaver::CreateDataManagementThread Start\n"));
 
-    m_hDataManagementThread = CreateThread(
+    m_hDataManagementThread = (HANDLE)_beginthreadex(
         NULL,                        // default security attributes 
         0,                           // use default stack size  
         DataManagementProcStub,      // thread function 
         NULL,                        // argument to thread function 
         0,                           // use default creation flags 
-        &dwThreadID );               // returns the thread identifier 
+        &tid );                      // returns the thread identifier
  
    if (m_hDataManagementThread == NULL) {
     	BOINCTRACE(_T("CScreensaver::CreateDataManagementThread: Failed to create data management thread '%d'\n"), GetLastError());
@@ -1086,6 +1090,8 @@ BOOL CScreensaver::DestroyDataManagementThread() {
     	BOINCTRACE(_T("CScreensaver::DestoryDataManagementThread: Failed to terminate thread '%d'\n"), GetLastError());
         return FALSE;
     }
+    CloseHandle(m_hDataManagementThread);
+    m_hDataManagementThread = NULL;
 
     return TRUE;
 }
@@ -1096,7 +1102,7 @@ BOOL CScreensaver::DestroyDataManagementThread() {
 // This function forwards to DataManagementProc, which has access to the
 //       "this" pointer.
 //
-DWORD WINAPI CScreensaver::DataManagementProcStub(LPVOID UNUSED(lpParam)) {
+unsigned int WINAPI CScreensaver::DataManagementProcStub(void* UNUSED(lpParam)) {
     return gspScreensaver->DataManagementProc();
 }
 

--- a/clientscr/screensaver_win.h
+++ b/clientscr/screensaver_win.h
@@ -139,7 +139,7 @@ protected:
     BOOL            DestroyInputActivityThread();
 
     DWORD WINAPI    InputActivityProc();
-    static DWORD WINAPI InputActivityProcStub( LPVOID lpParam );
+    static unsigned int WINAPI InputActivityProcStub(void*);
 
     HANDLE          m_hInputActivityThread;
 
@@ -152,7 +152,7 @@ protected:
     BOOL            DestroyGraphicsWindowPromotionThread();
 
     DWORD WINAPI    GraphicsWindowPromotionProc();
-    static DWORD WINAPI GraphicsWindowPromotionProcStub( LPVOID lpParam );
+    static unsigned int WINAPI GraphicsWindowPromotionProcStub(void*);
 
     HANDLE          m_hGraphicsWindowPromotionThread;
 
@@ -165,7 +165,7 @@ protected:
     BOOL            DestroyDataManagementThread();
 
     DWORD WINAPI    DataManagementProc();
-    static DWORD WINAPI DataManagementProcStub( LPVOID lpParam );
+    static unsigned int WINAPI DataManagementProcStub(void*);
 
     int             terminate_v6_screensaver(HANDLE graphics_application);
     int             terminate_screensaver(HANDLE graphics_application);

--- a/clienttray/tray_win.cpp
+++ b/clienttray/tray_win.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -110,14 +110,14 @@ INT CBOINCTray::Run( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR /* lpCm
 // Create the thread that is used to talk to the daemon.
 //
 BOOL CBOINCTray::CreateDataManagementThread() {
-    DWORD dwThreadID = 0;
-    m_hDataManagementThread = CreateThread(
+    unsigned int tid = 0;
+    m_hDataManagementThread = (HANDLE)_beginthreadex(
         NULL,                        // default security attributes 
         0,                           // use default stack size  
         DataManagementProcStub,      // thread function 
         NULL,                        // argument to thread function 
         0,                           // use default creation flags 
-        &dwThreadID );               // returns the thread identifier 
+        &tid );                      // returns the thread identifier
  
    if (m_hDataManagementThread == NULL) {
         return FALSE;
@@ -134,6 +134,8 @@ BOOL CBOINCTray::DestroyDataManagementThread() {
     if (!TerminateThread(m_hDataManagementThread, 0)) {
         return FALSE;
     }
+    CloseHandle(m_hDataManagementThread);
+    m_hDataManagementThread = NULL;
     return TRUE;
 }
 
@@ -163,7 +165,7 @@ DWORD WINAPI CBOINCTray::DataManagementProc() {
 // This function forwards to DataManagementProc, which has access to the
 //       "this" pointer.
 //
-DWORD WINAPI CBOINCTray::DataManagementProcStub(LPVOID) {
+unsigned int WINAPI CBOINCTray::DataManagementProcStub(void*) {
     return gspBOINCTray->DataManagementProc();
 }
 

--- a/clienttray/tray_win.h
+++ b/clienttray/tray_win.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -36,7 +36,7 @@ protected:
     BOOL                    DestroyDataManagementThread();
 
     DWORD WINAPI            DataManagementProc();
-    static DWORD WINAPI     DataManagementProcStub( LPVOID lpParam );
+    static unsigned int WINAPI     DataManagementProcStub( void* );
 	LRESULT                 TrayProc( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
     static LRESULT CALLBACK TrayProcStub( HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam );
 

--- a/samples/gfx_html/webserver.cpp
+++ b/samples/gfx_html/webserver.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2014-2015 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -114,7 +114,7 @@ static int webserver_handler() {
 }
 
 #ifdef _WIN32
-DWORD WINAPI webserver_thread(void*) {
+static unsigned int WINAPI webserver_thread(void*) {
     while (webserver_handler()) {}
     return 0;
 }
@@ -127,9 +127,12 @@ static void* webserver_thread(void*) {
 
 int start_webserver_thread() {
 #ifdef _WIN32
-    if (!CreateThread(NULL, 0, webserver_thread, 0, 0, NULL)) {
+    unsigned int tid;
+    HANDLE hThread = (HANDLE)_beginthreadex(NULL, 0, webserver_thread, 0, 0, &tid);
+    if (!hThread) {
         return GetLastError();
     }
+    CloseHandle(hThread);
 #else
     int retval = pthread_create(NULL, NULL, webserver_thread, NULL);
     if (retval) {

--- a/samples/wrappture/wrappture.cpp
+++ b/samples/wrappture/wrappture.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2010 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -424,7 +424,7 @@ void send_status_message(
 // looking for progress tags
 //
 #ifdef _WIN32
-DWORD WINAPI parse_app_stdout(void*) {
+static unsigned int WINAPI parse_app_stdout(void*) {
 #else
 static void block_sigalrm() {
     sigset_t mask;
@@ -459,10 +459,12 @@ static void* parse_app_stdout(void*) {
 
 int create_parser_thread() {
 #ifdef _WIN32
-    DWORD parser_thread_id;
-    if (!CreateThread(NULL, 0, parse_app_stdout, 0, 0, &parser_thread_id)) {
+    unsigned int parser_thread_id;
+    HANDLE hThread = (HANDLE)_beginthreadex(NULL, 0, parse_app_stdout, 0, 0, &parser_thread_id);
+    if (!hThread) {
         return ERR_THREAD;
     }
+    CloseHandle(hThread);
 #else
     pthread_t parser_thread_handle;
     pthread_attr_t thread_attrs;


### PR DESCRIPTION
Also fixes the handle leaks from discarding the return value