### PR TITLE
[Android] Fix GPU detection

### DIFF
--- a/lib/cl_boinc.h
+++ b/lib/cl_boinc.h
@@ -127,6 +127,7 @@ typedef cl_bitfield         cl_command_queue_properties;
 #define CL_DEVICE_TYPE_CPU                          (1 << 1)
 #define CL_DEVICE_TYPE_GPU                          (1 << 2)
 #define CL_DEVICE_TYPE_ACCELERATOR                  (1 << 3)
+#define CL_DEVICE_TYPE_CUSTOM                       (1 << 4)
 #define CL_DEVICE_TYPE_ALL                          0xFFFFFFFF
 
 /* cl_device_info */

--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -72,7 +72,7 @@ struct OPENCL_DEVICE_PROP {
     int get_device_version_int();       // call this to encode
     int opencl_driver_revision;         // OpenCL runtime revision is available
     int get_opencl_driver_revision();   // call this to encode
-    char opencl_driver_version[32];     // For example: "CLH 1.0"
+    char opencl_driver_version[512];    // For example: "CLH 1.0"
     int device_num;                     // temp used in scan process
     double peak_flops;                  // temp used in scan process
     COPROC_USAGE is_used;               // temp used in scan process


### PR DESCRIPTION
Starting from Android 8, the GPU detection is broken due to the fact that dlopen() now return NULL. This was done to fix issues with library names resolution. New API was introduced, but it's not available from the NDK. Instead, we have to load the library manually and call the function directly. Unfortunately, on Android this behavior was changed even more, and now we need to look for other functions.

By fixing this behavior, we have now successful Mali GPU detection. But unfortunately, this doesn't work for Qualcomm Adreno GPUs.

Looks like implementation of Qualcomm has some problems with clGetDeviceIDs. It returns CL_DEVICE_NOT_FOUND for CL_DEVICE_TYPE_GPU and CL_DEVICE_TYPE_ACCELERATOR combined. But it returns CL_SUCCESS when asking separately for CL_DEVICE_TYPE_GPU or CL_DEVICE_TYPE_ACCELERATOR. So we will ask for CL_DEVICE_TYPE_GPU and CL_DEVICE_TYPE_ACCELERATOR separately.

This fixes #3613 and #4204.
