### PR TITLE
Move random_int() to util.cpp

### DIFF
--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -90,6 +90,7 @@ int main(int argc, char** argv) {
     R_RSA_PUBLIC_KEY public_key;
     R_RSA_PRIVATE_KEY private_key;
     int i, n, retval;
+    unsigned int srand_seed;
     bool is_valid;
     DATA_BLOCK signature, in, out;
     unsigned char signature_buf[256], buf[256], buf2[256];
@@ -120,7 +121,18 @@ int main(int argc, char** argv) {
         printf("creating keys in %s and %s\n", argv[3], argv[4]);
         n = atoi(argv[2]);
 
-        srand(random_int());
+        retval = random_int(srand_seed);
+        if (retval == 1) {
+            die("can't load ADVAPI32.DLL");
+        } else if (retval == 2) {
+            die("can't open /dev/random");
+        } else if (retval == 3) {
+            die("can't read from /dev/random");
+        } else if (retval) {
+            die("random_int");
+        }
+        srand(srand_seed);
+        
         e = BN_new();
         retval = BN_set_word(e, (unsigned long)65537);
         if (retval != 1) {

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv) {
             die("random_int");
         }
         srand(srand_seed);
-        
+
         e = BN_new();
         retval = BN_set_word(e, (unsigned long)65537);
         if (retval != 1) {

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -56,6 +56,7 @@
 
 #include "crypt.h"
 #include "md5_file.h"
+#include "util.h"
 
 void die(const char* p) {
     fprintf(stderr, "Error: %s\n", p);
@@ -83,41 +84,6 @@ void usage() {
         "-cert_verify file signature certificate_dir\n"
         "    verify a signature using a directory of certificates\n"
    );
-}
-
-unsigned int random_int() {
-    unsigned int n;
-#if defined(_WIN32)
-#if defined(__CYGWIN32__)
-    HMODULE hLib=LoadLibrary((const char *)"ADVAPI32.DLL");
-#else
-    HMODULE hLib=LoadLibrary("ADVAPI32.DLL");
-#endif
-    if (!hLib) {
-        die("Can't load ADVAPI32.DLL");
-    }
-    BOOLEAN (APIENTRY *pfn)(void*, ULONG) =
-        (BOOLEAN (APIENTRY *)(void*,ULONG))GetProcAddress(hLib,"SystemFunction036");
-    if (pfn) {
-        char buff[32];
-        ULONG ulCbBuff = sizeof(buff);
-        if(pfn(buff,ulCbBuff)) {
-            // use buff full of random goop
-            memcpy(&n,buff,sizeof(n));
-        }
-    }
-    FreeLibrary(hLib);
-#else
-    FILE* f = fopen("/dev/random", "r");
-    if (!f) {
-        die("can't open /dev/random\n");
-    }
-    if (1 != fread(&n, sizeof(n), 1, f)) {
-        die("couldn't read from /dev/random\n");
-    }
-    fclose(f);
-#endif
-    return n;
 }
 
 int main(int argc, char** argv) {

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -565,13 +565,14 @@ int random_int(unsigned int &n) {
     }
     FreeLibrary(hLib);
 #else
-    FILE* f = fopen("/dev/random", "r");
+    FILE* f = boinc::fopen("/dev/random", "r");
     if (!f) {
         return 2;
     }
-    if (1 != fread(&n, sizeof(n), 1, f)) {
+    if (1 != boinc::fread(&n, sizeof(n), 1, f)) {
         return 3;
     }
-    fclose(f);
+    boinc::fclose(f);
 #endif
+    return 0
 }

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -574,5 +574,5 @@ int random_int(unsigned int &n) {
     }
     boinc::fclose(f);
 #endif
-    return 0
+    return 0;
 }

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -543,8 +543,7 @@ bool process_exists(int pid) {
 
 #endif
 
-unsigned int random_int() {
-    unsigned int n;
+int random_int(unsigned int &n) {
 #if defined(_WIN32)
 #if defined(__CYGWIN32__)
     HMODULE hLib=LoadLibrary((const char *)"ADVAPI32.DLL");
@@ -552,7 +551,7 @@ unsigned int random_int() {
     HMODULE hLib=LoadLibraryA("ADVAPI32.DLL");
 #endif
     if (!hLib) {
-        fprintf(stderr, "Error: can't load ADVAPI32.DLL\n");
+        return 1;
     }
     BOOLEAN (APIENTRY *pfn)(void*, ULONG) =
         (BOOLEAN (APIENTRY *)(void*,ULONG))GetProcAddress(hLib,"SystemFunction036");
@@ -568,12 +567,11 @@ unsigned int random_int() {
 #else
     FILE* f = fopen("/dev/random", "r");
     if (!f) {
-        fprintf(stderr, "Error: can't open /dev/random\n");
+        return 2;
     }
     if (1 != fread(&n, sizeof(n), 1, f)) {
-        fprintf(stderr, "Error: can't read from /dev/random\n");
+        return 3;
     }
     fclose(f);
 #endif
-    return n;
 }

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -549,11 +549,10 @@ unsigned int random_int() {
 #if defined(__CYGWIN32__)
     HMODULE hLib=LoadLibrary((const char *)"ADVAPI32.DLL");
 #else
-    HMODULE hLib=LoadLibrary("ADVAPI32.DLL");
+    HMODULE hLib=LoadLibraryA("ADVAPI32.DLL");
 #endif
     if (!hLib) {
         fprintf(stderr, "Error: can't load ADVAPI32.DLL\n");
-        exit(2);
     }
     BOOLEAN (APIENTRY *pfn)(void*, ULONG) =
         (BOOLEAN (APIENTRY *)(void*,ULONG))GetProcAddress(hLib,"SystemFunction036");
@@ -570,11 +569,9 @@ unsigned int random_int() {
     FILE* f = fopen("/dev/random", "r");
     if (!f) {
         fprintf(stderr, "Error: can't open /dev/random\n");
-        exit(2);
     }
     if (1 != fread(&n, sizeof(n), 1, f)) {
         fprintf(stderr, "Error: can't read from /dev/random\n");
-        exit(2);
     }
     fclose(f);
 #endif

--- a/lib/util.h
+++ b/lib/util.h
@@ -30,7 +30,7 @@ extern double dtime();
 extern double dday();
 extern void boinc_sleep(double);
 extern void push_unique(std::string, std::vector<std::string>&);
-extern unsigned int random_int();
+extern int random_int(unsigned int&);
 
 // NOTE: use #include <functional>   to get max,min
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -30,6 +30,7 @@ extern double dtime();
 extern double dday();
 extern void boinc_sleep(double);
 extern void push_unique(std::string, std::vector<std::string>&);
+extern unsigned int random_int();
 
 // NOTE: use #include <functional>   to get max,min
 


### PR DESCRIPTION
`random_int()` can easily be used as seed for `srand()` from various functions if it is in `util.cpp`.
This is not possible if it is in `crypt_prog.cpp` since `crypt_prog.cpp` is not included in the standard build process.
Instead, `tools/makefile_sign_executable` must be used to build it.

See:
https://boinc.berkeley.edu/trac/wiki/KeySetup#Filesigningutilities
