### PR TITLE
[Android] Revert back to target API 21

### DIFF
--- a/android/BOINC/.idea/misc.xml
+++ b/android/BOINC/.idea/misc.xml
@@ -1,10 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="15">
+        <list size="16">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -20,12 +21,13 @@
           <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
           <item index="13" class="java.lang.String" itemvalue="io.reactivex.annotations.Nullable" />
           <item index="14" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.Nullable" />
+          <item index="15" class="java.lang.String" itemvalue="org.jspecify.nullness.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="14">
+        <list size="15">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
@@ -40,9 +42,10 @@
           <item index="11" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
           <item index="12" class="java.lang.String" itemvalue="io.reactivex.annotations.NonNull" />
           <item index="13" class="java.lang.String" itemvalue="io.reactivex.rxjava3.annotations.NonNull" />
+          <item index="14" class="java.lang.String" itemvalue="org.jspecify.nullness.NonNull" />
         </list>
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK" />
 </project>

--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -332,7 +332,7 @@ android {
     defaultConfig {
         applicationId "edu.berkeley.boinc"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 21
         versionCode buildVersionCode().toInteger()
         versionName buildVersionName()
 

--- a/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
+++ b/android/BOINC/app/src/main/aidl/edu/berkeley/boinc/client/IMonitor.aidl
@@ -100,10 +100,12 @@ List<ImageWrapper> getSlideshowForProject(in String url);   // clientStatus.getS
 ////// app preference ////////////////////////////////////////////
 void setAutostart(in boolean isAutoStart);          // Monitor.getAppPrefs().setAutostart(boolean);
 void setShowNotificationForNotices(in boolean isShow);   // Monitor.getAppPrefs().setShowNotificationForNotices(boolean);
+void setShowNotificationDuringSuspend(in boolean isShow);   // Monitor.getAppPrefs().setShowNotificationDuringSuspend(boolean);
 boolean getShowAdvanced();           // Monitor.getAppPrefs().getShowAdvanced();
 boolean getIsRemote();              // Monitor.getAppPrefs().getIsRemote();
 boolean getAutostart();              // Monitor.getAppPrefs().getAutostart();
 boolean getShowNotificationForNotices();       // Monitor.getAppPrefs().getShowNotificationForNotices();
+boolean getShowNotificationDuringSuspend();       // Monitor.getAppPrefs().getShowNotificationDuringSuspend();
 int getLogLevel();                   // Monitor.getAppPrefs().getLogLevel();
 void setLogLevel(in int level);               // Monitor.getAppPrefs().setLogLevel(int);
 List<String> getLogCategories();

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/AppPreferences.kt
@@ -32,6 +32,8 @@ class AppPreferences @Inject constructor(val context: Context) {
     var autostart = prefs.getBoolean("autostart", context.resources.getBoolean(R.bool.prefs_default_autostart))
     var showNotificationForNotices = prefs.getBoolean("showNotifications",
             context.resources.getBoolean(R.bool.prefs_default_notification_notices))
+    var showNotificationDuringSuspend = prefs.getBoolean("showNotificationsDuringSuspend",
+            context.resources.getBoolean(R.bool.prefs_default_notification_suspended))
     var showAdvanced = prefs.getBoolean("showAdvanced", context.resources.getBoolean(R.bool.prefs_default_advanced))
     var isRemote     = prefs.getBoolean("remoteEnable", context.resources.getBoolean(R.bool.prefs_default_remote))
     var logLevel = prefs.getInt("logLevel", context.resources.getInteger(R.integer.prefs_default_loglevel))
@@ -58,6 +60,7 @@ class AppPreferences @Inject constructor(val context: Context) {
 
         Logging.logDebug(Logging.Category.SETTINGS,
             "appPrefs read successful: autostart: [$autostart] showNotificationForNotices: [$showNotificationForNotices] " +
+            "showNotificationDuringSuspend: [$showNotificationDuringSuspend] " +
             "showAdvanced: [$showAdvanced] logLevel: [$logLevel] powerSourceAc: [$powerSourceAc] powerSourceUsb: [$powerSourceUsb] " +
             "powerSourceWireless: [$powerSourceWireless] stationaryDeviceMode: [$stationaryDeviceMode] suspendWhenScreenOn: [$suspendWhenScreenOn]")
     }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/Monitor.kt
@@ -1366,6 +1366,16 @@ class Monitor : LifecycleService() {
         }
 
         @Throws(RemoteException::class)
+        override fun setShowNotificationDuringSuspend(isShow: Boolean) {
+            appPreferences.showNotificationDuringSuspend = isShow
+        }
+
+        @Throws(RemoteException::class)
+        override fun getShowNotificationDuringSuspend(): Boolean {
+            return appPreferences.showNotificationDuringSuspend
+        }
+
+        @Throws(RemoteException::class)
         override fun runBenchmarks(): Boolean {
             return clientInterface.runBenchmarks()
         }

--- a/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/MonitorAsync.kt
+++ b/android/BOINC/app/src/main/java/edu/berkeley/boinc/client/MonitorAsync.kt
@@ -195,6 +195,14 @@ class MonitorAsync(monitor: IMonitor?) : IMonitor {
         return monitor.cancelNoticeNotification()
     }
 
+    override fun setShowNotificationDuringSuspend(isShow: Boolean) {
+        monitor.showNotificationDuringSuspend = isShow
+    }
+
+    override fun getShowNotificationDuringSuspend(): Boolean {
+        return monitor.showNotificationDuringSuspend
+    }
+
     override fun getWelcomeStateFile(): Boolean {
         return monitor.welcomeStateFile
     }

--- a/android/BOINC/app/src/main/res/values-en/strings.xml
+++ b/android/BOINC/app/src/main/res/values-en/strings.xml
@@ -2,17 +2,17 @@
   This file is part of BOINC.
   http://boinc.berkeley.edu
   Copyright (C) 2022 University of California
-  
+
   BOINC is free software; you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License
   as published by the Free Software Foundation,
   either version 3 of the License, or (at your option) any later version.
-  
+
   BOINC is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   See the GNU Lesser General Public License for more details.
-  
+
   You should have received a copy of the GNU Lesser General Public License
   along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 -->
@@ -151,6 +151,7 @@
     <string name="prefs_remote_header">Enable Remote Control</string>
     <string name="prefs_remote_summary">When changed, the BOINC client will be relaunched.</string>
     <string name="prefs_show_notification_notices_header">Show notification for new notices</string>
+    <string name="prefs_show_notification_suspended_header">Show notification when suspended</string>
     <string name="prefs_cpu_number_cpus_header">Used CPU cores</string>
     <string name="prefs_cpu_number_cpus_description">Limits the number of CPU cores BOINC uses for computation.</string>
     <string name="prefs_cpu_other_load_suspension_header">Pause at CPU usage above (%)</string>

--- a/android/BOINC/app/src/main/res/values/strings.xml
+++ b/android/BOINC/app/src/main/res/values/strings.xml
@@ -151,6 +151,7 @@
     <string name="prefs_remote_header">Enable Remote Control</string>
     <string name="prefs_remote_summary">When changed, the BOINC client will be relaunched.</string>
     <string name="prefs_show_notification_notices_header">Show notification for new notices</string>
+    <string name="prefs_show_notification_suspended_header">Show notification when suspended</string>
     <string name="prefs_cpu_number_cpus_header">Used CPU cores</string>
     <string name="prefs_cpu_number_cpus_description">Limits the number of CPU cores BOINC uses for computation.</string>
     <string name="prefs_cpu_other_load_suspension_header">Pause at CPU usage above (%)</string>

--- a/android/BOINC/app/src/main/res/xml/root_preferences.xml
+++ b/android/BOINC/app/src/main/res/xml/root_preferences.xml
@@ -36,6 +36,12 @@
                 app:title="@string/prefs_show_notification_notices_header" />
 
         <CheckBoxPreference
+                app:defaultValue="@bool/prefs_default_notification_suspended"
+                app:iconSpaceReserved="false"
+                app:key="showErrorNotifications"
+                app:title="@string/prefs_show_notification_suspended_header" />
+
+        <CheckBoxPreference
                 app:defaultValue="@bool/prefs_default_advanced"
                 app:iconSpaceReserved="false"
                 app:key="showAdvanced"


### PR DESCRIPTION
In #3418 I changed the behavior of BOINC to run always in the foreground mode. This lead to the situation when notification was always shown, even when BOINC in not running, and thus making a lot of notification noise. 3 years ago I thought that this is good decision and a necessary evil. Unfortunately, I was wrong.
My main motivation of this was to be able to be on track, and have our application in the Play Store. But every new API increase the limitations from the Android side become stronger and stronger, and prevent us from doing what we want. For example, in the Android versions starting from Oreo, it is not possible to start a service from the background. And while we can leave with that fact, we received and issue with the notifications. I thought, that if we will have BOINC always running on the foreground, it will be possible to keep it always running and prevent it from being killed by the system. Unfortunately, this is not the case.
The system still kills the application, and the notification is still shown. And this is not the only problem.
Other problem is that starting from API 29, we are not able to start executables downloaded from the server. Since this is a core functionality, we are not able to target API 29 or higher. And since we are not able to target API 29 or higher, we are not able to put BOINC in the Play Store. And thus it makes no sense to target any API higher than 21 because it will just kill the functionality of the application. So, I decided to revert back to the API 21, and make the application work as it was before. But even in this case there is a chance that on the newer version of Android, some of the gard limitations will be applied, and it will prevent (again) BOINC from working. But at least currently application is working, and we can add necessary features to it. The only issue I see now is that the user will see a notification, that this application was developed for the older version of Android and thus might not work correctly, but I believe we can live with that.

This fixes: #4189, #4218 and #4190
