### PR TITLE
Update required wxWidgets to 3.1.3 (first with wxSystemAppearance)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1084,7 +1084,7 @@ fi
 
 dnl ---------- wxWidgets --------------------------------------------------
 if test "${enable_manager}" = yes ; then
-  BOINC_OPTIONS_WXWIDGETS([3.0.0])
+  BOINC_OPTIONS_WXWIDGETS([3.1.3])
 else
   AM_CONDITIONAL([GUI_GTK], false)
 fi


### PR DESCRIPTION
…e, added in BOINC/boinc@/e2a130f648ae2d581d69da0b8fc0de1eef3327c0

Fixes #

**Description of the Change**
BOINC/boinc@/e2a130f648ae2d581d69da0b8fc0de1eef3327c0 uses wxSystemAppearance, which was added to wxWidgets in version 3.1.3.
As such, BOINC will fail to build with earlier versions of wxWidgets, so this pull request updates the minimum required version accordingly.

**Alternate Designs**
N/A

**Release Notes**
N/A
