### PR TITLE
Replace deprecated VBoxManage command

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -354,9 +354,9 @@ int VBOX_VM::create_vm() {
     vboxlog_msg("Disabling Audio Support for VM.");
     command  = "modifyvm \"" + vm_name + "\" ";
     if (is_virtualbox_version_newer(7, 0, 4)) {
-        command += "--audio-enabled off";
+        command += "--audio-enabled off ";
     } else {
-        command += "--audio none";
+        command += "--audio none ";
     }
 
 

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -353,7 +353,12 @@ int VBOX_VM::create_vm() {
     //
     vboxlog_msg("Disabling Audio Support for VM.");
     command  = "modifyvm \"" + vm_name + "\" ";
-    command += "--audio none ";
+    if (is_virtualbox_version_newer(7, 0, 4)) {
+        command += "--audio-enabled off";
+    } else {
+        command += "--audio none";
+    }
+
 
     vbm_popen(command, output, "modifyaudio", false, false);
 


### PR DESCRIPTION


The changelog for VirtualBox 7.0.6 (released January 17 2023) states this:
"Audio: The "--audio" option in VBoxManage is now marked as deprecated; please use "--audio-driver" and "--audio-enabled" instead. This will allow more flexibility when changing the driver and/or controlling the audio functionality"

See:
https://www.virtualbox.org/wiki/Changelog-7.0#v6

Since vboxwrapper uses "--audio none" to disable the VM's audio hardware it should be modified to a conditional "--audio-enabled off" for VirtualBox releases newer than 7.0.4.
