### PR TITLE
Fix screensaver crash bug introduced in PR #5197 commit 689a6eae25

### DIFF
--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -119,7 +119,7 @@ bool CScreensaver::is_same_task(RESULT* taska, RESULT* taskb) {
 }
 
 int CScreensaver::count_active_graphic_apps(RESULTS& res, RESULT* exclude) {
-    size_t i = 0;
+    int i = 0;  // Must be a signed integer
     unsigned int graphics_app_count = 0;
 
     // Count the number of active graphics-capable apps excluding the specified result.


### PR DESCRIPTION
Commit 689a6eae25 changed the variable from a signed variable (`int`) to unsigned (`size_t`), effectively causing an infinite `for` loop.

I believe this crash bug also affects MS Windows. I don't know whether this code is used for the X11 screensaver, but if so that will also be affected.

Once this is merged, it should be cherry-picked into the 7.22 branch so that we can build BOINC 7.22.2 for all platforms. I will next create another PR to improve backtrace generation on the Mac, which should also be included in BOINC 7.22.2.