### PR TITLE
Work around uselocale() apparently broken in MacOS 13.3.1

### DIFF
--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -788,7 +788,9 @@ struct RPC {
 };
 
 
-#if defined(HAVE__CONFIGTHREADLOCALE) || defined(HAVE_USELOCALE)
+// MacOS 13.3.1 apparently broke per-thread locale uselocale() so we must
+// use our SET_LOCALE struct on MacOS even though HAVE_USELOCALE is defined.
+#if (defined(HAVE__CONFIGTHREADLOCALE) || defined(HAVE_USELOCALE)) && !defined(__APPLE__)
 // no-op, the calling thread is already set to use C locale
 struct SET_LOCALE {
     SET_LOCALE() {}


### PR DESCRIPTION
MacOS 13.3.1 apparently broke per-thread locale uselocale() so we must use our SET_LOCALE struct on MacOS even though HAVE_USELOCALE is defined.

When BOINC Manager is run with a locale which uses comma instead of period as the decimal delimiter, this bug in MacOS causes strtod() to stop on the period decimal point. XML_PARSER::parse_double() then returns false because strtod() reports that it has processed fewer characters than expected. This results in all values obtained by parse_double() being set to zero.

Fixes #5205
