### PR TITLE
[Manager] Add button in event log to display only alerts (errors)

### DIFF
--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -50,7 +50,7 @@
 
 const int dlgEventlogInitialWidth = 640;
 const int dlgEventLogInitialHeight = 480;
-const int dlgEventlogMinWidth = 600;
+const int dlgEventlogMinWidth = 620;
 const int dlgEventlogMinHeight = 250;
 
 #define COLUMN_PROJECT              0

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -50,7 +50,7 @@
 
 const int dlgEventlogInitialWidth = 640;
 const int dlgEventLogInitialHeight = 480;
-const int dlgEventlogMinWidth = 620;
+const int dlgEventlogMinWidth = 600;
 const int dlgEventlogMinHeight = 250;
 
 #define COLUMN_PROJECT              0

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -79,6 +79,7 @@ BEGIN_EVENT_TABLE( CDlgEventLog, DlgEventLogBase )
     EVT_BUTTON(wxID_OK, CDlgEventLog::OnOK)
     EVT_BUTTON(ID_COPYAll, CDlgEventLog::OnMessagesCopyAll)
     EVT_BUTTON(ID_COPYSELECTED, CDlgEventLog::OnMessagesCopySelected)
+    EVT_BUTTON(ID_TASK_MESSAGES_FILTERBYERROR, CDlgEventLog::OnErrorFilter)
     EVT_BUTTON(ID_TASK_MESSAGES_FILTERBYPROJECT, CDlgEventLog::OnMessagesFilter)
     EVT_BUTTON(ID_SIMPLE_HELP, CDlgEventLog::OnButtonHelp)
 	EVT_MENU(ID_SGDIAGNOSTICLOGFLAGS, CDlgEventLog::OnDiagnosticLogFlags)
@@ -326,6 +327,9 @@ void CDlgEventLog::CreateControls()
     wxBoxSizer* itemBoxSizer4 = new wxBoxSizer(wxHORIZONTAL);
 
     itemFlexGridSizer2->Add(itemBoxSizer4, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 12);
