### PR TITLE
Add some files (in samples/) that are needed to run the example apps as VM apps.

### DIFF
--- a/samples/vboxwrapper/boinc_resolve
+++ b/samples/vboxwrapper/boinc_resolve
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+sed 's/<soft_link>..\/..\/projects\///; s/[^\/]*\//\/root\/project\//; s/<\/soft_link>//' $1 | tr -d '\r\n'

--- a/samples/worker/run_worker_1.sh
+++ b/samples/worker/run_worker_1.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+# script for running worker in a VM, with shared slot and project dirs
+
+mkdir /root/project
+mount -t vboxsf project /root/project
+execpath=`./boinc_resolve worker`
+inpath=`./boinc_resolve in`
+outpath=`./boinc_resolve out`
+
+$execpath $inpath $outpath

--- a/samples/worker/vbox_job_1.xml
+++ b/samples/worker/vbox_job_1.xml
@@ -1,0 +1,7 @@
+<vbox_job>
+    <memory_size_mb>512</memory_size_mb>
+    <os_name>Linux26_64</os_name>
+    <share_slot_dir/>
+    <share_project_dir/>
+    <multiattach_vdi_file>vm_image_x64_1.vdi</multiattach_vdi_file>
+</vbox_job>

--- a/samples/worker/vm_version.xml
+++ b/samples/worker/vm_version.xml
@@ -1,0 +1,30 @@
+<version>
+    <file>
+        <physical_name>vboxwrapper_26207_windows_x86_64.exe</physical_name>
+        <main_program/>
+    </file>
+    <file>
+        <physical_name>worker_2_x86_64-pc-linux-gnu</physical_name>
+        <logical_name>worker</logical_name>
+    </file>
+    <file>
+        <physical_name>run_worker_1.sh</physical_name>
+        <logical_name>boinc_app</logical_name>
+        <copy_file/>
+    </file>
+    <file>
+        <physical_name>boinc_resolve_1</physical_name>
+        <logical_name>boinc_resolve</logical_name>
+        <copy_file/>
+    </file>
+    <file>
+        <physical_name>vbox_job_1.xml</physical_name>
+        <logical_name>vbox_job.xml</logical_name>
+    </file>
+    <file>
+        <physical_name>vm_image_x64_1.vdi</physical_name>
+        <logical_name>vm_image.vdi</logical_name>
+    </file>
+    <dont_throttle/>
+    <is_wrapper/>
+</version>


### PR DESCRIPTION
This makes the cookbooks simpler.