### PR TITLE
client: when not requesting work for a resource, show correct message

### DIFF
--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -1289,7 +1289,7 @@ const char* project_reason_string(PROJECT* p, char* buf, int len) {
         if (coprocs.n_rsc == 1) {
             snprintf(buf, len,
                 "don't need (%s)",
-                rsc_reason_string(rsc_work_fetch[0].dont_fetch_reason)
+                rsc_reason_string(p->rsc_pwf[0].rsc_project_reason)
             );
         } else {
             string x;
@@ -1299,7 +1299,7 @@ const char* project_reason_string(PROJECT* p, char* buf, int len) {
                 snprintf(buf2, sizeof(buf2),
                     "%s: %s",
                     rsc_name_long(i),
-                    rsc_reason_string(rsc_work_fetch[i].dont_fetch_reason)
+                    rsc_reason_string(p->rsc_pwf[i].rsc_project_reason)
                 );
                 x += buf2;
                 if (i < coprocs.n_rsc-1) {


### PR DESCRIPTION
e.g.:
1/8/2024 1:12:13 AM | BOINC test project | Not requesting tasks: don't need (CPU: blocked by project preferences; NVIDIA GPU: blocked by project preferences; Intel GPU: no applications)

It used to say

1/8/2024 1:12:13 AM | BOINC test project | Not requesting tasks: don't need (CPU: ; NVIDIA GPU: ; Intel GPU:)
