### PR TITLE
Delete unnecessary checks before calls of the function “free”

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -922,10 +922,8 @@ int boinc_parse_init_data_file() {
     int retval;
     char buf[256];
 
-    if (aid.project_preferences) {
-        free(aid.project_preferences);
-        aid.project_preferences = NULL;
-    }
+    free(aid.project_preferences);
+    aid.project_preferences = NULL;
     aid.clear();
     aid.checkpoint_period = DEFAULT_CHECKPOINT_PERIOD;
 

--- a/client/cs_trickle.cpp
+++ b/client/cs_trickle.cpp
@@ -317,8 +317,6 @@ void TRICKLE_UP_OP::handle_reply(int http_op_retval) {
             "[trickle] Replicated trickle done; retval %d", http_op_retval
         );
     }
-    if (req_buf) {
-        free(req_buf);
-        req_buf = 0;
-    }
+    free(req_buf);
+    req_buf = 0;
 }

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1137,7 +1137,7 @@ int get_network_usage_totals(
 
     if (sysctl(mib, 6, NULL, &currentSize, NULL, 0) != 0) return errno;
     if (!sysctlBuffer || (currentSize > sysctlBufferSize)) {
-        if (sysctlBuffer) free(sysctlBuffer);
+        free(sysctlBuffer);
         sysctlBufferSize = 0;
         sysctlBuffer = (uint8_t*)malloc(currentSize);
         if (!sysctlBuffer) return ERR_MALLOC;

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -566,10 +566,10 @@ SCHEDULER_REPLY::SCHEDULER_REPLY() {
 }
 
 SCHEDULER_REPLY::~SCHEDULER_REPLY() {
-    if (global_prefs_xml) free(global_prefs_xml);
-    if (project_prefs_xml) free(project_prefs_xml);
-    if (code_sign_key) free(code_sign_key);
-    if (code_sign_key_signature) free(code_sign_key_signature);
+    free(global_prefs_xml);
+    free(project_prefs_xml);
+    free(code_sign_key);
+    free(code_sign_key_signature);
 }
 
 #ifndef SIM

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -924,8 +924,8 @@ void CBOINCGUIApp::DetectDataDirectory() {
 
     // Cleanup
 	if (hkSetupHive) RegCloseKey(hkSetupHive);
-    if (lpszValue) free(lpszValue);
-    if (lpszExpandedValue) free(lpszExpandedValue);
+    free(lpszValue);
+    free(lpszExpandedValue);
 #endif
 #ifdef __WXMAC__
     m_strBOINCMGRDataDirectory = wxT("/Library/Application Support/BOINC Data");

--- a/clientsetup/win/boinccas.cpp
+++ b/clientsetup/win/boinccas.cpp
@@ -514,7 +514,7 @@ UINT BOINCCABase::GetProperty(
             NULL,
             strMessage.c_str()
         );
-        if ( lpszBuffer ) free( lpszBuffer );
+        free(lpszBuffer);
         return ERROR_INSTALL_FAILURE;
         break;
     }

--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -41,10 +41,8 @@ APP_INIT_DATA::APP_INIT_DATA() {
 }
 
 APP_INIT_DATA::~APP_INIT_DATA() {
-    if (project_preferences) {
-        free(project_preferences);
-        project_preferences=0;      // paranoia
-    }
+    free(project_preferences);
+    project_preferences = 0;      // paranoia
 }
 
 APP_INIT_DATA::APP_INIT_DATA(const APP_INIT_DATA& a) {
@@ -324,10 +322,8 @@ int parse_init_data_file(FILE* f, APP_INIT_DATA& ai) {
         return ERR_XML_PARSE;
     }
 
-    if (ai.project_preferences) {
-        free(ai.project_preferences);
-        ai.project_preferences = 0;
-    }
+    free(ai.project_preferences);
+    ai.project_preferences = 0;
     ai.clear();
     ai.fraction_done_start = 0;
     ai.fraction_done_end = 1;

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -341,7 +341,7 @@ RPC::RPC(RPC_CLIENT* rc) : xp(&fin) {
 }
 
 RPC::~RPC() {
-    if (mbuf) free(mbuf);
+    free(mbuf);
 }
 
 // return value indicates only whether network comm succeeded

--- a/lib/mfile.cpp
+++ b/lib/mfile.cpp
@@ -40,7 +40,7 @@ MFILE::MFILE() {
 }
 
 MFILE::~MFILE() {
-    if (buf) free(buf);
+    free(buf);
 }
 
 int MFILE::open(const char* path, const char* mode) {
@@ -156,10 +156,8 @@ int MFILE::close() {
         boinc::fclose(f);
         f = NULL;
     }
-    if (buf) {
-        free(buf);
-        buf = NULL;
-    }
+    free(buf);
+    buf = NULL;
     return retval;
 }
 

--- a/lib/translate.cpp
+++ b/lib/translate.cpp
@@ -380,7 +380,7 @@ void BOINCTranslationCleanup() {
 
     for (i=0; i<MAXCATALOGS; ++i) {
         pCatalog = &(theCatalogData[i]);
-        if (pCatalog->pData) free(pCatalog->pData);
+        free(pCatalog->pData);
         pCatalog->pData = NULL;
         pCatalog->nSize = 0;
         pCatalog->NumStrings = 0;

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -114,8 +114,8 @@ void chdir_to_data_dir() {
     }
 
     if (hkSetupHive) RegCloseKey(hkSetupHive);
-    if (lpszValue) free(lpszValue);
-    if (lpszExpandedValue) free(lpszExpandedValue);
+    free(lpszValue);
+    free(lpszExpandedValue);
 }
 
 std::wstring boinc_ascii_to_wide(const std::string& str) {

--- a/samples/gfx_html/mongoose.cpp
+++ b/samples/gfx_html/mongoose.cpp
@@ -431,7 +431,7 @@ int ns_avprintf(char **buf, size_t size, const char *fmt, va_list ap) {
     // succeed or out of memory.
     *buf = NULL;
     while (len < 0) {
-      if (*buf) NS_FREE(*buf);
+      NS_FREE(*buf);
       size *= 2;
       if ((*buf = (char *) NS_MALLOC(size)) == NULL) break;
       va_copy(ap_copy, ap);
@@ -5025,10 +5025,8 @@ const char *mg_set_option(struct mg_server *server, const char *name,
     return NULL;
   }
 
-  if (*v != NULL) {
-    NS_FREE(*v);
-    *v = NULL;
-  }
+  NS_FREE(*v);
+  *v = NULL;
 
   if (value == NULL || value[0] == '\0') return NULL;
 

--- a/samples/openclapp/openclapp.cpp
+++ b/samples/openclapp/openclapp.cpp
@@ -638,20 +638,12 @@ int cleanup_cl(void) {
  * \brief Releases program's resources
  */
 void cleanup_host(void) {
-    if (input != NULL) {
-        free(input);
-        input = NULL;
-    }
-
-    if (output != NULL) {
-        free(output);
-        output = NULL;
-    }
-
-    if (source != NULL) {
-        free((char *)source);
-        source = NULL;
-    }
+    free(input);
+    input = NULL;
+    free(output);
+    output = NULL;
+    free(source);
+    source = NULL;
 }
 
 /*

--- a/zip/boinc_zip.cpp
+++ b/zip/boinc_zip.cpp
@@ -338,7 +338,7 @@ int boinc_UnzipToMemory (char *zip, char *file, string &retstr) {
         retstr =  (string) buf.strptr;
     }
 
-    if (buf.strptr) free (buf.strptr);
+    free(buf.strptr);
 
     return ret;
 


### PR DESCRIPTION
**Description of the Change**
[The function “free”](https://stackoverflow.com/questions/18775608/free-a-null-pointer-anyway-or-check-first "Free a null pointer anyway or check first?") is documented in the way that no action shall occur for a passed null pointer.
:thought_balloon: Redundant safety checks can be avoided.

**Release Notes**
An analysis by the means of the Coccinelle software pointed the potential out to simplify some source code places.
Thus extra null pointer checks could be omitted in some function implementations.