### PR TITLE
server (all components that use DB): don't use MYSQL_OPT_RECONNECT if deprecated

### DIFF
--- a/db/db_base.cpp
+++ b/db/db_base.cpp
@@ -46,9 +46,12 @@ int DB_CONN::open(
     //
     // v < 5.0.13: not supported
     // 5.0.13 <= v < 5.0.19: set option after real_connect()
-    // 5.0.19 < v < 5.1: set option before real_connect();
+    // 5.0.19 < v < 5.1: set option before real_connect()
     // 5.1.0 <= v < 5.1.6: set option after real_connect()
-    // 5.1.6 <= v: set option before real_connect
+    // 5.1.6 <= v: set option before real_connect()
+    // 5.1.6 < v < 8.0.34: set option after real_connect()
+    // 8.0.34 <= v: reconnect feature deprecated
+    // https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-34.html#mysqld-8-0-34-deprecation-removal
 
     int v = MYSQL_VERSION_ID;
     bool set_opt_before = false, set_opt_after = false;
@@ -59,7 +62,7 @@ int DB_CONN::open(
         set_opt_before = true;
     } else if (v < 50106) {
         set_opt_after = true;
-    } else {
+    } else if (v < 80034) {
         set_opt_before = true;
     }
 


### PR DESCRIPTION
Starting with 8.0.34, the MySQL reconnection option is deprecated, and using it produces a warning message.
So don't use it with MySQL 8.0.34 and later.

Note: this means that if the MySQL server dies,
long-running programs like the transitioner will stop working, and you'll have to stop/start the project.
If this proves to be a problem, we could add our own reconnect logic.

Fixes #5341