### PR TITLE
client: ignore old prefs sent by projects or AM

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -799,13 +799,18 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
         // process prefs if any
         //
         if (!global_prefs_xml.empty()) {
-            retval = gstate.save_global_prefs(
-                global_prefs_xml.c_str(), ami.master_url, ami.master_url
+            double mod_time = GLOBAL_PREFS::parse_mod_time(
+                global_prefs_xml.c_str()
             );
-            if (retval) {
-                msg_printf(NULL, MSG_INTERNAL_ERROR, "Can't save global prefs");
+            if (mod_time > gstate.global_prefs.mod_time) {
+                retval = gstate.save_global_prefs(
+                    global_prefs_xml.c_str(), ami.master_url, ami.master_url
+                );
+                if (retval) {
+                    msg_printf(NULL, MSG_INTERNAL_ERROR, "Can't save global prefs");
+                }
+                read_prefs = true;
             }
-            read_prefs = true;
         }
 
         // process prefs if prefs or venue changed

--- a/client/cs_account.cpp
+++ b/client/cs_account.cpp
@@ -596,7 +596,7 @@ int CLIENT_STATE::add_project(
     if (strlen(email_addr)) {
         md5_block(
             (unsigned char*)email_addr,
-            strlen(email_addr),
+            (int)strlen(email_addr),
             project->email_hash
         );
     }

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -673,7 +673,8 @@ int CLIENT_STATE::handle_scheduler_reply(
     // if the scheduler reply includes global preferences,
     // insert extra elements, write to disk, and parse
     //
-    if (sr.global_prefs_xml) {
+    double mod_time = sr.global_prefs_xml?GLOBAL_PREFS::parse_mod_time(sr.global_prefs_xml):0;
+    if (sr.global_prefs_xml && mod_time > gstate.global_prefs.mod_time) {
         // ignore prefs if we're using prefs from account mgr
         // BAM! currently has mixed http, https; trim off
         char* p = strchr(global_prefs.source_project, '/');

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -936,3 +936,10 @@ int GLOBAL_PREFS::write_subset(MIOFILE& f, GLOBAL_PREFS_MASK& mask) {
     return 0;
 }
 
+// parse the <mod_time> element from a prefs XML string
+//
+double GLOBAL_PREFS::parse_mod_time(const char* p) {
+    const char *q = strstr(p, "<mod_time>");
+    if (!q) return 0;
+    return atof(q+strlen("<mod_time>"));
+}

--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -212,6 +212,7 @@ struct GLOBAL_PREFS {
     inline double cpu_scheduling_period() {
         return cpu_scheduling_period_minutes*60;
     }
+    static double parse_mod_time(const char*);
 };
 
 #endif


### PR DESCRIPTION
Fixes #5255

Old approach: the client sends its global prefs to projects and AMs,
and they decide whether they have newer prefs,
and if so send them to the client.

New approach: the client doesn't send global prefs to projects or AMs.
They send what they have to the client,
and the client decides whether to use them (based on mod time)