### PR TITLE
Wrapper (Unix): use SIGSTOP instead of SIGTSTP to suspend subprocesses

### DIFF
--- a/lib/proc_control.h
+++ b/lib/proc_control.h
@@ -35,11 +35,13 @@ extern void kill_descendants();
 extern int suspend_or_resume_threads(
     std::vector<int> pids, DWORD threadid, bool resume, bool check_exempt
 );
-#else
-extern void kill_descendants(int child_pid=0);
-#endif
 extern void suspend_or_resume_descendants(bool resume);
 extern void suspend_or_resume_process(int pid, bool resume);
+#else
+extern void kill_descendants(int child_pid=0);
+extern void suspend_or_resume_descendants(bool resume, bool use_tstp=false);
+extern void suspend_or_resume_process(int pid, bool resume, bool use_tstp=false);
+#endif
 
 extern int process_priority_value(int);
 

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -1001,15 +1001,26 @@ void TASK::kill() {
     kill_descendants(pid);
 #endif
 }
-
+#ifdef _WIN32
+void TASK::stop() {
+    if (multi_process) {
+        suspend_or_resume_descendants(false);
+    } else {
+        suspend_or_resume_process(pid, false);
+    }
+    suspended = true;
+}
+#else
 void TASK::stop() {
     if (multi_process) {
         suspend_or_resume_descendants(false, use_tstp);
-    } else {
+    }
+    else {
         suspend_or_resume_process(pid, false, use_tstp);
     }
     suspended = true;
 }
+#endif
 
 void TASK::resume() {
     if (multi_process) {


### PR DESCRIPTION
The former can't be caught, the latter can.
The goal was to support wrapped program that are themselves wrappers of some sort.

Problem (as reported in #5840): contrary to documentation, SIGTSTP doesn't actually stop processes not connected to a TTY (at least on Linux - I checked).

This PR changes the default signal back to SIGSTOP, but provides the option (via a --use_tstp cmdline arg to wrapper) to use SIGTSTP instead.

Fixes #5840
