### PR TITLE
client: if GPU is missing, discard app versions and results that refer to it.

### DIFF
--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -293,13 +293,18 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
                 }
             }
             if (avp->missing_coproc) {
-                msg_printf(project, MSG_INFO,
-                    "App version uses missing GPU '%s' - discarding",
-                    avp->missing_coproc_name
-                );
                 if (strstr(avp->missing_coproc_name, "Apple ")) {
+                    msg_printf(project, MSG_INFO,
+                        "App version uses deprecated GPU type '%s' - discarding",
+                        avp->missing_coproc_name
+                    );
                     delete avp;
                     continue;
+                } else {
+                    msg_printf(project, MSG_INFO,
+                        "App version uses missing GPU '%s'",
+                        avp->missing_coproc_name
+                    );
                 }
             }
             retval = link_app_version(project, avp);

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -294,9 +294,11 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
             }
             if (avp->missing_coproc) {
                 msg_printf(project, MSG_INFO,
-                    "Application uses missing %s GPU",
+                    "App version uses missing GPU '%s' - discarding",
                     avp->missing_coproc_name
                 );
+                delete avp;
+                continue;
             }
             retval = link_app_version(project, avp);
             if (retval) {

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -297,8 +297,10 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
                     "App version uses missing GPU '%s' - discarding",
                     avp->missing_coproc_name
                 );
-                delete avp;
-                continue;
+                if (strstr(avp->missing_coproc_name, "Apple ")) {
+                    delete avp;
+                    continue;
+                }
             }
             retval = link_app_version(project, avp);
             if (retval) {


### PR DESCRIPTION
This addresses an issue introduced when we changed GPU names from (e.g.) 'Apple M3 Pro' to 'apple_gpu'.

Note: this means that if a host has in-progress jobs using a discrete GPU, and you remove that GPU, those jobs will be discarded. This is a change, which I think is good because otherwise you'd get error messages forever.