### PR TITLE
Eliminate some PHP warnings.

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -159,6 +159,7 @@ class BoincDb extends DbConn {
 }
 
 class BoincUser {
+    public $prefs;
     static $cache;
     static function lookup($clause) {
         $db = BoincDb::get();

--- a/html/inc/prefs_util.inc
+++ b/html/inc/prefs_util.inc
@@ -192,7 +192,9 @@ class PREF_CONSENT extends PREF {
         $this->tooltip_tr();
         echo "<td class=\"text-right \">$this->desc</td>";
         $consent_type_id = $this->consent_type_id;
-        $cr = BoincLatestConsent::lookup("userid={$user->id} AND consent_type_id='${consent_type_id}'");
+        $cr = BoincLatestConsent::lookup(
+            "userid=$user->id AND consent_type_id='$consent_type_id'"
+        );
         if ($cr) {
             $this->show_value($user);
         } else {
@@ -210,7 +212,9 @@ class PREF_CONSENT extends PREF {
         $this->tooltip_tr();
         echo "<td class=\"text-right \">$this->desc</td>";
         $consent_type_id = $this->consent_type_id;
-        $cr = BoincLatestConsent::lookup("userid={$user->id} AND consent_type_id='${consent_type_id}'");
+        $cr = BoincLatestConsent::lookup(
+            "userid=$user->id AND consent_type_id='$consent_type_id'"
+        );
         if ($cr) {
             $this->show_value($user);
         } else {
@@ -228,7 +232,9 @@ class PREF_CONSENT extends PREF {
 
     function show_value($user) {
         $consent_type_id = $this->consent_type_id;
-        $cr = BoincLatestConsent::lookup("userid={$user->id} AND consent_type_id='${consent_type_id}'");
+        $cr = BoincLatestConsent::lookup(
+            "userid=$user->id AND consent_type_id='$consent_type_id'"
+        );
         if ($cr) {
             $value = $cr->consent_flag;
         } else {
@@ -238,7 +244,8 @@ class PREF_CONSENT extends PREF {
     }
     function show_form($user, $error) {
         $consent_type_id = $this->consent_type_id;
-        $cr = BoincLatestConsent::lookup("userid={$user->id} AND consent_type_id='${consent_type_id}'");
+        $cr = BoincLatestConsent::lookup(
+            "userid=$user->id AND consent_type_id='$consent_type_id'");
         if ($cr) {
             if ($this->invert) {
                 $checked = !$cr->consent_flag;
@@ -265,11 +272,14 @@ class PREF_CONSENT extends PREF {
         // Check to see if latest consent of this name is already
         // given, i.e., consent_flag set to "formget". If not, consent
         // to this consent type.
-        $cr = BoincLatestConsent::lookup("userid={$user->id} AND consent_type_id='${consent_type_id}'");
+        $cr = BoincLatestConsent::lookup(
+            "userid=$user->id AND consent_type_id='$consent_type_id$'"
+        );
 
-        if ( (($cr) and ($cr->consent_flag!=$flag)) or
-             (!$cr) ) {
-            $rc = consent_to_a_policy($user, $consent_type_id, $flag, 0, 'Webform', time());
+        if ((($cr) and ($cr->consent_flag!=$flag)) or (!$cr)) {
+            $rc = consent_to_a_policy(
+                $user, $consent_type_id, $flag, 0, 'Webform', time()
+            );
             if (!$rc) {
                 error_page(tra("Database error:").BoincDb::error());
             }
@@ -286,7 +296,9 @@ class PREF_CONSENT extends PREF {
     function set_default(&$user) {
         $consent_type_id = $this->consent_type_id;
 
-        $rc = consent_to_a_policy($user, $consent_type_id, $this->default, 0, 'Webform');
+        $rc = consent_to_a_policy(
+            $user, $consent_type_id, $this->default, 0, 'Webform'
+        );
         if (!$rc) {
             error_page(tra("Database error:").BoincDb::error());
         }

--- a/html/user/login_form.php
+++ b/html/user/login_form.php
@@ -23,9 +23,11 @@ require_once("../inc/account.inc");
 check_get_args(array("next_url"));
 
 $next_url = get_str('next_url', true);
-$next_url = urldecode($next_url);
-$next_url = sanitize_local_url($next_url);
-$next_url = urlencode($next_url);
+if ($next_url) {
+    $next_url = urldecode($next_url);
+    $next_url = sanitize_local_url($next_url);
+    $next_url = urlencode($next_url);
+}
 
 $user = get_logged_in_user(false);
 if ($user) {

--- a/html/user/notices.php
+++ b/html/user/notices.php
@@ -69,6 +69,7 @@ $since_clause = "and create_time > $since_time";
 
 $notifies = BoincNotify::enum("userid = $userid $since_clause");
 
+$threads = [];
 $forum = news_forum();
 if ($forum) {
     $threads = BoincThread::enum(


### PR DESCRIPTION
Note: PHP 8.2 deprecates stuff like dynamic elements. There may be other instances.

Fixes #5442