### PR TITLE
Make wrappers work with sporadic apps

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -551,6 +551,8 @@ static void sporadic_files() {
     if (!ret) {
 #ifdef _WIN32
         time_t t = sbuf.st_mtime;
+#elif defined(__APPLE__)
+        time_t t = sbuf.st_mtimespec.tv_sec;
 #else
         time_t t = sbuf.st_mtim.tv_sec;
 #endif

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -539,7 +539,7 @@ static void sporadic_files() {
     if (last_ca_state != boinc_status.ca_state) {
         sprintf(buf, "%d\n", boinc_status.ca_state);
         lseek(ac_fd, 0, SEEK_SET);
-        if (write(ac_fd, buf, strlen(buf))){};
+        if (write(ac_fd, buf, sizeof(buf))) {}
             // one way to avoid warnings
     }
 
@@ -548,10 +548,14 @@ static void sporadic_files() {
     struct stat sbuf;
     int ret = fstat(ac_fd, &sbuf);
     if (!ret) {
+#ifdef _WIN32
+        time_t t = sbuf.st_mtime;
+#else
         time_t t = sbuf.st_mtim.tv_sec;
+#endif
         if (t != last_ac_mod_time) {
             lseek(ac_fd, 0, SEEK_SET);
-            ret = read(ac_fd, buf, 256);
+            ret = read(ac_fd, buf, sizeof(buf));
             if (!ret) {
                 int val;
                 int n = sscanf(buf, "%d", &val);

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -148,6 +148,7 @@ extern int boinc_finish_message(
 );
 extern void boinc_sporadic_set_ac_state(SPORADIC_AC_STATE);
 extern SPORADIC_CA_STATE boinc_sporadic_get_ca_state();
+extern int boinc_sporadic_dir(const char*);
 
 /////////// API ENDS HERE
 

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -738,8 +738,8 @@ void ACTIVE_TASK_SET::send_heartbeats() {
         if (log_flags.heartbeat_debug) {
             if (sent) {
                 msg_printf(atp->result->project, MSG_INFO,
-                    "[heartbeat] Heartbeat sent to task %s",
-                    atp->result->name
+                    "[heartbeat] Heartbeat sent to task %s: %s",
+                    atp->result->name, buf
                 );
             } else {
                 msg_printf(atp->result->project, MSG_INFO,

--- a/client/app_test.cpp
+++ b/client/app_test.cpp
@@ -63,9 +63,11 @@ void CLIENT_STATE::app_test_init() {
     // can put other stuff here like
     av->avg_ncpus = 1;
     av->flops = 1e9;
+#if 0
     av->gpu_ram = 1e7;
     av->gpu_usage.rsc_type = PROC_TYPE_NVIDIA_GPU;
     av->gpu_usage.usage = 1;
+#endif
     app_versions.push_back(av);
 
     WORKUNIT *wu = new WORKUNIT;
@@ -77,6 +79,7 @@ void CLIENT_STATE::app_test_init() {
     wu->rsc_fpops_bound = 1e12;
     wu->rsc_memory_bound = 1e9;
     wu->rsc_disk_bound = 1e9;
+    wu->command_line = "--sporadic";
     workunits.push_back(wu);
 
     RESULT *res = new RESULT;

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1626,10 +1626,12 @@ ACTIVE_TASK* CLIENT_STATE::get_task(RESULT* rp) {
     ACTIVE_TASK *atp = lookup_active_task_by_result(rp);
     if (!atp) {
         atp = new ACTIVE_TASK;
-        int retval = atp->get_free_slot(rp);
-        if (retval) {
-            delete atp;
-            return NULL;
+        if (!rp->project->app_test) {
+            int retval = atp->get_free_slot(rp);
+            if (retval) {
+                delete atp;
+                return NULL;
+            }
         }
         atp->init(rp);
         active_tasks.active_tasks.push_back(atp);

--- a/client/cs_cmdline.cpp
+++ b/client/cs_cmdline.cpp
@@ -49,6 +49,7 @@ static void print_options(char* prog) {
         "    --abort_jobs_on_exit           when client exits, abort and report jobs\n"
         "    --allow_remote_gui_rpc         allow remote GUI RPC connections\n"
         "    --allow_multiple_clients       allow >1 instances per host\n"
+        "    --app_test F                   run a simulated job with the given app\n"
         "    --attach_project <URL> <key>   attach to a project\n"
         "    --check_all_logins             for idle detection, check remote logins too\n"
         "    --daemon                       run as daemon (Unix)\n"

--- a/client/cs_sporadic.cpp
+++ b/client/cs_sporadic.cpp
@@ -82,6 +82,7 @@
 SPORADIC_RESOURCES sporadic_resources;
 
 void SPORADIC_RESOURCES::print() {
+    if (!ncpus_used) return;
     msg_printf(NULL, MSG_INFO, "Sporadic resources:");
     msg_printf(NULL, MSG_INFO, "   %f CPUs", ncpus_used);
     msg_printf(NULL, MSG_INFO, "   %f MB RAM", mem_used/MEGA);

--- a/samples/sporadic/sporadic.cpp
+++ b/samples/sporadic/sporadic.cpp
@@ -7,18 +7,27 @@
 //      when OK, compute for NCOMP secs
 //      suspend as needed
 //
-// computing is embedded in loop.
+// computing is embedded in the loop.
 // in a real app you'd want to use threads
+
+// by default this uses the BOINC API for communicating sporadic state.
+// --wrapped: use files instead (run under wrapper)
 
 #define NWAIT 10
 #define NCOMP 10
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
 
 #include "boinc_api.h"
 #include "util.h"
 #include "common_defs.h"
 
-void boinc_sporadic_set_ac_state(SPORADIC_AC_STATE);
-SPORADIC_CA_STATE boinc_sporadic_get_ca_state();
+bool wrapped = false;
+int ac_fd, ca_fd;
 
 void compute_one_sec() {
     double start = dtime();
@@ -31,22 +40,70 @@ void compute_one_sec() {
     }
 }
 
-int main(int, char**) {
-    boinc_init();
+void set_ac_state(SPORADIC_AC_STATE ac_state) {
+    static SPORADIC_AC_STATE last = AC_NONE;
+    if (wrapped) {
+        if (ac_state != last) {
+            char buf[256];
+            sprintf(buf, "%d\n", ac_state);
+            lseek(ac_fd, 0, SEEK_SET);
+            write(ac_fd, buf, strlen(buf));
+        }
+        last = ac_state;
+    } else {
+        boinc_sporadic_set_ac_state(ac_state);
+    }
+}
+
+SPORADIC_CA_STATE get_ca_state() {
+    if (wrapped) {
+        // could check mod time; don't bother
+        char buf[256];
+        lseek(ca_fd, 0, SEEK_SET);
+        read(ca_fd, buf, sizeof(buf));
+        int s;
+        int n = sscanf(buf, "%d", &s);
+        if (n==1) return (SPORADIC_CA_STATE)s;
+        fprintf(stderr, "can't read CA state\n");
+        exit(1);
+    } else {
+        return boinc_sporadic_get_ca_state();
+    }
+}
+
+int main(int argc, char** argv) {
     SPORADIC_CA_STATE ca_state;
     SPORADIC_AC_STATE ac_state;
+
+    for (int i=1; i<argc; i++) {
+        if (!strcmp(argv[i], "--wrapped")) {
+            wrapped = true;
+        }
+    }
+
+    if (wrapped) {
+        ca_fd = open("ca", O_RDONLY);
+        ac_fd = open("ac", O_WRONLY);
+        if (ca_fd<0 || ac_fd<0) {
+            fprintf(stderr, "can't open files\n");
+            exit(1);
+        }
+    } else {
+        boinc_init();
+    }
+
     fprintf(stderr, "starting\n");
     while (true) {
         // wait for a bit
         ac_state = AC_DONT_WANT_COMPUTE;
-        boinc_sporadic_set_ac_state(ac_state);
+        set_ac_state(ac_state);
         for (int i=0; i<NWAIT; i++) {
             fprintf(stderr, "sleep - don't want to compute\n");
             boinc_sleep(1);
         }
         // wait until client says we can possibly compute
         while (1) {
-            ca_state = boinc_sporadic_get_ca_state();
+            ca_state = get_ca_state();
             if (ca_state != CA_COULD_COMPUTE) {
                 fprintf(stderr, "sleep - waiting for COULD_COMPUTE\n");
                 boinc_sleep(1);
@@ -56,11 +113,11 @@ int main(int, char**) {
         }
         // tell the client we want to compute
         ac_state = AC_WANT_COMPUTE;
-        boinc_sporadic_set_ac_state(ac_state);
+        set_ac_state(ac_state);
         int n = NCOMP;
         while (true) {
             // compute only if client says so
-            ca_state = boinc_sporadic_get_ca_state();
+            ca_state = get_ca_state();
             fprintf(stderr, "CA state: %d\n", ca_state);
             if (ca_state == CA_COMPUTING) {
                 fprintf(stderr, "computing 1 sec\n");

--- a/samples/sporadic/sporadic.cpp
+++ b/samples/sporadic/sporadic.cpp
@@ -18,7 +18,9 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <fcntl.h>
 #include <stdio.h>
 

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -75,7 +75,6 @@
 #include "app_ipc.h"
 #include "graphics2.h"
 #include "boinc_zip.h"
-#include "diagnostics.h"
 #include "error_numbers.h"
 #include "filesys.h"
 #include "parse.h"
@@ -1244,14 +1243,6 @@ int main(int argc, char** argv) {
     options.handle_process_control = true;
 
     boinc_init_options(&options);
-    fprintf(stderr,
-        "%s wrapper (%d.%d.%d): starting\n",
-        boinc_msg_prefix(buf, sizeof(buf)),
-        BOINC_MAJOR_VERSION,
-        BOINC_MINOR_VERSION,
-        WRAPPER_RELEASE
-    );
-
     boinc_get_init_data(aid);
 
 #ifdef CHECK_EXECUTABLES


### PR DESCRIPTION
Add --sporadic option to wrapper and vboxwrapper.
When used, the wrapper communicates sporadic state with the app via files.
This allows, for example, sporadic apps that run in VMs.

The logic for reading/writing these files is in the BOINC runtime library;
to enable it, the wrapper calls boinc_sporadic_dir().
So changes to the wrappers is minimal.