### PR TITLE
Mac: add script to notarize BOINC executables

### DIFF
--- a/mac_installer/AddRemoveUser_ReadMe.rtf
+++ b/mac_installer/AddRemoveUser_ReadMe.rtf
@@ -1,0 +1,42 @@
+{\rtf1\ansi\ansicpg1252\cocoartf2709
+\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;\f1\fswiss\fcharset0 Helvetica-Oblique;\f2\fmodern\fcharset0 Courier;
+\f3\fnil\fcharset0 TrebuchetMS;\f4\fnil\fcharset0 Menlo-Regular;}
+{\colortbl;\red255\green255\blue255;\red255\green255\blue255;\red246\green247\blue249;}
+{\*\expandedcolortbl;;\cssrgb\c100000\c100000\c100000;\cssrgb\c97255\c97647\c98039;}
+\margl1440\margr1440\vieww12740\viewh8400\viewkind0
+\deftab720
+\pard\pardeftab720\sa152\partightenfactor0
+
+\f0\fs32 \cf0 \cb2 \expnd0\expndtw0\kerning0
+NOTE: AddRemoveUser cannot be run from the Finder. You must run it from within the Terminal application
+\f1\i  
+\f2\i0 /Applications/Utilities/Terminal
+\f0  by a user with administrator privileges, as follows:\
+To add user1, user2 and user3 to group boinc_master, enter the following in the Terminal application:
+\f3 \cb1 \
+\pard\pardeftab720\partightenfactor0
+
+\f2 \cf0 \cb3  sudo \{path\}/AddRemoveUser -a user1 user2 user3
+\f4 \
+\pard\pardeftab720\sa152\partightenfactor0
+
+\f0 \cf0 \cb2 where 
+\f1\i \{path\}
+\f0\i0  is the path to the AddRemoveUser application. This also sets a login item for each specified user so that BOINC Manager will start automatically when that user logs in.\cb1 \
+\cb2 You can also use:\cb1 \
+\pard\pardeftab720\partightenfactor0
+
+\f2 \cf0 \cb3  sudo \{path\}/AddRemoveUser -s user1 user2 user3
+\f4 \
+\pard\pardeftab720\sa152\partightenfactor0
+
+\f0 \cf0 \cb2 This is the same as the -an option and also sets BOINC as the screensaver for the specified users.\cb1 \
+\cb2 To remove user1, user2 and user3 from group boinc_master, enter the following in the Terminal application:\cb1 \
+\pard\pardeftab720\partightenfactor0
+
+\f2 \cf0 \cb3  sudo \{path\}/AddRemoveUser -r user1 user2 user3
+\f4 \
+\pard\pardeftab720\sa152\partightenfactor0
+
+\f0 \cf0 \cb2 This also removes the BOINCManager login item for each specified user. If any of the specified users had BOINC set as their screensaver, it will change their screensaver to Flurry.\cb1 \
+}

--- a/mac_installer/ReadMe.rtf
+++ b/mac_installer/ReadMe.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2708
+{\rtf1\ansi\ansicpg1252\cocoartf2709
 \cocoascreenfonts1\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;\red251\green2\blue7;\red56\green110\blue255;}
 {\*\expandedcolortbl;;\cssrgb\c100000\c14913\c0;\csgenericrgb\c21961\c43137\c100000;}
