### PR TITLE
complete #5123: client and server: increase p_features size from 1024 to 8192

### DIFF
--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -366,7 +366,7 @@ struct HOST {
     // but not stored in the DB
     // TODO: move this stuff to a derived class HOST_SCHED
     //
-    char p_features[1024];
+    char p_features[P_FEATURES_SIZE];
     char virtualbox_version[256];
     bool p_vm_extensions_disabled;
     int num_opencl_cpu_platforms;

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -22,6 +22,7 @@
 
 #include "util.h"
 #include "coproc.h"
+#include "hostinfo.h"
 
 #include "sched_config.h"
 #include "sched_customize.h"
@@ -269,7 +270,7 @@ bool PLAN_CLASS_SPEC::check(
     // so we can look for them with strstr()
     //
     if (!cpu_features.empty()) {
-        char buf[8192], buf2[512];
+        char buf[P_FEATURES_SIZE], buf2[512];
         sprintf(buf, " %s ", sreq.host.p_features);
         char* p = strrchr(sreq.host.p_model, '[');
         if (p) {


### PR DESCRIPTION
Fixes #5123

In the current version of the code (master branch), p_features size of the host record is still fixed 1024. That doesn't look right (and probably won't help):

char p_features[1024];

https://github.com/BOINC/boinc/blob/master/db/boinc_db_types.h#L369