### PR TITLE
Mac: Support Dark Mode in Advanced View

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1980,6 +1980,53 @@ void CAdvancedFrame::OnSelectAll(wxCommandEvent& WXUNUSED(event)) {
 }
 
 
+// On the Mac, we must destroy and recreate each wxListCtrl
+// to properly transition between dark mode and regular mode
+void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) ) {
+    CBOINCBaseView* theView = NULL;;
+    CBOINCListCtrl* theListCtrl = NULL;
+    long bottomItem;
+    wxTimerEvent    timerEvent;
+    int currentPage = _GetCurrentViewPage();
+
+    StopTimers();
+    SaveState();
+    // Get the list copntrol's current scroll position
+    if ((currentPage > 0) && (currentPage <4)) {     // CViewProjects = 1, CViewWork = 2, CViewTransfers = 3
+        theView = (CBOINCBaseView*)(m_pNotebook->GetPage(currentPage));
+        theListCtrl = theView->GetListCtrl();
+        bottomItem = theListCtrl->GetTopItem() + theListCtrl->GetCountPerPage() - 1;
+    }
+    RepopulateNotebook();
+    RestoreState();
+
+    // The last tab label ("Disk") is ellipsed here unless the window is resized
+    // TODO: figure out how to replace this hack with a proper fix
+    int x, y;
+    GetSize(&x, &y);
+    SetSize(x+1, y);
+    SetSize(x, y);
+
+    // Scroll the recreated list control to the same row as before
+    if ((currentPage > 0) && (currentPage <4)) {
+        theView = (CBOINCBaseView*)(m_pNotebook->GetPage(currentPage));
+        theView->FireOnListRender(timerEvent);
+        theListCtrl = theView->GetListCtrl();
+        if (theListCtrl->GetCountPerPage() < theListCtrl->GetItemCount()) {
+            theListCtrl->EnsureVisible(bottomItem);
+        }
+    }
+    StartTimers();
+
+    CDlgEventLog*   eventLog = wxGetApp().GetEventLog();
+    if (eventLog) {
+        wxGetApp().OnEventLogClose();   // 
+        delete eventLog;    // eventLog->Destroy() creates a race condition if used here.
+        wxGetApp().DisplayEventLog();
+    }
+}
+
+
 void CAdvancedFrame::UpdateActivityModeControls( CC_STATUS& status ) {
     wxMenuBar* pMenuBar = GetMenuBar();
     wxASSERT(pMenuBar);

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1982,6 +1982,7 @@ void CAdvancedFrame::OnSelectAll(wxCommandEvent& WXUNUSED(event)) {
 
 // On the Mac, we must destroy and recreate each wxListCtrl
 // to properly transition between dark mode and regular mode
+//
 void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) ) {
     CBOINCBaseView* theView = NULL;;
     CBOINCListCtrl* theListCtrl = NULL;
@@ -1991,7 +1992,11 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
 
     StopTimers();
     SaveState();
-    // Get the list copntrol's current scroll position
+
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    wxGetApp().SetIsDarkMode(appearance.IsDark());
+
+    // Get the list control's current scroll position
     if ((currentPage == VW_PROJ) || (currentPage == VW_TASK) || (currentPage == VW_XFER)) {
         theView = (CBOINCBaseView*)(m_pNotebook->GetPage(m_pNotebook->GetSelection()));
         theListCtrl = theView->GetListCtrl();
@@ -2002,6 +2007,7 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
 
     // The last tab label ("Disk") is ellipsed here unless the window is resized
     // TODO: figure out how to replace this hack with a proper fix
+
     int x, y;
     GetSize(&x, &y);
     SetSize(x+1, y);

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1984,6 +1984,7 @@ void CAdvancedFrame::OnSelectAll(wxCommandEvent& WXUNUSED(event)) {
 // to properly transition between dark mode and regular mode
 //
 void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) ) {
+#if SUPPORTDARKMODE
     CBOINCBaseView* theView = NULL;;
     CBOINCListCtrl* theListCtrl = NULL;
     long bottomItem;
@@ -2032,6 +2033,7 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
         delete eventLog;    // eventLog->Destroy() creates a race condition if used here.
         wxGetApp().DisplayEventLog();
     }
+#endif  // #if SUPPORTDARKMODE
 }
 
 

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -2020,7 +2020,7 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
 
     CDlgEventLog*   eventLog = wxGetApp().GetEventLog();
     if (eventLog) {
-        wxGetApp().OnEventLogClose();   // 
+        wxGetApp().OnEventLogClose();
         delete eventLog;    // eventLog->Destroy() creates a race condition if used here.
         wxGetApp().DisplayEventLog();
     }

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1992,8 +1992,8 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
     StopTimers();
     SaveState();
     // Get the list copntrol's current scroll position
-    if ((currentPage > 0) && (currentPage <4)) {     // CViewProjects = 1, CViewWork = 2, CViewTransfers = 3
-        theView = (CBOINCBaseView*)(m_pNotebook->GetPage(currentPage));
+    if ((currentPage == VW_PROJ) || (currentPage == VW_TASK) || (currentPage == VW_XFER)) {
+        theView = (CBOINCBaseView*)(m_pNotebook->GetPage(m_pNotebook->GetSelection()));
         theListCtrl = theView->GetListCtrl();
         bottomItem = theListCtrl->GetTopItem() + theListCtrl->GetCountPerPage() - 1;
     }
@@ -2008,14 +2008,16 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
     SetSize(x, y);
 
     // Scroll the recreated list control to the same row as before
-    if ((currentPage > 0) && (currentPage <4)) {
-        theView = (CBOINCBaseView*)(m_pNotebook->GetPage(currentPage));
+    if ((currentPage == VW_PROJ) || (currentPage == VW_TASK) || (currentPage == VW_XFER)) {
+        theView = (CBOINCBaseView*)(m_pNotebook->GetPage(m_pNotebook->GetSelection()));
         theView->FireOnListRender(timerEvent);
         theListCtrl = theView->GetListCtrl();
         if (theListCtrl->GetCountPerPage() < theListCtrl->GetItemCount()) {
             theListCtrl->EnsureVisible(bottomItem);
         }
     }
+    // TODO: figure out how to preserve notices tab (currentPage == VW_NOTIF) scrolled position
+
     StartTimers();
 
     CDlgEventLog*   eventLog = wxGetApp().GetEventLog();

--- a/clientgui/AdvancedFrame.h
+++ b/clientgui/AdvancedFrame.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/AdvancedFrame.h
+++ b/clientgui/AdvancedFrame.h
@@ -67,6 +67,7 @@ public:
     void OnNetworkSelection( wxCommandEvent& event );
 
     void OnSelectAll( wxCommandEvent& event );
+    void OnDarkModeChanged( wxSysColourChangedEvent& event );
 
     void OnMenuOpening( wxMenuEvent &event);
     void OnOptions( wxCommandEvent& event );

--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -62,6 +62,7 @@ BEGIN_EVENT_TABLE (CBOINCBaseFrame, wxFrame)
     EVT_CLOSE(CBOINCBaseFrame::OnClose)
     EVT_MENU(ID_CLOSEWINDOW, CBOINCBaseFrame::OnCloseWindow)
     EVT_MENU(wxID_EXIT, CBOINCBaseFrame::OnExit)
+    EVT_SYS_COLOUR_CHANGED(CBOINCBaseFrame::OnDarkModeChanged)
 END_EVENT_TABLE ()
 
 
@@ -374,6 +375,9 @@ void CBOINCBaseFrame::OnExit(wxCommandEvent& WXUNUSED(event)) {
     }
 
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnExit - Function End"));
+}
+
+void CBOINCBaseFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) ) {
 }
 
 

--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -62,7 +62,9 @@ BEGIN_EVENT_TABLE (CBOINCBaseFrame, wxFrame)
     EVT_CLOSE(CBOINCBaseFrame::OnClose)
     EVT_MENU(ID_CLOSEWINDOW, CBOINCBaseFrame::OnCloseWindow)
     EVT_MENU(wxID_EXIT, CBOINCBaseFrame::OnExit)
+#if SUPPORTDARKMODE
     EVT_SYS_COLOUR_CHANGED(CBOINCBaseFrame::OnDarkModeChanged)
+#endif
 END_EVENT_TABLE ()
 
 

--- a/clientgui/BOINCBaseFrame.h
+++ b/clientgui/BOINCBaseFrame.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/BOINCBaseFrame.h
+++ b/clientgui/BOINCBaseFrame.h
@@ -64,6 +64,7 @@ public:
     virtual void        OnClose( wxCloseEvent& event );
     virtual void        OnCloseWindow( wxCommandEvent& event );
     virtual void        OnExit( wxCommandEvent& event );
+    virtual void        OnDarkModeChanged( wxSysColourChangedEvent& event );
 
     void                OnWizardAttachProject( wxCommandEvent& event );
     void                OnWizardUpdate( wxCommandEvent& event );