@@ -57,7 +57,7 @@ For more information or technical details of the implementation, please see {\fi
 \
 The installer sets BOINCManager as a Login item for 
 \f0\b all
-\f1\b0  authorized users, not just the user who ran the installer.  You can add or remove Login Items by using the Accounts Pane in the System Preferences (accessible from the Apple menu).  \
+\f1\b0  authorized users, not just the user who ran the installer.  You can add or remove Login Items by using the Accounts Pane in the System Preferences (accessible from the Apple menu).  On MacOS 13 (Ventura) or later, Login Items are in the General section of System Settings under the Apple menu.\
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 

--- a/mac_installer/notarize_boinc.sh
+++ b/mac_installer/notarize_boinc.sh
@@ -21,7 +21,7 @@
 # Notarization Script for Macintosh BOINC Manager 5/17/23 by Charlie Fenton
 
 ##
-## This script will notarize and staple the release created by the script 
+## This script will notarize and staple the release created by the script
 ##    mac_installer/release_boinc.sh
 ##
 ## As of MacOS 10.15 Catalina, the OS does not allow the user to run downloaded
@@ -38,7 +38,7 @@
 ##  * Created an app-specific password by following the instructions on
 ##      "Using app-specific passwords" at <https://support.apple.com/en-us/HT204397>.
 ##      NOTE: You cannot use your normal Apple ID password.
-##  * Created a profile named "notarycredentials" in your keychain using the 
+##  * Created a profile named "notarycredentials" in your keychain using the
 ##      "notarytool store-credentials" command (see "man notarytool" for details.)
 ##  * Run the release_boinc.sh script
 ##
@@ -61,7 +61,7 @@ if [ $? -ne 0 ]; then return 1; fi
 ##       * REGENERATE THE DIRECTORY TREE FROM THE ZIP FILE WE SUBMITTED,
 ##       * STAPLE THE EXECUTABLES IN THE NEW TREE
 ##       * THEN CREATE A NEW ZIP FILE FROM THE STAPLED.
-##   FOR SAFETY, I FIRST RENAME THE ORIGINAL DIRECTORY TREE AND ZIP FILE RATHER THAN 
+##   FOR SAFETY, I FIRST RENAME THE ORIGINAL DIRECTORY TREE AND ZIP FILE RATHER THAN
 ##   TRASHING THEM ***
 
 mv "$basepath/boinc_$1.$2.$3_macOSX_universal" "$basepath/boinc_$1.$2.$3_macOSX_universal-orig"

--- a/mac_installer/notarize_boinc.sh
+++ b/mac_installer/notarize_boinc.sh
@@ -1,0 +1,157 @@
+#!/bin/csh
+
+# This file is part of BOINC.
+# http://boinc.berkeley.edu
+# Copyright (C) 2023 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+##
+# Notarization Script for Macintosh BOINC Manager 5/17/23 by Charlie Fenton
+
+##
+## This script will notarize and staple the release created by the script 
+##    mac_installer/release_boinc.sh
+##
+## As of MacOS 10.15 Catalina, the OS does not allow the user to run downloaded
+## software unless it has been "notarized" by Apple.
+##
+## cd to the root directory of the boinc tree, for example:
+##     cd [path]/boinc
+##
+## Invoke this script with the three parts of the version number as arguments.
+## For example, if the version is 3.2.1:
+##     source [path_to_this_script] 3 2 1
+##
+## You must have done the following before running this script:
+##  * Created an app-specific password by following the instructions on
+##      "Using app-specific passwords" at <https://support.apple.com/en-us/HT204397>.
+##      NOTE: You cannot use your normal Apple ID password.
+##  * Created a profile named "notarycredentials" in your keychain using the 
+##      "notarytool store-credentials" command (see "man notarytool" for details.)
+##  * Run the release_boinc.sh script
+##
+## - for more information:
+##  $ xcrun notarytool --help
+##  $ man stapler
+##
+
+basepath="../BOINC_Installer/New_Release_$1_$2_$3"
+
+echo
+echo "***** Notarizing Installer and Uninstaller *****"
+echo
+
+xcrun notarytool submit "$basepath/boinc_$1.$2.$3_macOSX_universal.zip" --keychain-profile "notarycredentials" --wait
+
+if [ $? -ne 0 ]; then return 1; fi
+
+##   *** STAPLING THE ORIGINAL FILES NEVER WORKS. FOR SOME REASON, WE MUST:
+##       * REGENERATE THE DIRECTORY TREE FROM THE ZIP FILE WE SUBMITTED,
+##       * STAPLE THE EXECUTABLES IN THE NEW TREE
+##       * THEN CREATE A NEW ZIP FILE FROM THE STAPLED.
+##   FOR SAFETY, I FIRST RENAME THE ORIGINAL DIRECTORY TREE AND ZIP FILE RATHER THAN 
+##   TRASHING THEM ***
+
+mv "$basepath/boinc_$1.$2.$3_macOSX_universal" "$basepath/boinc_$1.$2.$3_macOSX_universal-orig"
+
+open -W "$basepath/boinc_$1.$2.$3_macOSX_universal.zip"
+
+echo
+echo "***** Stapling Installer *****"
+echo
+
+xcrun stapler staple "$basepath/boinc_$1.$2.$3_macOSX_universal/BOINC Installer.app"
+
+if [ $? -ne 0 ]; then return 1; fi
+
+echo
+echo "***** Stapling Uninstaller *****"
+echo
+
+xcrun stapler staple "$basepath/boinc_$1.$2.$3_macOSX_universal/extras/Uninstall BOINC.app"
+
+if [ $? -ne 0 ]; then return 1; fi
+
+echo
+echo "***** Zipping Installer and Uninstaller *****"
+echo
+
+mv "$basepath/boinc_$1.$2.$3_macOSX_universal.zip" "$basepath/boinc_$1.$2.$3_macOSX_universal-raw.zip"
+
+ditto -ck --sequesterRsrc --keepParent "$basepath/boinc_$1.$2.$3_macOSX_universal" "$basepath/boinc_$1.$2.$3_macOSX_universal.zip"
+
+##    *** Now notarize the command-line version ***
+echo
+echo "***** Notarizing command-line version *****"
+echo
+
+xcrun notarytool submit "$basepath/boinc_$1.$2.$3_universal-apple-darwin.dmg" --keychain-profile "notarycredentials" --wait
+
+if [ $? -ne 0 ]; then return 1; fi
+
+##   *** STAPLING THE ORIGINAL DMG NEVER WORKS. FOR SOME REASON, WE MUST MAKE A
+##        COPY OF THE ORIGINAL DMG AND STAPLE THAT. FOR SAFETY, I:
+##       * FIRST RENAME THE ORIGINAL DMG RATHER THAN TRASHING IT
+##       * MAKE A COPY WITH THE ORIGINAL NAME
+##       * STAPLE THE NEW COPY (WITH THE ORIGINAL NAME) ***
+
+mv "$basepath/boinc_$1.$2.$3_universal-apple-darwin.dmg" "$basepath/boinc_$1.$2.$3_universal-apple-darwin-raw.dmg"
+
+cp "$basepath/boinc_$1.$2.$3_universal-apple-darwin-raw.dmg" "$basepath/boinc_$1.$2.$3_universal-apple-darwin.dmg"
+
+echo
+echo "***** Stapling command-line version *****"
+echo
+
+stapler staple "$basepath/boinc_$1.$2.$3_universal-apple-darwin.dmg"
+
+if [ $? -ne 0 ]; then return 1; fi
+
+echo
+echo "***** Notarizing AddRemoveUser *****"
+echo
+
+## Command line tools such as AddRemoveuser cannot be notarized and so cannot be
+## launched directly from the Finder (e.g. by double-clicking them), even if
+## contained in a notarized dmg or zip file. But gatekeeper won't block them if
+## they are run from within Terminal, as long as the containing dmg or zip file
+## has been notarized (the zip file can't be stapled, and doesn't need to be.)
+## For more information about this, see
+## <https://developer.apple.com/forums/thread/127403>.
+
+xcrun notarytool submit "$basepath/boinc_$1.$2.$3_$arch-AddRemoveUser.dmg" --keychain-profile "notarycredentials" --wait
+
+if [ $? -ne 0 ]; then return 1; fi
+
+##   *** STAPLING THE ORIGINAL DMG NEVER WORKS. FOR SOME REASON, WE MUST MAKE A
+##        COPY OF THE ORIGINAL DMG AND STAPLE THAT. FOR SAFETY, I:
+##       * FIRST RENAME THE ORIGINAL DMG RATHER THAN TRASHING IT
+##       * MAKE A COPY WITH THE ORIGINAL NAME
+##       * STAPLE THE NEW COPY (WITH THE ORIGINAL NAME) ***
+
+mv "$basepath/boinc_$1.$2.$3_$arch-AddRemoveUser.dmg" "$basepath/boinc_$1.$2.$3_$arch-AddRemoveUser-raw.dmg"
+
+cp "$basepath/boinc_$1.$2.$3_$arch-AddRemoveUser-raw.dmg" "$basepath/boinc_$1.$2.$3_$arch-AddRemoveUser.dmg"
+
+echo
+echo "***** Stapling AddRemoveUser *****"
+echo
+
+stapler staple "$basepath/boinc_$1.$2.$3_$arch-AddRemoveUser.dmg"
+
+if [ $? -ne 0 ]; then return 1; fi
+
+
+return 0;

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -60,6 +60,7 @@
 ## Updated 6/9/22 to eliminate harmless error message
 ## Updated 3/7/23 for boinc_finish_install to be a full application bundle
 ## Updated 4/30/23 code sign AddRemoveUser; eliminate old code signing workaround
+## Updated 5/17/23 to add comments about notarize_BOINC.sh script
 ##
 ## NOTE: This script requires Mac OS 10.7 or later, and uses XCode developer
 ##   tools.  So you must have installed XCode Developer Tools on the Mac
@@ -74,7 +75,7 @@
 
 ## To have this script build the combined BOINC+VirtualBox installer:
 ## * Create a directory named "VirtualBox Installer" in the same
-##   directory which contains he root directory of the boinc tree.
+##   directory which contains the root directory of the boinc tree.
 ## * Copy VirtualBox.pkg from the VirtualBox installer disk image (.dmg)
 ##   into this "VirtualBox Installer" directory.
 ## * Copy VirtualBox_Uninstall.tool from the VirtualBox installer disk
@@ -93,6 +94,8 @@
 ## We have asked Oracle to include their uninstall script inside the VirtualBox
 ## bundle, or some other standard place where our BOINC uninstaller can find
 ## the current version, but they have not yet done so.
+##
+## In addition, the notarize.sh script does not currently handle VirtualBox.
 
 ## Usage:
 ##
@@ -117,57 +120,12 @@
 ## For example, if the version is 3.2.1:
 ##     source [path_to_this_script] 3 2 1 -dev
 
-## As of OS 10.14 Mojave, Apple has introduced a new level of security which
-## Apple calls "notarization". Under OS 10.14, the only difference is that
-## Gatekeeper adds the sentence "Apple checked it for malicious software and
-## found none." However, Apple has warned: "In an upcoming release of macOS,
-## Gatekeeper will require Developer ID–signed software to be notarized by
-## Apple."
+## As of MacOS 10.15 Catalina, the OS does not allow the user to run downloaded
+## software unless it has been "notarized" by Apple.
 ##
-## To notarize the installer and uninstaller:
-## NOTE: Do not use your normal Apple ID password. You must create an
-## app-specific password at https://appleid.apple.com/account/manage.
-##
-## NOTE: in the following instructions, subsitute the 3 part version number
-##       for x.y.z and the architecture (usually "universal" for $arch) so
-##       substitute the quoted full path for ".../boinc_x.y.z_macOSX_$arch"
-## - Use the command line tools in Xcode 13 or later
-## - Provide valid application & installer code signing identities as above
-## - In the instructions below, substitute the appropriate architcture for $arch
-##     (either x86_64, arm64 or universal)
-## - In Terminal:
-##  $ xcrun notarytool submit ".../boinc_x.y.z_macOSX_$arch.zip" --apple-id {your_Apple_ID} --password {password} --team-id {your_team_ID) --wait
-##
-## - If the notarytool submit request was approved, attach tickets to top level applications as follows:
-## NOTE: Stapling the original files never works. We must rename the original
-##       directory and recreate it from the zip file we just submitted
-##  $ mv ".../boinc_x.y.z_macOSX_$arch" ".../boinc_x.y.z_macOSX_$arch-orig"
-##  $ open ".../boinc_x.y.z_macOSX_$arch.zip"
-##  $ xcrun stapler staple ".../boinc_x.y.z_macOSX_$arch/BOINC Installer.app"
-##  $ xcrun stapler staple {path to ".../boinc_x.y.z_macOSX_$arch.zip/extras/Uninstall BOINC.app"
-## - delete or rename the original ".../boinc_x.y.z_macOSX_$arch.zip" file
-## - Run this ditto command again to create a new zip archive containing
-##   the updated (notarized) BOINC Installer.app and Uninstall BOINC.app:
-##  $ ditto -ck --sequesterRsrc --keepParent ".../boinc_x.y.z_macOSX_$arch" ".../boinc_x.y.z_macOSX_$arch.zip"
-##
-## Then notarize the bare-core (apple-darwin) release as follows:
-##  $ xcrun notarytool submit ".../boinc_x.y.z_$arch-apple-darwin.dmg" --apple-id {your_Apple_ID} --password {password} --team-id {your_team_ID) --wait
-##  $ xcrun altool --notarization-info {UUID from last step} -u {userID} -p {password}
-##
-## - If the notarize-app request was approved, attach a ticket to the disk image:
-## NOTE: Stapling the original files never works. We must rename the original
-##       disk image we just submitted and make a copy of it
-##  $ mv ".../boinc_x.y.z_$arch-apple-darwin.dmg" ".../boinc_x.y.z_$arch-apple-darwin-orig.dmg"
-##  $ cp ".../boinc_x.y.z_$arch-apple-darwin-orig.dmg" ".../boinc_x.y.z_$arch-apple-darwin.dmg"
-##  $ xcrun stapler staple ".../boinc_x.y.z_$arch-apple-darwin.dmg"
-##
-## - for more information:
-##  $ xcrun notarytool --help
-##  $ man stapler
-##
-## TODO: Add code to optionally automate notarization either in this script or
-## TODO: in a separate script. Perhaps adapt notarization and stapler code from
-## TODO: <https://github.com/smittytone/scripts/blob/master/packcli.zsh>
+## To notarize the installer and uninstaller after successfully running this script,
+## follow the instructions in the comments at the start of the script
+##    mac_installer/notarize_boinc.sh.
 ##
 
 if [ $# -lt 3 ]; then
@@ -562,6 +520,7 @@ fi
 cp -fpRL mac_build/Mac_SA_Insecure.sh ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/
 cp -fpRL mac_build/Mac_SA_Secure.sh ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/
 cp -fpRL "${BUILDPATH}/AddRemoveUser" ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-AddRemoveUser
+cp -fp mac_installer/AddRemoveUser_ReadMe.rtf ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-AddRemoveUser/ReadMe.rtf
 cp -fpRL COPYING ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/COPYING.txt
 cp -fpRL COPYING.LESSER ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/COPYING.LESSER.txt
 cp -fpRL COPYRIGHT ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_$arch-apple-darwin/COPYRIGHT.txt
@@ -626,6 +585,11 @@ if [ -d boinc_$1.$2.$3_macOSX_${arch}_vbox ]; then
 fi
 sudo hdiutil create -srcfolder boinc_$1.$2.$3_$arch-apple-darwin -ov -format UDZO boinc_$1.$2.$3_$arch-apple-darwin.dmg
 
+## Command line tools such as AddRemoveuser cannot be notarized and so cannot be
+## launched directly from the Finder (e.g. by double-clicking them), even if
+## contained in a notarized dmg or zip file. But gatekeeper won't block them if
+## they are run from within Terminal. For more information about this, see
+## <https://developer.apple.com/forums/thread/127403>.
 sudo hdiutil create -srcfolder boinc_$1.$2.$3_$arch-AddRemoveUser -ov -format UDZO boinc_$1.$2.$3_$arch-AddRemoveUser.dmg
 
 #popd


### PR DESCRIPTION
Mac: add script to notarize BOINC Installer, Uninstaller, stand-alone client and AddRemoveUser utility.

As of MacOS 10.15 Catalina, the OS does not allow the user to run downloaded software unless it has been "notarized" by Apple. This PR adds the mac_installer/notarize_boinc.sh script, which can be run to notarize the downloadable BOINC executables after building the installer, uninstaller, etc. with the mac_installer/release_boinc.sh script.

Instructions for running both mac_installer/release_boinc.sh and mac_installer/notarize_boinc.sh can be found in the comments near the top of each script.

I have tested these changes and this PR will be ready to merge as soon as CI checks finish.
