### PR TITLE
Manager (Unix): fix "Show VM" bug

### DIFF
--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -1945,7 +1945,19 @@ int CMainDocument::WorkShowVMConsole(RESULT* res) {
         wxExecute(strCommand);
 #elif defined(__WXGTK__)
         strCommand = wxT("rdesktop-vrdp ") + strConnection;
-        wxExecute(strCommand);
+        int pid = wxExecute(strCommand);
+        // newer versions of VirtualBox don't include rdesktop-vrdp;
+        // try a standard version instead
+        //
+        if (pid == 0) {
+            strCommand = wxT("rdesktop ") + strConnection;
+            pid = wxExecute(strCommand);
+        }
+        if (pid == 0) {
+            strCommand = wxT("xfreerdp ") + strConnection;
+            pid = wxExecute(strCommand);
+        }
+        // show an error if all the above fail?
 #elif defined(__WXMAC__)
         OSStatus status = noErr;
         char pathToCoRD[MAXPATHLEN];


### PR DESCRIPTION
The manager runs "rdesktop-vrdp" to connect to a running VM. This program used to be included with VBox but no longer is. If it's not there, try "rdesktop" instead, then "xfreerdp". See https://www.helpwire.app/blog/rdesktop-linux/

Fixes #5214