### PR TITLE
Report TIMEOUT from vbm_popen

### DIFF
--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -1171,7 +1171,10 @@ int VBOX_BASE::vbm_popen(string& command, string& output, const char* item, bool
             }
 
             // Timeout?
-            if (retry_count >= 5) break;
+            if (retry_count >= 5) {
+                retval = ERR_TIMEOUT;
+                break;
+            }
 
             retry_count++;
             boinc_sleep(sleep_interval);


### PR DESCRIPTION
TIMEOUT is checked by various functions calling `vbm_popen`.
Ensure `vbm_popen` reports it.