### PR TITLE
[libboinc] fix build when integrator tries to link app with libboinc

### DIFF
--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -63,6 +63,7 @@
 
 #include "error_numbers.h"
 #include "filesys.h"
+#include "str_replace.h"
 #include "str_util.h"
 #include "util.h"
 

--- a/lib/str_util.h
+++ b/lib/str_util.h
@@ -22,8 +22,6 @@
 #include <vector>
 #include <string.h>
 
-#include "str_replace.h"
-
 #define safe_strcpy(x, y) strlcpy(x, y, sizeof(x))
 #define safe_strcat(x, y) strlcat(x, y, sizeof(x))
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -17,6 +17,7 @@
 
 #if defined(_WIN32)
 #include "boinc_win.h"
+#include "str_replace.h"
 #include "str_util.h"
 #include "win_util.h"
 #endif

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -23,6 +23,7 @@
 #include "util.h"
 #include "filesys.h"
 #include "win_util.h"
+#include "str_replace.h"
 #include "str_util.h"
 
 /**


### PR DESCRIPTION
Header files that are exposed should not contain any 'config.h' file reference.
By this PR next issue is fixed:

```
In file included from /home/runner/work/boinc-apps/boinc-apps/build/boinc-autodock-vina/x64-linux-static/vcpkg_installed/x64-linux-static/include/boinc/str_util.h:25,
                 from /home/runner/work/boinc-apps/boinc-apps/build/boinc-autodock-vina/x64-linux-static/vcpkg_installed/x64-linux-static/include/boinc/parse.h:31,
                 from /home/runner/work/boinc-apps/boinc-apps/build/boinc-autodock-vina/x64-linux-static/vcpkg_installed/x64-linux-static/include/boinc/coproc.h:83,
                 from /home/runner/work/boinc-apps/boinc-apps/build/boinc-autodock-vina/x64-linux-static/vcpkg_installed/x64-linux-static/include/boinc/hostinfo.h:32,
                 from /home/runner/work/boinc-apps/boinc-apps/build/boinc-autodock-vina/x64-linux-static/vcpkg_installed/x64-linux-static/include/boinc/app_ipc.h:28,
                 from /home/runner/work/boinc-apps/boinc-apps/build/boinc-autodock-vina/x64-linux-static/vcpkg_installed/x64-linux-static/include/boinc/boinc_api.h:26,
                 from /home/runner/work/boinc-apps/boinc-apps/boinc-autodock-vina/src/boinc-autodock-vina/boinc-autodock-vina.cpp:24:
/home/runner/work/boinc-apps/boinc-apps/build/boinc-autodock-vina/x64-linux-static/vcpkg_installed/x64-linux-static/include/boinc/str_replace.h:28:10: fatal error: config.h: No such file or directory
   28 | #include "config.h"
      |          ^~~~~~~~~~
compilation terminated.
```