### PR TITLE
Client: fix non-compute-intensive logic

### DIFF
--- a/client/app.h
+++ b/client/app.h
@@ -197,7 +197,7 @@ struct ACTIVE_TASK {
         return wup->app->sporadic;
     }
     inline bool non_cpu_intensive() {
-        return result->app->non_cpu_intensive;
+        return result->non_cpu_intensive();
     }
     inline bool always_run() {
         return sporadic() || non_cpu_intensive();

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1283,9 +1283,6 @@ FILE_INFO* CLIENT_STATE::lookup_file_info(PROJECT* p, const char* name) {
 int CLIENT_STATE::link_app(PROJECT* p, APP* app) {
     if (lookup_app(p, app->name)) return ERR_NOT_UNIQUE;
     app->project = p;
-    if (!app->non_cpu_intensive) {
-        p->non_cpu_intensive = false;
-    }
     return 0;
 }
 

--- a/client/project.cpp
+++ b/client/project.cpp
@@ -245,6 +245,7 @@ int PROJECT::parse_state(XML_PARSER& xp) {
         if (xp.parse_int("send_job_log", send_job_log)) continue;
         if (xp.parse_bool("send_full_workload", send_full_workload)) continue;
         if (xp.parse_bool("dont_use_dcf", dont_use_dcf)) continue;
+        if (xp.parse_bool("non_cpu_intensive", non_cpu_intensive)) continue;
         if (xp.parse_bool("suspended_via_gui", suspended_via_gui)) continue;
         if (xp.parse_bool("dont_request_more_work", dont_request_more_work)) continue;
         if (xp.parse_bool("detach_when_done", detach_when_done)) continue;
@@ -421,7 +422,7 @@ int PROJECT::write_state(MIOFILE& out, bool gui_rpc) {
         "    <njobs_error>%d</njobs_error>\n"
         "    <elapsed_time>%f</elapsed_time>\n"
         "    <last_rpc_time>%f</last_rpc_time>\n"
-        "%s%s%s%s%s%s%s%s%s%s%s%s",
+        "%s%s%s%s%s%s%s%s%s%s%s%s%s",
         master_url,
         project_name,
         symstore,
@@ -464,6 +465,7 @@ int PROJECT::write_state(MIOFILE& out, bool gui_rpc) {
         trickle_up_pending?"    <trickle_up_pending/>\n":"",
         send_full_workload?"    <send_full_workload/>\n":"",
         dont_use_dcf?"    <dont_use_dcf/>\n":"",
+        non_cpu_intensive?"    <non_cpu_intensive/>\n":"",
         suspended_via_gui?"    <suspended_via_gui/>\n":"",
         dont_request_more_work?"    <dont_request_more_work/>\n":"",
         detach_when_done?"    <detach_when_done/>\n":"",
@@ -602,6 +604,7 @@ void PROJECT::copy_state_fields(PROJECT& p) {
     pwf = p.pwf;
     send_full_workload = p.send_full_workload;
     dont_use_dcf = p.dont_use_dcf;
+    non_cpu_intensive = p.non_cpu_intensive;
     send_time_stats_log = p.send_time_stats_log;
     send_job_log = p.send_job_log;
     suspended_via_gui = p.suspended_via_gui;

--- a/client/project.h
+++ b/client/project.h
@@ -170,7 +170,6 @@ struct PROJECT : PROJ_AM {
     bool non_cpu_intensive;
         // The project has asserted (in sched reply) that
         // all apps are non-CPU-intensive.
-        // Cleared if this is not the case.
     bool use_symlinks;
     bool report_results_immediately;
     bool sched_req_no_work[MAX_RSC];

--- a/client/project.h
+++ b/client/project.h
@@ -169,7 +169,7 @@ struct PROJECT : PROJ_AM {
         // use those apps rather then getting from server
     bool non_cpu_intensive;
         // The project has asserted (in sched reply) that
-        // all apps are non-CPU-intensive.
+        // all its apps are non-CPU-intensive.
     bool use_symlinks;
     bool report_results_immediately;
     bool sched_req_no_work[MAX_RSC];

--- a/client/result.h
+++ b/client/result.h
@@ -156,6 +156,7 @@ struct RESULT {
         return avp->gpu_usage.rsc_type;
     }
     inline bool non_cpu_intensive() {
+        if (project->non_cpu_intensive) return true;
         return app->non_cpu_intensive;
     }
     inline bool sporadic() {


### PR DESCRIPTION
If a project says it's NCI, treat all its apps as NCI.
Save project.non_compute_intensive in the client state file.