### PR TITLE
Vboxwrapper - handling of outdated vboxmanage command options

### DIFF
--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -593,7 +593,7 @@ bool VBOX_BASE::is_virtualbox_version_newer(int maj, int min, int rel) {
         if (min > vbox_minor) return false;
         if (rel < vbox_release) return true;
     }
-    return false;
+    return true;
 }
 
 int VBOX_BASE::get_system_log(

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -1846,6 +1846,7 @@ int VBOX_VM::get_version_information(string& version_raw, string& version_displa
             );
             version_display = buf;
         } else {
+            vboxlog_msg("VBoxManage version raw: %s", output.c_str());
             version_raw = "Unknown";
             version_display = "VirtualBox VboxManage Interface (Version: Unknown)";
         }


### PR DESCRIPTION
Certain Vbox tasks from LHC@home recently failed with log entries like this:

```
2024-04-13 16:06:31 (7532): Detected: VirtualBox VboxManage Interface (Version: Unknown)
.
.
.
2024-04-13 16:06:43 (7532): Error in add storage controller (fixed disk) for VM: -108
Command:
VBoxManage -q storagectl "boinc_2f92bf95dc688693" --name "Hard Disk Controller" --add "sata" --controller "IntelAHCI" --hostiocache off --sataportcount 3
Output:
Oracle VM VirtualBox Command Line Management Interface Version 7.0.8
Copyright (C) 2005-2023 Oracle and/or its affiliates

VBoxManage.exe: error: Unknown option: --sataportcount
Usage - Manage a storage controller:

  VBoxManage storagectl <uuid | vmname> <--name=controller-name> [--add= floppy
      | ide | pcie | sas | sata | scsi | usb ] [--controller= BusLogic | I82078
      | ICH6 | IntelAhci | LSILogic | LSILogicSAS | NVMe | PIIX3 | PIIX4 | USB
      | VirtIO ] [--bootable= on | off ] [--hostiocache= on | off ]
      [--portcount=count] [--remove] [--rename=new-controller-name]

2024-04-13 16:06:43 (7532): Could not create VM
2024-04-13 16:06:43 (7532): ERROR: VM failed to start
```


The root cause is that (for an unknown reason) the VirtualBox version could not be detected.
Vboxwrapper then used `--sataportcount` which is set since `is_virtual_box_version_newer()` returns false as default.
The log also shows that the VirtualBox version used on this computer is 7.0.8.

**Suggestion**
To give a task a chance to run `is_virtual_box_version_newer()` should return `true` as default which would set recent vboxmanage command options as default.

