### PR TITLE
client: fix non-CPU-intensive logic

### DIFF
--- a/client/project.cpp
+++ b/client/project.cpp
@@ -86,7 +86,7 @@ void PROJECT::init() {
     disk_usage = 0.0;
     disk_share = 0.0;
     anonymous_platform = false;
-    non_cpu_intensive = true;   // true until link a non-NCI app
+    non_cpu_intensive = false;
     report_results_immediately = false;
     pwf.reset(this);
     send_time_stats_log = 0;

--- a/client/project.h
+++ b/client/project.h
@@ -168,8 +168,9 @@ struct PROJECT : PROJ_AM {
         // app_versions.xml file found in project dir;
         // use those apps rather then getting from server
     bool non_cpu_intensive;
-        // All this project's apps are non-CPU-intensive.
-        // (determined dynamically)
+        // The project has asserted (in sched reply) that
+        // all apps are non-CPU-intensive.
+        // Cleared if this is not the case.
     bool use_symlinks;
     bool report_results_immediately;
     bool sched_req_no_work[MAX_RSC];

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -14,6 +14,10 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// Functions for doing scheduler RPCs,
+// including creating requests and parsing replies.
+// The reply handler is in cs_scheduler.cpp
 
 #include "cpp.h"
 
@@ -883,6 +887,8 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
         } else if (xp.parse_bool("send_full_workload", send_full_workload)) {
             continue;
         } else if (xp.parse_bool("dont_use_dcf", dont_use_dcf)) {
+            continue;
+        } else if (xp.parse_bool("non_cpu_intensive", project->non_cpu_intensive)) {
             continue;
         } else if (xp.parse_int("send_time_stats_log", send_time_stats_log)){
             continue;


### PR DESCRIPTION
Problem: If a project is non-CPU-intensive and has no jobs we ask it for work repeatedly, without backoff.
A project is marked as non-CPU-intensive if
it has no CPU-intensive apps.
This means that a project with no apps
(e.g. because it doesn't have any jobs)
is marked as non-CPU-intensive and pinged without backoff.

Solution: mark a project as non-CPU-intensive only if its scheduler reply says it is
(i.e. there's <non_cpu_intensive/> in its config.xml).