### PR TITLE
Mac: update backtrace for MacOS 13.4

### DIFF
--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -443,11 +443,14 @@ int diagnostics_init(
     }
 #endif // ANDROID_VOODOO
 
+// Our PrintBactrace() won't work in MacOS screensaver so let
+// the MacOS handle signals and write backtrace to stderr.
+#if !(defined (__APPLE__) && defined(SCREENSAVER))
     // Install unhandled exception filters and signal traps.
     if (BOINC_SUCCESS != boinc_install_signal_handlers()) {
         return ERR_SIGNAL_OP;
     }
-
+#endif
 
     // Store various pieces of inforation for future use.
     if (flags & BOINC_DIAG_BOINCAPPLICATION) {

--- a/lib/mac/mac_backtrace.cpp
+++ b/lib/mac/mac_backtrace.cpp
@@ -199,7 +199,8 @@ void PrintBacktrace(void) {
     }
 
     atosExists = boinc_file_exists("/usr/bin/atos");
-    cppfiltExists = boinc_file_exists("/usr/bin/atos");
+    cppfiltExists = boinc_file_exists("/usr/bin/c++filt");
+
     if (atosExists || cppfiltExists) {
         // The bidirectional popen only works if the NSUnbufferedIO environment
         // variable is set, so we save and restore its current value.
@@ -222,7 +223,7 @@ void PrintBacktrace(void) {
 #elif defined (__i386__)
         snprintf(atosPipeBuf, sizeof(atosPipeBuf), "/usr/bin/atos -o \"%s\" -arch i386", pathToThisProcess);
 #elif defined (__arm64__)
-        snprintf(atosPipeBuf, sizeof(atosPipeBuf), "/usr/bin/atos -o \"%s\" -arch arm", pathToThisProcess);
+        snprintf(atosPipeBuf, sizeof(atosPipeBuf), "/usr/bin/atos -o \"%s\" -arch arm64", pathToThisProcess);
 #else
         snprintf(atosPipeBuf, sizeof(atosPipeBuf), "/usr/bin/atos -o \"%s\" -arch ppc", pathToThisProcess);
 #endif
@@ -234,7 +235,7 @@ void PrintBacktrace(void) {
     }
 
     if (cppfiltExists) {
-        cppfiltPipe = popen("/usr/bin/c++filt -s gnu -n", "r+");
+        cppfiltPipe = popen("/usr/bin/c++filt --format=gnu -n", "r+");
         if (cppfiltPipe) {
             setbuf(cppfiltPipe, 0);
         }

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -4779,6 +4779,14 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = "ScreenSaver-Info.plist";
+				OTHER_CFLAGS = (
+					"-D_THREAD_SAFE",
+					"-DNDEBUG",
+					"-DSCREENSAVER",
+					"-DSANDBOX",
+					"-include",
+					../clientgui/mac/config.h,
+				);
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,
@@ -4967,6 +4975,14 @@
 					"$(PROJECT_DIR)",
 				);
 				INFOPLIST_FILE = "ScreenSaver-Info.plist";
+				OTHER_CFLAGS = (
+					"-D_THREAD_SAFE",
+					"-D_DEBUG",
+					"-DSCREENSAVER",
+					"-DSANDBOX",
+					"-include",
+					../clientgui/mac/config.h,
+				);
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,


### PR DESCRIPTION
Fixes some issues with Mac backtrace under macOS 13.4.

This is ready to be merged and should then be cherry-picked into the 7.22 branch.