### PR TITLE
[Client] Add alert if idle time to resume computing is greater than idle time to suspend computing

### DIFF
--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -675,7 +675,7 @@ void CLIENT_STATE::print_global_prefs() {
     //
     msg_printf(NULL, MSG_INFO, "-  When computer is in use");
     msg_printf(NULL, MSG_INFO,
-        "-     'In use' means mouse/keyboard input in last %.1f minutes",
+        "-     'In use' means mouse/keyboard input in last %.2f minutes",
         global_prefs.idle_time_to_run
     );
     if (!global_prefs.run_if_user_active) {
@@ -736,7 +736,7 @@ void CLIENT_STATE::print_global_prefs() {
     );
     if (global_prefs.suspend_if_no_recent_input > 0) {
         msg_printf(NULL, MSG_INFO,
-            "-     Suspend if no input in last %f minutes",
+            "-     Suspend if no input in last %2f minutes",
             global_prefs.suspend_if_no_recent_input
         );
     }

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -743,9 +743,12 @@ void CLIENT_STATE::print_global_prefs() {
     // It is possible that computing (CPU or GPU) could be suspended indefinitely if the idle time required before continuing computing
     // is longer than the time required to suspend computing when the computer is idle.  In this case an alert message will be sent.
     //
-    if ((!global_prefs.run_if_user_active || !global_prefs.run_gpu_if_user_active) &&
+    if ((!global_prefs.run_if_user_active || !global_prefs.run_gpu_if_user_active) && (global_prefs.suspend_if_no_recent_input > 0) &&
         ((global_prefs.idle_time_to_run - global_prefs.suspend_if_no_recent_input) >= 0)) {
-        msg_printf(0, MSG_USER_ALERT, "Idle time required to resume computing is greater than idle time required to suspend computing and will suspend CPU and/or GPU computing indefinitely.  Please edit time settings under Computing Preferences.");
+        msg_printf(0, MSG_USER_ALERT,
+            "Preference settings don't allow computing (%.2f > %.2f). Please review.",
+            global_prefs.idle_time_to_run, global_prefs.suspend_if_no_recent_input
+        );
     }
 
     // general

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -736,7 +736,7 @@ void CLIENT_STATE::print_global_prefs() {
     );
     if (global_prefs.suspend_if_no_recent_input > 0) {
         msg_printf(NULL, MSG_INFO,
-            "-     Suspend if no input in last %2f minutes",
+            "-     Suspend if no input in last %.2f minutes",
             global_prefs.suspend_if_no_recent_input
         );
     }

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -739,6 +739,13 @@ void CLIENT_STATE::print_global_prefs() {
             "-     Suspend if no input in last %f minutes",
             global_prefs.suspend_if_no_recent_input
         );
+    }
+    // It is possible that computing (CPU or GPU) could be suspended indefinitely if the idle time required before continuing computing
+    // is longer than the time required to suspend computing when the computer is idle.  In this case an alert message will be sent.
+    //
+    if ((!global_prefs.run_if_user_active || !global_prefs.run_gpu_if_user_active) &&
+        ((global_prefs.idle_time_to_run - global_prefs.suspend_if_no_recent_input) >= 0)) {
+        msg_printf(0, MSG_USER_ALERT, "Idle time required to resume computing is greater than idle time required to suspend computing and will suspend CPU and/or GPU computing indefinitely.  Please edit time settings under Computing Preferences.");
     }
 
     // general


### PR DESCRIPTION
Partially fixes #4939 

**Description of the Change**
When global preferences are read in the client, a check is in place to see if the idle time to resume computing is greater than the idle time to suspend computing, but only if CPU or GPU computing is to be suspended when the computer is in use.  If this condition is true, CPU or GPU computing could be suspended indefinitely regardless of the activity of the computer.  This check will send an alert to the user to make them aware.

**Alternate Designs**
Previous ideas were discussed in #4960, but this was favored since it did not modify preferences.  Thank you to @AenBleidd and @davidpanderson for the feedback!

**Release Notes**
[Client] Alert added if idle time to resume computing exceeds idle time to suspend computing.