### PR TITLE
Add an optional sleep function to lib/util.cpp

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -20,6 +20,7 @@
 #ifndef BOINC_UTIL_H
 #define BOINC_UTIL_H
 
+#include <random>
 #include <stdlib.h>
 #include <string>
 #include <vector>
@@ -29,6 +30,7 @@
 extern double dtime();
 extern double dday();
 extern void boinc_sleep(double);
+extern void boinc_wobble_sleep(double, double, double);
 extern void push_unique(std::string, std::vector<std::string>&);
 
 // NOTE: use #include <functional>   to get max,min


### PR DESCRIPTION
Typical usecase:
Sleep commands are often called in loops when a process waits for the availability of a resource.
BOINC provides a universal sleep function "boinc_sleep" in lib/util.cpp.

This PR adds "boinc_wobble_sleep" to lib/util.cpp.
It can be seen as a wrapper to boinc_sleep adding some configurable randomness.
