### PR TITLE
Automake: use $(libexecdir) instead of $(libdir)

### DIFF
--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -3,7 +3,7 @@
 
 include $(top_srcdir)/Makefile.incl
 
-exampledir = $(libdir)/boinc-apps-examples
+exampledir = $(libexecdir)/boinc-apps-examples
 example_PROGRAMS = upper_case concat 1sec
 
 upper_case_SOURCES = upper_case.cpp

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -8,7 +8,7 @@ bin_PROGRAMS =
 # Stuff needed for server builds goes here.
 if ENABLE_SERVER
 
-serverbindir = $(libdir)/boinc-server-maker/lib
+serverbindir = $(libexecdir)/boinc-server-maker/lib
 serverbin_PROGRAMS = crypt_prog parse_test
 
 endif

--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -87,9 +87,9 @@ endif
 
 if ENABLE_SERVER
 
-schedcgidir = $(libdir)/boinc-server-maker/sched
-schedsharedir = $(libdir)/boinc-server-maker/sched
-schedbindir = $(libdir)/boinc-server-maker/sched
+schedcgidir = $(libexecdir)/boinc-server-maker/sched
+schedsharedir = $(libexecdir)/boinc-server-maker/sched
+schedbindir = $(libexecdir)/boinc-server-maker/sched
 
 schedbin_PROGRAMS = \
     adjust_user_priority \

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,9 +1,9 @@
 ## -*- mode: makefile; tab-width: 4 -*-
 include $(top_srcdir)/Makefile.incl
 
-scheddir = $(libdir)/boinc-server-maker/sched
-toolsdir = $(libdir)/boinc-server-maker/tools
-toolbindir = $(libdir)/boinc-server-maker/tools
+scheddir = $(libexecdir)/boinc-server-maker/sched
+toolsdir = $(libexecdir)/boinc-server-maker/tools
+toolbindir = $(libexecdir)/boinc-server-maker/tools
 
 toolbin_PROGRAMS = \
 	cancel_jobs \

--- a/vda/Makefile.am
+++ b/vda/Makefile.am
@@ -1,6 +1,6 @@
 include $(top_srcdir)/Makefile.incl
 
-vdadir=$(libdir)/boinc-server-maker/vda
+vdadir=$(libexecdir)/boinc-server-maker/vda
 vda_PROGRAMS = vda vdad ssim
 
 AM_CXXFLAGS += $(MYSQL_CFLAGS)


### PR DESCRIPTION
Fixes wrong #5085 (d727a3d61611891b5601b57577d449ebdababc9e).

**Release Notes**
Install server executables to `$(libexecdir)` instead of `$(libdir)`.