### PR TITLE
Mgr: compare best translations for selected languages

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -219,7 +219,6 @@ bool CBOINCGUIApp::OnInit() {
         if (pTranslations) {
             // Get best match from our available translations for automatic detection
             defaultLanguageCode = pTranslations->GetBestTranslation(wxT("BOINC-Manager"), wxLANGUAGE_DEFAULT);
-//            selectedLanguageCode = pTranslations->GetBestTranslation(wxT("BOINC-Manager"), wxLANGUAGE_FRENCH_CHAD);
             // Get best match from our available translations for the
             // language the user selected from the Other Options dialog
             selectedLanguageCode = pTranslations->GetBestTranslation(wxT("BOINC-Manager"), m_strISOLanguageCode);


### PR DESCRIPTION
We offer a limited number of translated languages, but the list of possible languages is much larger. Currently, when a user upgrades from an older version BOINC before Automatic Detection of language was offered as a formal option, the Manager decides whether or not to use Automatic Detection by comparing the user's previous language selection with the language which the computer system is set to use. But the translation software picks our closest available translation to the one requested by the user, not necessarily the exact one the user chose.

Old way: compare the actual default language code (the language the system is set to use) with the code for the exact language the user selected from the menu in the Other Options dialog. 
New way: compare the actual languages being used by our translation software.

Also, this allows the same code to be used on the Mac as on other platforms.

@BrianNixon Please take a look at this proposed change and let me know what you think.
