### PR TITLE
Web: sanitize user URLs to prevent XSS attacks

### DIFF
--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -226,6 +226,8 @@ function weak_auth($user) {
 // it to a canonical form, with the protocol prefix.
 //
 function normalize_user_url($url) {
+    $url = sanitize_user_url($url);
+    if (!$url) return '';
     $x = strtolower($url);
     if (substr($x, 0, 7) == 'http://') {
         return 'http://'.substr($url, 7);
@@ -251,7 +253,10 @@ function show_user_info_private($user) {
     }
     if (USER_URL && $user->url) {
         $u = normalize_user_url($user->url);
-        row2(tra("URL"), sprintf('<a href="%s">%s</a>', $u, $u));
+        row2(
+            tra("URL"),
+            $u?sprintf('<a href="%s">%s</a>', $u, $u):tra('Invalid URL')
+        );
     }
     if (USER_COUNTRY) {
         row2(tra("Country"), $user->country);

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -1027,6 +1027,27 @@ function sanitize_local_url($x) {
     return $x;
 }
 
+function sanitize_user_url($x) {
+    // if protocol is given, must be http: or https:
+    $y = explode('//', $x);
+    switch (count($y)) {
+    case 1:
+        $z = $x;
+        break;
+    case 2:
+        $z = $y[1];
+        if (strtolower($y[0]) == 'http:') break;
+        if (strtolower($y[0]) == 'https:') break;
+        return '';
+    default: return '';
+    }
+    // everything else must be alphanumeric, or -_/.#?&=
+    if (preg_match('/^[-_.\/#?&=a-zA-Z0-9]*$/', $z)) {
+        return $x;
+    }
+    return '';
+}
+
 // strip HTML tags
 //
 function sanitize_tags($x) {

--- a/html/user/edit_user_info_action.php
+++ b/html/user/edit_user_info_action.php
@@ -40,8 +40,11 @@ $country = "";
 $postal_code = "";
 if (USER_URL) {
     $url = post_str("url", true);
-    $url = sanitize_tags($url);
-    $url = BoincDb::escape_string($url);
+    $x = sanitize_user_url($url);
+    if ($x != $url) {
+        error_page("Invalid URL");
+    }
+    $url = BoincDb::escape_string($x);
 }
 if (USER_COUNTRY) {
     $country = post_str("country");


### PR DESCRIPTION
Add a function sanitize_user_url() to do this.
It accepts things like

google.com
http://google.com
https://google.com?blah=foo&x=y

but nothing else.
There doesn't seem to be a PHP function that works, and stack overflow didn't yield anything plausible.

When showing a user page,
show 'Invalid URL' if it's nonempty and doesn't pass this.

When a user edits their info, show error page if they enter an invalid URL.

Fixes #5491