### PR TITLE
Mac screensaver: update for MacOS 14.0 Sonoma

### DIFF
--- a/clientscr/Mac_Saver_Module.h
+++ b/clientscr/Mac_Saver_Module.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2020 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -40,6 +40,7 @@ int             startBOINCSaver(void);
 int             getSSMessage(char **theMessage, int* coveredFreq);
 void            windowIsCovered();
 void            drawPreview(CGContextRef myContext);
+void            stopAllGFXApps(void);
 void            closeBOINCSaver(void);
 void            setDefaultDisplayPeriods(void);
 bool            getShow_default_ss_first();
@@ -61,6 +62,8 @@ extern char     gUserName[64];
 extern bool     gIsMojave;
 extern bool     gIsCatalina;
 extern bool     gIsHighSierra;
+extern bool     gIsSonoma;
+extern bool     gCant_Use_Shared_Offscreen_Buffer;
 
 #ifdef __cplusplus
 }	// extern "C"
@@ -164,6 +167,7 @@ public:
     int             getSSMessage(char **theMessage, int* coveredFreq);
     void            windowIsCovered(void);
     void            drawPreview(CGContextRef myContext);
+    void            Shared_Offscreen_Buffer_Unavailable(void);
     void            ShutdownSaver();
     void            markAsIncompatible(char *gfxAppName);
     bool            isIncompatible(char *appName);

--- a/clientscr/Mac_Saver_ModuleView.h
+++ b/clientscr/Mac_Saver_ModuleView.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2020 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -77,6 +77,7 @@ int             startBOINCSaver(void);
 int             getSSMessage(char **theMessage, int* coveredFreq);
 void            windowIsCovered();
 void            drawPreview(CGContextRef myContext);
+void            stopAllGFXApps(void);
 void            closeBOINCSaver(void);
 void            setDefaultDisplayPeriods(void);
 bool            getShow_default_ss_first();
@@ -98,6 +99,8 @@ void            PrintBacktrace(void);
 extern bool     gIsCatalina;
 extern bool     gIsHighSierra;
 extern bool     gIsMojave;
+extern bool     gIsSonoma;
+extern bool     gCant_Use_Shared_Offscreen_Buffer;
 
 #ifdef __cplusplus
 }    // extern "C"

