### PR TITLE
Avoid compiler warning in vboxwrapper.cpp

### DIFF
--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -681,7 +681,7 @@ int main(int argc, char** argv) {
 
     // Copy files to the shared directory
     //
-    for (int i=0; i<pVM->copy_to_shared.size(); ++i) {
+    for (long unsigned int i=0; i<pVM->copy_to_shared.size(); ++i) {
         string source = pVM->copy_to_shared[i];
         string destination = string("shared/") + source;
         if (!boinc_file_exists(destination.c_str())) {


### PR DESCRIPTION
Got a compiler warning in vboxwrapper.cpp

```
vboxwrapper.cpp:684:20: warning: comparison of integer expressions of different signedness: 'int' and 'std::vector<std::__cxx11::basic_string<char> >::size_type' {aka 'long unsigned int'} [-Wsign-compare]
  684 |     for (int i=0; i<pVM->copy_to_shared.size(); ++i) {
      |                   ~^~~~~~~~~~~~~~~~~~~~~~~~~~~

```
Declared i as long unsigned int to avoid it.
