### PR TITLE
web: showing PHP errors on web pages is optional

### DIFF
--- a/gl
+++ b/gl
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/gl.py
+++ b/gl.py
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
-# http://boinc.berkeley.edu
-# Copyright (C) 2021 University of California
+# https://boinc.berkeley.edu
+# Copyright (C) 2024 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License

--- a/html/inc/db_ops.inc
+++ b/html/inc/db_ops.inc
@@ -20,10 +20,6 @@
 // in admin web pages
 // TODO: most of this code shouldn't exist; use the standard code instead
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
 require_once("../inc/util_basic.inc");
 require_once("../inc/util_ops.inc");
 require_once("../inc/result.inc");

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -20,10 +20,6 @@
 // Stuff that's not web-specific (e.g. that's used in non-web scripts)
 // should go in util_basic.inc
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
 require_once("../inc/util_basic.inc");
 require_once("../project/project.inc");
 require_once("../inc/countries.inc");
@@ -33,7 +29,7 @@ require_once("../inc/translation.inc");
 require_once("../inc/profile.inc");
 require_once("../inc/bootstrap.inc");
 
-// parse some stuff from config.xml (do it here for efficiency)
+// parse config.xml (do it here for efficiency)
 //
 $config = get_config();
 global $master_url;
@@ -41,28 +37,21 @@ $master_url = parse_config($config , "<master_url>");
 $recaptcha_public_key = parse_config($config, "<recaptcha_public_key>");
 $recaptcha_private_key = parse_config($config, "<recaptcha_private_key>");
 
-// the following default to on
-//
+// Set parameters to defaults if not defined in config.xml
+
 $x = parse_config($config, "<user_country>");
 define('USER_COUNTRY', ($x===null)?1:(int)$x);
 
 $x = parse_config($config, "<user_url>");
 define('USER_URL', ($x===null)?1:(int)$x);
 
-// don't allow /... at the end of URL
-//
-if (array_key_exists("PATH_INFO", $_SERVER)) {
-    die("bad URL");
-}
+// Set parameters to defaults if not defined in project.inc
 
-// define TIMEZONE in project.inc
-//
 if (defined('TIMEZONE')) {
     date_default_timezone_set(TIMEZONE);
 } else {
     date_default_timezone_set('UTC');
 }
-
 if (!defined('DISABLE_PROFILES')) {
     define('DISABLE_PROFILES', false);
 }