+
+    m_pErrorFilterButton = new wxButton(this, ID_TASK_MESSAGES_FILTERBYERROR, _("Show only aler&ts"), wxDefaultPosition, wxDefaultSize);
+    itemBoxSizer4->Add(m_pErrorFilterButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
     m_pFilterButton = new wxButton(this, ID_TASK_MESSAGES_FILTERBYPROJECT, _("&Show only this project"),  wxDefaultPosition, wxDefaultSize);
     itemBoxSizer4->Add(m_pFilterButton, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5);

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -973,6 +973,89 @@ void CDlgEventLog::ResetMessageFiltering() {
 }
 
 
+// Function to search through messages and find messages that contain an error.  This function first reads the input
+// to see if it should search all indexes or a pre-filtered set of indexes.  Then, it will search through the indexes.
+// For each index that is an error (priority == MSG_USER_ALERT), it will add that message's index to a temporary
+// array of indexes.  After the for loop is complete, the recently filtered indexes will be written to m_iFilteredIndexes
+// and the recently filtered indexes will be stored in m_iFilteredDocCount.
+// 
+// The following input variable is required:
+//  isfiltered:  If the wxArrayInt that we want to search is already filtered (m_iFilteredIndexes), this will be true.
+//                 If we want to search all indexes (m_iTotalIndexes), this will be false).
+//
+void CDlgEventLog::finderrormessages(bool isfiltered) {
+    wxArrayInt filteredindexes;
+    MESSAGE* message;
+    wxInt32 i = 0;
+    if (isfiltered) {
+        for (i; i < m_iFilteredDocCount; i++) {
+            message = wxGetApp().GetDocument()->message(GetFilteredMessageIndex(i));
+            if (message) {
+                if (message->priority == MSG_USER_ALERT) {
+                    filteredindexes.Add(GetFilteredMessageIndex(i));
+                }
+            }
+        }
+    }
+    else {
+        for (i; i < m_iTotalDocCount; i++) {
+            message = wxGetApp().GetDocument()->message(i);
+            if (message) {
+                if (message->priority == MSG_USER_ALERT) {
+                    filteredindexes.Add(i);
+                }
+            }
+        }
+    }
+    m_iFilteredIndexes = filteredindexes;
+    m_iFilteredDocCount = static_cast<wxInt32>(filteredindexes.GetCount());
+}
+
+
+// Function to search through messages and find all messages that are associated with a specific project.  Messages that do
+// not have a project are included in the filtered indexes.
+// 
+// This function first reads the input to see if it should search all indexes or a pre-filtered set of indexes.
+// Then, it will search through those indexes.  For each message that matches the associated
+// project (s_strFilteredProjectName) or has no associated project, it will add that message's index to a temporary
+// array of indexes.  After the for loop is complete, the recently filtered indexes will be written to
+// m_iFilteredIndexes and the recently filtered indexes will be stored in m_iFilteredDocCount.
+// 
+// It is assumed s_strFilteredProjectName is correct prior to this function being called.
+// 
+// The following input variable is required:
+//  isfiltered:  If the wxArrayInt that we want to search is already filtered (m_iFilteredIndexes), this will be true.
+//                 If we want to search all indexes (m_iTotalIndexes), this will be false).
+//
+void CDlgEventLog::findprojectmessages(bool isfiltered) {
+    wxArrayInt filteredindexes;
+    MESSAGE* message;
+    wxInt32 i = 0;
+    if (isfiltered) {
+        for (i; i < m_iFilteredDocCount; i++) {
+            message = wxGetApp().GetDocument()->message(GetFilteredMessageIndex(i));
+            if (message) {
+                if (message->project.empty() || message->project == s_strFilteredProjectName) {
+                    filteredindexes.Add(GetFilteredMessageIndex(i));
+                }
+            }
+        }
+    }
+    else {
+        for (i; i < m_iTotalDocCount; i++) {
+            message = wxGetApp().GetDocument()->message(i);
+            if (message) {
+                if (message->project.empty() || message->project == s_strFilteredProjectName) {
+                    filteredindexes.Add(i);
+                }
+            }
+        }
+    }
+    m_iFilteredIndexes = filteredindexes;
+    m_iFilteredDocCount = static_cast<wxInt32>(m_iFilteredIndexes.GetCount());
+}
+
+
 void CDlgEventLog::UpdateButtons() {
     bool enableFilterButton = s_bIsFiltered;
     bool enableCopySelectedButton = false;

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -60,6 +60,8 @@ const int dlgEventlogMinHeight = 250;
 
 static bool s_bIsFiltered = false;
 static bool s_bFilteringChanged = false;
+static bool s_bErrorIsFiltered = false;
+static bool s_bErrorFilteringChanged = false;
 static std::string s_strFilteredProjectName;
 
 /*!

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -390,14 +390,14 @@ void CDlgEventLog::SetFilterButtonText() {
 #endif
     }
     if (s_bErrorIsFiltered) {
-        m_pErrorFilterButton->SetLabel(_("Show all message &types"));
+        m_pErrorFilterButton->SetLabel(_("Show al&l"));
         m_pErrorFilterButton->SetHelpText(_("Shows messages of all types (information, alerts, etc.)"));
 #ifdef wxUSE_TOOLTIPS
         m_pErrorFilterButton->SetToolTip(_("Shows messages of all types (information, alerts, etc.)"));
 #endif
     }
     else {
-        m_pErrorFilterButton->SetLabel(_("Show only aler&t messages"));
+        m_pErrorFilterButton->SetLabel(_("Show only aler&ts"));
         m_pErrorFilterButton->SetHelpText(_("Shows only the messages that are alerts"));
 #ifdef wxUSE_TOOLTIPS
         m_pErrorFilterButton->SetToolTip(_("Show only the messages that are alerts"));

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -1076,7 +1076,7 @@ void CDlgEventLog::ResetMessageFiltering() {
 // For each index that is an error (priority == MSG_USER_ALERT), it will add that message's index to a temporary
 // array of indexes.  After the for loop is complete, the recently filtered indexes will be written to m_iFilteredIndexes
 // and the recently filtered indexes will be stored in m_iFilteredDocCount.
-// 
+//
 // The following input variable is required:
 //  isfiltered:  If the wxArrayInt that we want to search is already filtered (m_iFilteredIndexes), this will be true.
 //                 If we want to search all indexes (m_iTotalIndexes), this will be false).
@@ -1112,15 +1112,15 @@ void CDlgEventLog::FindErrorMessages(bool isFiltered) {
 
 // Function to search through messages and find all messages that are associated with a specific project.  Messages that do
 // not have a project are included in the filtered indexes.
-// 
+//
 // This function first reads the input to see if it should search all indexes or a pre-filtered set of indexes.
 // Then, it will search through those indexes.  For each message that matches the associated
 // project (s_strFilteredProjectName) or has no associated project, it will add that message's index to a temporary
 // array of indexes.  After the for loop is complete, the recently filtered indexes will be written to
 // m_iFilteredIndexes and the recently filtered indexes will be stored in m_iFilteredDocCount.
-// 
+//
 // It is assumed s_strFilteredProjectName is correct prior to this function being called.
-// 
+//
 // The following input variable is required:
 //  isfiltered:  If the wxArrayInt that we want to search is already filtered (m_iFilteredIndexes), this will be true.
 //                 If we want to search all indexes (m_iTotalIndexes), this will be false).

--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -516,7 +516,7 @@ void CDlgEventLog::OnErrorFilter(wxCommandEvent& WXUNUSED(event)) {
         // by the project.
         //
         if (s_bIsFiltered) {  // Errors are currently filtered and a project is filtered
-            findprojectmessages(false);
+            FindProjectMessages(false);
         }
     }
     else {
@@ -527,7 +527,7 @@ void CDlgEventLog::OnErrorFilter(wxCommandEvent& WXUNUSED(event)) {
             m_iFilteredIndexes.Clear();
             m_iTotalDeletedFilterRows = 0;
         }
-        finderrormessages(s_bIsFiltered);
+        FindErrorMessages(s_bIsFiltered);
     }
 
     s_bErrorFilteringChanged = true;
@@ -561,7 +561,7 @@ void CDlgEventLog::OnMessagesFilter( wxCommandEvent& WXUNUSED(event) ) {
         // by errors.
         //
         if (s_bErrorIsFiltered) {  // List is currently filtered by project and by error.
-            finderrormessages(false);
+            FindErrorMessages(false);
         }
     } else {  // List will now be filtered by a project.
         // Get project name to be filtered.
@@ -582,7 +582,7 @@ void CDlgEventLog::OnMessagesFilter( wxCommandEvent& WXUNUSED(event) ) {
             m_iFilteredDocCount = m_iTotalDocCount;
             m_iTotalDeletedFilterRows = 0;
         }
-        findprojectmessages(s_bErrorIsFiltered);
+        FindProjectMessages(s_bErrorIsFiltered);
         s_bIsFiltered = true;
     }
 
@@ -1081,11 +1081,11 @@ void CDlgEventLog::ResetMessageFiltering() {
 //  isfiltered:  If the wxArrayInt that we want to search is already filtered (m_iFilteredIndexes), this will be true.
 //                 If we want to search all indexes (m_iTotalIndexes), this will be false).
 //
-void CDlgEventLog::finderrormessages(bool isfiltered) {
+void CDlgEventLog::FindErrorMessages(bool isFiltered) {
     wxArrayInt filteredindexes;
     MESSAGE* message;
     wxInt32 i = 0;
-    if (isfiltered) {
+    if (isFiltered) {
         for (i; i < m_iFilteredDocCount; i++) {
             message = wxGetApp().GetDocument()->message(GetFilteredMessageIndex(i));
             if (message) {
@@ -1125,11 +1125,11 @@ void CDlgEventLog::finderrormessages(bool isfiltered) {
 //  isfiltered:  If the wxArrayInt that we want to search is already filtered (m_iFilteredIndexes), this will be true.
 //                 If we want to search all indexes (m_iTotalIndexes), this will be false).
 //
-void CDlgEventLog::findprojectmessages(bool isfiltered) {
+void CDlgEventLog::FindProjectMessages(bool isFiltered) {
     wxArrayInt filteredindexes;
     MESSAGE* message;
     wxInt32 i = 0;
-    if (isfiltered) {
+    if (isFiltered) {
         for (i; i < m_iFilteredDocCount; i++) {
             message = wxGetApp().GetDocument()->message(GetFilteredMessageIndex(i));
             if (message) {

--- a/clientgui/DlgEventLog.h
+++ b/clientgui/DlgEventLog.h
@@ -202,8 +202,8 @@ private:
 
     void                    ResetMessageFiltering();
 
-    void                    finderrormessages(bool isfiltered);
-    void                    findprojectmessages(bool isfiltered);
+    void                    FindErrorMessages(bool isFiltered);
+    void                    FindProjectMessages(bool isFiltered);
 
     bool                    EnsureLastItemVisible();
     wxInt32                 FormatProjectName( wxInt32 item, wxString& strBuffer ) const;

--- a/clientgui/DlgEventLog.h
+++ b/clientgui/DlgEventLog.h
@@ -199,6 +199,9 @@ private:
 
     void                    ResetMessageFiltering();
 
+    void                    finderrormessages(bool isfiltered);
+    void                    findprojectmessages(bool isfiltered);
+
     bool                    EnsureLastItemVisible();
     wxInt32                 FormatProjectName( wxInt32 item, wxString& strBuffer ) const;
     wxInt32                 FormatTime( wxInt32 item, wxString& strBuffer ) const;

--- a/clientgui/DlgEventLog.h
+++ b/clientgui/DlgEventLog.h
@@ -124,6 +124,9 @@ public:
     /// wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_COPYSELECTED
     void OnMessagesCopySelected( wxCommandEvent& event );
 
+    // wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_TASK_MESSAGES_FILTERBYERROR
+    void OnErrorFilter(wxCommandEvent& event);
+
     /// wxEVT_COMMAND_BUTTON_CLICKED event handler for ID_TASK_MESSAGES_FILTERBYPROJECT
     void OnMessagesFilter( wxCommandEvent& event );
 

--- a/clientgui/DlgEventLog.h
+++ b/clientgui/DlgEventLog.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -173,6 +173,7 @@ private:
     wxInt32                 m_iPreviousRowCount;
     wxButton*               m_pFilterButton;
     wxButton*               m_pCopySelectedButton;
+    wxButton*               m_pErrorFilterButton;
 
     wxListItemAttr*         m_pMessageInfoAttr;
     wxListItemAttr*         m_pMessageErrorAttr;

--- a/clientgui/Events.h
+++ b/clientgui/Events.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -138,6 +138,7 @@
 #define ID_TASK_MESSAGES_COPYALL                9400
 #define ID_TASK_MESSAGES_COPYSELECTED           9401
 #define ID_TASK_MESSAGES_FILTERBYPROJECT        9402
+#define ID_TASK_MESSAGES_FILTERBYERROR          9403
 #define ID_TASK_STATISTICS_USERTOTAL            9500
 #define ID_TASK_STATISTICS_USERAVERAGE          9501
 #define ID_TASK_STATISTICS_HOSTTOTAL            9502


### PR DESCRIPTION
Fixes #4258 

**Description of the Change**
Button added to the event log window to filter out alerts (aka errors).  Button toggles to display only alerts and to all message types.  Functionality was also added to the "show all messages" button as well.  For example, if messages are filtered by a project and then the alert button is clicked, then only alerts for that specific project are displayed.

Screen shots:
 
New button added:
![New button](https://github.com/BOINC/boinc/assets/58096400/c98e9b0e-6253-4c34-9e29-a4681143023c)

When alerts are filtered:
![Alerts filtered](https://github.com/BOINC/boinc/assets/58096400/9e26def8-e922-4c9f-8c9e-c607c80f6e07)

When alerts and a project are filtered:
![Alert and project filtered](https://github.com/BOINC/boinc/assets/58096400/8b3a2899-1c25-4ad9-b525-e659b98617c2)

**Alternate Designs**
None considered.

**Release Notes**
Add button in event log to display only alerts.
