### PR TITLE
Updated hostinfo_win.cpp - missing Windows SKUs (IoT Enterprise, Azure..)

### DIFF
--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -194,6 +194,21 @@
 #ifndef PRODUCT_ENTERPRISE_S_N_EVALUATION
 #define PRODUCT_ENTERPRISE_S_N_EVALUATION           0x00000082
 #endif
+#ifndef PRODUCT_IOTENTERPRISE
+#define PRODUCT_IOTENTERPRISE                       0x000000BC
+#endif
+#ifndef PRODUCT_IOTENTERPRISES
+#define PRODUCT_IOTENTERPRISES                      0x000000BF
+#endif
+#ifndef PRODUCT_AZURESTACKHCI_SERVER_CORE
+#define PRODUCT_AZURESTACKHCI_SERVER_CORE           0x00000196
+#endif
+#ifndef PRODUCT_DATACENTER_SERVER_AZURE_EDITION
+#define PRODUCT_DATACENTER_SERVER_AZURE_EDITION     0x00000197
+#endif
+#ifndef PRODUCT_DATACENTER_SERVER_CORE_AZURE_EDITION
+#define PRODUCT_DATACENTER_SERVER_CORE_AZURE_EDITION 0x00000198
+#endif
 
 
 // new Architecture(s)
@@ -367,7 +382,9 @@ int get_os_information(
                         strlcat(os_name, "Windows 10", os_name_size);
                     }
                 } else {
-                    if ( osvi.dwBuildNumber >= 20348 ) {
+                    if (osvi.dwBuildNumber >= 25398) {
+                        strlcat(os_name, "Windows Server 23H2", os_name_size);
+                    } else if (osvi.dwBuildNumber >= 20348) {
                         strlcat(os_name, "Windows Server 2022", os_name_size);
                     } else if ( osvi.dwBuildNumber >= 17623) {
                         strlcat(os_name, "Windows Server 2019", os_name_size);
@@ -559,6 +576,12 @@ int get_os_information(
                             case PRODUCT_HOME_PREMIUM_N:
                                 safe_strcat(szSKU, "Home Premium N ");
                                 break;
+                            case PRODUCT_IOTENTERPRISE:
+                                safe_strcat(szSKU, "IoT Enterprise ");
+                                break;
+                            case PRODUCT_IOTENTERPRISES:
+                                safe_strcat(szSKU, "IoT Enterprise LTSC ");
+                                break;
                             case PRODUCT_IOTUAP:
                                 safe_strcat(szSKU, "Internet of Things ");
                                 break;
@@ -657,6 +680,9 @@ int get_os_information(
                             case PRODUCT_ARM64_SERVER:
                                 safe_strcat(szSKU, "ARM64 Server ");
                                 break;
+                            case PRODUCT_AZURESTACKHCI_SERVER_CORE:
+                                safe_strcat(szSKU, "Azure Stack HCI ");
+                                break;
                             case PRODUCT_CLOUD_HOST_INFRASTRUCTURE_SERVER:
                                 safe_strcat(szSKU, "Cloud Host Infrastructure Server ");
                                 break;
@@ -681,8 +707,14 @@ int get_os_information(
                             case PRODUCT_DATACENTER_SERVER:
                                 safe_strcat(szSKU, "Datacenter ");
                                 break;
+                            case PRODUCT_DATACENTER_SERVER_AZURE_EDITION:
+                                safe_strcat(szSKU, "Datacenter Azure ");
+                                break;
                             case PRODUCT_DATACENTER_SERVER_CORE:
                                 safe_strcat(szSKU, "Datacenter (core installation) ");
+                                break;
+                            case PRODUCT_DATACENTER_SERVER_CORE_AZURE_EDITION:
+                                safe_strcat(szSKU, "Datacenter Azuure (core installation) ");
                                 break;
                             case PRODUCT_DATACENTER_SERVER_CORE_V:
                                 safe_strcat(szSKU, "Datacenter (core installation without Hyper-V) ");


### PR DESCRIPTION
**added missing Windows SKUs**:
- IoT Enterprise & Enterprise LTSC
- Azure HCI
- Datacenter Azure Edition

**added detection of Windows Server 23H2**

Until now BOINC cant identify some current/new Windows SKUs

Windows 10 IoT Enterprise LTSC is only identified as "Microsoft Windows 10 x64 Edition, (10.00.19044.00)" see https://yafu.myfirewall.org/yafu/show_host_detail.php?hostid=58911

BOINC cant even identify the newest stable Windows Server version (10.00.25398.0) as Windows Server 23H2 - see https://support.microsoft.com/en-us/topic/windows-server-version-23h2-update-history-68c851ff-825a-4dbc-857b-51c5aa0ab248