### PR TITLE
Improve text related to weak auth (account key)

### DIFF
--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -210,6 +210,7 @@ struct USER {
         // the "external CPID" that  gets exported to stats sites
         // is MD5(cpid, email)
     char passwd_hash[256];
+        // MD5(password, email_addr)
     bool email_validated;           // deprecated
     int donated;
     char login_token[32];

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -204,6 +204,16 @@ function notify_description($notify) {
     return null;
 }
 
+// a string that can be used to authenticate some operations,
+// but can't be used to log in to the account
+// (e.g. can't be used to change email addr or passwd)
+//
+// this is a function of
+// - authenticator (never changes)
+// - user ID (never changes)
+// - password
+// - email addr
+//
 function weak_auth($user) {
     $x = md5($user->authenticator.$user->passwd_hash);
     return "{$user->id}_$x";

--- a/html/user/edit_email_form.php
+++ b/html/user/edit_email_form.php
@@ -24,6 +24,8 @@ check_get_args(array());
 $user = get_logged_in_user();
 
 page_head(tra("Change email address"));
+echo tra("Note: if you change your email address, your %1weak account key%2 will change.", "<a href=weak_auth.php>", "</a>");
+echo "<p>";
 
 $email_text = "";
 if (is_valid_email_addr($user->email_addr)) {

--- a/html/user/edit_passwd_form.php
+++ b/html/user/edit_passwd_form.php
@@ -24,6 +24,8 @@ check_get_args(array());
 $user = get_logged_in_user();
 
 page_head(tra("Change password"));
+echo tra("Note: if you change your password, your %1weak account key%2 will change.", "<a href=weak_auth.php>", "</a>");
+echo "<p>";
 
 form_start(secure_url_base()."edit_passwd_action.php", "post");
 form_input_text(tra("New password"), "passwd", "", "password",'id="passwd"',passwd_visible_checkbox("passwd"));

--- a/html/user/weak_auth.php
+++ b/html/user/weak_auth.php
@@ -20,7 +20,6 @@ require_once("../inc/util.inc");
 require_once("../inc/user.inc");
 
 $user = get_logged_in_user();
-page_head(tra("Account keys"));
 
 $weak_auth = weak_auth($user);
 
@@ -48,21 +47,23 @@ for ($i=0; $i<strlen($url); $i++) {
 //
 $account_file = "account_" . rtrim($url, '_') . ".xml";
 
+page_head(tra("Account keys"));
+text_start();
 echo "<table><tr><td>",
     tra("You can access your account either by using your email address and password,
     or by using an assigned 'account key'.
     Your account key is:"),
-    "<pre>$user->authenticator</pre>
+    "<p><pre>$user->authenticator</pre>
     <p>",
     tra("This key can be used to:"),
     "<ul>
     <li><a href=get_passwd.php>",tra("log in to your account on the web"),"</a>;
     <li>",
-        tra("to attach a computer to your account without using the BOINC Manager.
+        tra("attach a computer to your account without using the BOINC Manager.
        To do so, install BOINC,
        create a file named %1 in the BOINC
        data directory, and set its contents to:","<b>$account_file</b>"),"
-    <pre>",
+    <p><pre>",
     htmlspecialchars(
 "<account>
     <master_url>".$master_url."</master_url>
@@ -76,11 +77,11 @@ echo "<table><tr><td>",
     If you want to attach untrusted or insecure computers to your account,
     do so using your weak account key.
     Your weak account key is:"),"
-    <pre>$weak_auth</pre>
-    <p>",
-    tra("If you change your password, your weak account key changes, and your previous weak account key becomes invalid."),"
+    <p><pre>$weak_auth</pre><p>
+    ",
+    tra("The key depends on your account's email address and password.  If you change either of these, the weak account key will change."),"
     </td></tr></table>"
 ;
-
+text_end();
 page_tail();
 ?>


### PR DESCRIPTION
- in the page showing the weak auth, say that it depends on password and email addr (and make this page nicer looking)
- in the pages for changing password and email addr, say that doing so will change your weak auth.