### PR TITLE
Correctly detect CPU cores when cpuset cgroup is used

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1334,6 +1334,12 @@ int HOST_INFO::get_cpu_count() {
     if(cpus_sys_path > p_ncpus){
         p_ncpus = cpus_sys_path;
     }
+#elif __GNU_LIBRARY__ /* glibc */
+    cpu_set_t set;
+
+    if (sched_getaffinity (0, sizeof (set), &set) == 0) {
+        p_ncpus = CPU_COUNT (&set);
+    }
 #elif defined(_SC_NPROCESSORS_ONLN) && !defined(__EMX__) && !defined(__APPLE__)
     // sysconf not working on OS2
     p_ncpus = sysconf(_SC_NPROCESSORS_ONLN);


### PR DESCRIPTION
**Description of the Change**
CPU cores are not correctly detected when eg running within a container that uses cgroup cpusets. This change should improve the detection. I am not 100% sure about other platforms and may need some ifdefing, but I do not have many platforms to test it on.

**Alternate Designs**
this code was checked against `nproc` which uses the same method

**Release Notes**
Detect CPU cores when using cpuset to limit core count