### PR TITLE
Add more error messages for directory locking

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -343,7 +343,13 @@ static int initialize() {
     if (!cc_config.allow_multiple_clients) {
         retval = wait_client_mutex(".", 10);
         if (retval) {
-            log_message_error("Another instance of BOINC is running.");
+            if (retval == ERR_ALREADY_RUNNING) {
+                log_message_error("Another instance of BOINC is running.");
+            } else if (retval == ERR_OPEN) {
+                log_message_error("Failed to open lockfile. Check file/directory permissions.");
+            } else {
+                log_message_error("Failed to lock directory.", retval);
+            }
             return ERR_EXEC;
         }
     }


### PR DESCRIPTION
Fixes #2156

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->
Adds a couple new error messages to the lockfile check. This change ensures that there is no confusion caused by the application incorrectly reporting the presence of another instance.

**Alternate Designs**
No alternate solutions were considered. The current solution is sufficiently small and simple.

**Release Notes**
Fix misleading "Another instance of BOINC is running" messages