### PR TITLE
Fix bad data in Diskwhen client disconnects

### DIFF
--- a/clientgui/ViewResources.cpp
+++ b/clientgui/ViewResources.cpp
@@ -233,7 +233,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 			m_pieCtrlBOINC->Refresh();
 			m_BOINCwasEmpty=true;
 			refreshBOINC=true;
-            project_total = 0;
+			project_total = 0;
         }
 	}
 
@@ -304,7 +304,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		part.SetColour(isDarkMode ? wxColour(140,140,140) : wxColour(192,192,192));
 		m_pieCtrlTotal->m_Series.Add(part);
 		m_pieCtrlTotal->Refresh();
-    }
+	}
 }
 
 wxInt32 CViewResources::FormatDiskSpace(double bytes, wxString& strBuffer) const {

--- a/clientgui/ViewResources.cpp
+++ b/clientgui/ViewResources.cpp
@@ -228,11 +228,12 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 			wxPiePart part;
             part.SetLabel(_("no projects: 0 bytes used"));
 			part.SetValue(1);
-			part.SetColour(wxColour(0,0,0));
+			part.SetColour(isDarkMode ? wxColour(255, 255, 255) : wxColour(0,0,0));
 			m_pieCtrlBOINC->m_Series.Add(part);
 			m_pieCtrlBOINC->Refresh();
 			m_BOINCwasEmpty=true;
 			refreshBOINC=true;
+            project_total = 0;
         }
 	}
 
@@ -303,7 +304,7 @@ void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
 		part.SetColour(isDarkMode ? wxColour(140,140,140) : wxColour(192,192,192));
 		m_pieCtrlTotal->m_Series.Add(part);
 		m_pieCtrlTotal->Refresh();
-	}
+    }
 }
 
 wxInt32 CViewResources::FormatDiskSpace(double bytes, wxString& strBuffer) const {


### PR DESCRIPTION
Fixes #5330

**Description of the Change**
The bad data occurred as project_total was not cleared out when a client disconnects. A simple addition fixes the issue. I also updated dark mode display of empty BOINC disk.

**Alternate Designs**

**Release Notes**
