### PR TITLE
[Linux] When user closes BOINC Manager window with the EventLog open, close properly the application

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -290,6 +290,12 @@ CAdvancedFrame::~CAdvancedFrame() {
         wxCHECK_RET(DeleteNotebook(), _T("Failed to delete notebook."));
     }
 
+#ifdef __WXGTK__
+    if (wxGetApp().GetEventLog()) {
+        wxGetApp().GetEventLog()->Close();
+    }
+#endif
+
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::~CAdvancedFrame - Function End"));
 }
 


### PR DESCRIPTION
This fixes: #4100.
