### PR TITLE
[Android] Increase Target SDK Version API to 28.

### DIFF
--- a/android/BOINC/app/build.gradle
+++ b/android/BOINC/app/build.gradle
@@ -332,7 +332,7 @@ android {
     defaultConfig {
         applicationId "edu.berkeley.boinc"
         minSdkVersion 16
-        targetSdkVersion 21
+        targetSdkVersion 28
         versionCode buildVersionCode().toInteger()
         versionName buildVersionName()
 


### PR DESCRIPTION
Most of the breaking changes from API 21 to API 28 were made in a way that it doesn't really matter which API your applications targets. That is why there is no risk by increasing API level to 28. This will remove the message about outdated application, and also will remove an issue with the newer phones that have 4k display. It's not possible to increase it further, because starting from API 29 W^X feature was introduced, and this prevent us from running any executable that is not the part of our APK (even the client that we are copying from the assets folder based on the current device architecture).
