### PR TITLE
client: the default value for the "suspend_if_no_recent_input" pref should to 0, not 60

### DIFF
--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -252,7 +252,7 @@ void GLOBAL_PREFS::defaults() {
 #else
     suspend_cpu_usage = 25;
 #endif
-    suspend_if_no_recent_input = 60;
+    suspend_if_no_recent_input = 0;
     vm_max_used_frac = 0.75;
     work_buf_additional_days = 0.5;
     work_buf_min_days = 0.1;

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -272,6 +272,7 @@ void GLOBAL_PREFS::defaults() {
 //
 void GLOBAL_PREFS::enabled_defaults() {
     defaults();
+    suspend_if_no_recent_input = 60;
     disk_max_used_gb = 100;
     disk_min_free_gb = 1.0;
     daily_xfer_limit_mb = 10000;


### PR DESCRIPTION
Otherwise BOINC will stop computing after 60 minutes of idleness.

Is this a show-stopper?  Quite possibly.

BTW, this should have been called "suspend_if_no_recent_input_min" (times are in seconds unless otherwise specified)

