### PR TITLE
Mac: Fix build break introduced by commit 8ea2aba1d8

### DIFF
--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -41,7 +41,6 @@
 
 /* Begin PBXBuildFile section */
 		81FD378F2AB95D4A00E29818 /* app_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 81FD378E2AB95D4A00E29818 /* app_test.cpp */; };
-		81FD37902AB95D4A00E29818 /* app_test.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 81FD378E2AB95D4A00E29818 /* app_test.cpp */; };
 		B13E2D172655655000D5C977 /* detect_rosetta_cpu.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B13E2D162655655000D5C977 /* detect_rosetta_cpu.cpp */; };
 		DD000D6A24D0208E0083DE77 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
 		DD000D6B24D020940083DE77 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
@@ -3963,7 +3962,6 @@
 				DD99172A1E69A92A00555337 /* mac_spawn.cpp in Sources */,
 				DDE586B310FC8E9B00DFA887 /* mfile.cpp in Sources */,
 				DD3741D610FC948C001257EB /* filesys.cpp in Sources */,
-				81FD37902AB95D4A00E29818 /* app_test.cpp in Sources */,
 				DD3741D910FC94BA001257EB /* url.cpp in Sources */,
 				DD76BF9717CB465C0075936D /* opencl_boinc.cpp in Sources */,
 			);

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -714,6 +714,20 @@
 			remoteGlobalIDString = DD96AFF80811075000A06F22;
 			remoteInfo = ScreenSaver;
 		};
+		DD7C3B102ABC3F85000C307D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDFF2ACA0A53D4AE002BC19D;
+			remoteInfo = setprojectgrp;
+		};
+		DD7C3B122ABC3F85000C307D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDD0953E0A3EDD2500C95BA4;
+			remoteInfo = switcher;
+		};
 		DD81C823144D904D000BE61A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
@@ -2590,6 +2604,8 @@
 			dependencies = (
 				B1A32E55265D206800896566 /* PBXTargetDependency */,
 				DD25E20D220438090040366F /* PBXTargetDependency */,
+				DD7C3B112ABC3F85000C307D /* PBXTargetDependency */,
+				DD7C3B132ABC3F85000C307D /* PBXTargetDependency */,
 			);
 			name = BOINC_Client;
 			productName = BOINC_Client;
@@ -4223,6 +4239,16 @@
 			isa = PBXTargetDependency;
 			target = DD96AFF80811075000A06F22 /* ScreenSaver */;
 			targetProxy = DD791FF00819063C00BE2906 /* PBXContainerItemProxy */;
+		};
+		DD7C3B112ABC3F85000C307D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDFF2ACA0A53D4AE002BC19D /* setprojectgrp */;
+			targetProxy = DD7C3B102ABC3F85000C307D /* PBXContainerItemProxy */;
+		};
+		DD7C3B132ABC3F85000C307D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDD0953E0A3EDD2500C95BA4 /* switcher */;
+			targetProxy = DD7C3B122ABC3F85000C307D /* PBXContainerItemProxy */;
 		};
 		DD81C824144D904D000BE61A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
Remove app_test.cpp from build of switcher

Also, add switcher and setprojectgrp targets as dependencies to client so CI builds will detect problems building them.