### PR TITLE
Fix 'File name too long' on Darwin

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -2342,7 +2342,7 @@ int VBOX_VM::set_race_mitigation_lock(int& fd_race_mitigator, string& lock_name,
     // lock_name should be derived from the full path of the disk's filename.
     //
     // Darwin limits the file name size to 32 characters (including the trailing '0').
-    // On POSIX we set a '/' as prefix. 
+    // On POSIX we set a '/' as prefix.
     // Hence, 'lock_name' must be shorter than 15 characters.
     //
     lock_name  = "boinc_lock_";

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -2341,7 +2341,11 @@ int VBOX_VM::set_race_mitigation_lock(int& fd_race_mitigator, string& lock_name,
     //
     // lock_name should be derived from the full path of the disk's filename.
     //
-    lock_name  = "boinc_vboxwrapper_lock_";
+    // Darwin limits the file name size to 32 characters (including the trailing '0').
+    // On POSIX we set a '/' as prefix. 
+    // Hence, 'lock_name' must be shorter than 15 characters.
+    //
+    lock_name  = "boinc_lock_";
     lock_name += md5_string(medium_file).substr(0, 16);
 
     // Tests with Linux on a 16c/32t computer


### PR DESCRIPTION
On LHC@home a user running Darwin 19.6.0 and Darwin 23.4.0 got the following error:

```
Could not set race mitigation lock.
Lockname: '/boinc_vboxwrapper_lock_c94b628801c684e7'
Error: 63, File name too long
```

A couple of internet sources state that on Darwin the filename size is limited to 31 characters plus trailing '0'.
