### PR TITLE
Mac: Use strtod_l() only in Manager. Use strtod() in client, etc.

### DIFF
--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -747,7 +747,7 @@ bool XML_PARSER::parse_double(const char* start_tag, double& x) {
         }
     }
     errno = 0;
-#ifdef __APPLE__
+#if (defined(__APPLE__) && defined(BUILDING_MANAGER))
 // MacOS 13.3.1 apparently broke per-thread locale uselocale()
     double val = strtod_l(buf, &end, LC_C_LOCALE);
 #else

--- a/lib/parse.h
+++ b/lib/parse.h
@@ -312,7 +312,7 @@ inline bool parse_double(const char* buf, const char* tag, double& x) {
     const char* p = strstr(buf, tag);
     if (!p) return false;
     errno = 0;
-#ifdef __APPLE__
+#if (defined(__APPLE__) && defined(BUILDING_MANAGER))
 // MacOS 13.3.1 apparently broke per-thread locale uselocale()
     y = strtod_l(p+strlen(tag), NULL, LC_C_LOCALE);
 #else

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -4422,6 +4422,7 @@
 					"-D_THREAD_SAFE",
 					"-D__WXMAC__",
 					"-D_DEBUG",
+					"-DBUILDING_MANAGER",
 					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
@@ -4434,6 +4435,7 @@
 					"-D_THREAD_SAFE",
 					"-D__WXMAC__",
 					"-D_DEBUG",
+					"-DBUILDING_MANAGER",
 					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);
@@ -4446,6 +4448,7 @@
 					"-D_THREAD_SAFE",
 					"-D__WXMAC__",
 					"-D_DEBUG",
+					"-DBUILDING_MANAGER",
 					"-DMAC_OS_X_VERSION_MAX_ALLOWED=101300",
 					"-DwxADJUST_MINSIZE=0",
 				);


### PR DESCRIPTION
Fixes #5249, #5211

PR #5211 implemented a workaround for MacOS 13.3.1 having apparently broken the per-thread locale API `useloclae()`, by using the `strtod_l()` function instead of `strtod()`. This change was needed only in the Manager (since the client doesn't use a separate RPC thread), but the changes were in _lib/parse.cpp_ and  _lib/parse.h_ which are used by the BOINC client as well as the BOINC Manager (and also other components of BOINC.)

While my tests indicate that `strtod_l()` actually takes less CPU time than `strtod()` on the M1 Mac, this PR lists the use of `strtod_l()` to BIONC Manager just in case its use in the client might contribute to the long task CPU times reported in issue #5249.