@@ -107,7 +108,7 @@ public:
     virtual bool        RestoreState();
     virtual bool        SaveState();
     virtual bool        CreateMenus(){return true;}
-    void ResetReminderTimers();
+    void                ResetReminderTimers();
 
 protected:
 

--- a/clientgui/BOINCBaseView.cpp
+++ b/clientgui/BOINCBaseView.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/BOINCBaseView.h
+++ b/clientgui/BOINCBaseView.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -75,8 +75,11 @@ bool CBOINCGUIApp::OnInit() {
     g_use_sandbox = false;
 #endif
 
+    m_isDarkMode = false;
+#if SUPPORTDARKMODE
     wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
     m_isDarkMode = appearance.IsDark();
+#endif
 
     s_bSkipExitConfirmation = false;
     m_bFilterEvents = false;

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -75,6 +75,9 @@ bool CBOINCGUIApp::OnInit() {
     g_use_sandbox = false;
 #endif
 
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    m_isDarkMode = appearance.IsDark();
+
     s_bSkipExitConfirmation = false;
     m_bFilterEvents = false;
     m_bAboutDialogIsOpen = false;

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -128,6 +128,8 @@ protected:
 
     int                 m_bSafeMessageBoxDisplayed;
 
+    bool                m_isDarkMode;
+
 public:
 
     bool                OnInit();
@@ -242,6 +244,8 @@ public:
     void                SetAboutDialogIsOpen(bool set) { m_bAboutDialogIsOpen = set; }
     bool                GetAboutDialogIsOpen() { return m_bAboutDialogIsOpen; }
 
+    void                SetIsDarkMode (bool isDarkMode) { m_isDarkMode = isDarkMode; }
+    bool                GetIsDarkMode() { return m_isDarkMode; }
 #ifdef __WXMAC__
     // The following Cocoa routines are in CBOINCGUIApp.mm
     //

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -34,6 +34,19 @@
 #define BOINC_ADVANCEDGUI                   1
 #define BOINC_SIMPLEGUI                     2
 
+// NOTE: MacOS automatically adjusts all standard OS-drawn UI items
+// in Dark Mode, so BOINC must not modify their colors for Dark Mode.
+// For MacOS, we adjust Dark Mode colors only for our custom UI items.
+// If you implement Dark Mode support for another OS which requires
+// BOINC to adjust standard UI items for Dark Mode, be sure to guard
+// those changes so they do not affect the Mac implementation.
+//
+#if defined(__WXMAC__)
+#define SUPPORTDARKMODE true
+#else
+#define SUPPORTDARKMODE false
+#endif
+
 
 class wxLogBOINC;
 class CBOINCBaseFrame;
@@ -244,8 +257,13 @@ public:
     void                SetAboutDialogIsOpen(bool set) { m_bAboutDialogIsOpen = set; }
     bool                GetAboutDialogIsOpen() { return m_bAboutDialogIsOpen; }
 
+#if SUPPORTDARKMODE
     void                SetIsDarkMode (bool isDarkMode) { m_isDarkMode = isDarkMode; }
     bool                GetIsDarkMode() { return m_isDarkMode; }
+#else
+    void                SetIsDarkMode (bool WXUNUSED(isDarkMode)) {}
+    bool                GetIsDarkMode() { return false; }
+#endif
 #ifdef __WXMAC__
     // The following Cocoa routines are in CBOINCGUIApp.mm
     //

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -41,7 +41,7 @@
 // BOINC to adjust standard UI items for Dark Mode, be sure to guard
 // those changes so they do not affect the Mac implementation.
 //
-#if defined(__WXMAC__)
+#if (defined(__WXMAC__) || defined(__WXGTK__))
 #define SUPPORTDARKMODE true
 #else
 #define SUPPORTDARKMODE false

--- a/clientgui/BOINCListCtrl.cpp
+++ b/clientgui/BOINCListCtrl.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/BOINCListCtrl.cpp
+++ b/clientgui/BOINCListCtrl.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include "stdwx.h"
+#include "BOINCGUIApp.h"
 #include "BOINCBaseView.h"
 #include "BOINCListCtrl.h"
 #include "Events.h"
@@ -81,6 +82,8 @@ CBOINCListCtrl::CBOINCListCtrl(
     pView, iListWindowID, wxDefaultPosition, wxSize(-1, -1), iListWindowFlags
 ) {
     m_pParentView = pView;
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    m_isDarkMode = appearance.IsDark();
 
     // Enable Zebra Striping
     EnableAlternateRowColours(true);
@@ -522,7 +525,7 @@ void CBOINCListCtrl::DrawProgressBars()
     int n = (int)m_iRowsNeedingProgressBars.GetCount();
     if (n <= 0) return;
 
-    wxColour progressColor = wxTheColourDatabase->Find(wxT("LIGHT BLUE"));
+    wxColour progressColor = wxTheColourDatabase->Find(m_isDarkMode ? wxT("DARK GREEN") : wxT("LIGHT BLUE"));
     wxBrush progressBrush(progressColor);
 
     numItems = GetItemCount();
@@ -604,8 +607,8 @@ void CBOINCListCtrl::DrawProgressBars()
             dc.SetPen(bkgd);
             dc.SetBrush(bkgd);
 #else
-            dc.SetPen(*wxWHITE_PEN);
-            dc.SetBrush(*wxWHITE_BRUSH);
+            dc.SetPen(m_isDarkMode ? *wxBLACK_PEN : *wxWHITE_PEN);
+            dc.SetBrush(m_isDarkMode ? *wxBLACK_BRUSH : *wxWHITE_BRUSH);
 #endif
             dc.DrawRectangle( rr );
 

--- a/clientgui/BOINCListCtrl.cpp
+++ b/clientgui/BOINCListCtrl.cpp
@@ -525,7 +525,7 @@ void CBOINCListCtrl::DrawProgressBars()
     int n = (int)m_iRowsNeedingProgressBars.GetCount();
     if (n <= 0) return;
 
-    wxColour progressColor = wxTheColourDatabase->Find(m_isDarkMode ? wxT("DARK GREEN") : wxT("LIGHT BLUE"));
+    wxColour progressColor = m_isDarkMode ? wxColour(0, 64, 128) : wxColour(192, 217, 217);
     wxBrush progressBrush(progressColor);
 
     numItems = GetItemCount();

--- a/clientgui/BOINCListCtrl.cpp
+++ b/clientgui/BOINCListCtrl.cpp
@@ -82,8 +82,6 @@ CBOINCListCtrl::CBOINCListCtrl(
     pView, iListWindowID, wxDefaultPosition, wxSize(-1, -1), iListWindowFlags
 ) {
     m_pParentView = pView;
-    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
-    m_isDarkMode = appearance.IsDark();
 
     // Enable Zebra Striping
     EnableAlternateRowColours(true);
@@ -505,6 +503,7 @@ void CBOINCListCtrl::DrawProgressBars()
     wxRect r, rr;
     int w = 0, x = 0, xx, yy, ww;
     int progressColumn = -1;
+    bool isDarkMode = wxGetApp().GetIsDarkMode();
 
     if (m_pParentView->GetProgressColumn() >= 0) {
         progressColumn = m_pParentView->m_iColumnIDToColumnIndex[m_pParentView->GetProgressColumn()];
@@ -525,7 +524,7 @@ void CBOINCListCtrl::DrawProgressBars()
     int n = (int)m_iRowsNeedingProgressBars.GetCount();
     if (n <= 0) return;
 
-    wxColour progressColor = m_isDarkMode ? wxColour(0, 64, 128) : wxColour(192, 217, 217);
+    wxColour progressColor = isDarkMode ? wxColour(0, 64, 128) : wxColour(192, 217, 217);
     wxBrush progressBrush(progressColor);
 
     numItems = GetItemCount();
@@ -607,8 +606,8 @@ void CBOINCListCtrl::DrawProgressBars()
             dc.SetPen(bkgd);
             dc.SetBrush(bkgd);
 #else
-            dc.SetPen(m_isDarkMode ? *wxBLACK_PEN : *wxWHITE_PEN);
-            dc.SetBrush(m_isDarkMode ? *wxBLACK_BRUSH : *wxWHITE_BRUSH);
+            dc.SetPen(isDarkMode ? *wxBLACK_PEN : *wxWHITE_PEN);
+            dc.SetBrush(isDarkMode ? *wxBLACK_BRUSH : *wxWHITE_BRUSH);
 #endif
             dc.DrawRectangle( rr );
 

--- a/clientgui/BOINCListCtrl.h
+++ b/clientgui/BOINCListCtrl.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2015 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/BOINCListCtrl.h
+++ b/clientgui/BOINCListCtrl.h
@@ -97,6 +97,7 @@ private:
 
     CBOINCBaseView*         m_pParentView;
     wxArrayInt              m_iRowsNeedingProgressBars;
+    bool                    m_isDarkMode;
 
 #if ! USE_LIST_CACHE_HINT
     void                    OnMouseDown(wxMouseEvent& event);

--- a/clientgui/BOINCListCtrl.h
+++ b/clientgui/BOINCListCtrl.h
@@ -97,7 +97,6 @@ private:
 
     CBOINCBaseView*         m_pParentView;
     wxArrayInt              m_iRowsNeedingProgressBars;
-    bool                    m_isDarkMode;
 
 #if ! USE_LIST_CACHE_HINT
     void                    OnMouseDown(wxMouseEvent& event);

--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -102,7 +102,11 @@ bool CNoticeListCtrl::Create( wxWindow* parent ) {
 
     m_itemCount = 0;
     if (wxGetApp().GetIsDarkMode()){
+#if wxUSE_WEBVIEW
         m_noticesBody = wxT("<html><style>body{background-color:black;color:white;}</style><head></head><body></body></html>");
+#else
+        m_noticesBody = wxT("<html><head></head><body bgcolor=black></body></html>");
+#endif
     } else {
         m_noticesBody = wxT("<html><head></head><body></body></html>");
     }
@@ -153,9 +157,13 @@ void CNoticeListCtrl::SetItemCount(int newCount) {
 
 
     if (wxGetApp().GetIsDarkMode()){
-            m_noticesBody =  wxT("<html><style>body{background-color:black;color:white;}</style><head></head><body><font face=helvetica>");
+#if wxUSE_WEBVIEW
+        m_noticesBody =  wxT("<html><style>body{background-color:black;color:white;}</style><head></head><body><font face=helvetica>");
+#else
+       m_noticesBody =  wxT("<html><head></head><body bgcolor=black><font face=helvetica color=white bgcolor=black>");
+#endif
     } else {
-            m_noticesBody =  wxT("<html><head></head><body><font face=helvetica>");
+        m_noticesBody =  wxT("<html><head></head><body><font face=helvetica>");
     }
 
     for (i=0; i<newCount; ++i) {

--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -93,6 +93,9 @@ bool CNoticeListCtrl::Create( wxWindow* parent ) {
 #endif
 ////@end CNoticeListCtrl creation
 
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    m_isDarkMode = appearance.IsDark();
+
     wxBoxSizer *topsizer;
     topsizer = new wxBoxSizer(wxVERTICAL);
 
@@ -101,7 +104,18 @@ bool CNoticeListCtrl::Create( wxWindow* parent ) {
     SetSizer(topsizer);
 
     m_itemCount = 0;
-    m_noticesBody = wxT("<html><head></head><body></body></html>");
+    if (m_isDarkMode){
+        m_noticesBody = wxT("<html><style>body{background-color:black;color:white;}</style><head></head><body></body></html>");
+    } else {
+        m_noticesBody = wxT("<html><head></head><body></body></html>");
+    }
+
+    // In Dark Mode, paint the windoe black immediately
+#if wxUSE_WEBVIEW
+    m_browser->SetPage(m_noticesBody, wxEmptyString);
+#else
+    m_browser->SetPage(m_noticesBody);
+#endif
 
     // Display the fetching notices message until we have notices
     // to display or have determined that there are no notices.
@@ -139,7 +153,13 @@ void CNoticeListCtrl::SetItemCount(int newCount) {
     wxASSERT(wxDynamicCast(pSkinAdvanced, CSkinAdvanced));
 
     m_itemCount = newCount;
-    m_noticesBody =  wxT("<html><head></head><body><font face=helvetica>");
+
+
+    if (m_isDarkMode){
+            m_noticesBody =  wxT("<html><style>body{background-color:black;color:white;}</style><head></head><body><font face=helvetica>");
+    } else {
+            m_noticesBody =  wxT("<html><head></head><body><font face=helvetica>");
+    }
 
     for (i=0; i<newCount; ++i) {
         if (pDoc->IsConnected()) {

--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -93,9 +93,6 @@ bool CNoticeListCtrl::Create( wxWindow* parent ) {
 #endif
 ////@end CNoticeListCtrl creation
 
-    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
-    m_isDarkMode = appearance.IsDark();
-
     wxBoxSizer *topsizer;
     topsizer = new wxBoxSizer(wxVERTICAL);
 
@@ -104,13 +101,13 @@ bool CNoticeListCtrl::Create( wxWindow* parent ) {
     SetSizer(topsizer);
 
     m_itemCount = 0;
-    if (m_isDarkMode){
+    if (wxGetApp().GetIsDarkMode()){
         m_noticesBody = wxT("<html><style>body{background-color:black;color:white;}</style><head></head><body></body></html>");
     } else {
         m_noticesBody = wxT("<html><head></head><body></body></html>");
     }
 
-    // In Dark Mode, paint the windoe black immediately
+    // In Dark Mode, paint the window black immediately
 #if wxUSE_WEBVIEW
     m_browser->SetPage(m_noticesBody, wxEmptyString);
 #else
@@ -155,7 +152,7 @@ void CNoticeListCtrl::SetItemCount(int newCount) {
     m_itemCount = newCount;
 
 
-    if (m_isDarkMode){
+    if (wxGetApp().GetIsDarkMode()){
             m_noticesBody =  wxT("<html><style>body{background-color:black;color:white;}</style><head></head><body><font face=helvetica>");
     } else {
             m_noticesBody =  wxT("<html><head></head><body><font face=helvetica>");

--- a/clientgui/NoticeListCtrl.h
+++ b/clientgui/NoticeListCtrl.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/NoticeListCtrl.h
+++ b/clientgui/NoticeListCtrl.h
@@ -67,7 +67,6 @@ private:
     bool        m_bNeedsReloading;
     int         m_itemCount;
     wxString    m_noticesBody;
-    bool        m_isDarkMode;
 };
 
 #endif

--- a/clientgui/NoticeListCtrl.h
+++ b/clientgui/NoticeListCtrl.h
@@ -67,6 +67,7 @@ private:
     bool        m_bNeedsReloading;
     int         m_itemCount;
     wxString    m_noticesBody;
+    bool        m_isDarkMode;
 };
 
 #endif

--- a/clientgui/SkinManager.cpp
+++ b/clientgui/SkinManager.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/SkinManager.cpp
+++ b/clientgui/SkinManager.cpp
@@ -380,7 +380,6 @@ void CSkinSimple::Clear() {
     m_iPanelOpacity = DEFAULT_OPACITY;
 }
 
-
 int CSkinSimple::Parse(MIOFILE& in) {
     char buf[256];
     std::string strBuffer;
@@ -432,7 +431,7 @@ bool CSkinSimple::InitializeDelayedValidation() {
     );
     m_DialogBackgroundImage.SetDefaults(
         wxT("dialog background"), (const char**)dialog_background_image_xpm,
-        wxT("255:255:255"), BKGD_ANCHOR_HORIZ_CENTER, BKGD_ANCHOR_VERT_CENTER
+        wxGetApp().GetIsDarkMode() ? wxT("0:0:0") : wxT("255:255:255"), BKGD_ANCHOR_HORIZ_CENTER, BKGD_ANCHOR_VERT_CENTER
     );
     m_ProjectImage.SetDefaults(
         wxT("project"), (const char**)project_image_xpm

--- a/clientgui/SkinManager.h
+++ b/clientgui/SkinManager.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/ViewResources.cpp
+++ b/clientgui/ViewResources.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/ViewResources.cpp
+++ b/clientgui/ViewResources.cpp
@@ -47,6 +47,9 @@ CViewResources::CViewResources(wxNotebook* pNotebook) :
 {
 	m_BOINCwasEmpty=false;
 
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    m_isDarkMode = appearance.IsDark();
+
 	wxGridSizer* itemGridSizer = new wxGridSizer(2, 0, 3);
     wxASSERT(itemGridSizer);
 
@@ -58,7 +61,7 @@ CViewResources::CViewResources(wxNotebook* pNotebook) :
     m_pieCtrlTotal->SetTransparent(true);
     m_pieCtrlTotal->SetHorLegendBorder(10);
     m_pieCtrlTotal->SetLabelFont(*wxSWISS_FONT);
-    m_pieCtrlTotal->SetLabelColour(wxColour(0,0,0));
+    m_pieCtrlTotal->SetLabelColour(m_isDarkMode ? *wxWHITE : *wxBLACK);
     m_pieCtrlTotal->SetLabel(_("Total disk usage"));
 
     // initialize pie control
@@ -79,7 +82,7 @@ CViewResources::CViewResources(wxNotebook* pNotebook) :
     m_pieCtrlBOINC->SetTransparent(true);
     m_pieCtrlBOINC->SetHorLegendBorder(10);
     m_pieCtrlBOINC->SetLabelFont(*wxSWISS_FONT);
-    m_pieCtrlBOINC->SetLabelColour(wxColour(0,0,0));
+    m_pieCtrlTotal->SetLabelColour(m_isDarkMode ? *wxWHITE : *wxBLACK);
     m_pieCtrlBOINC->SetLabel(_("Disk usage by BOINC projects"));
 
     // initialize pie control
@@ -260,7 +263,8 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
         FormatDiskSpace(boinc_total, diskspace);
         part.SetLabel(_("used by BOINC: ") + diskspace);
 		part.SetValue(boinc_total);
-		part.SetColour(wxColour(0,0,0));
+        part.SetColour(m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0));
+		part.SetColour(m_isDarkMode ? *wxWHITE : *wxBLACK);
 		m_pieCtrlTotal->m_Series.Add(part);
 
         if (pDoc->disk_usage.d_allowed > 0) {
@@ -270,7 +274,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
             FormatDiskSpace(avail, diskspace);
             part.SetLabel(_("free, available to BOINC: ") + diskspace);
             part.SetValue(avail == 0 ? 1 : avail);
-            part.SetColour(wxColour(128, 128, 128));
+            part.SetColour(m_isDarkMode ? wxColour(108, 108, 108) : wxColour(128, 128, 128));
             m_pieCtrlTotal->m_Series.Add(part);
 
             double not_avail = free - avail;
@@ -278,7 +282,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		        FormatDiskSpace(not_avail, diskspace);
                 part.SetLabel(_("free, not available to BOINC: ") + diskspace);
 		        part.SetValue(not_avail);
-		        part.SetColour(wxColour(238,238,238));
+		        part.SetColour(m_isDarkMode ? wxColour(172,172,172) : wxColour(238,238,238));
 		        m_pieCtrlTotal->m_Series.Add(part);
             }
         } else {
@@ -288,7 +292,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		    FormatDiskSpace(free, diskspace);
             part.SetLabel(_("free: ") + diskspace);
 		    part.SetValue(free);
-		    part.SetColour(wxColour(238,238,238));
+            part.SetColour(m_isDarkMode ? wxColour(172,172,172) : wxColour(238,238,238));
 		    m_pieCtrlTotal->m_Series.Add(part);
         }
 
@@ -297,7 +301,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		FormatDiskSpace(used_by_others, diskspace);
         part.SetLabel(_("used by other programs: ") + diskspace);
 		part.SetValue(used_by_others);
-		part.SetColour(wxColour(192,192,192));
+		part.SetColour(m_isDarkMode ? wxColour(140,140,140) : wxColour(192,192,192));
 		m_pieCtrlTotal->m_Series.Add(part);
 		m_pieCtrlTotal->Refresh();
 	}

--- a/clientgui/ViewResources.cpp
+++ b/clientgui/ViewResources.cpp
@@ -45,10 +45,8 @@ CViewResources::CViewResources()
 CViewResources::CViewResources(wxNotebook* pNotebook) :
 	CBOINCBaseView(pNotebook)
 {
+    bool isDarkMode = wxGetApp().GetIsDarkMode();
 	m_BOINCwasEmpty=false;
-
-    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
-    m_isDarkMode = appearance.IsDark();
 
 	wxGridSizer* itemGridSizer = new wxGridSizer(2, 0, 3);
     wxASSERT(itemGridSizer);
@@ -61,7 +59,7 @@ CViewResources::CViewResources(wxNotebook* pNotebook) :
     m_pieCtrlTotal->SetTransparent(true);
     m_pieCtrlTotal->SetHorLegendBorder(10);
     m_pieCtrlTotal->SetLabelFont(*wxSWISS_FONT);
-    m_pieCtrlTotal->SetLabelColour(m_isDarkMode ? *wxWHITE : *wxBLACK);
+    m_pieCtrlTotal->SetLabelColour(isDarkMode ? *wxWHITE : *wxBLACK);
     m_pieCtrlTotal->SetLabel(_("Total disk usage"));
 
     // initialize pie control
@@ -82,7 +80,7 @@ CViewResources::CViewResources(wxNotebook* pNotebook) :
     m_pieCtrlBOINC->SetTransparent(true);
     m_pieCtrlBOINC->SetHorLegendBorder(10);
     m_pieCtrlBOINC->SetLabelFont(*wxSWISS_FONT);
-    m_pieCtrlTotal->SetLabelColour(m_isDarkMode ? *wxWHITE : *wxBLACK);
+    m_pieCtrlTotal->SetLabelColour(isDarkMode ? *wxWHITE : *wxBLACK);
     m_pieCtrlBOINC->SetLabel(_("Disk usage by BOINC projects"));
 
     // initialize pie control
@@ -175,6 +173,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
     wxString diskspace;
 	static double project_total=0.0;
 	unsigned int i;
+    bool isDarkMode = wxGetApp().GetIsDarkMode();
 
     wxASSERT(pDoc);
     wxASSERT(wxDynamicCast(pDoc, CMainDocument));
@@ -263,8 +262,8 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
         FormatDiskSpace(boinc_total, diskspace);
         part.SetLabel(_("used by BOINC: ") + diskspace);
 		part.SetValue(boinc_total);
-        part.SetColour(m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0));
-		part.SetColour(m_isDarkMode ? *wxWHITE : *wxBLACK);
+        part.SetColour(isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0));
+		part.SetColour(isDarkMode ? *wxWHITE : *wxBLACK);
 		m_pieCtrlTotal->m_Series.Add(part);
 
         if (pDoc->disk_usage.d_allowed > 0) {
@@ -274,7 +273,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
             FormatDiskSpace(avail, diskspace);
             part.SetLabel(_("free, available to BOINC: ") + diskspace);
             part.SetValue(avail == 0 ? 1 : avail);
-            part.SetColour(m_isDarkMode ? wxColour(108, 108, 108) : wxColour(128, 128, 128));
+            part.SetColour(isDarkMode ? wxColour(108, 108, 108) : wxColour(128, 128, 128));
             m_pieCtrlTotal->m_Series.Add(part);
 
             double not_avail = free - avail;
@@ -282,7 +281,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		        FormatDiskSpace(not_avail, diskspace);
                 part.SetLabel(_("free, not available to BOINC: ") + diskspace);
 		        part.SetValue(not_avail);
-		        part.SetColour(m_isDarkMode ? wxColour(172,172,172) : wxColour(238,238,238));
+		        part.SetColour(isDarkMode ? wxColour(172,172,172) : wxColour(238,238,238));
 		        m_pieCtrlTotal->m_Series.Add(part);
             }
         } else {
@@ -292,7 +291,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		    FormatDiskSpace(free, diskspace);
             part.SetLabel(_("free: ") + diskspace);
 		    part.SetValue(free);
-            part.SetColour(m_isDarkMode ? wxColour(172,172,172) : wxColour(238,238,238));
+            part.SetColour(isDarkMode ? wxColour(172,172,172) : wxColour(238,238,238));
 		    m_pieCtrlTotal->m_Series.Add(part);
         }
 
@@ -301,7 +300,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		FormatDiskSpace(used_by_others, diskspace);
         part.SetLabel(_("used by other programs: ") + diskspace);
 		part.SetValue(used_by_others);
-		part.SetColour(m_isDarkMode ? wxColour(140,140,140) : wxColour(192,192,192));
+		part.SetColour(isDarkMode ? wxColour(140,140,140) : wxColour(192,192,192));
 		m_pieCtrlTotal->m_Series.Add(part);
 		m_pieCtrlTotal->Refresh();
 	}

--- a/clientgui/ViewResources.h
+++ b/clientgui/ViewResources.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/ViewResources.h
+++ b/clientgui/ViewResources.h
@@ -52,7 +52,6 @@ protected:
 	wxPieCtrl*				m_pieCtrlTotal;
 
 	bool					m_BOINCwasEmpty;
-    bool                    m_isDarkMode;
 
     virtual void            UpdateSelection();
 

--- a/clientgui/ViewResources.h
+++ b/clientgui/ViewResources.h
@@ -52,6 +52,7 @@ protected:
 	wxPieCtrl*				m_pieCtrlTotal;
 
 	bool					m_BOINCwasEmpty;
+    bool                    m_isDarkMode;
 
     virtual void            UpdateSelection();
 

--- a/clientgui/ViewStatistics.cpp
+++ b/clientgui/ViewStatistics.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/ViewStatistics.cpp
+++ b/clientgui/ViewStatistics.cpp
@@ -74,6 +74,7 @@ CPaintStatistics::CPaintStatistics(wxWindow* parent, wxWindowID id, const wxPoin
 {	m_font_standart = *wxSWISS_FONT;
 	m_font_bold = *wxSWISS_FONT;
 	m_font_standart_italic = *wxSWISS_FONT;
+    bool isDarkMode = wxGetApp().GetIsDarkMode();
 
 	m_SelectedStatistic = show_user_total;
 	heading = wxT("");
@@ -155,9 +156,6 @@ CPaintStatistics::CPaintStatistics(wxWindow* parent, wxWindowID id, const wxPoin
 	m_Legend_dY = 0;
 	m_LegendDraw = true;
 
-    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
-    m_isDarkMode = appearance.IsDark();
-
 // Default colours
 	m_pen_MarkerLineColour = wxColour(0, 0, 0);
 	m_pen_ZoomRectColour = wxColour (128, 64, 95);
@@ -168,20 +166,20 @@ CPaintStatistics::CPaintStatistics(wxWindow* parent, wxWindowID id, const wxPoin
 	m_pen_AxisColourAutoZoom = wxColour(64, 128, 192);
 	m_pen_AxisXColour = wxColour(64, 128, 192);
 	m_pen_AxisYColour = wxColour(64, 128, 192);
-	m_pen_AxisXTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
-	m_pen_AxisYTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_pen_AxisXTextColour = isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_pen_AxisYTextColour = isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
 
-	m_brush_LegendColour = m_isDarkMode ? wxColour(0, 64, 128) : wxColour(235, 255, 255);
+	m_brush_LegendColour = isDarkMode ? wxColour(0, 64, 128) : wxColour(235, 255, 255);
 	m_brush_LegendSelectColour = wxColour(192, 224, 255);
 	m_pen_LegendSelectColour = wxColour(64, 128, 192);
-	m_pen_LegendSelectTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_pen_LegendSelectTextColour = isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
 	m_pen_LegendColour = wxColour(64, 128, 192);
-	m_pen_LegendTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
-	m_brush_MainColour = m_isDarkMode ? wxColour(0,0,0) : wxColour(255, 255, 255);
+	m_pen_LegendTextColour = isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_brush_MainColour = isDarkMode ? wxColour(0,0,0) : wxColour(255, 255, 255);
 	m_pen_MainColour = wxColour(64, 128, 192);
 
-	m_pen_HeadTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
-	m_pen_ProjectHeadTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_pen_HeadTextColour = isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_pen_ProjectHeadTextColour = isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
 
 	m_pen_GraphTotalColour = wxColour(255, 0, 0);
 	m_pen_GraphRACColour = wxColour(0, 160, 0);
@@ -627,7 +625,7 @@ void CPaintStatistics::DrawLegend(wxDC &dc, PROJECTS* proj, CMainDocument* pDoc,
 			dc.SetFont(m_font_bold);
 		}else {
 			dc.SetFont(m_font_standart_italic);
-            graphColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+            graphColour = wxGetApp().GetIsDarkMode() ? wxColour(255, 255, 255) : wxColour(0,0,0);
 
 		}
 

--- a/clientgui/ViewStatistics.cpp
+++ b/clientgui/ViewStatistics.cpp
@@ -155,6 +155,9 @@ CPaintStatistics::CPaintStatistics(wxWindow* parent, wxWindowID id, const wxPoin
 	m_Legend_dY = 0;
 	m_LegendDraw = true;
 
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    m_isDarkMode = appearance.IsDark();
+
 // Default colours
 	m_pen_MarkerLineColour = wxColour(0, 0, 0);
 	m_pen_ZoomRectColour = wxColour (128, 64, 95);
@@ -165,21 +168,20 @@ CPaintStatistics::CPaintStatistics(wxWindow* parent, wxWindowID id, const wxPoin
 	m_pen_AxisColourAutoZoom = wxColour(64, 128, 192);
 	m_pen_AxisXColour = wxColour(64, 128, 192);
 	m_pen_AxisYColour = wxColour(64, 128, 192);
-	m_pen_AxisXTextColour = wxColour(0, 0, 0);
-	m_pen_AxisYTextColour = wxColour(0, 0, 0);
+	m_pen_AxisXTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_pen_AxisYTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
 
-	m_brush_LegendColour = wxColour(235, 255, 255);//wxColour(220, 240, 255);
+	m_brush_LegendColour = m_isDarkMode ? wxColour(0, 64, 128) : wxColour(235, 255, 255);
 	m_brush_LegendSelectColour = wxColour(192, 224, 255);
 	m_pen_LegendSelectColour = wxColour(64, 128, 192);
-	m_pen_LegendSelectTextColour = wxColour(0, 0, 0);
+	m_pen_LegendSelectTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
 	m_pen_LegendColour = wxColour(64, 128, 192);
-	m_pen_LegendTextColour = wxColour(0, 0, 0);
-
-	m_brush_MainColour = wxColour(255, 255, 255);
+	m_pen_LegendTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_brush_MainColour = m_isDarkMode ? wxColour(0,0,0) : wxColour(255, 255, 255);
 	m_pen_MainColour = wxColour(64, 128, 192);
 
-	m_pen_HeadTextColour = wxColour(0, 0, 0);
-	m_pen_ProjectHeadTextColour = wxColour(0, 0, 0);
+	m_pen_HeadTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+	m_pen_ProjectHeadTextColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
 
 	m_pen_GraphTotalColour = wxColour(255, 0, 0);
 	m_pen_GraphRACColour = wxColour(0, 160, 0);
@@ -625,7 +627,8 @@ void CPaintStatistics::DrawLegend(wxDC &dc, PROJECTS* proj, CMainDocument* pDoc,
 			dc.SetFont(m_font_bold);
 		}else {
 			dc.SetFont(m_font_standart_italic);
-			graphColour = wxColour(0, 0, 0);
+            graphColour = m_isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0);
+
 		}
 
 		x0 = wxCoord(m_WorkSpace_X_end) + buffer_x1 + wxCoord(7) + wxCoord(m_GraphPointWidth);

--- a/clientgui/ViewStatistics.h
+++ b/clientgui/ViewStatistics.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/ViewStatistics.h
+++ b/clientgui/ViewStatistics.h
@@ -183,6 +183,8 @@ public:
     wxColour                m_pen_GraphTotalHostColour;
     wxColour                m_pen_GraphRACHostColour;
 
+    bool                    m_isDarkMode;
+
 protected:
     void OnPaint(wxPaintEvent& event);
 	void OnEraseBackground(wxEraseEvent & /*event*/){};

--- a/clientgui/ViewStatistics.h
+++ b/clientgui/ViewStatistics.h
@@ -183,8 +183,6 @@ public:
     wxColour                m_pen_GraphTotalHostColour;
     wxColour                m_pen_GraphRACHostColour;
 
-    bool                    m_isDarkMode;
-
 protected:
     void OnPaint(wxPaintEvent& event);
 	void OnEraseBackground(wxEraseEvent & /*event*/){};

--- a/clientgui/common/wxPieCtrl.cpp
+++ b/clientgui/common/wxPieCtrl.cpp
@@ -48,14 +48,18 @@ wxPieCtrl::wxPieCtrl(wxWindow * parent, wxWindowID id, wxPoint pos,
 		wxSize sz, long style, wxString name)
 		:wxWindow(parent, id, pos, sz, style, name)
 {
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    m_isDarkMode = appearance.IsDark();
+    if (m_isDarkMode) SetBackgroundColour(*wxBLACK);
+
 	m_ShowEdges=true;
 	m_CanRepaint=true;
-	m_BackColour=*wxWHITE;
+	m_BackColour = m_isDarkMode ? *wxBLACK : *wxWHITE;
 	m_padding=10;
 
-	m_TitleColour = wxColour(0,0,0);
-	m_LabelColour = *wxBLACK;
-	m_LegendBackColour = wxColour(255,255,0);
+	m_TitleColour = m_isDarkMode ? wxColour(255,255,255) : wxColour(0,0,0);
+	m_LabelColour = m_isDarkMode ? *wxWHITE : *wxBLACK;
+	m_LegendBackColour = m_isDarkMode ? wxColour(0, 0, 255) : wxColour(255,255,0);
 	m_TitleFont = *wxSWISS_FONT;
 	m_TitleFont.SetWeight(wxBOLD);
 	m_LabelFont = *wxSWISS_FONT;

--- a/clientgui/common/wxPieCtrl.cpp
+++ b/clientgui/common/wxPieCtrl.cpp
@@ -10,6 +10,7 @@
 /////////////////////////////////////////////////////////////////////////////
 #include <vector>
 #include <algorithm>
+#include "BOINCGUIApp.h"
 #include "wxPieCtrl.h"
 #include <wx/arrimpl.cpp>
 
@@ -48,18 +49,18 @@ wxPieCtrl::wxPieCtrl(wxWindow * parent, wxWindowID id, wxPoint pos,
 		wxSize sz, long style, wxString name)
 		:wxWindow(parent, id, pos, sz, style, name)
 {
-    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
-    m_isDarkMode = appearance.IsDark();
-    if (m_isDarkMode) SetBackgroundColour(*wxBLACK);
+    bool isDarkMode = wxGetApp().GetIsDarkMode();
+
+    if (isDarkMode) SetBackgroundColour(*wxBLACK);
 
 	m_ShowEdges=true;
 	m_CanRepaint=true;
-	m_BackColour = m_isDarkMode ? *wxBLACK : *wxWHITE;
+	m_BackColour = isDarkMode ? *wxBLACK : *wxWHITE;
 	m_padding=10;
 
-	m_TitleColour = m_isDarkMode ? wxColour(255,255,255) : wxColour(0,0,0);
-	m_LabelColour = m_isDarkMode ? *wxWHITE : *wxBLACK;
-	m_LegendBackColour = m_isDarkMode ? wxColour(0, 0, 255) : wxColour(255,255,0);
+	m_TitleColour = isDarkMode ? wxColour(255,255,255) : wxColour(0,0,0);
+	m_LabelColour = isDarkMode ? *wxWHITE : *wxBLACK;
+	m_LegendBackColour = isDarkMode ? wxColour(0, 0, 255) : wxColour(255,255,0);
 	m_TitleFont = *wxSWISS_FONT;
 	m_TitleFont.SetWeight(wxBOLD);
 	m_LabelFont = *wxSWISS_FONT;

--- a/clientgui/common/wxPieCtrl.cpp
+++ b/clientgui/common/wxPieCtrl.cpp
@@ -10,6 +10,7 @@
 /////////////////////////////////////////////////////////////////////////////
 #include <vector>
 #include <algorithm>
+#include "stdwx.h"
 #include "BOINCGUIApp.h"
 #include "wxPieCtrl.h"
 #include <wx/arrimpl.cpp>

--- a/clientgui/common/wxPieCtrl.h
+++ b/clientgui/common/wxPieCtrl.h
@@ -87,7 +87,6 @@ protected:
     wxScrollBar* m_scrollBar;
     int m_Scrollbar_width;
     int m_firstlabelToDraw;
-    bool m_isDarkMode;
 
 	//internal methods
 	void GetPartAngles(wxArrayDouble & angles);

--- a/clientgui/common/wxPieCtrl.h
+++ b/clientgui/common/wxPieCtrl.h
@@ -87,6 +87,7 @@ protected:
     wxScrollBar* m_scrollBar;
     int m_Scrollbar_width;
     int m_firstlabelToDraw;
+    bool m_isDarkMode;
 
 	//internal methods
 	void GetPartAngles(wxArrayDouble & angles);

--- a/clientgui/mac/MacBitmapComboBox.h
+++ b/clientgui/mac/MacBitmapComboBox.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -84,6 +84,7 @@ public:
     wxString GetValue() { return m_ChoiceControl->GetStringSelection(); }
     wxString GetString(unsigned int n) const { return m_ChoiceControl->GetString(n); }
     wxString GetStringSelection() { return m_ChoiceControl->GetStringSelection(); }
+    int FindString(const wxString &s, bool bCase=false) { return m_ChoiceControl->FindString(s, bCase); }
 
     int Append(const wxString& item, const wxBitmap& bitmap);
     int Append(const wxString& item, const wxBitmap& bitmap, void *clientData);

--- a/clientgui/mac/templates/Info.plist
+++ b/clientgui/mac/templates/Info.plist
@@ -22,7 +22,5 @@
 	<string>%VERSION%</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>NSRequiresAquaSystemAppearance</key>
-	<true/>
 </dict>
 </plist>

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -941,7 +941,6 @@ void CSimpleFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) )
     panelSizer->Replace(m_pBackgroundPanel->m_taskPanel, newTaskPanel);
     m_pBackgroundPanel->m_taskPanel->Destroy();
     m_pBackgroundPanel->m_taskPanel = newTaskPanel;
-    m_pBackgroundPanel->m_taskPanel->ReskinInterface();
 
     CSimpleProjectPanel* newProjectpanel = new CSimpleProjectPanel(m_pBackgroundPanel);
     panelSizer->Replace(m_pBackgroundPanel->m_projPanel, newProjectpanel);
@@ -950,9 +949,7 @@ void CSimpleFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) )
 
     m_pBackgroundPanel->Layout();
 
-    // Force a redraw in case a modal dialog is also open
-    m_pBackgroundPanel->m_taskPanel->UpdatePanel(false);
-    m_pBackgroundPanel->m_projPanel->UpdateInterface();
+    m_pBackgroundPanel->ReskinInterface();
 
     // Restore our task and project settings
     int iTask = m_pBackgroundPanel->m_taskPanel->GetTaskSelectionCtrl()->FindString(taskStr);
@@ -1177,6 +1174,28 @@ void CSimpleGUIPanel::SetBackgroundBitmap() {
 
     wxMemoryDC srcDC(*srcBmp);
     dc.Blit(destX, destY, w, h, &srcDC, srcX, srcY, wxCOPY);
+
+#ifdef __WXMAC__
+    // In Dark Mode, MacOS makes button backgrounds partly tranparent
+    // rather than black. It uses a slightly darker rendition of the
+    // underlying bitmap, which can make the button's white text hard
+    // to read with some skins. So we force these button backgrounds
+    // to be dark gray.
+    if (wxGetApp().GetIsDarkMode()) {
+        wxPen oldPen = dc.GetPen();
+        dc.SetPen(*wxBLACK);
+        wxBrush oldBrush = dc.GetBrush();
+        dc.SetBrush(*wxBLACK_BRUSH);
+        wxRect r = m_NoticesButton->GetRect();
+        dc.DrawRoundedRectangle(r, 5);
+        r = m_SuspendResumeButton->GetRect();
+        dc.DrawRoundedRectangle(r, 5);
+        r = m_HelpButton->GetRect();
+        dc.DrawRoundedRectangle(r, 5);
+        dc.SetPen(oldPen);
+        dc.SetBrush(oldBrush);
+    }
+#endif
 
 //    dc.DrawBitmap(*pSkinSimple->GetBackgroundImage()->GetBitmap(), 0, 0, false);
 

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -48,6 +48,7 @@
 #include "DlgOptions.h"
 #include "DlgDiagnosticLogFlags.h"
 #include "AdvancedFrame.h"
+#include "NoticeListCtrl.h"
 
 
 #ifdef __WXMAC__
@@ -924,8 +925,17 @@ void CSimpleFrame::OnEventLog(wxCommandEvent& WXUNUSED(event)) {
 
 
 void CSimpleFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) ) {
+#if SUPPORTDARKMODE
     wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
     wxGetApp().SetIsDarkMode(appearance.IsDark());
+
+    CSkinManager* theSkinManagr = wxGetApp().GetSkinManager();
+    theSkinManagr->ReloadSkin(theSkinManagr->GetSelectedSkin());
+
+    if (dlgMsgsPtr) {
+        dlgMsgsPtr->GetMsgsPanel()->RedrawNoticesListCtrl();
+    }
+#endif
 }
 
 

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -923,6 +923,12 @@ void CSimpleFrame::OnEventLog(wxCommandEvent& WXUNUSED(event)) {
 }
 
 
+void CSimpleFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event) ) {
+    wxSystemAppearance appearance = wxSystemSettings::GetAppearance();
+    wxGetApp().SetIsDarkMode(appearance.IsDark());
+}
+
+
 IMPLEMENT_DYNAMIC_CLASS(CSimpleGUIPanel, wxPanel)
 
 BEGIN_EVENT_TABLE(CSimpleGUIPanel, wxPanel)

--- a/clientgui/sg_BoincSimpleFrame.h
+++ b/clientgui/sg_BoincSimpleFrame.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/sg_BoincSimpleFrame.h
+++ b/clientgui/sg_BoincSimpleFrame.h
@@ -123,6 +123,7 @@ public:
     void OnRefreshView( CFrameEvent& event );
     void OnNotification( CFrameEvent& event );
     void OnEventLog(wxCommandEvent& event);
+    void OnDarkModeChanged( wxSysColourChangedEvent& event );
 
 	void SetMsgsDlgOpen(CDlgMessages* newDlgPtr) { dlgMsgsPtr = newDlgPtr; }
     bool isMessagesDlgOpen() { return (dlgMsgsPtr != NULL); }

--- a/clientgui/sg_BoincSimpleFrame.h
+++ b/clientgui/sg_BoincSimpleFrame.h
@@ -29,6 +29,7 @@ class CSimpleTaskPanel;
 class CSimpleProjectPanel;
 class CSimpleTaskPanel;
 class CDlgMessages;
+class CDlgPreferences;
 
 class CSimpleGUIPanel : public wxPanel
 {
@@ -154,6 +155,8 @@ protected:
 
 private:
     CDlgMessages* dlgMsgsPtr;
+    CDlgPreferences* dlgPrefsPtr;
+
     wxBoxSizer* mainSizer;
 
     DECLARE_EVENT_TABLE()

--- a/clientgui/sg_DlgMessages.cpp
+++ b/clientgui/sg_DlgMessages.cpp
@@ -371,6 +371,9 @@ void CPanelMessages::RedrawNoticesListCtrl() {
     bool fetchingNoticesTextWasDisplayed = m_bFetchingNoticesTextWasDisplayed;
     bool noNoticesTextWasDisplayed = m_bNoNoticesTextWasDisplayed;
 
+    m_closeButton->Destroy();
+    m_closeButton = NULL;
+
     CreateControls();
 
     m_bFetchingNoticesTextWasDisplayed = fetchingNoticesTextWasDisplayed;

--- a/clientgui/sg_DlgMessages.cpp
+++ b/clientgui/sg_DlgMessages.cpp
@@ -365,6 +365,7 @@ bool CPanelMessages::OnRestoreState(wxConfigBase* /* pConfig */) {
 
 void CPanelMessages::RedrawNoticesListCtrl() {
     SetSizer(NULL);
+    m_pHtmlListPane->Destroy();
     CreateControls();
     m_pHtmlListPane->UpdateUI();
 }

--- a/clientgui/sg_DlgMessages.cpp
+++ b/clientgui/sg_DlgMessages.cpp
@@ -125,7 +125,7 @@ void CPanelMessages::CreateControls()
                                     _("Fetching notices; please wait..."),
                                     wxPoint(20, 20), wxDefaultSize, 0
                                     );
-    m_FetchingNoticesText->SetBackgroundColour(*wxWHITE);
+    m_FetchingNoticesText->SetBackgroundColour(wxGetApp().GetIsDarkMode() ? *wxBLACK :  *wxWHITE);
     itemFlexGridSizer2->Add(m_FetchingNoticesText, 0, wxEXPAND | wxLEFT | wxRIGHT, 5);
 
     m_NoNoticesText = new wxStaticText(
@@ -133,7 +133,7 @@ void CPanelMessages::CreateControls()
                                     _("There are no notices at this time."),
                                     wxPoint(20, 20), wxDefaultSize, 0
                                     );
-    m_NoNoticesText->SetBackgroundColour(*wxWHITE);
+    m_NoNoticesText->SetBackgroundColour(wxGetApp().GetIsDarkMode() ? *wxBLACK :  *wxWHITE);
     itemFlexGridSizer2->Add(m_NoNoticesText, 0, wxEXPAND | wxLEFT | wxRIGHT, 5);
 
 
@@ -366,7 +366,27 @@ bool CPanelMessages::OnRestoreState(wxConfigBase* /* pConfig */) {
 void CPanelMessages::RedrawNoticesListCtrl() {
     SetSizer(NULL);
     m_pHtmlListPane->Destroy();
+    m_FetchingNoticesText->Destroy();
+    m_NoNoticesText->Destroy();
+    bool fetchingNoticesTextWasDisplayed = m_bFetchingNoticesTextWasDisplayed;
+    bool noNoticesTextWasDisplayed = m_bNoNoticesTextWasDisplayed;
+
     CreateControls();
+
+    m_bFetchingNoticesTextWasDisplayed = fetchingNoticesTextWasDisplayed;
+    if (fetchingNoticesTextWasDisplayed) {
+        m_bFetchingNoticesTextWasDisplayed = true;
+        m_FetchingNoticesText->Show();
+    }
+    if (noNoticesTextWasDisplayed) {
+        m_bNoNoticesTextWasDisplayed = true;
+        m_NoNoticesText->Show();
+    }
+
+    if (m_bFetchingNoticesTextWasDisplayed || m_bNoNoticesTextWasDisplayed) {
+        Layout();
+    }
+
     m_pHtmlListPane->UpdateUI();
 }
 

--- a/clientgui/sg_DlgMessages.cpp
+++ b/clientgui/sg_DlgMessages.cpp
@@ -92,6 +92,7 @@ bool CPanelMessages::Create()
 ////@begin CPanelMessages member initialisation
     m_bProcessingRefreshEvent = false;
 ////@end CPanelMessages member initialisation
+    m_closeButton = NULL;
 
     CreateControls();
 
@@ -143,9 +144,11 @@ void CPanelMessages::CreateControls()
 
     wxBoxSizer* itemBoxSizer4 = new wxBoxSizer(wxHORIZONTAL);
 
-    wxButton* itemButton44 = new wxButton(itemDialog1, wxID_OK, _("&Close"),  wxDefaultPosition, wxDefaultSize);
+    if (!m_closeButton) {
+        m_closeButton = new wxButton(itemDialog1, wxID_OK, _("&Close"),  wxDefaultPosition, wxDefaultSize);
+    }
 
-    itemBoxSizer4->Add(itemButton44, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
+    itemBoxSizer4->Add(m_closeButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
 #ifdef __WXMAC__            // Don't let Close button overlap window's grow icon
     itemFlexGridSizer2->Add(itemBoxSizer4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 12);
@@ -205,6 +208,19 @@ void CPanelMessages::OnEraseBackground(wxEraseEvent& event){
     if ( (w < sz.x) || (h < sz.y) ) {
         // Check to see if they need to be rescaled to fit in the window
         wxImage img = bmp.ConvertToImage();
+
+        if (wxGetApp().GetIsDarkMode()) {
+            // Darken the image
+            unsigned char *bgImagePixels = img.GetData(); // RGBRGBRGB...
+            for (int i=0; i<w; ++i) {
+                for (int j=0; j<h; ++j) {
+                    for (int k=0; k<3; ++k) {
+                        *bgImagePixels /= 4;
+                        ++bgImagePixels;
+                    }
+                }
+            }
+        }
         img.Rescale((int) sz.x, (int) sz.y);
 
         // Draw our cool background (centered)
@@ -215,9 +231,27 @@ void CPanelMessages::OnEraseBackground(wxEraseEvent& event){
         x = wxMax(0, (w - sz.x)/2);
         y = wxMax(0, (h - sz.y)/2);
 
-        // Select the desired bitmap into the memory DC so we can take
-        //   the center chunk of it.
         memDC.SelectObject(bmp);
+        // Select the desired bitmap (or its darkened version) into
+        //   the memory DC so we can take the center chunk of it.
+        if (wxGetApp().GetIsDarkMode()) {
+            // Darken the bitmap
+            wxImage bgImage = bmp.ConvertToImage();
+            unsigned char *bgImagePixels;
+            bgImagePixels = bgImage.GetData(); // RGBRGBRGB...
+           for (int i=0; i<w; ++i) {
+                for (int j=0; j<h; ++j) {
+                    for (int k=0; k<3; ++k) {
+                        *bgImagePixels /= 4;
+                        ++bgImagePixels;
+                    }
+                }
+            }
+            wxBitmap darkened(bgImage);
+            memDC.SelectObject(darkened);
+        } else {
+            memDC.SelectObject(bmp);
+        }
 
         // Draw the center chunk on the window
         dc.Blit(0, 0, w, h, &memDC, x, y, wxCOPY);
@@ -326,6 +360,13 @@ bool CPanelMessages::OnSaveState(wxConfigBase* /* pConfig */) {
 
 bool CPanelMessages::OnRestoreState(wxConfigBase* /* pConfig */) {
     return true;
+}
+
+
+void CPanelMessages::RedrawNoticesListCtrl() {
+    SetSizer(NULL);
+    CreateControls();
+    m_pHtmlListPane->UpdateUI();
 }
 
 

--- a/clientgui/sg_DlgMessages.h
+++ b/clientgui/sg_DlgMessages.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -102,6 +102,8 @@ public:
     /// wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_SIMPLE_HELP
     void OnButtonHelp( wxCommandEvent& event );
 
+    void RedrawNoticesListCtrl();
+
 ////@end CPanelMessages event handler declarations
 
 ////@begin CPanelMessages member function declarations
@@ -119,6 +121,7 @@ protected:
     wxStaticText*           m_NoNoticesText;
     bool                    m_bFetchingNoticesTextWasDisplayed;
     bool                    m_bNoNoticesTextWasDisplayed;
+    wxButton*               m_closeButton;
 };
 
 
@@ -151,6 +154,7 @@ public:
 
     void OnRefresh() { m_pBackgroundPanel->OnRefresh(); }
 
+    CPanelMessages* GetMsgsPanel() { return m_pBackgroundPanel; }
 private:
 
     bool SaveState();

--- a/clientgui/sg_DlgPreferences.cpp
+++ b/clientgui/sg_DlgPreferences.cpp
@@ -427,6 +427,11 @@ void CPanelPreferences::MakeBackgroundBitmap() {
     wxASSERT(pSkinSimple);
     wxASSERT(wxDynamicCast(pSkinSimple, CSkinSimple));
 
+    if (m_backgroundBitmap) {
+        delete m_backgroundBitmap;
+        m_backgroundBitmap = NULL;
+    }
+
     wxMemoryDC memDC;
     wxCoord w, h, x, y;
 

--- a/clientgui/sg_DlgPreferences.cpp
+++ b/clientgui/sg_DlgPreferences.cpp
@@ -97,7 +97,8 @@ bool CPanelPreferences::Create()
 {
     m_backgroundBitmap = NULL;
     lastErrorCtrl = NULL;
-    stdTextBkgdColor = *wxWHITE;
+    
+    stdTextBkgdColor = wxGetApp().GetIsDarkMode() ? *wxBLACK : *wxWHITE;
 
     CreateControls();
 
@@ -446,6 +447,19 @@ void CPanelPreferences::MakeBackgroundBitmap() {
     if ( (w < sz.x) || (h < sz.y) ) {
         // Check to see if they need to be rescaled to fit in the window
         wxImage img = bmp.ConvertToImage();
+
+        if (wxGetApp().GetIsDarkMode()) {
+            // Darken the image
+            unsigned char *bgImagePixels = img.GetData(); // RGBRGBRGB...
+            for (int i=0; i<w; ++i) {
+                for (int j=0; j<h; ++j) {
+                    for (int k=0; k<3; ++k) {
+                        *bgImagePixels /= 4;
+                        ++bgImagePixels;
+                    }
+                }
+            }
+        }
         img.Rescale((int) sz.x, (int) sz.y);
 
         // Draw our cool background (enlarged and centered)
@@ -477,9 +491,26 @@ void CPanelPreferences::MakeBackgroundBitmap() {
             break;
         }
 
-        // Select the desired bitmap into the memory DC so we can take
-        //   the desired chunk of it.
-        memDC.SelectObject(bmp);
+        // Select the desired bitmap (or its negative) into the
+        //   memory DC so we can take the desired chunk of it.
+        if (wxGetApp().GetIsDarkMode()) {
+            // Darken the bitmap
+            wxImage bgImage = bmp.ConvertToImage();
+            unsigned char *bgImagePixels;
+            bgImagePixels = bgImage.GetData(); // RGBRGBRGB...
+           for (int i=0; i<w; ++i) {
+                for (int j=0; j<h; ++j) {
+                    for (int k=0; k<3; ++k) {
+                        *bgImagePixels /= 4;
+                        ++bgImagePixels;
+                    }
+                }
+            }
+            wxBitmap negative(bgImage);
+            memDC.SelectObject(negative);
+        } else {
+            memDC.SelectObject(bmp);
+        }
 
         // Draw the desired chunk on the window
         dc.Blit(0, 0, sz.x, sz.y, &memDC, x, y, wxCOPY);

--- a/clientgui/sg_DlgPreferences.cpp
+++ b/clientgui/sg_DlgPreferences.cpp
@@ -97,7 +97,7 @@ bool CPanelPreferences::Create()
 {
     m_backgroundBitmap = NULL;
     lastErrorCtrl = NULL;
-    
+
     stdTextBkgdColor = wxGetApp().GetIsDarkMode() ? *wxBLACK : *wxWHITE;
 
     CreateControls();

--- a/clientgui/sg_DlgPreferences.cpp
+++ b/clientgui/sg_DlgPreferences.cpp
@@ -491,8 +491,8 @@ void CPanelPreferences::MakeBackgroundBitmap() {
             break;
         }
 
-        // Select the desired bitmap (or its negative) into the
-        //   memory DC so we can take the desired chunk of it.
+        // Select the desired bitmap (or its darkened version) into
+        //   the memory DC so we can take the desired chunk of it.
         if (wxGetApp().GetIsDarkMode()) {
             // Darken the bitmap
             wxImage bgImage = bmp.ConvertToImage();
@@ -506,8 +506,8 @@ void CPanelPreferences::MakeBackgroundBitmap() {
                     }
                 }
             }
-            wxBitmap negative(bgImage);
-            memDC.SelectObject(negative);
+            wxBitmap darkened(bgImage);
+            memDC.SelectObject(darkened);
         } else {
             memDC.SelectObject(bmp);
         }

--- a/clientgui/sg_DlgPreferences.h
+++ b/clientgui/sg_DlgPreferences.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/sg_DlgPreferences.h
+++ b/clientgui/sg_DlgPreferences.h
@@ -219,6 +219,8 @@ public:
 
     bool OKToShow() { return m_pBackgroundPanel->OKToShow(); }
 
+    CPanelPreferences* GetPrefsPanel() { return m_pBackgroundPanel; }
+
 private:
 ////@begin CDlgPreferences member variables
 

--- a/clientgui/sg_PanelBase.cpp
+++ b/clientgui/sg_PanelBase.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/sg_PanelBase.cpp
+++ b/clientgui/sg_PanelBase.cpp
@@ -76,6 +76,10 @@ void CSimplePanelBase::MakeBGBitMap() {
 
     int white_weight = pSkinSimple->GetPanelOpacity();
     int image_weight = MAX_OPACITY - white_weight;
+    if (wxGetApp().GetIsDarkMode()) { // Darken the panel
+        white_weight /= 4;
+        white_weight /=4;
+    }
 
 // Workaround for CSimpleGUIPanel not reliably getting
 // Paint or EraseBackground events under Linux

--- a/clientgui/sg_PanelBase.h
+++ b/clientgui/sg_PanelBase.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/clientgui/sg_ProjectPanel.cpp
+++ b/clientgui/sg_ProjectPanel.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -78,7 +78,7 @@ CSimpleProjectPanel::CSimpleProjectPanel( wxWindow* parent ) :
     m_sSynchronizeToolTip = _("Synchronize projects with account manager system");
 
     m_GotBGBitMap = false; // Can't be made until parent has been laid out.
-    SetForegroundColour(*wxBLACK);
+    SetForegroundColour(wxGetApp().GetIsDarkMode() ? *wxWHITE : *wxBLACK);
 
     wxBoxSizer* bSizer1;
     bSizer1 = new wxBoxSizer( wxVERTICAL );

--- a/clientgui/sg_ProjectPanel.h
+++ b/clientgui/sg_ProjectPanel.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -45,6 +45,8 @@ class CSimpleProjectPanel : public CSimplePanelBase
 		~CSimpleProjectPanel();
 
         ProjectSelectionData* GetProjectSelectionData();
+        wxString GetSelectedProjectString() { return m_ProjectSelectionCtrl->GetValue(); }
+        CBOINCBitmapComboBox* GetProjectSelectionCtrl() { return m_ProjectSelectionCtrl; }
         void UpdateInterface();
         void ReskinInterface();
 

--- a/clientgui/sg_TaskPanel.cpp
+++ b/clientgui/sg_TaskPanel.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -53,7 +53,7 @@ CScrolledTextBox::CScrolledTextBox() {
 CScrolledTextBox::CScrolledTextBox( wxWindow* parent) :
     wxScrolledWindow( parent, ID_SGPROJECTDESCRIPTION, wxDefaultPosition, wxDefaultSize, wxVSCROLL)
 {
-    SetForegroundColour(*wxBLACK);
+    SetForegroundColour(wxGetApp().GetIsDarkMode() ? *wxWHITE : *wxBLACK);
 
     m_TextSizer = new wxBoxSizer( wxVERTICAL );
     m_hLine = GetCharHeight();
@@ -462,7 +462,10 @@ CSimpleTaskPanel::CSimpleTaskPanel( wxWindow* parent ) :
     m_sNotAvailableString = _("Not available");
     m_progressBarRect = NULL;
 
-    SetForegroundColour(*wxBLACK);
+    CSkinSimple* pSkinSimple = wxGetApp().GetSkinManager()->GetSimple();
+    wxColour bgColor(*pSkinSimple->GetDialogBackgroundImage()->GetBackgroundColor());
+    SetBackgroundColour(bgColor);
+    SetForegroundColour(wxGetApp().GetIsDarkMode() ? *wxWHITE : *wxBLACK);
 
     wxBoxSizer* bSizer1;
     bSizer1 = new wxBoxSizer( wxVERTICAL );

--- a/clientgui/sg_TaskPanel.h
+++ b/clientgui/sg_TaskPanel.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -118,12 +118,13 @@ class CSimpleTaskPanel : public CSimplePanelBase
 
         TaskSelectionData* GetTaskSelectionData();
         wxString GetSelectedTaskString() { return m_TaskSelectionCtrl->GetValue(); }
+        CBOINCBitmapComboBox* GetTaskSelectionCtrl() { return m_TaskSelectionCtrl; }
         void UpdatePanel(bool delayShow=false);
+        void OnTaskSelection(wxCommandEvent &event);
         wxRect* GetProgressRect();
         void ReskinInterface();
 
 	private:
-        void OnTaskSelection(wxCommandEvent &event);
         void GetApplicationAndProjectNames(RESULT* result, wxString* appName, wxString* projName);
         wxString GetElapsedTimeString(double f);
         wxString GetTimeRemainingString(double f);


### PR DESCRIPTION
Fixes #3115 (at least for macOS)

Implementing Dark Mode support for macOS and possibly for Windows and Linux. I am initially not guarding my changes with `#ifdef __APPLE__ ` or `#ifdef __WXMAC__` to allow testing of theWindows and Linux CI build artifacts to see how well my Mc changes work on those platforms. I expect to add those guards before submitting this PR for merging.

So far, I have Dark Mode working on the Projects, Tasks, Transfers and Disk tabs in Advanced View, as well as the Event Log and various Advanced View dialogs. I have not been able to work on the Notices tab because my attached BOINC projects currently have no notices.

I still need to implement Dark Mode for the Simple View.