@@ -111,9 +100,14 @@ if (!defined('POST_MAX_LINKS')) {
 if (!defined('DARK_MODE')) {
     define('DARK_MODE', false);
 }
-// require validated email to post in forums, send PMs, or make a profile
 if (!defined('VALIDATE_EMAIL_TO_POST')) {
     define('VALIDATE_EMAIL_TO_POST', false);
+}
+
+// don't allow anything between .php and ? in URL
+//
+if (array_key_exists("PATH_INFO", $_SERVER)) {
+    die("bad URL");
 }
 
 // sleep this long on any login failure

--- a/html/inc/util_basic.inc
+++ b/html/inc/util_basic.inc
@@ -16,13 +16,31 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// minimal set of utility functions, usable outside a BOINC project.
-// Doesn't pull in translation.inc etc.
+// PHP utility functions for cmdline tools and RPC handlers
+// as well as web pages.
+// Doesn't contain web-specific stuff like translation.inc
 
 require_once("../inc/random_compat/random.inc");
 
+// show PHP errors in output (e.g. web pages).
+// Call this from your project.inc if you want.
+// Not recommended for production projects;
+// check the Apache error log instead.
+//
+function display_errors() {
+    error_reporting(E_ALL);
+    ini_set('display_errors', true);
+    ini_set('display_startup_errors', true);
+}
+
+// always log errors
+ini_set('log_errors', true);
+
+// set to true in RPC handlers.
+// Suppresses output that would invalidate the XML
 $generating_xml = false;
 
+// get project dir, assuming we're running in html/user or html/ops
 function project_dir() {
     $d = dirname(__FILE__);
     return "$d/../..";
@@ -145,11 +163,13 @@ function parse_config($config, $tag) {
     return $element;
 }
 
+// uniform 0..1
+//
 function drand() {
     return ((double)rand())/getrandmax();
 }
 
-// kludge
+// does the plan class use a GPU?
 //
 function is_gpu($plan_class) {
     if (strstr($plan_class, "ati")) return true;
@@ -171,7 +191,6 @@ function url_get_contents($url) {
     curl_close($ch);
     return $content;
 }
-
 
 // return hard-to-guess string of 32 random hex chars
 //

--- a/html/inc/util_ops.inc
+++ b/html/inc/util_ops.inc
@@ -18,13 +18,11 @@
 
 // utility functions for admin web pages
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
 require_once("../inc/db_ops.inc");
 require_once("../inc/util.inc");
 require_once("../project/project.inc");
+
+display_errors();
 
 function admin_page_head($title) {
     echo "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">";

--- a/html/project.sample/project.inc
+++ b/html/project.sample/project.inc
@@ -34,17 +34,10 @@ define("POST_REPORT_EMAILS", "moderator1@$master_url|moderator2@$master_url");
     // Email addresses separated by pipe ( | ) that will receive user reports
     // of offensive forum posts.
 
-//-------------- Delete Account
-//define("DELETE_DELAY", 2);
-    // When deleting an account, invalidate the authenticator and then wait this
-    // many seconds before proceeding with the delete.  This is intended to give the
-    // an existing scheduler request sufficient time to complete.  Some projects
-    // might want to increase this to a longer time.  Simply uncomment and set the
-    // delay to what the project needs.
-
-//-------------- Caching
-
-//define("MEMCACHE_SERVERS", "127.0.0.1:11211");
+//-------------- PHP error reporting
+// Show PHP errors in web pages.
+// Comment this out when your project is public.
+display_errors();
 
 //-------------- CSS styling
 
@@ -143,6 +136,10 @@ function project_footer($show_return, $show_date, $prefix) {
     }
 }
 
+//-------------- Caching
+
+//define("MEMCACHE_SERVERS", "127.0.0.1:11211");
+
 //-------------- Ops access control
 
 // Authorize access to administrative pages.
@@ -216,6 +213,15 @@ function project_delete_account($user) {
     // inc/delete_account.inc meets the need of the project
     die("This function must be implemented before it can be used");
 }
+
+//-------------- Delete Account
+// TODO: get rid of this. Doesn't need to be configurable, or even exist.
+//define("DELETE_DELAY", 2);
+    // When deleting an account, invalidate the authenticator and then wait this
+    // many seconds before proceeding with the delete.  This is intended to give the
+    // an existing scheduler request sufficient time to complete.  Some projects
+    // might want to increase this to a longer time.  Simply uncomment and set the
+    // delay to what the project needs.
 
 //-------------- Support for per-app credit
 

--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -68,10 +68,6 @@
 //              create job_files record
 //              create batch_file_assoc record if needed
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
 require_once("../inc/boinc_db.inc");
 require_once("../inc/submit_db.inc");
 require_once("../inc/dir_hier.inc");

--- a/html/user/lammps.php
+++ b/html/user/lammps.php
@@ -11,13 +11,12 @@
 // project/lammps_test/USERID.
 // We assume that lammps_test exists and contains the LAMMPS executable
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
 require_once("../inc/util.inc");
 require_once("../inc/submit_db.inc");
 require_once("../inc/sandbox.inc");
+
+display_errors();
+
 $debug=0;
 
 // test a LAMMPS job

--- a/html/user/manage_app.php
+++ b/html/user/manage_app.php
@@ -18,10 +18,6 @@
 
 // app-specific management interface
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
 require_once("../inc/submit_util.inc");
 require_once("../inc/util.inc");
 

--- a/html/user/sandbox.php
+++ b/html/user/sandbox.php
@@ -31,13 +31,11 @@
 // upload_max_filesize = 64M
 // post_max_size = 64M
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
-
 require_once("../inc/sandbox.inc");
 require_once("../inc/submit_db.inc");
 require_once("../inc/submit_util.inc");
+
+display_errors();
 
 function list_files($user, $notice) {
     $dir = sandbox_dir($user);

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -28,9 +28,7 @@ require_once("../inc/result.inc");
 require_once("../inc/submit_util.inc");
 require_once("../project/project.inc");
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
+display_errors();
 
 define("PAGE_SIZE", 20);
 

--- a/html/user/submit_example.php
+++ b/html/user/submit_example.php
@@ -38,9 +38,7 @@ require_once("../inc/submit_util.inc");
 require_once("../inc/util.inc");
 require_once("../project/project.inc");
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
+display_errors();
 
 // hardwired app name for now
 define('APP_NAME', 'remote_test');

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -26,9 +26,6 @@ require_once("../inc/dir_hier.inc");
 require_once("../inc/result.inc");
 require_once("../inc/submit_util.inc");
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
 ini_set("memory_limit", "4G");
 
 function get_wu($name) {

--- a/html/user/submit_status.php
+++ b/html/user/submit_status.php
@@ -19,9 +19,6 @@
 // web interfaces for viewing and controlling batches
 // DEPRECATED: replaced by submit.php
 
-ini_set('display_errors', 'stdout');
-error_reporting(E_ALL);
-
 require_once("../inc/util.inc");
 require_once("../inc/boinc_db.inc");
 require_once("../inc/result.inc");

--- a/html/user/tree_threader.php
+++ b/html/user/tree_threader.php
@@ -15,9 +15,7 @@ require_once("../inc/dir_hier.inc");
 require_once("../inc/result.inc");
 require_once("../inc/submit_util.inc");
 
-error_reporting(E_ALL);
-ini_set('display_errors', true);
-ini_set('display_startup_errors', true);
+display_errors();
 
 $app_name = "treeThreader";
 $log = fopen("/tmp/tt_job.log","a+");


### PR DESCRIPTION
Move the code to show PHP errors into a function display_errors(). If you want to show PHP errors in web pages, call this from your project.inc.

But always show errors in:
- admin pages
- job submission pages
These pages are not seen by regular users.

Fixes #5492