### PR TITLE
RPM workflow

### DIFF
--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -1,0 +1,319 @@
+name: Rpm-Package
+
+env:
+  PKG_PREFIX: boinc
+  ARCH: x86_64
+  MANTAINER: BOINC <***@***.com>
+  HOMEPAGE: https://boinc.berkeley.edu/
+  DESCRIPTION: BOINC lets you help cutting-edge science research using your computer. The BOINC app, running on your computer, downloads scientific computing jobs and runs them invisibly in the background. It's easy and safe.
+  BASEREPO: https://boinc.berkeley.edu/dl/linux # no trailing slash
+  GH_REPO_API: parvit/boinc # no trailing or prefix slash
+  PUBKEY: boinc.gpg # keep extension
+  PUBKEY_HASH: D1F9C8B6E7F7C31B9D445CA47B92EDCD762DEAEA
+
+concurrency:
+  group: rpm-package
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+          description: 'release repository type to generate'
+          type: choice
+          options:
+            - alpha
+            - stable
+          required: true
+      build_run_id:
+        description: 'workflow run id to download artifacts, default latest one'
+        type: integer
+        default: 0
+        required: false
+      allow_repo_create:
+        description: 'Allow to recreate the repo on mirror error'
+        type: boolean
+        default: false
+        required: true
+      remove_package:
+        description: 'Removes the specified package from the repo'
+        type: boolean
+        default: false
+        required: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+run-name: RPM publish [${{ inputs.release_type }}][CanCreate:${{ inputs.allow_repo_create }}][Remove:${{ inputs.remove_package }}]
+
+jobs:
+  build:
+    name: generate-rpm
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:38
+      volumes:
+        - ${{ github.workspace }}:/work
+    strategy:
+      max-parallel: 4
+      matrix:
+         os: [fc38, fc37, suse15_5, suse15_4]
+         package_type: [linux_client-vcpkg, linux_manager-without-webview]
+    environment:
+      name: ${{ inputs.release_type }}
+    steps:
+      - name: Checkout files
+        uses: Bhacaz/checkout-files@v2
+        with:
+          branch: ${{ github.head_ref || github.ref_name }}
+          files: .github version.h
+      
+      - name: DNF Preparation
+        id: dnf-prep
+        run: |
+          {
+            echo "===== Step DNF Preparation ====="
+
+            sudo echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
+            sudo echo "fastestmirror=True" >> /etc/dnf/dnf.conf
+
+            # setup required packages
+            sudo dnf install -y wget rpm rpm-build rpm-sign expect createrepo_c dnf-utils jq p7zip-plugins
+
+          } &> "/work/steps.log"
+
+      - name: Preparation
+        id: prep
+        run: |
+          {
+            echo "===== Step Preparation ====="
+
+            # extract version
+            PKG_VERSION=$(cat version.h | grep BOINC_VERSION_STRING | sed -e 's|#define BOINC_VERSION_STRING||' | jq -r .)
+            if [[ "${PKG_VERSION}" == "" ]]; then
+              printf "Could not obtain release package version from version.h"
+              exit 1
+            fi
+
+            # Setup Environment vars
+            PKG_NAME=$(echo "${{ env.PKG_PREFIX }}-${{ matrix.package_type }}" | sed "s|_|-|")
+            PKG_CLEAN=$(echo "$PKG_NAME" | sed "s|-vcpkg||")
+            PKG_FULL="${PKG_CLEAN}-${PKG_VERSION}-1.${{ env.ARCH }}"
+
+            echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_ENV
+            echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV
+            echo "PKG_CLEAN=${PKG_CLEAN}" >> $GITHUB_ENV
+            echo "PKG_FULL=${PKG_FULL}" >> $GITHUB_ENV
+            echo "PUBKEY=${{ env.PUBKEY }}" >> $GITHUB_ENV
+
+            echo "Orig. Package name ${PKG_NAME}"
+            echo "Package name ${PKG_CLEAN}"
+            echo "Package version ${PKG_VERSION}"
+            echo "Full name ${PKG_FULL}"
+            echo "Key file ${{ env.PUBKEY }}"
+
+            # Setup gpg keys
+            echo "${{ secrets.REPO_PRIV_KEY }}" > /work/boinc.priv.key
+            echo "${{ secrets.REPO_KEY }}" > /work/boinc.pub.key
+
+            cp "/work/boinc.pub.key" "/work/${{ env.PUBKEY }}"
+
+            # Setup temp directory for packages
+            mkdir pkgs/
+            mkdir ${PKG_FULL}
+
+          } &> "/work/steps.log"
+
+      - name: DownloadArtifacts
+        if: inputs.remove_package == false
+        shell: bash
+        run: |
+          {
+            echo "===== Step DownloadArtifacts ====="
+
+            # Downloads artifacts of the latest run
+            ID="${{ inputs.build_run_id }}"
+            TYPE="${{ matrix.package_type }}"
+            if [[ "$ID" -eq "0" ]]; then
+              ID=$(curl -s -XGET "https://api.github.com/repos/${GH_REPO_API}/actions/workflows/linux.yml/runs" | jq .workflow_runs[0].id)
+            fi
+            URL=$(curl -s -XGET "https://api.github.com/repos/${GH_REPO_API}/actions/runs/$ID/artifacts" | jq -r ".artifacts[] | select(.name==\"${TYPE}_\") | .archive_download_url")
+            if [[ "$URL" -eq "" ]]; then
+              printf "Could not find artifact for ${TYPE} in run ${ID}"
+              exit 1
+            fi
+            wget -O pkgs/${PKG_NAME}.zip -d --header='Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' $URL
+
+          } &>> "/work/steps.log"
+
+      - name: CreateRpmFolder
+        if: inputs.remove_package == false
+        run: |
+          {
+            echo "===== Step CreateRpmFolder ====="
+            bash -x /work/.github/workflows/rpmrepo/package_prepare.sh "${{ matrix.os }}" "${PKG_FULL}" "${PKG_NAME}" "${{ matrix.package_type }}"
+
+          } &>> "/work/steps.log"
+
+      - name: CreateRpmDefinition
+        if: inputs.remove_package == false
+        run: |
+          {
+            echo "===== Step CreateRpmDefinition ====="
+
+            # Derive the package dependencies for the selected package / os / release combination selected
+            cd /work/.github/workflows/rpmrepo/
+            PKG_DEPS=$(bash package_depends.sh ${{ matrix.os }} ${{ matrix.package_type }})
+            PKG_FILELIST=$(bash package_filelist.sh ${{ matrix.os }} ${{ matrix.package_type }})
+
+            cd /work/rpmbuild
+            echo """
+          Name:${PKG_CLEAN}
+          Version:${PKG_VERSION}
+          Release:1
+          BuildArch:${{ env.ARCH }}
+          URL:${{ env.HOMEPAGE }}
+          Summary:${{ env.DESCRIPTION }}
+          License:LGPL3+
+          Requires:${PKG_DEPS}
+
+          %changelog
+          # not extracted
+
+          %description
+          ${{ env.DESCRIPTION }}
+
+          %prep
+          # nothing build is not done here
+
+          %build
+          # nothing to build
+
+          %install
+          cp -rfa * %{buildroot}
+
+          %files
+          ${PKG_FILELIST}
+          """ > SPECS/${PKG_FULL}.spec
+
+            cat SPECS/${PKG_FULL}.spec
+            
+          } &>> "/work/steps.log"
+
+      - name: BuildRpmPackage (Fedora/Suse)
+        if: inputs.remove_package == false && ( matrix.os == 'fc38' || matrix.os == 'fc37' || matrix.os == 'suse15_5' || matrix.os == 'suse15_4' )
+        run: |
+          {
+            export GPG_TTY=$(tty) # fixes gpg signing
+
+            echo "===== Step BuildRpmPackage (Fedora) ====="
+
+            # build package
+            cd /work/rpmbuild
+            rpmbuild --define "_topdir `pwd`" -v -ba SPECS/*
+
+            # keyring prepare
+            gpg --import "/work/boinc.pub.key"
+            gpg --import "/work/boinc.priv.key"
+            expect -c 'spawn gpg --edit-key ${{ env.PUBKEY_HASH }} trust quit; send "5\ry\r"; expect eof'
+
+            gpg --list-keys
+
+            echo """%_signature gpg
+          %_gpg_path ${HOME}/.gnupg
+          %_gpg_name boinc
+          %_gpgbin /usr/bin/gpg2
+          %__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --batch --verbose --no-armor --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'
+          """ > $HOME/.rpmmacros
+
+            # import for rpm
+            rpm --import "/work/boinc.pub.key"
+
+            # sign package
+            rpm --addsign "RPMS/x86_64/${PKG_FULL}.rpm"
+
+            # check signature
+            rpm --checksig "RPMS/x86_64/${PKG_FULL}.rpm"
+            rpm -qp --qf '%|DSAHEADER?{%{DSAHEADER:pgpsig}}:{%|RSAHEADER?{%{RSAHEADER:pgpsig}}:{(none)}|}|\n' "RPMS/x86_64/${PKG_FULL}.rpm"
+
+          } &>> "/work/steps.log"
+
+      - name: AddUpdateRepository
+        if: inputs.remove_package == false
+        run: |
+          {
+            echo "===== Step AddUpdateRepository ====="
+            # Bash scripts do not support boolean values so convert to 0 true / 1 false
+            ALLOW_CREATE=1
+            if [[ "${{ inputs.allow_repo_create }}" == "true" ]]; then
+              ALLOW_CREATE=0
+            fi
+
+            cd /work/.github/workflows/rpmrepo/
+            # Updates or creates the repository
+            bash -x repo_update.sh "$ALLOW_CREATE" ${{ env.BASEREPO }} /work ${{ matrix.os }} ${{ inputs.release_type }} \
+                                    ${{ env.PUBKEY }} ${{ env.PUBKEY_HASH }} ${{ env.ARCH }}
+
+            # useful for debug
+            find /work
+
+          } &>> "/work/steps.log"
+
+      - name: RemoveUpdateRepository
+        if: inputs.remove_package == true
+        run: |
+          {
+            echo "===== Step RemoveUpdateRepository ====="
+
+            cd /work/.github/workflows/rpmrepo/
+            # Removes the package from the repository
+            bash -x repo_remove.sh "${PKG_FULL}" ${{ env.BASEREPO }} "/work" ${{ matrix.os }} ${{ inputs.release_type }} \
+                                   ${{ env.PUBKEY }} ${{ env.PUBKEY_HASH }} ${{ env.ARCH }}
+
+            # useful for debug
+            find /work
+
+          } &>> "/work/steps.log"
+
+      # archive contains the repository to be uploaded to the boinc server
+      - uses: actions/upload-artifact@v3
+        with:
+          name: repo-${{ inputs.release_type }}-${{ matrix.os }}
+          path: "/work/repo-${{ inputs.release_type }}-${{ matrix.os }}.tar.gz"
+
+      # archives for reference the public key used (included in the archive published)
+      - uses: actions/upload-artifact@v3
+        with:
+          name: keys
+          path: "/work/${{ env.PUBKEY }}"
+
+      # Execution logs
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ${{ matrix.os }}-${{ matrix.package_type }}-steps-logs
+          path: "/work/steps.log"
+
+      # Deployment of the repository for the combination channel / osversion
+      - name: Deploy to boinc server
+        run: |
+            set -e
+            curl \
+              -s --fail --write-out "%{http_code}" \
+              -F 'upload_file=@/work/repo-${{ inputs.release_type }}-${{ matrix.os }}.tar.gz' \
+              https://boinc.berkeley.edu/upload.php --cookie "auth=${{ secrets.BOINC_AUTH }} " \
+              --form "submit=on"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          {
+            echo "===== Step Cleanup ====="
+            find .
+
+            # Clean all files secret or not needed
+            rm -rf /work/*.key || true
+            rm -rf /work/trustedkeys.gpg || true
+          } &>> "/work/steps.log"

--- a/.github/workflows/rpm-package.yml
+++ b/.github/workflows/rpm-package.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           branch: ${{ github.head_ref || github.ref_name }}
           files: .github version.h
-      
+
       - name: DNF Preparation
         id: dnf-prep
         run: |
@@ -199,7 +199,7 @@ jobs:
           """ > SPECS/${PKG_FULL}.spec
 
             cat SPECS/${PKG_FULL}.spec
-            
+
           } &>> "/work/steps.log"
 
       - name: BuildRpmPackage (Fedora/Suse)

--- a/.github/workflows/rpmrepo/Dockerfile.fedora
+++ b/.github/workflows/rpmrepo/Dockerfile.fedora
@@ -1,0 +1,38 @@
+# example build usage:
+# LINUX: export BUILDKIT_PROGRESS=plain
+# WINDOWS: set BUILDKIT_PROGRESS=plain
+# docker build -t fedora38-boinc --build-arg PACKAGE=boinc-linux-client --build-arg VERSION=1.0.0-1 -f ./Dockerfile .
+
+ARG DISTRO=fedora
+ARG RELEASE=38
+
+FROM $DISTRO:$RELEASE
+
+# All args are cleared after a FROM instruction
+ARG RELEASE=38
+
+ARG REPOBASE=https://boinc.berkeley.edu/dl/linux
+ARG REPOTYPE=stable
+ARG PACKAGE=boinc-linux-client
+ARG VERSION=7.23.0-1
+ARG REPOKEY=boinc-202305.gpg
+
+USER root
+
+WORKDIR /root
+
+RUN bash -c 'echo "defaultyes=True" >> /etc/dnf/dnf.conf'
+
+RUN bash -c 'echo "fastestmirror=True" >> /etc/dnf/dnf.conf'
+
+RUN bash -c 'echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf'
+
+RUN bash -c 'dnf update && dnf -y install wget'
+
+RUN bash -c 'cd /etc/yum.repos.d && wget $REPOBASE/$REPOTYPE/fc$RELEASE/boinc-${REPOTYPE}-fc${RELEASE}.repo'
+
+RUN bash -c 'dnf update'
+
+RUN bash -c 'dnf list | grep $PACKAGE'
+
+RUN bash -c 'dnf -y install $PACKAGE-$VERSION'

--- a/.github/workflows/rpmrepo/Dockerfile.suse
+++ b/.github/workflows/rpmrepo/Dockerfile.suse
@@ -1,0 +1,40 @@
+# example build usage:
+# LINUX: export BUILDKIT_PROGRESS=plain
+# WINDOWS: set BUILDKIT_PROGRESS=plain
+# docker build -t jammy-boinc --build-arg PACKAGE=boinc-linux-client --build-arg VERSION=1.0.0-1 -f ./Dockerfile .
+
+ARG DISTRO=opensuse/leap
+ARG RELEASE=15.5
+
+FROM $DISTRO:$RELEASE
+
+# All args are cleared after a FROM instruction
+ARG RELEASE=15.5
+
+ARG REPOBASE=https://boinc.berkeley.edu/dl/linux
+ARG REPOTYPE=stable
+ARG PACKAGE=boinc-linux-client
+ARG VERSION=7.23.0-1
+ARG REPOKEY=boinc.gpg
+
+USER root
+
+WORKDIR /root
+
+RUN bash -c 'zypper -n update && zypper install -y wget expect'
+
+RUN printf '#!/bin/bash -xe \n\
+cd /etc/zypp/repos.d \n\
+VARIANT=$(echo $RELEASE | sed -e "s|\.|_|\") \n\
+wget $REPOBASE/$REPOTYPE/suse$VARIANT/boinc-${REPOTYPE}-suse${VARIANT}.repo \n\
+' > update.sh
+
+RUN bash -c 'cat update.sh'
+
+RUN bash -x update.sh
+
+RUN bash -c 'expect -c 'spawn zypper --gpg-auto-import-keys update; expect "Continue? [yes/no] (no)"; send "yes\r"; interact'
+
+RUN bash -c 'zypper search -v $PACKAGE'
+
+RUN bash -c 'zypper -y install $PACKAGE=$VERSION'

--- a/.github/workflows/rpmrepo/package_depends.sh
+++ b/.github/workflows/rpmrepo/package_depends.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# support functions
+function exit_usage() {
+	printf "Usage: deb_depends.sh <os-version> <package-name>\n"
+	exit 1
+}
+
+case "$1_$2" in
+# fedora distros
+"fc*_linux_client-vcpkg")
+    echo "glibc,libXScrnSaver >= 1.2.3"
+    ;;
+# opensuse distros
+"suse*_linux_client-vcpkg")
+    echo "glibc,libXss1 >= 1.2.3"
+    ;;
+
+*)  echo "glibc"
+	;;
+
+esac
+
+exit 0

--- a/.github/workflows/rpmrepo/package_filelist.sh
+++ b/.github/workflows/rpmrepo/package_filelist.sh
@@ -82,7 +82,7 @@ case "$1_$2" in
 /usr/share/icons/boinc
 """
     ;;
-    
+
 *)  echo "failed"
 	;;
 

--- a/.github/workflows/rpmrepo/package_filelist.sh
+++ b/.github/workflows/rpmrepo/package_filelist.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+case "$1_$2" in
+# fedora variants
+"fc38_linux_client-vcpkg")
+    echo """/etc/boinc-client/*
+/etc/default/*
+/etc/init.d/*
+/etc/bash_completion.d/*
+/var/lib/*
+/usr/lib/systemd/system/*
+/usr/bin/*
+/usr/lib/*
+"""
+    ;;
+"fc37_linux_client-vcpkg")
+    echo """/etc/boinc-client/*
+/etc/default/*
+/etc/init.d/*
+/etc/bash_completion.d/*
+/var/lib/*
+/usr/lib/systemd/system/*
+/usr/bin/*
+/usr/lib/*
+"""
+    ;;
+
+"fc38_linux_manager-without-webview")
+    echo """/usr/bin/*
+/usr/share/applications/*
+/usr/share/boinc-manager/*
+/usr/share/locale/boinc/*
+/usr/share/icons/boinc
+"""
+    ;;
+"fc37_linux_manager-without-webview")
+    echo """/usr/bin/*
+/usr/share/applications/*
+/usr/share/boinc-manager/*
+/usr/share/locale/boinc/*
+/usr/share/icons/boinc
+"""
+    ;;
+
+# suse variants
+"suse15_5_linux_client-vcpkg")
+    echo """/etc/boinc-client/*
+/etc/default/*
+/etc/init.d/*
+/etc/bash_completion.d/*
+/var/lib/*
+/usr/lib/systemd/system/*
+/usr/bin/*
+/usr/lib/*
+"""
+    ;;
+"suse15_4_linux_client-vcpkg")
+    echo """/etc/boinc-client/*
+/etc/default/*
+/etc/init.d/*
+/etc/bash_completion.d/*
+/var/lib/*
+/usr/lib/systemd/system/*
+/usr/bin/*
+/usr/lib/*
+"""
+    ;;
+
+"suse15_5_linux_manager-without-webview")
+    echo """/usr/bin/*
+/usr/share/applications/*
+/usr/share/boinc-manager/*
+/usr/share/locale/boinc/*
+/usr/share/icons/boinc
+"""
+    ;;
+"suse15_4_linux_manager-without-webview")
+    echo """/usr/bin/*
+/usr/share/applications/*
+/usr/share/boinc-manager/*
+/usr/share/locale/boinc/*
+/usr/share/icons/boinc
+"""
+    ;;
+    
+*)  echo "failed"
+	;;
+
+esac
+
+exit 0

--- a/.github/workflows/rpmrepo/package_prepare.sh
+++ b/.github/workflows/rpmrepo/package_prepare.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# support functions
+function exit_on_fail() {
+	errcode=$?
+	if [[ ! "$errcode" -eq "0" ]]; then
+		printf "Failed command, exitcode: %d\n" "$errcode"
+		exit 1
+	fi
+}
+
+function exit_usage() {
+	printf "Usage: prepare_package.sh <os-version> <full-name> <package-name> <root-package>\n"
+	exit 1
+}
+
+ROOT=$(pwd)
+
+OS="$1"      # distro for which the prepare is done
+FULLPKG="$2" # full name of the package
+PKG="$3"     # name of the artifact
+BASEPKG="$4" # name of the artifact type
+
+RPM_BUILDROOT=$ROOT/rpmbuild/BUILD
+
+# validity check
+case "$BASEPKG" in
+  "linux_client-vcpkg")
+     ;;
+  "linux_manager-without-webview")
+     ;;
+
+*)  echo "ERROR: Unknown package preparation requested"
+    exit_usage
+	;;
+esac
+
+function prepare_client() {
+    # prepare dir structure
+    mkdir -p $RPM_BUILDROOT/usr/bin
+    exit_on_fail
+    mkdir -p $RPM_BUILDROOT/etc/boinc-client $RPM_BUILDROOT/etc/default $RPM_BUILDROOT/etc/init.d
+    exit_on_fail
+    mkdir -p $RPM_BUILDROOT/usr/lib/systemd/system
+    exit_on_fail
+    mkdir -p $RPM_BUILDROOT/var/lib/boinc
+    exit_on_fail
+    mkdir -p $RPM_BUILDROOT/etc/bash_completion.d/
+    exit_on_fail
+
+    # copy files and directories
+    mv boinc boinccmd $RPM_BUILDROOT/usr/bin/
+    exit_on_fail
+    mv boinc-client.service $RPM_BUILDROOT/usr/lib/systemd/system/
+    exit_on_fail
+    cp boinc-client $RPM_BUILDROOT/etc/default/
+    exit_on_fail
+    mv boinc-client $RPM_BUILDROOT/etc/init.d/
+    exit_on_fail
+    mv boinc-client.conf $RPM_BUILDROOT/etc/boinc-client/boinc.conf
+    exit_on_fail
+    mv boinc.bash $RPM_BUILDROOT/etc/bash_completion.d/
+    exit_on_fail
+}
+
+function prepare_manager() {
+    # prepare dir structure
+    mkdir -p $RPM_BUILDROOT/usr/bin
+    exit_on_fail
+    mkdir -p $RPM_BUILDROOT/usr/share/applications $RPM_BUILDROOT/usr/share/boinc-manager $RPM_BUILDROOT/usr/share/icons/boinc $RPM_BUILDROOT/usr/share/locale/boinc
+    exit_on_fail
+
+    # copy files and directories
+    mv boincmgr $RPM_BUILDROOT/usr/bin/
+    exit_on_fail
+    mv boinc.desktop $RPM_BUILDROOT/usr/share/applications/
+    exit_on_fail
+    mv skins/ $RPM_BUILDROOT/usr/share/boinc-manager/
+    exit_on_fail
+    mv locale/* $RPM_BUILDROOT/usr/share/locale/boinc/
+    exit_on_fail
+    rm -rf locale/
+}
+
+# setup RPM toplevel dirs
+mkdir -p $ROOT/rpmbuild/{BUILD,BUILDROOT,RPMS,BUILDROOT,SOURCES,SPECS,SRPMS}
+exit_on_fail
+
+# setup of the archive
+stat "$ROOT/$FULLPKG"
+exit_on_fail
+
+pushd "$ROOT/$FULLPKG"
+exit_on_fail
+
+stat "${ROOT}/pkgs/$PKG.zip"
+exit_on_fail
+
+# unpack the github artifact
+7z x "${ROOT}/pkgs/$PKG.zip"
+exit_on_fail
+
+stat "${BASEPKG}.7z"
+exit_on_fail
+
+# unpack the boinc archive
+7z x "${BASEPKG}.7z"
+exit_on_fail
+
+rm -f "${BASEPKG}.7z"
+exit_on_fail
+
+find .
+
+mkdir -p $RPM_BUILDROOT
+exit_on_fail
+
+# specialized prepare
+case "$BASEPKG" in
+  "linux_client-vcpkg")
+     prepare_client
+     ;;
+  "linux_manager-without-webview")
+     prepare_manager
+     ;;
+*)  echo "ERROR: Unknown package preparation requested"
+    exit_usage
+	;;
+esac
+
+popd
+
+exit 0

--- a/.github/workflows/rpmrepo/repo_remove.sh
+++ b/.github/workflows/rpmrepo/repo_remove.sh
@@ -1,0 +1,130 @@
+#!/bin/bash -xe
+
+# support functions
+function exit_on_fail() {
+	errcode=$?
+	errmsg=$1
+	if [[ ! "$errcode" -eq "0" ]]; then
+		printf "Failed command, exitcode: %d, %s\n" "$errcode" "$errmsg"
+		exit 1
+	fi
+}
+
+function exit_usage() {
+	printf "Fail: $1\n"
+	printf "Usage: repo_update.sh <remove-pkg> <repo-url> <incoming-dir> [osversion(fc38,fc37,suse15_5,suse15_4)] [release-type(stable,alpha)] [release-key] [hash] [arch]\n"
+	exit 1
+}
+
+CWD=$(pwd)
+TYPE=stable
+DISTRO=fc38
+ARCH=x86_64
+RELEASEKEY=boinc.gpg
+
+# commandline params
+DEL_PACKAGE=$1
+
+BASEREPO=$2
+
+SRC=$3
+if [[ "$SRC" == "" ]]; then
+	exit_usage "No base directory specified"
+fi
+
+if [[ ! "$4" == "" ]]; then
+	DISTRO="$4"
+fi
+
+if [[ ! "$5" == "" ]]; then
+	case "$5" in
+	"stable") TYPE="stable"
+			  ;;
+	"alpha") TYPE="alpha"
+			  ;;
+	"*")  exit_usage "Unrecognized repo type specified: $5"
+			  ;;
+	esac
+fi
+
+RELEASEKEY="$6"
+HASH="$7"
+ARCH="$8"
+
+# static params
+PUBKEYFILE=${SRC}/boinc.pub.key
+PRIVKEYFILE=${SRC}/boinc.priv.key
+
+IS_MIRROR=1
+
+# required files check
+stat "$PUBKEYFILE" > /dev/null
+exit_on_fail "No public key file present"
+
+stat "$PRIVKEYFILE" > /dev/null
+exit_on_fail "No private key file present"
+
+pushd $CWD
+
+gpg --list-keys
+
+mkdir -p $CWD/mirror
+
+# create repo for indicated type and distribution
+echo """#
+# BOINC Repository
+#
+
+[boinc-$TYPE-$DISTRO]
+name = BOINC $TYPE $DISTRO repository
+baseurl = $BASEREPO/$TYPE/$DISTRO
+arch = $ARCH
+priority = 100
+enabled = 1
+gpgcheck = 1
+gpgkey = $BASEREPO/$TYPE/$DISTRO/$RELEASEKEY
+max_parallel_downloads = 2
+
+""" > "$CWD/mirror/boinc-$TYPE-$DISTRO.repo"
+
+# necessary for reposync to work correctly
+mkdir -p /etc/yum/repos.d/
+cp "$CWD/mirror/boinc-$TYPE-$DISTRO.repo" /etc/yum/repos.d/
+dnf update -y -qq
+
+# mirror the currently deployed repo (if any)
+cd $CWD/mirror
+reposync --nobest -a $ARCH --download-metadata --norepopath --repoid boinc-$TYPE-$DISTRO
+exit_on_fail "Could not mirror ${REPO}"
+
+# actual remove of the package from the repo
+rm -rf $CWD/mirror/$DEL_PACKAGE
+exit_on_fail "Failed to remove the indicated package"
+
+cd $CWD/mirror
+
+# update repository
+createrepo_c --update .
+exit_on_fail "Failed to update repository"
+
+# sign repository metadata
+cd $CWD/mirror/repodata
+gpg -s --default-key $HASH repomd.xml > repomd.xml.asc
+exit_on_fail "Could not sign repository metadata"
+
+cd $CWD/mirror
+
+# copy the key for the repo to the root of it
+SRCKEYFILE="$SRC/$RELEASEKEY"
+DSTKEYFILE="$CWD/mirror/$RELEASEKEY"
+cp "${SRCKEYFILE}" "${DSTKEYFILE}"
+exit_on_fail "Failed to publish the public key to the repo"
+
+find .
+
+# Archive the produced repo to the archive in the format expected by the upload script:
+# repo-<stable/alpha>-<osversion>.tar.gz
+tar -zcvf ${SRC}/repo-$TYPE-$DISTRO.tar.gz -C $CWD/mirror/ .
+exit_on_fail "Could not package the repository for upload"
+
+popd

--- a/.github/workflows/rpmrepo/repo_update.sh
+++ b/.github/workflows/rpmrepo/repo_update.sh
@@ -1,0 +1,154 @@
+#!/bin/bash -xe
+
+# support functions
+function exit_on_fail() {
+	errcode=$?
+	errmsg=$1
+	if [[ ! "$errcode" -eq "0" ]]; then
+		printf "Failed command, exitcode: %d, %s\n" "$errcode" "$errmsg"
+		exit 1
+	fi
+}
+
+function exit_usage() {
+	printf "Fail: $1\n"
+	printf "Usage: repo_update.sh <allow-create> <repo-url> <incoming-dir> [osversion] [release-type] [release-key] [key-hash] [arch]\n"
+	exit 1
+}
+
+CWD=$(pwd)
+TYPE=stable
+DISTRO=fc38
+ARCH=x86_64
+RELEASEKEY=boinc.gpg
+
+# commandline params
+ALLOW_CREATE=$1
+
+BASEREPO=$2
+
+SRC=$3
+if [[ "$SRC" == "" ]]; then
+	exit_usage "No base directory specified"
+fi
+
+DISTRO="$4"
+
+if [[ ! "$5" == "" ]]; then
+	case "$5" in
+	"stable") TYPE="stable"
+			  ;;
+	"alpha") TYPE="alpha"
+			  ;;
+	"*")  exit_usage "Unrecognized repo type specified: $5"
+			  ;;
+	esac
+fi
+
+RELEASEKEY="$6"
+HASH="$7"
+ARCH="$8"
+
+# static params
+PUBKEYFILE=${SRC}/boinc.pub.key
+PRIVKEYFILE=${SRC}/boinc.priv.key
+
+RPMSRC="$SRC/rpmbuild/RPMS/$ARCH"
+
+IS_MIRROR=1
+
+# required files check
+stat "$RPMSRC" > /dev/null
+exit_on_fail "No source directory present"
+
+stat "$PUBKEYFILE" > /dev/null
+exit_on_fail "No public key file present"
+
+stat "$PRIVKEYFILE" > /dev/null
+exit_on_fail "No private key file present"
+
+pushd $CWD
+
+gpg --list-keys
+
+mkdir -p $CWD/mirror
+
+# create repo for indicated type and distribution
+echo """#
+# BOINC Repository
+#
+
+[boinc-$TYPE-$DISTRO]
+name = BOINC $TYPE $DISTRO repository
+baseurl = $BASEREPO/$TYPE/$DISTRO
+arch = $ARCH
+priority = 100
+enabled = 1
+gpgcheck = 1
+gpgkey = $BASEREPO/$TYPE/$DISTRO/$RELEASEKEY
+max_parallel_downloads = 2
+
+""" > "$CWD/mirror/boinc-$TYPE-$DISTRO.repo"
+
+# necessary for reposync to work correctly
+mkdir -p /etc/yum/repos.d/
+cp "$CWD/mirror/boinc-$TYPE-$DISTRO.repo" /etc/yum/repos.d/
+dnf update -y -qq
+
+# mirror the currently deployed repo (if any)
+cd $CWD/mirror
+
+reposync --nobest -a $ARCH --download-metadata --norepopath --repoid boinc-$TYPE-$DISTRO
+if [[ "$?" -eq "0" ]]; then
+	# the command was successful and the mirror is created
+	IS_MIRROR=0
+fi
+
+echo
+echo "Is mirror: $IS_MIRROR"
+echo "Can create: $ALLOW_CREATE"
+echo
+
+if [[ ! "$IS_MIRROR" -eq "0" ]]; then
+	if [[ ! "$ALLOW_CREATE" -eq "0" ]]; then
+		# if neither the mirror was created, nor the new creation allowed, terminate
+		exit_usage "Could not mirror ${REPO} and creation is not allowed"
+	else
+		echo "Remote mirror failed but creation of new repo is allowed"
+	fi
+fi
+
+cp $RPMSRC/*.rpm $CWD/mirror/
+exit_on_fail "Failed to add new packages"
+
+cd $CWD/mirror/
+
+if [[ ! "$IS_MIRROR" -eq "0" ]]; then
+	createrepo_c .
+	exit_on_fail "Failed to create repository"
+else
+	createrepo_c --update .
+	exit_on_fail "Failed to update repository"
+fi
+
+# sign repository metadata
+cd $CWD/mirror/repodata
+gpg -s --default-key $HASH repomd.xml > repomd.xml.asc
+exit_on_fail "Could not sign repository metadata"
+
+cd $CWD/mirror/
+
+# copy the key for the repo to the root of it
+SRCKEYFILE="$SRC/$RELEASEKEY"
+DSTKEYFILE="$CWD/mirror/$RELEASEKEY"
+cp "${SRCKEYFILE}" "${DSTKEYFILE}"
+exit_on_fail "Failed to publish the public key to the repo"
+
+find .
+
+# Archive the produced repo to the archive in the format expected by the upload script:
+# repo-<stable/alpha>-<osversion>.tar.gz
+tar -zcvf ${SRC}/repo-$TYPE-$DISTRO.tar.gz -C $CWD/mirror/ .
+exit_on_fail "Could not package the repository for upload"
+
+popd


### PR DESCRIPTION
Fixes https://github.com/TheSCInitiative/bounties/issues/1, please review and send feedback.

## Description of the Change
The change implements a new workflow that allows to generate and manage an RPM repo.

## Versions
Support is implemented currently for:
* Fedora 38, 37
* OpenSuse Leap 15.5, 15.4

More versions or distros rpm-based can be included as necessary.

## Channels
Two channels will be available: 
* alpha
* stable

Both are uploaded to the https://boinc.berkeley.edu/dl/linux url, which can however be changed in the
workflow environment BASEREPO.

To add stable and alpha channel download the repository definition file, eg.:
> https://boinc.berkeley.edu/dl/linux/stable/fc38/boinc-stable-fc38.repo

And install it in the dnf/yum/zypper folder for repositories.

## Supported operations
Two operations are implemented:
* Repository update with new package
  * Done at the same time for *all* the distro versions
  * Will fail if the same package is present with same version in specified channel

* Repository update with package remove
  * Done at the same time for *all* the distro versions
  * Will fail if the same package is not present with indicated version in specified channel
  * Will fail if the repo cannot be mirrored

The managing of the repo is done by:
1.  mirroring the published repo
2.  updating it with new package / remove indicated package
  * Both operations keep the old versions of the packages previously published (if not explicitly removed)
4.  upload of the new repo state

If for some reason any step fails, the published repo remains untouched, unless the _allow_repo_create_ workflow parameter is true, in that case the repo is recreated losing
the previous state.

## Signing key
In addition the public key under https://boinc.berkeley.edu/dl/linux/<channel>/<version>/boinc.gpg (name can be changed in workflow environment PUBKEY) must be imported for the repo commands to work correctly.

The sign keys are provided via github secret and are _always_ removed on workflow finish.

## Secrets
Three Github secrets are necessary for correct operation:
* **secrets.REPO_KEY**: GPG Public key to be used to sign the packages and repo, must be exported in armor format
* **secrets.REPO_PRIV_KEY**: GPG Private key to be used to sign the packages and repo, must be exported in armor format
* **secrets.BOINC_AUTH**: Strong authenticator key for the service account that uploads to the boinc server

## Integration
Currently the workflow only has manual triggering implemented, but can be integrated into the linux.yml flow if deemed necessary.

## Testing
For convenience, under the `rpmrepo` dir, two `Dockerfile` have been prepared to execute the steps necessary to install the repo and a package, example execution:

`docker build -t fc38-boinc --build-arg PACKAGE=boinc-linux-client --build-arg VERSION=1.0.0-1 -f ./Dockerfile.fedora .`

Please refer to the Dockerfile for additional parameters available.

## Release Notes
Workflow for RPM repository management
