### PR TITLE
Add race mitigation lock to vboxwrapper

### DIFF
--- a/samples/vboxwrapper/Makefile
+++ b/samples/vboxwrapper/Makefile
@@ -77,4 +77,4 @@ vboxwrapper.o: vboxwrapper.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -c vboxwrapper.cpp
 
 vboxwrapper$(VBOXWRAPPER_RELEASE_SUFFIX): vboxwrapper.o vbox_common.o vbox_vboxmanage.o vboxcheckpoint.o vboxjob.o vboxlogging.o floppyio.o $(MAKEFILE_STDLIB) $(BOINC_LIB_DIR)/libboinc.a $(BOINC_API_DIR)/libboinc_api.a
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o vboxwrapper$(VBOXWRAPPER_RELEASE_SUFFIX) vboxwrapper.o vbox_common.o vbox_vboxmanage.o vboxcheckpoint.o vboxjob.o vboxlogging.o floppyio.o $(MAKEFILE_LDFLAGS) -lboinc_api -lboinc $(STDCPPTC)
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o vboxwrapper$(VBOXWRAPPER_RELEASE_SUFFIX) vboxwrapper.o vbox_common.o vbox_vboxmanage.o vboxcheckpoint.o vboxjob.o vboxlogging.o floppyio.o $(MAKEFILE_LDFLAGS) -lboinc_api -lboinc -lrt $(STDCPPTC)

--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -1171,7 +1171,10 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
             }
 
             // Timeout?
-            if (retry_count >= 5) break;
+            if (retry_count >= 5) {
+                retval = ERR_TIMEOUT;
+                break;
+            }
 
             retry_count++;
             boinc_sleep(sleep_interval);

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -48,6 +48,7 @@ using std::string;
 #include "util.h"
 #include "error_numbers.h"
 #include "procinfo.h"
+#include "md5_file.h"
 #include "network.h"
 #include "boinc_api.h"
 #include "floppyio.h"
