### PR TITLE
Mac: fix Apple Silicon GPU errors after MacOS update

### DIFF
--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -776,7 +776,7 @@ static OSStatus CreateUserAndGroup(char * user_name, char * group_name) {
     sprintf(buf2, "/users/%s", user_name);
 
     if ( userExists && groupExists )
-        goto setRealName;       // User and group already exist
+        goto setGroupForUser;       // User and group already exist
 
     // If only user or only group exists, try to use the same ID for the one we create
     if (userExists) {      // User exists but group does not
@@ -865,13 +865,19 @@ static OSStatus CreateUserAndGroup(char * user_name, char * group_name) {
             return err;
     }           // if (! userExists)
 
+setGroupForUser:
+    // A MacOS update sometimes changes the PrimaryGroupID of users boinc_master
+    // and boincproject to staff (20).
+    // This sets the correct PrimaryGroupId whether or not we just created the user.
+    sprintf(buf2, "/users/%s", user_name);
+    sprintf(buf3, "%d", groupid);
+
     // Always set the user gid if we created either the user or the group or both
     // Something like "dscl . -create /users/boinc_master gid 33"
     err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "gid", buf3, NULL);
     if (err)
         return err;
 
-setRealName:
     // Always set the RealName field to an empty string
     // Note: create RealName with empty string fails under OS 10.7, but
     // creating it with non-empty string and changing to empty string does work.


### PR DESCRIPTION
User boinc_master should have primary group boinc_master. User boincproject should have primary group boincproject. 
But updating MacOS to a new version sometimes changes the PrimaryGroupID of users boinc_master and boincproject to staff (20). This seems to be responsible for OpenCL projects failing after a MacOS update with the following error:
`UNSUPPORTED (log once): buildComputeProgram: cl2Metal failed
<built-in>:1:10: fatal error: cannot open file './opencl-c.h': Permission denied
#include "opencl-c.h"`
 
Fixes #5456

This PR makes the following changes:
* Added a check of the Primary Group IDs of users boinc_master and  boinc_project along with the other permissions checks when the Mac Manager or client is launched. If incorrect, refuses to run and displays an alert "BOINC ownership or permissions are not set properly; please reinstall BOINC".
* The Mac Installer: always sets Primary Group of users boinc_master boinc_project. (It previously did that  only if those users did not already exist.)
