### PR TITLE
Make delimiters argument const so it can (legally) be a string literal.

### DIFF
--- a/clientgui/BOINCListCtrl.cpp
+++ b/clientgui/BOINCListCtrl.cpp
@@ -315,7 +315,7 @@ bool CBOINCListCtrl::OnRestoreState(wxConfigBase* pConfig) {
 }
 
 
-void CBOINCListCtrl::TokenizedStringToArray(wxString tokenized, char * delimiters, wxArrayString* array) {
+void CBOINCListCtrl::TokenizedStringToArray(wxString tokenized, const char * delimiters, wxArrayString* array) {
     wxString name;
 
     array->Clear();

--- a/clientgui/BOINCListCtrl.h
+++ b/clientgui/BOINCListCtrl.h
@@ -74,7 +74,7 @@ public:
     virtual bool            OnSaveState(wxConfigBase* pConfig);
     virtual bool            OnRestoreState(wxConfigBase* pConfig);
 
-    void                    TokenizedStringToArray(wxString tokenized, char * delimiters, wxArrayString* array);
+    void                    TokenizedStringToArray(wxString tokenized, const char * delimiters, wxArrayString* array);
     void                    SetListColumnOrder(wxArrayString& orderArray);
     void                    SetStandardColumnOrder();
     bool                    IsColumnOrderStandard();


### PR DESCRIPTION
Fixes #

**Description of the Change**
This no-op change to TokenizedStringToArray's signature resolves the following compiler warning:
BOINCListCtrl.cpp:251:54: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]

**Alternate Designs**
N/A

**Release Notes**
N/A
