### PR TITLE
Fix Mac crash bug introduced by commit e0ffbf106d

### DIFF
--- a/clientgui/DlgEventLog.cpp
+++ b/clientgui/DlgEventLog.cpp
@@ -1086,7 +1086,7 @@ void CDlgEventLog::FindErrorMessages(bool isFiltered) {
     MESSAGE* message;
     wxInt32 i = 0;
     if (isFiltered) {
-        for (i; i < m_iFilteredDocCount; i++) {
+        for (i=0; i < m_iFilteredDocCount; i++) {
             message = wxGetApp().GetDocument()->message(GetFilteredMessageIndex(i));
             if (message) {
                 if (message->priority == MSG_USER_ALERT) {
@@ -1096,7 +1096,7 @@ void CDlgEventLog::FindErrorMessages(bool isFiltered) {
         }
     }
     else {
-        for (i; i < m_iTotalDocCount; i++) {
+        for (i=0; i < m_iTotalDocCount; i++) {
             message = wxGetApp().GetDocument()->message(i);
             if (message) {
                 if (message->priority == MSG_USER_ALERT) {
@@ -1130,7 +1130,7 @@ void CDlgEventLog::FindProjectMessages(bool isFiltered) {
     MESSAGE* message;
     wxInt32 i = 0;
     if (isFiltered) {
-        for (i; i < m_iFilteredDocCount; i++) {
+        for (i=0; i < m_iFilteredDocCount; i++) {
             message = wxGetApp().GetDocument()->message(GetFilteredMessageIndex(i));
             if (message) {
                 if (message->project.empty() || message->project == s_strFilteredProjectName) {
@@ -1140,7 +1140,7 @@ void CDlgEventLog::FindProjectMessages(bool isFiltered) {
         }
     }
     else {
-        for (i; i < m_iTotalDocCount; i++) {
+        for (i=0; i < m_iTotalDocCount; i++) {
             message = wxGetApp().GetDocument()->message(i);
             if (message) {
                 if (message->project.empty() || message->project == s_strFilteredProjectName) {

--- a/clientgui/DlgOptions.cpp
+++ b/clientgui/DlgOptions.cpp
@@ -623,8 +623,6 @@ bool CDlgOptions::ReadSettings() {
     wxASSERT(wxDynamicCast(pDoc, CMainDocument));
     wxASSERT(wxDynamicCast(pFrame, CBOINCBaseFrame));
 
-// wxWidgets System language detection does not work on Mac
-// so we always set UseDefaultLocale() to false on Mac
     // General Tab
     if (wxGetApp().UseDefaultLocale()) {
         // CBOINCGUIApp::InitSupportedLanguages() ensures "Auto" is the first item in the list
@@ -734,7 +732,7 @@ bool CDlgOptions::SaveSettings() {
     CSkinAdvanced*      pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     long                lBuffer = 0;
     wxString            strBuffer = wxEmptyString;
-
+    const wxLanguageInfo *newLanguageInfo = NULL;
 
     wxASSERT(pDoc);
     wxASSERT(pFrame);
@@ -750,13 +748,18 @@ bool CDlgOptions::SaveSettings() {
     int selLangIdx = m_LanguageSelectionCtrl->GetSelection();
     if (selLangIdx == 0) {
         // CBOINCGUIApp::InitSupportedLanguages() ensures "Auto" is the first item in the list
-        newLangCode = wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT)->CanonicalName;
+        newLanguageInfo = wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
+        // wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT) may return NULL on Macintosh
+        newLangCode = wxEmptyString;
     } else if (selLangIdx > 0) {
         const std::vector<GUI_SUPPORTED_LANG>& langs = wxGetApp().GetSupportedLanguages();
         if (selLangIdx < langs.size()) {
             const GUI_SUPPORTED_LANG& selLang = langs[selLangIdx];
-            newLangCode = wxLocale::GetLanguageInfo(selLang.Language)->CanonicalName;
+            newLanguageInfo = wxLocale::GetLanguageInfo(selLang.Language);
         }
+    }
+    if (newLanguageInfo) {
+        newLangCode = newLanguageInfo->CanonicalName;
     }
     if (newLangCode != oldLangCode) {
         wxString strDialogTitle;

--- a/clientgui/DlgOptions.cpp
+++ b/clientgui/DlgOptions.cpp
@@ -618,13 +618,13 @@ bool CDlgOptions::ReadSettings() {
     wxString            strBuffer = wxEmptyString;
     wxArrayString       astrDialupConnections;
 
-
     wxASSERT(pDoc);
     wxASSERT(pFrame);
     wxASSERT(wxDynamicCast(pDoc, CMainDocument));
     wxASSERT(wxDynamicCast(pFrame, CBOINCBaseFrame));
 
-
+// wxWidgets System language detection does not work on Mac
+// so we always set UseDefaultLocale() to false on Mac
     // General Tab
     if (wxGetApp().UseDefaultLocale()) {
         // CBOINCGUIApp::InitSupportedLanguages() ensures "Auto" is the first item in the list


### PR DESCRIPTION
Fixes #5321 

Commit e0ffbf106d failed t check for a NULL return from `wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT)` which causes BOINC Manager to crash if the default system locale is unknown to wxWidgets.

This also means that the code added by #5176 which adds automatic selection of the language to the list of languages does not work on the Mac. In fact, that code broke automatic language selection on the Mac, which worked correctly in BOINC 7.22.2.

I have tried to guard the new automatic language selection code with `#ifndef __WXMAC__`, but I am getting an assert from wxWidgets "Invalid combobox index" if I scroll all the way to the top of the language selection combo box. 
@BrianNixon can you please look at this and tel me what more I need to do. Also, please note that line 752 of DlgOptions.cpp also calls `wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT)` without checking for a NULL return.

I have also fixed 4 compiler warnings introduced by commit 59eb2c20ea.
