### PR TITLE
Mac: upgrade to wxWidgets 3.2.2.1

### DIFF
--- a/clientgui/BOINCTaskBar.h
+++ b/clientgui/BOINCTaskBar.h
@@ -22,6 +22,9 @@
 #pragma interface "BOINCTaskBar.cpp"
 #endif
 
+#ifdef __APPLE__
+#define NSInteger int
+#endif
 
 #if   defined(__WXMSW__)
 #include "msw/taskbarex.h"

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -4406,13 +4406,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ../clientgui/mac/MacGUI.pch;
 				HEADER_SEARCH_PATHS = (
-					"../../wxWidgets-3.1.6/include",
-					"../../wxWidgets-3.1.6/build/osx/setup/cocoa/include",
+					"../../wxWidgets-3.2.2.1/include",
+					"../../wxWidgets-3.2.2.1/build/osx/setup/cocoa/include",
 					../clientgui,
 					"../lib/**",
 				);
 				INFOPLIST_FILE = Info.plist;
-				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.1.6/build/osx/build/Debug";
+				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.2.2.1/build/osx/build/Debug";
 				OTHER_CFLAGS = (
 					"-DHAVE_CONFIG_H",
 					"-D_FILE_OFFSET_BITS=64",
@@ -4484,13 +4484,13 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = ../clientgui/mac/MacGUI.pch;
 				HEADER_SEARCH_PATHS = (
-					"../../wxWidgets-3.1.6/include",
-					"../../wxWidgets-3.1.6/build/osx/setup/cocoa/include",
+					"../../wxWidgets-3.2.2.1/include",
+					"../../wxWidgets-3.2.2.1/build/osx/setup/cocoa/include",
 					../clientgui,
 					"../lib/**",
 				);
 				INFOPLIST_FILE = Info.plist;
-				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.1.6/build/osx/build/Release";
+				LIBRARY_SEARCH_PATHS = "../../wxWidgets-3.2.2.1/build/osx/build/Release";
 				OTHER_CFLAGS = (
 					"-DHAVE_CONFIG_H",
 					"-D_FILE_OFFSET_BITS=64",

--- a/mac_build/buildWxMac.sh
+++ b/mac_build/buildWxMac.sh
@@ -45,6 +45,7 @@
 # Updated 10/18/21 to add -Werror=unguarded-availability compiler flag
 # Updated 2/6/23 changed MACOSX_DEPLOYMENT_TARGET to 10.13
 # Updated 4/6/23 for wxCocoa 3.1.6 and for args now accepted by patch utility
+# Updated 5/6/23/23 for wxCocoa 3.2.2.1
 #
 ## This script requires OS 10.6 or later
 ##
@@ -161,7 +162,7 @@ if [ ! -f src/osx/cocoa/choice.mm.orig ]; then
     cat >> /tmp/choice_mm_diff << ENDOFFILE
 --- src/osx/cocoa/choice.mm    2021-09-28 22:52:32.000000000 -0700
 +++ src/osx/cocoa/choice_patched.mm    2021-09-30 01:08:32.000000000 -0700
-@@ -130,6 +130,15 @@
+@@ -93,6 +93,15 @@
          m_popUpMenu->FindItemByPosition( pos )->SetItemLabel( s ) ;
      }
 

--- a/mac_build/dependencyNames.sh
+++ b/mac_build/dependencyNames.sh
@@ -52,10 +52,10 @@ curlBaseName="curl"
 curlFileName="curl-7.79.1.tar.gz"
 curlURL="https://curl.se/download/curl-7.79.1.tar.gz"
 
-wxWidgetsDirName="wxWidgets-3.1.6"
+wxWidgetsDirName="wxWidgets-3.2.2.1"
 wxWidgetsBaseName="wxWidgets"
-wxWidgetsFileName="wxWidgets-3.1.6.tar.bz2"
-wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.6/wxWidgets-3.1.6.tar.bz2"
+wxWidgetsFileName="wxWidgets-3.2.2.1.tar.bz2"
+wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2.1/wxWidgets-3.2.2.1.tar.bz2"
 
 freetypeDirName="freetype-2.11.0"
 freetypeBaseName="freetype"


### PR DESCRIPTION
Upgrade BOINC Manager for Macintosh to use wxWidgets 3.2.2.1