### PR TITLE
[Manager] fix:  remove conditional for saving max non-BOINC CPU usage

### DIFF
--- a/clientgui/DlgAdvPreferences.cpp
+++ b/clientgui/DlgAdvPreferences.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -510,7 +510,7 @@ bool CDlgAdvPreferences::SavePreferencesSettings() {
     }
     mask.suspend_if_no_recent_input = true;
 
-    if (m_txtMaxLoad->IsEnabled() || !prefs.run_if_user_active) {
+    if (m_txtMaxLoad->IsEnabled()) {
         m_txtMaxLoad->GetValue().ToDouble(&td);
         prefs.suspend_cpu_usage=RoundToHundredths(td);
     } else {


### PR DESCRIPTION
**Description of the Change**
There is an unexpected bug from #5146.  If suspend when non-BOINC CPU usage (NBCU) usage is blank, and either 'in use' or 'not in use' time is checked and set, then the value for either of those time settings is saved under NBCU.
For example, if you click on save settings with the following:
![image](https://github.com/BOINC/boinc/assets/58096400/d1f4b1b7-d629-45a5-879f-614316533fdc)

Then the next time you open preferences, you will see this:
![image](https://github.com/BOINC/boinc/assets/58096400/66dadb93-ac10-4d65-9813-16f33a223a46)

I was able to confirm this occurs in BOINC 7.22.1, 7.22.2, but not 7.22.0, all using Windows 10.

I believe the culprit is here:
[https://github.com/BOINC/boinc/blob/c520ed6c6006969a2d80bc8dc1f71baecf5298be/clientgui/DlgAdvPreferences.cpp#L513-L514](https://github.com/BOINC/boinc/blob/c520ed6c6006969a2d80bc8dc1f71baecf5298be/clientgui/DlgAdvPreferences.cpp#L513-L514)
if m_txtMaxLoad is null, GetValue() doesn't read the pointer in the way we would expect.  Instead, it uses td from the previous time it was used, which is either m_txtNoRecentInput or  m_txtProcIdleFor.

This PR removes the condition when NBCU is not checked to attempt to store the value.

**Alternate Designs**
The side affect of this PR is that NBCU will not be saved when NBCU is not active.  I feel this is acceptable for two reasons:

1. When clicking checkboxes in the preferences, if you had a value previously entered, that value will not be cleared (until you click save, and only if NBCU is not active).
2. It appears that most other preferences don't keep previously entered values.  As @CharlieFenton mentioned [here](https://github.com/BOINC/boinc/pull/5146#issuecomment-1467912201), it appears that providing this feature is outside of the scope of this PR.

**Release Notes**
[Manager] [Preferences] Fixes saving value for non-BOINC CPU usage when no value was entered.
