### PR TITLE
Safer work around uselocale() apparently broken in MacOS 13.3.1

### DIFF
--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -788,9 +788,7 @@ struct RPC {
 };
 
 
-// MacOS 13.3.1 apparently broke per-thread locale uselocale() so we must
-// use our SET_LOCALE struct on MacOS even though HAVE_USELOCALE is defined.
-#if (defined(HAVE__CONFIGTHREADLOCALE) || defined(HAVE_USELOCALE)) && !defined(__APPLE__)
+#if defined(HAVE__CONFIGTHREADLOCALE) || defined(HAVE_USELOCALE)
 // no-op, the calling thread is already set to use C locale
 struct SET_LOCALE {
     SET_LOCALE() {}

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -39,6 +39,10 @@
 #endif
 #endif
 
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
+
 #include "boinc_stdio.h"
 
 #include "error_numbers.h"
@@ -743,7 +747,12 @@ bool XML_PARSER::parse_double(const char* start_tag, double& x) {
         }
     }
     errno = 0;
+#ifdef __APPLE__
+// MacOS 13.3.1 apparently broke per-thread locale uselocale()
+    double val = strtod_l(buf, &end, LC_C_LOCALE);
+#else
     double val = strtod(buf, &end);
+#endif
     if (errno) return false;
     if (end != buf+strlen(buf)) return false;
 

--- a/lib/parse.h
+++ b/lib/parse.h
@@ -22,6 +22,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
 
 #include "miofile.h"
 #include "error_numbers.h"
@@ -309,7 +312,12 @@ inline bool parse_double(const char* buf, const char* tag, double& x) {
     const char* p = strstr(buf, tag);
     if (!p) return false;
     errno = 0;
+#ifdef __APPLE__
+// MacOS 13.3.1 apparently broke per-thread locale uselocale()
+    y = strtod_l(p+strlen(tag), NULL, LC_C_LOCALE);
+#else
     y = strtod(p+strlen(tag), NULL);
+#endif
     if (errno) return false;
     if (!boinc_is_finite(y)) {
         return false;


### PR DESCRIPTION
This is a safer version of #5207. I became concerned about the possibility that using setlocale() in BOINC Manager's separate RPC thread (used for asynchronous RPCs) might sometimes cause the main thread to temporarily have the "C" locale instead of the locale for the selected language. I have reverted my change in #5207.

MacOS 13.3.1 apparently broke per-thread locale `uselocale()`. 

When BOINC Manager is run with a locale which uses comma instead of period as the decimal delimiter, this bug in MacOS causes `strtod()` to stop on the period decimal point. `XML_PARSER::parse_double()` then returns false because `strtod()` reports that it has processed fewer characters than expected. This results in all values obtained by `XML_PARSER::parse_double()` being set to zero. This fix uses `strtod_l()` instead of `strtod()` in `XML_PARSER::parse_double()` to extract double values from strings returned by RPCs using the "C" locale without affecting anything else. 

Fixes #5205
Fixes #5207 