### PR TITLE
Mac: Add standard command-comma shortcut for Preferences menu item

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -387,7 +387,7 @@ bool CAdvancedFrame::CreateMenus() {
     // wxWidgets actually puts this in the BOINCManager menu
     menuFile->Append(
         wxID_PREFERENCES,
-        _("Preferences...")
+        _("Preferences...\tCtrl+,")
     );
 #endif
 

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -178,7 +178,7 @@ bool CSimpleFrame::CreateMenus() {
     // wxWidgets actually puts this in the BOINCManager menu
     menuFile->Append(
         wxID_PREFERENCES,
-        _("Preferences...")
+        _("Preferences...\tCtrl+,")
     );
 #endif
 


### PR DESCRIPTION
Mac: Add standard command-comma shortcut for Preferences (aka Settings) menu item.

Fixes #5273
