### PR TITLE
Mgr: Offer only languages for which we have translations

### DIFF
--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -85,6 +85,7 @@ protected:
     void                DetectRootDirectory();
     void                DetectDataDirectory();
 
+    bool                ShouldUseDefaultLocale();
     void                InitSupportedLanguages();
 
     int                 IdleTrackerAttach();


### PR DESCRIPTION
Before BOINC 7.24.0, the _Other Options_ dialog offered users all 897 languages and language variants possibly supported by wxWidgets. PR #5176 reduced this number by eliminating those for which we don't have a reasonable substitute translation for the requested language variant. For example, if the user selected the French dialect spoken in Chad (ISO language code `fr_TD`), BOINC substitutes generic French (ISO code `fr`); so the dialog offered `fr_TD` even though it would actually provide a generic French translation.

This is still an unwieldy number of choices and gives the false impression that BOINC actually provides all the listed dialects. This PR modifies the code to offer only the language dialects for which we provide actual translations. For backward compatibility, if the user had selected a dialect not in the new list while running an earlier version of BOINC, that dialect will continue to be listed.

In addition, this change makes it possible for me to make the improvement I unsuccessfully tried to implement in PR #5329: _Compare best translations for selected languages_.

@AenBleidd and @BrianNixon please tell me what you think.

Here is how the new trimmed language selection dialog looks now on the Mac:

<img width="662" alt="Screenshot 2023-08-16 at 3 34 39 AM" src="https://github.com/BOINC/boinc/assets/10470356/97488a25-718e-4192-9ffb-b9153099e6eb">