@@ -176,6 +177,7 @@ int VBOX_VM::create_vm() {
     bool disable_acceleration = false;
     char buf[256];
     int retval;
+    int save_retval;
 
     vboxlog_msg("Create VM. (%s, slot#%d)", vm_master_name.c_str(), aid.slot);
 
@@ -554,9 +556,22 @@ int VBOX_VM::create_vm() {
 
             vboxlog_msg("Adding virtual disk drive to VM. (%s)", multiattach_vdi_file.c_str());
 
+#ifdef _WIN32
+            HANDLE fd_race_mitigator = NULL;
+#else
+            int fd_race_mitigator = 0;
+#endif
             int retry_count = 0;
             bool log_error = false;
             bool vbox_bug_mitigation = false;
+            string lock_name = "";
+
+            retval = set_race_mitigation_lock(fd_race_mitigator, lock_name, medium_file);
+            if (retval) {
+                save_retval = retval;
+                vboxlog_msg("Could not set race mitigation lock in 'create_vm'.");
+                return save_retval;
+            }
 
             do {
                 string set_new_uuid = "";
@@ -568,6 +583,7 @@ int VBOX_VM::create_vm() {
 
                 retval = vbm_popen(command, output, "check if parent hdd is registered", false);
                 if (retval) {
+                    save_retval = retval;
                     // showhdinfo implicitly registers unregistered hdds.
                     // Hence, this has to be handled first.
                     //
@@ -584,11 +600,12 @@ int VBOX_VM::create_vm() {
                             );
                     } else {
                         // other errors
+                        remove_race_mitigation_lock(fd_race_mitigator, lock_name);
                         vboxlog_msg("Error in check if parent hdd is registered.\nCommand:\n%s\nOutput:\n%s",
                             command.c_str(),
                             output.c_str()
                         );
-                        return retval;
+                        return save_retval;
                     }
                 }
 
@@ -621,13 +638,21 @@ int VBOX_VM::create_vm() {
                     command += set_new_uuid + "--medium \"" + medium_file + "\" ";
 
                     retval = vbm_popen(command, output, "register parent vdi");
-                    if (retval) return retval;
+                    if (retval) {
+                        save_retval = retval;
+                        remove_race_mitigation_lock(fd_race_mitigator, lock_name);
+                        return save_retval;
+                    }
 
                     command  = command_fix_part;
                     command += "--medium none ";
 
                     retval = vbm_popen(command, output, "detach parent vdi");
-                    if (retval) return retval;
+                    if (retval) {
+                        save_retval = retval;
+                        remove_race_mitigation_lock(fd_race_mitigator, lock_name);
+                        return save_retval;
+                    }
                     // the vdi file is now registered and ready
                     // to be attached in multiattach mode
                 }
@@ -639,6 +664,7 @@ int VBOX_VM::create_vm() {
 
                     retval = vbm_popen(command, output, "storage attach (fixed disk - multiattach mode)", log_error);
                     if (retval) {
+                        save_retval = retval;
                         // VirtualBox occasionally writes the 'MultiAttach'
                         // attribute to the disk entry in VirtualBox.xml
                         // although this is not allowed there.
@@ -658,26 +684,29 @@ int VBOX_VM::create_vm() {
                                 command = "closemedium \"" + medium_file + "\" ";
 
                                 retval = vbm_popen(command, output, "deregister parent vdi");
-                                if (retval) return retval;
+                                if (retval) {
+                                    save_retval = retval;
+                                    remove_race_mitigation_lock(fd_race_mitigator, lock_name);
+                                    return save_retval;
+                                }
 
                                 retry_count++;
                                 log_error = true;
-                                boinc_sleep(1.0);
                                 break;
                         }
 
                         if (retry_count >= 1) {
                             // in case of other errors or if retry also failed
+                            remove_race_mitigation_lock(fd_race_mitigator, lock_name);
                             vboxlog_msg("Error in storage attach (fixed disk - multiattach mode).\nCommand:\n%s\nOutput:\n%s",
                                 command.c_str(),
                                 output.c_str()
                                 );
-                            return retval;
+                            return save_retval;
                         }
 
                         retry_count++;
                         log_error = true;
-                        boinc_sleep(1.0);
 
                     } else {
                         vbox_bug_mitigation = true;
@@ -687,6 +716,7 @@ int VBOX_VM::create_vm() {
                 while (true);
             }
             while (!vbox_bug_mitigation);
+            remove_race_mitigation_lock(fd_race_mitigator, lock_name);
         }
 
 
@@ -862,8 +892,15 @@ int VBOX_VM::register_vm() {
 }
 
 int VBOX_VM::deregister_vm(bool delete_media) {
+    int retval;
     string command;
     string output;
+    string lock_name = "";
+#ifdef _WIN32
+    HANDLE fd_race_mitigator = NULL;
+#else
+    int fd_race_mitigator = 0;
+#endif
 
     vboxlog_msg("Deregistering VM. (%s, slot#%d)", vm_name.c_str(), aid.slot);
 
@@ -890,12 +927,25 @@ int VBOX_VM::deregister_vm(bool delete_media) {
     }
 
     // Next, delete VM
+    // This automatically deletes child disk images connected to the VM.
     //
     vboxlog_msg("Removing VM from VirtualBox.");
     command  = "unregistervm \"" + vm_name + "\" ";
     command += "--delete ";
 
+    if (multiattach_vdi_file.size()) {
+        string medium_file  = aid.project_dir;
+        medium_file += "/" + multiattach_vdi_file;
+
+        retval = set_race_mitigation_lock(fd_race_mitigator, lock_name, medium_file);
+        if (retval) {
+            vboxlog_msg("Could not set race mitigation lock in 'deregister_vm'.");
+            vboxlog_msg("Warning: Will continue without a lock.");
+        }
+    }
+
     vbm_popen(command, output, "delete VM", false, false);
+    remove_race_mitigation_lock(fd_race_mitigator, lock_name);
 
     // Lastly delete medium(s) from Virtual Box Media Registry
     //
@@ -1712,14 +1762,16 @@ bool VBOX_VM::is_disk_image_registered() {
     string command;
     string output;
 
-    command = "showhdinfo \"" + slot_dir_path + "/" + image_filename + "\" ";
-    if (vbm_popen(command, output, "hdd registration", false, false) == 0) {
-        if ((output.find("VBOX_E_FILE_ERROR") == string::npos)
-            && (output.find("VBOX_E_OBJECT_NOT_FOUND") == string::npos)
-            && (output.find("does not match the value") == string::npos)
-        ) {
-            // Error message not found in text
-            return true;
+    if (!multiattach_vdi_file.size()) {
+        command = "showhdinfo \"" + slot_dir_path + "/" + image_filename + "\" ";
+        if (vbm_popen(command, output, "hdd registration", false, false) == 0) {
+            if ((output.find("VBOX_E_FILE_ERROR") == string::npos)
+                && (output.find("VBOX_E_OBJECT_NOT_FOUND") == string::npos)
+                && (output.find("does not match the value") == string::npos)
+            ) {
+                // Error message not found in text
+                return true;
+            }
         }
     }
 
@@ -2235,4 +2287,169 @@ bool VBOX_VM::is_hostrtc_set_to_utc() {
     // Non-Windows Systems usually set their rtc to UTC.
     return true;
 #endif
+}
+
+#ifdef _WIN32
+void VBOX_VM::remove_race_mitigation_lock(HANDLE& fd_race_mitigator, string& lock_name) {
+    DWORD err = BOINC_SUCCESS;
+    bool retval;
+
+    if (fd_race_mitigator) {
+        retval = CloseHandle(fd_race_mitigator);
+        err = GetLastError();
+        if (!retval) {
+            vboxlog_msg("Could not remove race mitigation lock.");
+            vboxlog_msg("Lockname: %s", lock_name.c_str());
+            vboxlog_msg("Error: %d, %s", err, strerror(err));
+        }
+    }
+}
+#else
+void VBOX_VM::remove_race_mitigation_lock(int& fd_race_mitigator, string& lock_name) {
+    int err = BOINC_SUCCESS;
+    int retval;
+
+    if (fd_race_mitigator > 0) {
+        retval = shm_unlink(lock_name.c_str());
+        err = errno;
+        if (retval) {
+            vboxlog_msg("Could not remove race mitigation lock.");
+            vboxlog_msg("Lockname: %s", lock_name.c_str());
+            vboxlog_msg("Error: %d, %s", err, strerror(err));
+        }
+    }
+}
+#endif
+
+#ifdef _WIN32
+int VBOX_VM::set_race_mitigation_lock(HANDLE& fd_race_mitigator, string& lock_name, const string& medium_file) {
+#else
+int VBOX_VM::set_race_mitigation_lock(int& fd_race_mitigator, string& lock_name, const string& medium_file) {
+#endif
+    int attempts = 1;
+    double timeout = 0.0;
+    double sleep_low = 0.7;
+    double sleep_high = 2.4;
+
+    // The lock ensures that only 1 vboxwrapper instance can
+    // modify a given virtual disk entry at a given time.
+    // This is a must for multiattach disks since some modifications
+    // need more than 1 call to VBoxManage.
+    //
+    // lock_name should be derived from the full path of the disk's filename.
+    //
+    lock_name  = "boinc_vboxwrapper_lock_";
+    lock_name += md5_string(medium_file).substr(0, 16);
+
+    // Tests with Linux on a 16c/32t computer
+    // typically register 30 VMs in less than 8 s.
+    //
+    timeout = dtime() + 90;
+
+#ifdef _WIN32
+    DWORD err = BOINC_SUCCESS;
+
+    while (1) {
+        // Parameter #5 (size) must not be 0 if INVALID_HANDLE_VALUE is used.
+        //
+        fd_race_mitigator = CreateFileMapping(
+            INVALID_HANDLE_VALUE,
+            NULL,
+            PAGE_READONLY,
+            NULL,
+            1,
+            (LPTSTR)lock_name.c_str()
+        );
+        err = GetLastError();
+
+        if (!err) {
+            // Successfully set a fresh lock.
+            // No error implies we also have a valid handle.
+            //
+            if (attempts > 1) {
+                vboxlog_msg("Attempts: %d", attempts);
+            }
+            break;
+        } else {
+            // If we got a handle, it must not be used.
+            // Close it immediately.
+            //
+            if (fd_race_mitigator) {
+                CloseHandle(fd_race_mitigator);
+                fd_race_mitigator = NULL;
+            }
+
+            if (err == ERROR_ALREADY_EXISTS) {
+                // a lock exists, most likely set by another vboxwrapper
+                //
+                if (dtime() >= timeout) {
+                    // Either the lock is stale
+                    // or far too many VMs are starting concurrently.
+                    //
+                    vboxlog_msg("Could not set race mitigation lock.");
+                    vboxlog_msg("Lockname: '%s'", lock_name.c_str());
+                    vboxlog_msg("Error: ERR_TIMEOUT");
+                    vboxlog_msg("Attempts: %d", attempts);
+
+                    return ERR_TIMEOUT;
+                }
+                boinc_sleep(sleep_low + sleep_high * drand());
+                attempts++;
+            } else {
+                vboxlog_msg("Could not set race mitigation lock.");
+                vboxlog_msg("Lockname: '%s'", lock_name.c_str());
+                vboxlog_msg("Error: %d, %s", err, strerror(err));
+                vboxlog_msg("Attempts: %d", attempts);
+
+                return ERR_FOPEN;
+            }
+        }
+    }
+#else
+    int err = BOINC_SUCCESS;
+    lock_name = "/" + lock_name;
+
+    while (1) {
+        fd_race_mitigator = shm_open(lock_name.c_str(), O_RDWR | O_CREAT | O_EXCL, 0600);
+        err = errno;
+
+        if (fd_race_mitigator > 0) {
+            // Successfully set a fresh lock.
+            //
+            if (attempts > 1) {
+                vboxlog_msg("Attempts: %d", attempts);
+            }
+            break;
+        } else {
+            if ((fd_race_mitigator == -1)
+                && (err == EEXIST)) {
+                // a lock exists, most likely set by another vboxwrapper
+                //
+                if (dtime() >= timeout) {
+                    // Either the lock is stale
+                    // or far too many VMs are starting concurrently.
+                    //
+                    vboxlog_msg("Could not set race mitigation lock.");
+                    vboxlog_msg("Lockname: '%s'", lock_name.c_str());
+                    vboxlog_msg("Error: ERR_TIMEOUT");
+                    vboxlog_msg("Attempts: %d", attempts);
+
+                    fd_race_mitigator = 0;
+                    return ERR_TIMEOUT;
+                }
+                boinc_sleep(sleep_low + sleep_high * drand());
+                attempts++;
+            } else {
+                vboxlog_msg("Could not set race mitigation lock.");
+                vboxlog_msg("Lockname: '%s'", lock_name.c_str());
+                vboxlog_msg("Error: %d, %s", err, strerror(err));
+                vboxlog_msg("Attempts: %d", attempts);
+
+                fd_race_mitigator = 0;
+                return ERR_FOPEN;
+            }
+        }
+    }
+#endif
+    return BOINC_SUCCESS;
 }

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -36,6 +36,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
 #endif
 
 using std::string;

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -603,8 +603,9 @@ int VBOX_VM::create_vm() {
                     } else {
                         // other errors
                         remove_race_mitigation_lock(fd_race_mitigator, lock_name);
-                        vboxlog_msg("Error in check if parent hdd is registered.\nCommand:\n%s\nOutput:\n%s",
+                        vboxlog_msg("Error in check if parent hdd is registered.\nCommand: %s\nExit Code: %d\nOutput:\n%s",
                             command.c_str(),
+                            save_retval,
                             output.c_str()
                         );
                         return save_retval;
@@ -700,8 +701,9 @@ int VBOX_VM::create_vm() {
                         if (retry_count >= 1) {
                             // in case of other errors or if retry also failed
                             remove_race_mitigation_lock(fd_race_mitigator, lock_name);
-                            vboxlog_msg("Error in storage attach (fixed disk - multiattach mode).\nCommand:\n%s\nOutput:\n%s",
+                            vboxlog_msg("Error in storage attach (fixed disk - multiattach mode).\nCommand: %s\nExit Code: %d\nOutput:\n%s",
                                 command.c_str(),
+                                save_retval,
                                 output.c_str()
                                 );
                             return save_retval;

--- a/samples/vboxwrapper/vbox_vboxmanage.h
+++ b/samples/vboxwrapper/vbox_vboxmanage.h
@@ -91,6 +91,7 @@ struct VBOX_VM : VBOX_BASE {
     int set_race_mitigation_lock(int& fd_race_mitigator, string& lock_name, const string& medium_file);
     void remove_race_mitigation_lock(int& fd_race_mitigator, string& lock_name);
 #endif
+    int remove_vbox_disk_orphans(string vbox_disk);
 };
 
 #endif

--- a/samples/vboxwrapper/vbox_vboxmanage.h
+++ b/samples/vboxwrapper/vbox_vboxmanage.h
@@ -20,6 +20,9 @@
 #ifndef BOINC_VBOX_VBOXMANAGE_H
 #define BOINC_VBOX_VBOXMANAGE_H
 
+#include <fcntl.h>
+#include <sys/mman.h>
+
 #include "vbox_common.h"
 
 struct VBOX_VM : VBOX_BASE {
@@ -84,6 +87,13 @@ struct VBOX_VM : VBOX_BASE {
         double bytes_sent,
         double bytes_received
     );
+#ifdef _WIN32
+    int set_race_mitigation_lock(HANDLE& fd_race_mitigator, string& lock_name, const string& medium_file);
+    void remove_race_mitigation_lock(HANDLE& fd_race_mitigator, string& lock_name);
+#else
+    int set_race_mitigation_lock(int& fd_race_mitigator, string& lock_name, const string& medium_file);
+    void remove_race_mitigation_lock(int& fd_race_mitigator, string& lock_name);
+#endif
 };
 
 #endif

--- a/samples/vboxwrapper/vbox_vboxmanage.h
+++ b/samples/vboxwrapper/vbox_vboxmanage.h
@@ -20,9 +20,6 @@
 #ifndef BOINC_VBOX_VBOXMANAGE_H
 #define BOINC_VBOX_VBOXMANAGE_H
 
-#include <fcntl.h>
-#include <sys/mman.h>
-
 #include "vbox_common.h"
 
 struct VBOX_VM : VBOX_BASE {

--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -440,6 +440,14 @@ int main(int argc, char** argv) {
     bool is_sporadic = false;
     bool register_only = false;
 
+    // seed random numbers
+    //
+#ifdef _WIN32
+    srand((unsigned int)GetCurrentProcessId());
+#else
+    srand((unsigned int)getpid());
+#endif
+
     // Initialize diagnostics system
     //
     boinc_init_diagnostics(BOINC_DIAG_DEFAULTS);
@@ -796,7 +804,6 @@ int main(int argc, char** argv) {
     // to stagger disk I/O.
     //
     if (!pVM->disable_automatic_checkpoints) {
-        srand((int)getpid());
         random_checkpoint_factor = drand() * 600;
 
         vboxlog_msg(


### PR DESCRIPTION
**Introduction**

Vboxwrapper allows to use VirtualBox multiattach/differencing disk images since version 26206.
Attaching a disk in this mode can't be done in 1 step.
Hence, a workaround suggested by VirtualBox had to be implemented in vboxwrapper and improved.

The required steps (in short):
1. Create a VM
2. Attach a virtual disk in normal mode to register it
3. Handle errors like the "4.0 or later" error ("closemedium"; see below)
4. Disconnect the disk from the VM but leave it in the registry
5. Reconnect the disk in multiattach mode ("storageattach")

For more details see:
#4602
#4603

Long term experience with LHC@home shows that errors like these happen more often than expected:

```
Command: VBoxManage -q storageattach "boinc_086a07090bec38dd" --storagectl "Hard Disk Controller" --port 0 --device 0 --type hdd --mtype multiattach --medium "/var/lib/boinc/projects/lhcathome.cern.ch_lhcathome/CMS_2022_09_07_prod.vdi"
Exit Code: -2135228409
Output:
VBoxManage: error: Cannot attach medium '/var/lib/boinc/projects/lhcathome.cern.ch_lhcathome/CMS_2022_09_07_prod.vdi': the media type 'MultiAttach' can only be attached to machines that were created with VirtualBox 4.0 or later
VBoxManage: error: Details: code VBOX_E_INVALID_OBJECT_STATE (0x80bb0007), component SessionMachine, interface IMachine, callee nsISupports
VBoxManage: error: Context: "AttachDevice(Bstr(pszCtl).raw(), port, device, DeviceType_HardDisk, pMedium2Mount)" at line 781 of file VBoxManageStorageController.cpp
```

```
Command:
VBoxManage -q closemedium "/var/lib/boinc/projects/lhcathome.cern.ch_lhcathome/Theory_2023_12_13.vdi" 
Output:
VBoxManage: error: Cannot close medium '/var/lib/boinc/projects/lhcathome.cern.ch_lhcathome/Theory_2023_12_13.vdi' because it has 2 child media
VBoxManage: error: Details: code VBOX_E_OBJECT_IN_USE (0x80bb000c), component MediumWrap, interface IMedium, callee nsISupports
VBoxManage: error: Context: "Close()" at line 1875 of file VBoxManageDisk.cpp
```

They usually happen when
- the parent disk is currently not attached to a VM but still registered and
- multiple fresh VMs start concurrently and try to go through the workaround (step 3 from above)

VirtualBox processes all incoming commands FIFO, hence "closemedium" and "storageattach" (normal/multiattach) from different vboxwrappers can easily be mixed.

**Suggested Solution**

This PR introduces a lock to protect the critical code sections.
All vboxwrapper instances trying to modify the same parent disk entry must own the lock or wait.
This is important when a VM gets registered as well as when a VM gets deregistered.


**Also included in this PR**

- some smaller modifications to improve error number reporting
- srand() has been moved at the beginning of main()

**Tests done**

Several series of concurrently starting VMs (CMS subproject from LHC@home)
- host: Linux, 16c/32t Threadripper, 128 GB RAM
- up to 30 VMs concurrently
- all were starting up within 7-8 s
- Lock request loops were called up to 5-7 times (max)