--- a/clientscr/gfx_cleanup.mm
+++ b/clientscr/gfx_cleanup.mm
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -207,7 +207,13 @@ int main(int argc, char* argv[]) {
 #endif
     parentPid = getppid();
 
-    bool cover_gfx_window = (compareOSVersionTo(10, 13) >= 0);
+    // Under MacOS 14.0, the legacyScreenSaver continues to run after the
+    // screensaver is dismissed. Our code elsewhere now kills it, but if
+    // that were to fail this black cover would block the user from
+    // accessing the desktop, so don't use the cover in MacOS 14 for now.
+
+    bool cover_gfx_window = (compareOSVersionTo(10, 13) >= 0) &&
+                                (compareOSVersionTo(10, 14) < 0);
 
     // Create shared app instance
     [NSApplication sharedApplication];

--- a/clientscr/gfx_switcher.cpp
+++ b/clientscr/gfx_switcher.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2023 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -18,9 +18,9 @@
 // gfx_switcher.C
 //
 // Used by screensaver to:
-//  - launch graphics application at given slot number as user & group boinc_project
-//  - launch default graphics application as user & group boinc_project
-//  - kill graphics application with given process ID as user & group boinc_project
+//  - launch graphics application at given slot number
+//  - launch default graphics application
+//  - kill graphics application with given process ID
 //
 
 // Special logic used only under OS 10.15 Catalina and later:
@@ -35,11 +35,11 @@
 // app. This script then launches gfx_switcher, which uses fork and execv to
 // launch the project graphics app. gfx_switcher writes the graphics app's
 // process ID to shared memory, to be read by the Screensaver Coordinator.
-// gfx_switcher waits for the graphics app to exit and notifies then notifies
-// the Screensaver Coordinator by writing 0 to the shared memory.
+// gfx_switcher waits for the graphics app to exit and then notifies the
+// Screensaver Coordinator by writing 0 to the shared memory.
 //
 // This Rube Goldberg process is necessary due to limitations on screensavers
-// introduced in OS 10.15 Catalina.
+// introduced in OS 10.15 Catalina and OS 14.0 Sonoma.
 //
 
 
@@ -106,7 +106,7 @@ int main(int argc, char** argv) {
 
     CFStringRef cf_gUserName = SCDynamicStoreCopyConsoleUser(NULL, NULL, NULL);
     CFStringGetCString(cf_gUserName, user_name, sizeof(user_name), kCFStringEncodingUTF8);
-//    strlcpy(user_name, getlogin(), sizeof(user_name));
+//    strlcpy(user_name, getenv("USER"), sizeof(user_name));
     strlcpy(group_name, "boinc_project", sizeof(group_name));
 
     // Under fast user switching, the BOINC client may be running under a
@@ -318,6 +318,10 @@ void * MonitorScreenSaverEngine(void* param) {
 #if VERBOSE           // For debugging only
         print_to_log_file("MonitorScreenSaverEngine: ScreenSaverEngine_Pid=%d", ScreenSaverEngine_Pid);
 #endif
+        if (ScreenSaverEngine_Pid == 0) {
+            // legacyScreenSaver name under MacOS 14 Sonoma
+            ScreenSaverEngine_Pid = getPidIfRunning("com.apple.ScreenSaver.Engine.legacyScreenSaver");
+        }
         if (ScreenSaverEngine_Pid == 0) {
 #ifdef __x86_64__
             ScreenSaverEngine_Pid = getPidIfRunning("com.apple.ScreenSaver.Engine.legacyScreenSaver.x86_64");

--- a/clientscr/res/mac_restrict_access.sb
+++ b/clientscr/res/mac_restrict_access.sb
@@ -6,3 +6,5 @@
 (deny file-write* (subpath "/Library/Application Support") )
 (allow file-write* (subpath "/Library/Application Support/BOINC Data") (subpath "/private/tmp") )
 (allow file-read* (subpath "/Library/Application Support/BOINC Data") (subpath "/private/tmp") )
+(allow file-read* (subpath "/private/var/select/sh") )
+(allow mach-lookup mach-register)


### PR DESCRIPTION
MacOS 14.0 Sonoma broke many third-party screensavers, including BOINC's. This PR addresses several issues:

[1] The most serious was that once the BOINC screensaver runs, the desktop remained black, leaving the user unable to access the desktop. The user had to log out using the keyboard shortcut to regain access. This is fixed.

[2] The BOINC screensaver can no longer run the default graphics _boincscr_ or any project graphics, though project graphics still work when launched from the BOINC Manager using the _Show graphics_ button.

To get around Apple's earlier sandbox restrictions on screensavers, we use IOSurfaceBuffers to allow the screensaver to display the project application's or _boincscr's_ graphics. This involves the use of Mach communication. But Apple has added a new sandbox restriction on screensavers preventing the use of Mach communication.

I have been working with Apple Developer Technical Support trying to find a solution. At their recommendation, I have filed a bug report with Apple asking them to remove this new restriction, and we are waiting for their decision. 

If Apple won't remove the new restriction, I have a possible new approach, but it involves significant changes in the code and would require all projects to at least relink their graphics apps with our updated libraries.

For now, the updated screensaver in this PR just shows a message "BOINC can't show screensaver graphics on this version of MacOS"

[3] Our installer has asked the user if they would like to set BOINC as their screensaver. If they answered yes, it would do that automatically. This ability is broken under MacOS 14.0. This is recognized as a bug, and I have filed a separate bug report with Apple for this issue, also at the recommendation of Apple Developer Technical Support. For now, the Installer does not offer that option when run on MacOS 14.


