### PR TITLE
Add check for stuck jobs in poll()

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -114,6 +114,7 @@ ACTIVE_TASK::ACTIVE_TASK() {
     fraction_done_elapsed_time = 0;
     first_fraction_done = 0;
     first_fraction_done_elapsed_time = 0;
+    stuck_fraction_done = 0;
     scheduler_state = CPU_SCHED_UNINITIALIZED;
     next_scheduler_state = CPU_SCHED_UNINITIALIZED;
     signal = 0;

--- a/client/app.h
+++ b/client/app.h
@@ -112,6 +112,8 @@ struct ACTIVE_TASK {
         // first frac done reported during this run of task
     double first_fraction_done_elapsed_time;
         // elapsed time when the above was reported
+    double stuck_fraction_done;
+        // keeps track if fraction has change to ensure it is not stuck
     SCHEDULER_STATE scheduler_state;
     SCHEDULER_STATE next_scheduler_state; // temp
     int signal;

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -149,6 +149,25 @@ bool ACTIVE_TASK_SET::poll() {
             }
         }
     }
+
+    // check if a job is "stuck" (did not make progress in the last hour)
+    // notify the user about the issue
+    // abort after some time
+    static double last_fraction_done_check_time = 0;
+    if (gstate.now - last_fraction_done_check_time > FRACTION_DONE_POLL_PERIOD) {
+        for (i=0; i<active_tasks.size(); i++){
+            ACTIVE_TASK* atp = active_tasks[i];
+            // do not consider the first pass
+            if (last_fraction_done_check_time == 0  && atp->stuck_fraction_done == atp->fraction_done 
+                    && atp->current_cpu_time < 10) {
+                msg_printf(atp->result->project, MSG_INFO, "Task has not made progress in last hour, consider aborting");
+                // atp->abort_task(EXIT_TASK_STUCK, "Task has not made progress in last hour, begin to abort");
+            }
+            atp->stuck_fraction_done = atp->fraction_done;
+        }
+        last_fraction_done_check_time = gstate.now;
+    }
+
     if (action) {
         gstate.set_client_state_dirty("ACTIVE_TASK_SET::poll");
     }

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -601,6 +601,9 @@ extern THREAD throttle_thread;
 #define MEMORY_USAGE_PERIOD     10
     // computer memory usage and check for exclusive apps this often
 
+#define FRACTION_DONE_POLL_PERIOD 3600
+    // poll if fraction done has change within an hour to see if it is stuck
+
 //////// WORK FETCH
 
 #define WORK_FETCH_PERIOD   60

--- a/lib/error_numbers.h
+++ b/lib/error_numbers.h
@@ -42,6 +42,7 @@
 #define EXIT_INIT_FAILURE           206
 #define EXIT_NO_SUB_TASKS           207
 #define EXIT_SUB_TASK_FAILURE       208
+#define EXIT_TASK_STUCK             209
 
 // Function return values.
 // NOTE:  add new errors to the end of the list and don't change


### PR DESCRIPTION
Fixes #5352

**Description of the Change**
Add a way to check if jobs were stuck by adding an addition poll that occurs every hour, it checks if an active_tasks fraction_done doesn't change and current_cpu_time < 10s. 

**Alternate Designs**

**Release Notes**

