### PR TITLE
Add CFBundleShortVersionString to macOS app plist files

### DIFF
--- a/clientgui/mac/templates/BoincCmd-Info.plist
+++ b/clientgui/mac/templates/BoincCmd-Info.plist
@@ -11,6 +11,8 @@
 	<key>CFBundleName</key>
 	<string> boinccmd </string>
 	<key>CFBundleVersion</key>
-	<string>5.10.7</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 </dict>
 </plist>

--- a/clientgui/mac/templates/Info.plist
+++ b/clientgui/mac/templates/Info.plist
@@ -17,7 +17,9 @@
 	<key>CFBundleSignature</key>
 	<string>BNC!</string>
 	<key>CFBundleVersion</key>
-	<string>7.15.0</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>

--- a/clientgui/mac/templates/Installer-Info.plist
+++ b/clientgui/mac/templates/Installer-Info.plist
@@ -19,6 +19,8 @@
 	<key>CFBundleName</key>
 	<string>BOINC Installer</string>
 	<key>CFBundleVersion</key>
-	<string>5.10.7</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 </dict>
 </plist>

--- a/clientgui/mac/templates/PostInstall-Info.plist
+++ b/clientgui/mac/templates/PostInstall-Info.plist
@@ -15,6 +15,8 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5.10.7</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 </dict>
 </plist>

--- a/clientgui/mac/templates/ScreenSaver-Info.plist
+++ b/clientgui/mac/templates/ScreenSaver-Info.plist
@@ -17,7 +17,9 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5.10.7</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 	<key>NSPrincipalClass</key>
 	<string>BOINC_Saver_ModuleView</string>
 </dict>

--- a/clientgui/mac/templates/SystemMenu-Info.plist
+++ b/clientgui/mac/templates/SystemMenu-Info.plist
@@ -15,6 +15,8 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5.10.7</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 </dict>
 </plist>

--- a/clientgui/mac/templates/Uninstaller-Info.plist
+++ b/clientgui/mac/templates/Uninstaller-Info.plist
@@ -19,6 +19,8 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>5.10.7</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 </dict>
 </plist>

--- a/clientgui/mac/templates/WaitPermissions-Info.plist
+++ b/clientgui/mac/templates/WaitPermissions-Info.plist
@@ -15,6 +15,8 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>6.11.0</string>
+	<string>%VERSION%</string>
+	<key>CFBundleShortVersionString</key>
+	<string>%VERSION%</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #3794 

**Description of the Change**
Adds the CFBundleShortVersionString property list key which is a [recommended key](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/AboutInformationPropertyListFiles.html#//apple_ref/doc/uid/TP40009254-SW1) to include with macOS apps. This is what is used to display the version in Spotlight, which is why the BOINC Manager is currently listed as having an "Unknown version" when searching for it.

Previously, SetVersion sort of tried to parse the plist files in clientgui/mac/templates, find the CFBundleVersion, and then replace the contents of the following <string> tags. This doesn't work well for replacing multiple property values however. So I instead simply search for and replace any instance of %VERSION%, which is an approach I've seen used in other projects for populating the app plist file.

**Alternate Designs**
I considered keeping the approach more similar to the original code, but it would have been more complicated, would have enforced an unnecessary ordering on some elements (the CFBundleVersion would have to come before the CFBundleShortVersionString, or vice versa), and worst of all from what I can tell the old code would have broke if the tag name happened to be split between buffers. The approach I took does have the disadvantage of loading the entire template file in memory (twice), but considering how small these files are, it actually works out to about the same size as the buffer currently being used and should not be a concern.

** Side Note **
I was only able to test this fix on macOS 10.13. I can't say for 100% certain that Spotlight behaves the same on newer versions of macOS, but as long as the version is being correctly inserted into the plist files (which it is for me at least), it should at the very least not make anything worse.

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->
Fix "Unknown version" listed when searching for BOINC apps on macOS's Spotlight