### PR TITLE
web: add option for making user name unique

### DIFF
--- a/db/constraints.sql
+++ b/db/constraints.sql
@@ -12,7 +12,7 @@ alter table user
     add unique(email_addr),
     add unique(authenticator),
     add index ind_tid (teamid),
-    add index user_name(name),
+    add unique(name),
     add index user_tot (total_credit desc),
         -- db_dump.C
     add index user_avg (expavg_credit desc),

--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -81,7 +81,7 @@ function navbar_right($user) {
         if ($user) {
             echo sprintf('
                 <li><a href=%s%s>%s</a></li>
-                ', url_base(), USER_HOME, $user->name
+                ', url_base(), HOME_PAGE, $user->name
             );
             $url_tokens = url_tokens($user->authenticator);
             echo sprintf('<li><a href="%slogout.php?%s">Log out</a></li>',
@@ -156,7 +156,7 @@ function sample_navbar(
 
     $x = array();
     if ($user) {
-        $x[] = array(tra("Account"), $url_prefix.USER_HOME);
+        $x[] = array(tra("Account"), $url_prefix.HOME_PAGE);
         $x[] = array(tra("Join"), $url_prefix."join.php");
         $x[] = array(tra("Preferences"), $url_prefix."prefs.php?subset=project");
     }

--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -809,6 +809,7 @@ function check_banished($user) {
 }
 
 function post_rules() {
+    if (defined(FORUM_RULES)) return FORUM_RULES;
     if (function_exists("project_forum_post_rules")) {
       $project_rules=project_forum_post_rules();
     } else {

--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -809,7 +809,7 @@ function check_banished($user) {
 }
 
 function post_rules() {
-    if (defined(FORUM_RULES)) return FORUM_RULES;
+    if (defined('FORUM_RULES')) return FORUM_RULES;
     if (function_exists("project_forum_post_rules")) {
       $project_rules=project_forum_post_rules();
     } else {

--- a/html/inc/friend.inc
+++ b/html/inc/friend.inc
@@ -1,7 +1,7 @@
 <?php
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -15,6 +15,8 @@
 //
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// code related to 'friend' features
 
 // The following two are what gets put into notification email digests
 //
@@ -39,7 +41,7 @@ function friend_notify_req_web_line($notify) {
     return sprintf(
         '<a href=friend.php?action=query&userid=%d>Friendship request</a> from <a href=%s?userid=%d>%s</a>',
         $notify->opaque,
-        defined('SHOW_USER_FILENAME')?SHOW_USER_FILENAME:'show_user.php',
+        SHOW_USER_PAGE,
         $user->id,
         $user->name
     );
@@ -65,7 +67,7 @@ $src_user->name says: $msg
 
     $message .= "
 Please accept or decline by visiting
-".secure_url_base().USER_HOME."
+".secure_url_base().HOME_PAGE."
 
 --------------------------
 To change email preferences, visit:
@@ -87,7 +89,7 @@ $dest_user->name says: $msg
 
     $message .= "
 Visit your Account page at
-".secure_url_base().USER_HOME."
+".secure_url_base().HOME_PAGE."
 
 --------------------------
 To change email preferences, visit:
@@ -116,7 +118,7 @@ function friend_accept_rss($notify, &$title, &$msg, &$url) {
     }
     $title = "Friendship confirmation";
     $msg = "$src_user->name has confirmed you as a friend";
-    $url = secure_url_base().USER_HOME;
+    $url = secure_url_base().HOME_PAGE;
 }
 
 // delete friendship connections

--- a/html/inc/friend.inc
+++ b/html/inc/friend.inc
@@ -36,9 +36,13 @@ function friend_notify_accept_email_line($notify) {
 function friend_notify_req_web_line($notify) {
     $user = BoincUser::lookup_id($notify->opaque);
     if (!$user) return null;
-    return "
-        <a href=friend.php?action=query&userid=$notify->opaque>Friendship request</a> from <a href=show_user.php?userid=$user->id>$user->name</a>
-    ";
+    return sprintf(
+        '<a href=friend.php?action=query&userid=%d>Friendship request</a> from <a href=%s?userid=%d>%s</a>',
+        $notify->opaque,
+        defined('SHOW_USER_FILENAME')?SHOW_USER_FILENAME:'show_user.php',
+        $user->id,
+        $user->name
+    );
 }
 
 function friend_notify_accept_web_line($notify) {

--- a/html/inc/more.inc
+++ b/html/inc/more.inc
@@ -31,6 +31,7 @@ function show_text_more($text, $nchars) {
 //
 function show_text_more_aux($text, $nchars) {
     static $count = 0;
+    if (!$text) return '';
 
     $n = strlen($text);
     if ($n < $nchars) {

--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -28,6 +28,7 @@ function pm_header() {
 }
 
 function pm_rules() {
+    if (defined(PM_RULES)) return PM_RULES;
     $x = "<table><tr><td align=left><small>";
     $x .= tra("
         <ul>

--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -28,7 +28,7 @@ function pm_header() {
 }
 
 function pm_rules() {
-    if (defined(PM_RULES)) return PM_RULES;
+    if (defined('PM_RULES')) return PM_RULES;
     $x = "<table><tr><td align=left><small>";
     $x .= tra("
         <ul>

--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -113,8 +113,8 @@ function pm_form($replyto, $userid, $error = null) {
         );
     }
 
-    $subject = null;
-    $content = null;
+    $subject = '';
+    $content = '';
     if ($replyto) {
         $message = BoincPrivateMessage::lookup_id($replyto);
         if (!$message || $message->userid != $g_logged_in_user->id) {
@@ -126,7 +126,7 @@ function pm_form($replyto, $userid, $error = null) {
         if (!$user) {
             error_page("Sender no longer exists");
         }
-        $writeto = $userid." (".$user->name.")";
+        $writeto = UNIQUE_USER_NAME?$user->name:$userid." (".$user->name.")";
         $subject = $message->subject;
         if (substr($subject, 0, 3) != "re:") {
             $subject = "re: ".$subject;
@@ -136,7 +136,7 @@ function pm_form($replyto, $userid, $error = null) {
         if (!$user) {
             error_page("Sender no longer exists");
         }
-        $writeto = $userid." (".$user->name.")";
+        $writeto = UNIQUE_USER_NAME?$user->name:$userid." (".$user->name.")";
     } else {
         $writeto = sanitize_tags(post_str("to", true));
         $subject = post_str("subject", true);

--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -154,7 +154,13 @@ function pm_form($replyto, $userid, $error = null) {
     echo "<input type=\"hidden\" name=\"action\" value=\"send\">\n";
     echo form_tokens($g_logged_in_user->authenticator);
     start_table();
-    row2(tra("To")."<br /><small>".tra("User IDs or unique usernames, separated with commas")."</small>",
+    row2(
+        sprintf('%s <br><small>%s</small>',
+            tra("To"),
+            UNIQUE_USER_NAME
+                ?tra('User names, separated with commas')
+                :tra("User IDs or unique usernames, separated with commas")
+        ),
         "<input type=\"text\" class=\"form-control\" name=\"to\" value=\"$writeto\">",
         null, '20%'
     );

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -341,7 +341,13 @@ function friend_links($user) {
         $alt = tra("Profile");
         $x .= ' <a href="'.url_base().'view_profile.php?userid='.$user->id.'"><img title="'.$title.'" src="'.$img_url.'" alt="'.$alt.'"></a><br>';
     }
-    $x .= " <a href=\"".url_base()."show_user.php?userid=".$user->id."\">".$user->name."</a>";
+    $x .= sprintf(
+        '<a href="%s%s?userid=%d">%s</a>',
+        url_base(),
+        defined('SHOW_USER_FILENAME')?SHOW_USER_FILENAME:'show_user.php',
+        $user->id,
+        $user->name
+    );
     if (function_exists("project_user_links")) {
         $x .= project_user_links($user);
     }

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -361,13 +361,26 @@ function user_links($user, $badge_height=0, $name_limit=0) {
     $x = "";
     if ($user->has_profile) {
         $img_url = url_base()."img/head_20.png";
-        $x .= ' <a href="'.url_base().'view_profile.php?userid='.$user->id.'"><img title="View the profile of '.$user->name.'" src="'.$img_url.'" alt="Profile"></a>';
+        $x .= sprintf(
+            ' <a href="%s%s?userid=%d"><img title="View the profile of %s" src="%s" alt="Profile"></a>',
+            url_base(),
+            'view_profile.php',
+            $user->id,
+            $user->name,
+            $img_url
+        );
     }
     $name = $user->name;
     if ($name_limit && strlen($name) > $name_limit) {
         $name = substr($name, 0, $name_limit)."...";
     }
-    $x .= " <a href=\"".url_base()."show_user.php?userid=".$user->id."\">".$name."</a>";
+    $x .= sprintf(
+        '<a href="%s%s?userid=%d">%s</a>',
+        url_base(),
+        defined('SHOW_USER_FILENAME')?SHOW_USER_FILENAME:'show_user.php',
+        $user->id,
+        $name
+    );
     if (function_exists("project_user_links")){
         $x .= project_user_links($user);
     }

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -325,11 +325,20 @@ function show_preference_links() {
     }
 }
 
+// return describing a friend: their name, and profile picture if it exists
+//
 function friend_links($user) {
     if (is_banished($user)) {
         return "";
     }
-    $x = "<table height=\"100\" width=\"150\" border=\"0\" cellpadding=\"4\"><tr><td class=\"friend\">";
+    $x = sprintf(
+        '<a href="%s%s?userid=%d" style="%s">%s</a>',
+        url_base(),
+        SHOW_USER_PAGE,
+        $user->id,
+        'vertical-align:top',
+        $user->name
+    );
     if ($user->has_profile) {
         $profile = BoincProfile::lookup_fields("has_picture", "userid=$user->id");
         if ($profile && $profile->has_picture) {
@@ -337,21 +346,20 @@ function friend_links($user) {
         } else {
             $img_url = url_base()."img/head_20.png";
         }
-        $title = tra("View the profile of %1", $user->name);
         $alt = tra("Profile");
-        $x .= ' <a href="'.url_base().'view_profile.php?userid='.$user->id.'"><img title="'.$title.'" src="'.$img_url.'" alt="'.$alt.'"></a><br>';
+        $x .= sprintf(
+            '<a href="%sview_profile.php?userid=%d"><img title="%s" src="%s" alt="%s"></a><br>',
+            url_base(),
+            $user->id,
+            tra("View the profile of %1", $user->name),
+            $img_url,
+            tra("Profile")
+        );
     }
-    $x .= sprintf(
-        '<a href="%s%s?userid=%d">%s</a>',
-        url_base(),
-        defined('SHOW_USER_FILENAME')?SHOW_USER_FILENAME:'show_user.php',
-        $user->id,
-        $user->name
-    );
     if (function_exists("project_user_links")) {
         $x .= project_user_links($user);
     }
-    $x .= "</td></tr></table>\n";
+    $x .= '</div>';
     return $x;
 }
 
@@ -383,7 +391,7 @@ function user_links($user, $badge_height=0, $name_limit=0) {
     $x .= sprintf(
         '<a href="%s%s?userid=%d">%s</a>',
         url_base(),
-        defined('SHOW_USER_FILENAME')?SHOW_USER_FILENAME:'show_user.php',
+        SHOW_USER_PAGE,
         $user->id,
         $name
     );
@@ -462,17 +470,16 @@ function show_community_private($user) {
     }
 
     $friends = BoincFriend::enum("user_src=$user->id and reciprocated=1");
-    $x = "<a href=\"user_search.php\">".tra("Find friends")."</a><br/>\n";
-    $n = count($friends);
-    if ($n) {
+    $x = '';
+    if ($friends) {
         foreach($friends as $friend) {
             $fuser = BoincUser::lookup_id($friend->user_dest);
             if (!$fuser) continue;
             $x .= friend_links($fuser);
         }
-        row2(tra("Friends")." ($n)", $x);
-    } else {
         row2(tra("Friends"), $x);
+    } else {
+        row2(tra("Friends"), '---');
     }
 }
 
@@ -528,6 +535,8 @@ function get_community_links_object($user){
     return $cache_object;
 }
 
+// show community links of another user (described by $clo)
+//
 function community_links($clo, $logged_in_user){
     $user = $clo->user;
     $team = $clo->team;
@@ -561,11 +570,11 @@ function community_links($clo, $logged_in_user){
     }
 
     if ($friends) {
-        $x = "";
+        $x = '';
         foreach($friends as $friend) {
             $x .= friend_links($friend);
         }
-        row2(tra("Friends")." (".sizeof($friends).")", $x);
+        row2(tra('Friends'), $x);
     }
 }
 

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -286,7 +286,9 @@ function show_user_info_private($user) {
             .$delete_account_str
         );
     }
-    row2(tra("User ID")."<br/><p class=\"small\">".tra("Used in community functions")."</p>", $user->id);
+    if (!UNIQUE_USER_NAME) {
+        row2(tra("User ID")."<br/><p class=\"small\">".tra("Used in community functions")."</p>", $user->id);
+    }
     if (!NO_COMPUTING) {
         row2(
             tra("Account keys"),
@@ -459,7 +461,9 @@ function show_community_private($user) {
 //
 function show_user_summary_public($user) {
     global $g_logged_in_user;
-    row2(tra("User ID"), $user->id);
+    if (!UNIQUE_USER_NAME) {
+        row2(tra("User ID"), $user->id);
+    }
     row2(tra("%1 member since", PROJECT), date_str($user->create_time));
     if (USER_COUNTRY) {
         row2(tra("Country"), $user->country);

--- a/html/inc/user_util.inc
+++ b/html/inc/user_util.inc
@@ -90,6 +90,10 @@ function is_valid_user_name($name, &$reason) {
         $reason = tra("user name may not contain HTML tags");
         return false;
     }
+    if (is_numeric($name)) {
+        $reason = tra("user name may not be a number");
+        return false;
+    }
     return true;
 }
 
@@ -227,6 +231,23 @@ function validate_post_make_user() {
     $new_name = post_str("new_name");
     if (!is_valid_user_name($new_name, $reason)) {
         show_error($reason);
+    }
+    if (UNIQUE_USER_NAME) {
+        $u = BoincUser::lookup_name($new_name);
+        if ($u) {
+            page_head("That name is in use");
+            echo "<p>The following user names are taken;
+                please go back and use a different one.<p>
+            ";
+            $users = BoincUser::enum(
+                sprintf("name like '%s%%'", $new_name)
+            );
+            foreach ($users as $u){
+                echo "<p>$u->name\n";
+            }
+            page_tail();
+            exit;
+        }
     }
 
     $new_email_addr = strtolower(post_str("new_email_addr"));

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -553,7 +553,7 @@ function rowify($string) {
     echo "<tr><td>$string</td></tr>";
 }
 
-function row_array($x, $attrs) {
+function row_array($x, $attrs=null) {
     echo "<tr>\n";
     $i = 0;
     foreach ($x as $h) {

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -553,10 +553,13 @@ function rowify($string) {
     echo "<tr><td>$string</td></tr>";
 }
 
-function row_array($x) {
+function row_array($x, $attrs) {
     echo "<tr>\n";
+    $i = 0;
     foreach ($x as $h) {
-        echo "<td>$h</td>\n";
+        $a = $attrs?$attrs[$i]:"";
+        echo "<td $a>$h</td>\n";
+        $i++;
     }
     echo "</tr>\n";
 }

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -103,6 +103,9 @@ if (!defined('DARK_MODE')) {
 if (!defined('VALIDATE_EMAIL_TO_POST')) {
     define('VALIDATE_EMAIL_TO_POST', false);
 }
+if (!defined('UNIQUE_USER_NAME')) {
+    define('UNIQUE_USER_NAME', false);
+}
 
 // don't allow anything between .php and ? in URL
 //

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -91,9 +91,21 @@ if (!defined('NO_STATS')) {
 if (!defined('NO_GLOBAL_PREFS')) {
     define('NO_GLOBAL_PREFS', false);
 }
-if (!defined('USER_HOME')) {
-    define('USER_HOME', 'home.php');
+
+// the 'home page' of the logged-in user.
+// go here after login, account creation, team operations, etc.
+//
+if (!defined('HOME_PAGE')) {
+    define('HOME_PAGE', 'home.php');
 }
+
+// the page showing another user.
+// Link to here wherever we show a user name.
+//
+if (!defined('SHOW_USER_PAGE')) {
+    define('SHOW_USER_PAGE', 'show_user.php');
+}
+
 if (!defined('POST_MAX_LINKS')) {
     define('POST_MAX_LINKS', 0);
 }

--- a/html/project.sample/project.inc
+++ b/html/project.sample/project.inc
@@ -47,6 +47,7 @@ display_errors();
 
 //-------------- enable/disable web features
 
+define('UNIQUE_USER_NAME', true);
 define("FORUM_QA_MERGED_MODE", true);
     // Set to true to merge Message boards and Q&A section
 define ("DISABLE_PROFILES", true);

--- a/html/user/account_finish_action.php
+++ b/html/user/account_finish_action.php
@@ -58,7 +58,7 @@ if (!$retval) {
 // if so, skip team-finder
 //
 if ($user->teamid) {
-    Header("Location: ".USER_HOME);
+    Header("Location: ".HOME_PAGE);
 } else {
     Header("Location: team_search.php");
 }

--- a/html/user/create_account_action.php
+++ b/html/user/create_account_action.php
@@ -29,7 +29,7 @@ $next_url = sanitize_local_url($next_url);
 if ($next_url) {
     Header("Location: ".url_base()."$next_url");
 } else {
-    Header("Location: ".url_base().USER_HOME);
+    Header("Location: ".url_base().HOME_PAGE);
     send_cookie('init', "1", true);
     send_cookie('via_web', "1", true);
 }

--- a/html/user/edit_forum_preferences_action.php
+++ b/html/user/edit_forum_preferences_action.php
@@ -130,15 +130,27 @@ $user->prefs->update("images_as_links=$images_as_links, link_popup=$link_popup, 
 
 }   // DISABLE_FORUMS
 
-$add_user_to_filter = (isset($_POST["add_user_to_filter"]) && $_POST["add_user_to_filter"]!="");
-if ($add_user_to_filter){
-    $user_to_add = trim($_POST["forum_filter_user"]);
-    if ($user_to_add!="" and $user_to_add==strval(intval($user_to_add))){
-        $other_user = BoincUser::lookup_id($user_to_add);
-        if (!$other_user) {
-            echo tra("No such user:")." ".$user_to_add;
-        } else {
-            add_ignored_user($user, $other_user);
+if (UNIQUE_USER_NAME) {
+    $name = post_str('forum_filter_user', true);
+    if ($name) {
+        $other_user = BoincUser::lookup(
+            sprintf("name='%s'", BoincDb::escape_string($name))
+        );
+        if (!$other_user) error_page('No such user');
+        add_ignored_user($user, $other_user);
+    }
+} else {
+    // todo: clean up the following
+    $add_user_to_filter = (isset($_POST["add_user_to_filter"]) && $_POST["add_user_to_filter"]!="");
+    if ($add_user_to_filter){
+        $user_to_add = trim($_POST["forum_filter_user"]);
+        if ($user_to_add!="" and $user_to_add==strval(intval($user_to_add))){
+            $other_user = BoincUser::lookup_id($user_to_add);
+            if (!$other_user) {
+                echo tra("No such user:")." ".$user_to_add;
+            } else {
+                add_ignored_user($user, $other_user);
+            }
         }
     }
 }
@@ -146,6 +158,7 @@ if ($add_user_to_filter){
 // Or remove some from the ignore list
 //
 $ignored_users = get_ignored_list($user);
+// todo: use foreach
 for ($i=0;$i<sizeof($ignored_users);$i++){
     $remove = "remove".trim($ignored_users[$i]);
     if (isset($_POST[$remove]) && $_POST[$remove]!=""){

--- a/html/user/edit_forum_preferences_form.php
+++ b/html/user/edit_forum_preferences_form.php
@@ -82,15 +82,26 @@ $signature_by_default = $user->prefs->no_signature_by_default==false?"checked=\"
 
 $signature=$user->prefs->signature;
 $maxlen=250;
+$x = '';
+if (!NO_COMPUTING) {
+    $x = tra(
+        "Check out %1 various free services %2 <br> providing dynamic 'signature images' <br> showing your latest credit info, project news, etc.",
+        '<a href=https://github.com/BOINC/boinc/wiki/WebResources>',
+        '</a>'
+    );
+}
 row2(
-    tra("Signature for message board posts")
-    .bbcode_info()
-    ."<br><br>"
-    .tra("Check out %1 various free services %2
-<br> providing dynamic 'signature images'
-<br> showing your latest credit info, project news, etc.", "<a href=https://boinc.berkeley.edu/links.php#sigs>", "</a>"),
-    textarea_with_counter("signature", 250, $signature)
-    ."<br><input type=\"checkbox\" name=\"signature_by_default\" ".$signature_by_default."> ".tra("Attach signature by default")
+    sprintf(
+        'Signature for message board posts%s<br><br>%s',
+        bbcode_info(),
+        $x
+    ),
+    sprintf(
+        '%s <br><input type="checkbox" name="signature_by_default" %s> %s',
+        textarea_with_counter("signature", 250, $signature),
+        $signature_by_default,
+        tra("Attach signature by default")
+    )
 );
 if ($user->prefs->signature!=""){
     row2(tra("Signature preview").
@@ -138,25 +149,24 @@ row1(tra("Message blocking"));
 
 // get list of blocked users
 //
-$filtered_userlist = get_ignored_list($user);
-$forum_filtered_userlist = "";
-for ($i=0; $i<sizeof($filtered_userlist); $i++){
-    $id = (int)$filtered_userlist[$i];
+$blocked_users = get_ignored_list($user);
+$blocked_str = "";
+foreach ($blocked_users as $id) {
     if ($id) {
-        $filtered_user = BoincUser::lookup_id($id);
-        if (!$filtered_user) {
+        $blocked_user = BoincUser::lookup_id((int)$id);
+        if (!$blocked) {
             echo "Missing user $id";
             continue;
         }
-        $forum_filtered_userlist .= sprintf(
+        $blocked_str .= sprintf(
             '
                 %s %s
                 <input class="btn btn-default" type="submit" name="remove%d" value="%s">
                 <br>
             ',
-            UNIQUE_USER_NAME?'':"$filtered_user->id -",
-            user_links($filtered_user),
-            $filtered_user->id,
+            UNIQUE_USER_NAME?'':"$blocked_user->id -",
+            user_links($blocked_user),
+            $blocked_user->id,
             tra("Unblock")
         );
     }
@@ -168,7 +178,7 @@ row2(
         tra("Blocked users"),
         tra('Ignore message board posts and private messages from these users.')
     ),
-    $forum_filtered_userlist
+    $blocked_str?$blocked_str:'---'
 );
 row2(
     tra('Block user'),
@@ -184,7 +194,10 @@ row2(
 );
 
 row1(tra("Update"));
-row2(tra("Click here to update preferences"), "<input class=\"btn btn-success\" type=submit value=\"".tra("Update")."\">");
+row2(
+    tra("Click here to update preferences"),
+    "<input class=\"btn btn-success\" type=submit value=\"".tra("Update")."\">"
+);
 echo "</form>\n";
 row1(tra("Reset"));
 row2(tra("Or click here to reset preferences to the defaults"),

--- a/html/user/edit_forum_preferences_form.php
+++ b/html/user/edit_forum_preferences_form.php
@@ -134,8 +134,10 @@ row2(tra("How to sort"),
 
 // ------------ Message filtering  -----------
 
-row1(tra("Message filtering"));
+row1(tra("Message blocking"));
 
+// get list of blocked users
+//
 $filtered_userlist = get_ignored_list($user);
 $forum_filtered_userlist = "";
 for ($i=0; $i<sizeof($filtered_userlist); $i++){
@@ -146,16 +148,39 @@ for ($i=0; $i<sizeof($filtered_userlist); $i++){
             echo "Missing user $id";
             continue;
         }
-        $forum_filtered_userlist .= "<input class=\"btn btn-default\" type=\"submit\" name=\"remove".$filtered_user->id."\" value=\"".tra("Remove")."\"> ".$filtered_user->id." - ".user_links($filtered_user)."<br>";
+        $forum_filtered_userlist .= sprintf(
+            '
+                %s %s
+                <input class="btn btn-default" type="submit" name="remove%d" value="%s">
+                <br>
+            ',
+            UNIQUE_USER_NAME?'':"$filtered_user->id -",
+            user_links($filtered_user),
+            $filtered_user->id,
+            tra("Unblock")
+        );
     }
 }
 
-row2(tra("Filtered users").
-    "<br><p class=\"text-muted\">".tra("Ignore message board posts and private messages from these users.")."</p>",
-    "$forum_filtered_userlist
-        <input type=\"text\" name=\"forum_filter_user\" size=12> ".tra("User ID (For instance: 123456789)")."
-        <p></p><input class=\"btn btn-default\" type=\"submit\" name=\"add_user_to_filter\" value=\"".tra("Add user to filter")."\">
-    "
+row2(
+    sprintf(
+        '%s<br><p class="text-muted">%s</p>',
+        tra("Blocked users"),
+        tra('Ignore message board posts and private messages from these users.')
+    ),
+    $forum_filtered_userlist
+);
+row2(
+    tra('Block user'),
+    sprintf(
+        '
+            %s
+            <input type="text" name="forum_filter_user" size=12>
+            <input class="btn btn-default" type="submit" name="add_user_to_filter" value="%s">
+        ',
+        UNIQUE_USER_NAME?tra('User name'):tra('User ID (For instance: 123456789)'),
+        tra("Block")
+    )
 );
 
 row1(tra("Update"));

--- a/html/user/edit_user_info_action.php
+++ b/html/user/edit_user_info_action.php
@@ -35,6 +35,11 @@ if (strlen($name) == 0) {
 }
 $name = BoincDb::escape_string($name);
 
+$u = BoincUser::lookup(sprintf("name='%s'", $name));
+if ($u) {
+    error_page('That name is in use - go back and try another.');
+}
+
 $url = "";
 $country = "";
 $postal_code = "";

--- a/html/user/edit_user_info_action.php
+++ b/html/user/edit_user_info_action.php
@@ -66,7 +66,7 @@ $result = $user->update(
     "name='$name', url='$url', country='$country', postal_code='$postal_code'"
 );
 if ($result) {
-    Header("Location: ".USER_HOME);
+    Header("Location: ".HOME_PAGE);
 } else {
     error_page(tra("Couldn't update user info."));
 }

--- a/html/user/edit_user_info_action.php
+++ b/html/user/edit_user_info_action.php
@@ -36,7 +36,7 @@ if (strlen($name) == 0) {
 $name = BoincDb::escape_string($name);
 
 $u = BoincUser::lookup(sprintf("name='%s'", $name));
-if ($u) {
+if ($u && ($u->id != $user->id)) {
     error_page('That name is in use - go back and try another.');
 }
 

--- a/html/user/friend.php
+++ b/html/user/friend.php
@@ -248,7 +248,7 @@ function handle_cancel_confirm($user) {
         ) ."<p>\n"
     ;
     show_button("friend.php?action=cancel&userid=$destid", tra("Yes"), tra("Cancel friendship"));
-    show_button(USER_HOME, tra("No"), tra("Stay friends"));
+    show_button(HOME_PAGE, tra("No"), tra("Stay friends"));
     echo "</ul>";
     page_tail();
 }

--- a/html/user/login_action.php
+++ b/html/user/login_action.php
@@ -102,7 +102,7 @@ function login_via_link($id, $t, $h) {
 
     // Intercept next_url if consent has not yet been given
     //
-    $next_url = intercept_login($user, true, USER_HOME);
+    $next_url = intercept_login($user, true, HOME_PAGE);
     Header("Location: ".url_base()."$next_url");
 }
 
@@ -165,7 +165,7 @@ if ($next_url) {
     $next_url = sanitize_local_url($next_url);
 }
 if (!$next_url) {
-    $next_url = USER_HOME;
+    $next_url = HOME_PAGE;
 }
 
 $perm = false;

--- a/html/user/login_form.php
+++ b/html/user/login_form.php
@@ -58,9 +58,9 @@ $config = get_config();
 if (!parse_bool($config, "disable_account_creation")
     && !parse_bool($config, "no_web_account_creation")
 ) {
-    echo tra("or %1 create an account %2.",
-        "<a href=\"create_account_form.php?next_url=$next_url\">",
-        "</a>"
+    show_button(
+        "create_account_form.php?next_url=$next_url",
+        tra("Create account")
     );
 }
 

--- a/html/user/openid_login.php
+++ b/html/user/openid_login.php
@@ -146,7 +146,7 @@ try {
         if ($next_url) {
             Header("Location: ".url_base()."$next_url");
         } else {
-            Header("Location: ".url_base().USER_HOME);
+            Header("Location: ".url_base().HOME_PAGE);
             send_cookie('init', "1", true);
             send_cookie('via_web', "1", true);
         }

--- a/html/user/pm.php
+++ b/html/user/pm.php
@@ -257,7 +257,17 @@ function do_send($logged_in_user) {
         }
         BoincForumPrefs::lookup($user);
         if (is_ignoring($user, $logged_in_user)) {
-            pm_form($replyto, $userid, tra("User %1 (ID: %2) is not accepting private messages from you.", $user->name, $user->id));
+            pm_form(
+                $replyto, $userid,
+                UNIQUE_USER_NAME
+                ?tra("User %1 is not accepting private messages from you.",
+                    $user->name
+                )
+                :tra("User %1 (ID: %2) is not accepting private messages from you.",
+                    $user->name,
+                    $user->id
+                )
+            );
         }
         if (!isset($userids[$user->id])) {
             $userlist[] = $user;

--- a/html/user/stats.php
+++ b/html/user/stats.php
@@ -57,7 +57,7 @@ echo tra("You can also get your current statistics in the form of a \"signature 
 shuffle($sig_sites);
 site_list($sig_sites);
 echo tra("Additionally you can get your individual statistics summed across all BOINC projects from several sites; see your %1 home page %2.",
-    sprintf('<a href="%s">', USER_HOME), "</a>"
+    sprintf('<a href="%s">', HOME_PAGE), "</a>"
 );
 
 echo "</td></tr>";

--- a/html/user/team_founder_transfer_action.php
+++ b/html/user/team_founder_transfer_action.php
@@ -120,7 +120,7 @@ case "finalize_transfer":
         $team->update("userid=$user->id, ping_user=0, ping_time=0");
         echo tra("Congratulations, you are now the founder of team %1. Go to %2 Your Account page %3 to find the Team Admin options.",
             $team->name,
-            sprintf('<a href="%s%s">', secure_url_base(), USER_HOME),
+            sprintf('<a href="%s%s">', secure_url_base(), HOME_PAGE),
             "</a>"
         );
     } else {

--- a/html/user/team_join.php
+++ b/html/user/team_join.php
@@ -39,7 +39,7 @@ if ($user->teamid == $team->id) {
 } else {
     $success = user_join_team($team, $user);
     if ($success) {
-        Header("Location: ".USER_HOME);
+        Header("Location: ".HOME_PAGE);
     } else {
         error_page(tra("Couldn't join team - please try again later."));
     }

--- a/html/user/team_quit_action.php
+++ b/html/user/team_quit_action.php
@@ -29,7 +29,7 @@ $teamid = post_int("id");
 $team = BoincTeam::lookup_id($teamid);
 if ($user->teamid == $team->id) {
     user_quit_team($user);
-    Header("Location: ".USER_HOME);
+    Header("Location: ".HOME_PAGE);
 } else {
     page_head(tra("Unable to quit team"));
     echo tra("Team doesn't exist, or you don't belong to it.");

--- a/html/user/team_search.php
+++ b/html/user/team_search.php
@@ -210,7 +210,7 @@ if ($submit || $xml) {
     if (isset($_COOKIE['init'])) {
         echo "<p>
             ".tra("%1 I'm not interested %2 in joining a team right now.",
-                sprintf('<a href="%s">', USER_HOME),
+                sprintf('<a href="%s">', HOME_PAGE),
                 "</a>"
             );
     }

--- a/html/user/user_agreetermsofuse_action.php
+++ b/html/user/user_agreetermsofuse_action.php
@@ -33,7 +33,7 @@ $next_url = post_str("next_url", true);
 $next_url = urldecode($next_url);
 $next_url = sanitize_local_url($next_url);
 if (strlen($next_url) == 0) {
-    $next_url = USER_HOME;
+    $next_url = HOME_PAGE;
 }
 
 // validate checkbox

--- a/html/user/user_search.php
+++ b/html/user/user_search.php
@@ -20,32 +20,40 @@ require_once("../inc/boinc_db.inc");
 require_once("../inc/util.inc");
 require_once("../inc/user.inc");
 
+if (!function_exists('show_user')) {
 function show_user($user) {
-    echo sprintf('<tr><td>%s%s</td>',
+    $x = [];
+    $y = [];
+    $x[] = sprintf('%s%s',
         user_links($user, BADGE_HEIGHT_MEDIUM),
         UNIQUE_USER_NAME?'':" (ID $user->id)"
     );
+    $y[] = null;
     if (!DISABLE_TEAMS) {
         if ($user->teamid) {
             $team = BoincTeam::lookup_id($user->teamid);
-            echo "
-                <td> <a href=team_display.php?teamid=$team->id>$team->name</a> </td>
-            ";
+            $x[] = sprintf(
+                '<a href=team_display.php?teamid=%d>%s</a>',
+                $team->id,
+                $team->name
+            );
         } else {
-            echo "<td><br></td>";
+            $x[] = '';
         }
+        $y[] = null;
     }
     if (!NO_COMPUTING) {
-        echo "
-            <td align=right>", format_credit($user->expavg_credit), "</td>
-            <td align=right>", format_credit_large($user->total_credit), "</td>
-        ";
+        $x[] = format_credit($user->expavg_credit);
+        $y[] = ALIGN_RIGHT;
+        $x[] = format_credit_large($user->total_credit);
+        $y[] = ALIGN_RIGHT;
     }
-    echo "
-        <td>", $user->country, "</td>
-        <td>", time_str($user->create_time),"</td>
-        </tr>
-    ";
+    $x[] = $user->country;
+    $x[] = time_str($user->create_time);
+    $y[] = null;
+    $y[] = null;
+    row_array($x, $y);
+}
 }
 
 function user_search_form() {

--- a/html/user/user_search.php
+++ b/html/user/user_search.php
@@ -21,21 +21,27 @@ require_once("../inc/util.inc");
 require_once("../inc/user.inc");
 
 function show_user($user) {
-    echo "
-        <tr>
-        <td>", user_links($user, BADGE_HEIGHT_MEDIUM), " (ID $user->id)</td>
-    ";
-    if ($user->teamid) {
-        $team = BoincTeam::lookup_id($user->teamid);
+    echo sprintf('<tr><td>%s%s</td>',
+        user_links($user, BADGE_HEIGHT_MEDIUM),
+        UNIQUE_USER_NAME?'':" (ID $user->id)"
+    );
+    if (!DISABLE_TEAMS) {
+        if ($user->teamid) {
+            $team = BoincTeam::lookup_id($user->teamid);
+            echo "
+                <td> <a href=team_display.php?teamid=$team->id>$team->name</a> </td>
+            ";
+        } else {
+            echo "<td><br></td>";
+        }
+    }
+    if (!NO_COMPUTING) {
         echo "
-            <td> <a href=team_display.php?teamid=$team->id>$team->name</a> </td>
+            <td align=right>", format_credit($user->expavg_credit), "</td>
+            <td align=right>", format_credit_large($user->total_credit), "</td>
         ";
-    } else {
-        echo "<td><br></td>";
     }
     echo "
-        <td align=right>", format_credit($user->expavg_credit), "</td>
-        <td align=right>", format_credit_large($user->total_credit), "</td>
         <td>", $user->country, "</td>
         <td>", time_str($user->create_time),"</td>
         </tr>
@@ -57,20 +63,26 @@ function user_search_form() {
     echo "<select class=\"form-control\" name=\"country\"><option value=\"any\" selected>".tra("Any")."</option>";
     echo country_select_options("asdf");
     echo "</select></td></tr>";
-    row2(tra("With profile?"),
-        "<input type=radio name=profile value=either checked=1> ".tra("Either")."
-        &nbsp;<input type=radio name=profile value=no> ".tra("No")."
-        &nbsp;<input type=radio name=profile value=yes> ".tra("Yes")."
-    ");
-    row2(tra("On a team?"),
-        "<input type=radio name=team value=either checked=1> ".tra("Either")."
-        &nbsp;<input type=radio name=team value=no> ".tra("No")."
-        &nbsp;<input type=radio name=team value=yes> ".tra("Yes")."
-    ");
-    row1(tra("Ordering"), 2, "heading");
-    row2(tra("Decreasing sign-up time"), "<input type=radio name=search_type value=\"date\" checked>");
-    row2(tra("Decreasing average credit"), "<input type=radio name=search_type value=\"rac\">");
-    row2(tra("Decreasing total credit"), "<input type=radio name=search_type value=\"total\">");
+    if (!DISABLE_PROFILES) {
+        row2(tra("With profile?"),
+            "<input type=radio name=profile value=either checked=1> ".tra("Either")."
+            &nbsp;<input type=radio name=profile value=no> ".tra("No")."
+            &nbsp;<input type=radio name=profile value=yes> ".tra("Yes")."
+        ");
+    }
+    if (!DISABLE_TEAMS) {
+        row2(tra("On a team?"),
+            "<input type=radio name=team value=either checked=1> ".tra("Either")."
+            &nbsp;<input type=radio name=team value=no> ".tra("No")."
+            &nbsp;<input type=radio name=team value=yes> ".tra("Yes")."
+        ");
+    }
+    if (!NO_COMPUTING) {
+        row1(tra("Ordering"), 2, "heading");
+        row2(tra("Decreasing sign-up time"), "<input type=radio name=search_type value=\"date\" checked>");
+        row2(tra("Decreasing average credit"), "<input type=radio name=search_type value=\"rac\">");
+        row2(tra("Decreasing total credit"), "<input type=radio name=search_type value=\"total\">");
+    }
     row2("", "<input class=\"btn btn-success\" type=submit name=action value=".tra("Search").">");
     end_table();
     echo "
@@ -96,17 +108,21 @@ function search_action() {
         $s = BoincDb::escape_string($country);
         $where .= " and country='$s'";
     }
-    $t = get_str('team');
-    if ($t == 'yes') {
-        $where .= " and teamid<>0";
-    } else if ($t == 'no') {
-        $where .= " and teamid=0";
+    if (!DISABLE_TEAMS) {
+        $t = get_str('team');
+        if ($t == 'yes') {
+            $where .= " and teamid<>0";
+        } else if ($t == 'no') {
+            $where .= " and teamid=0";
+        }
     }
-    $t = get_str('profile');
-    if ($t == 'yes') {
-        $where .= " and has_profile<>0";
-    } else if ($t == 'no') {
-        $where .= " and has_profile=0";
+    if (!DISABLE_PROFILES) {
+        $t = get_str('profile');
+        if ($t == 'yes') {
+            $where .= " and has_profile<>0";
+        } else if ($t == 'no') {
+            $where .= " and has_profile=0";
+        }
     }
 
     $search_type = get_str('search_type', true);
@@ -124,17 +140,23 @@ function search_action() {
     foreach ($users as $user) {
         if ($n==0) {
             start_table('table-striped');
-            row_heading_array(
-                array(
-                    tra("Name"),
-                    tra("Team"),
-                    tra("Average credit"),
-                    tra("Total credit"),
-                    tra("Country"),
-                    tra("Joined")
-                ),
-                array(null, null, ALIGN_RIGHT, ALIGN_RIGHT, null, null)
-            );
+            $x = ['Name'];
+            $y = [null];
+            if (!DISABLE_TEAMS) {
+                $x[] = 'Team';
+                $y[] = null;
+            }
+            if (!NO_COMPUTING) {
+                $x[] = 'Average credit';
+                $y[] = ALIGN_RIGHT;
+                $x[] = 'Total credit';
+                $y[] = ALIGN_RIGHT;
+            }
+            $x[] = 'Country';
+            $y[] = null;
+            $x[] = 'Joined';
+            $y[] = null;
+            row_heading_array($x, $y);
         }
         show_user($user);
         $n++;

--- a/html/user/user_search.php
+++ b/html/user/user_search.php
@@ -20,7 +20,6 @@ require_once("../inc/boinc_db.inc");
 require_once("../inc/util.inc");
 require_once("../inc/user.inc");
 
-if (!function_exists('show_user')) {
 function show_user($user) {
     $x = [];
     $y = [];
@@ -53,7 +52,6 @@ function show_user($user) {
     $y[] = null;
     $y[] = null;
     row_array($x, $y);
-}
 }
 
 function user_search_form() {


### PR DESCRIPTION
We currently allow different accounts to have the same user name.
Hence in places where we need to identify users
(sending PMs, blocking users) we have to use numeric IDs,
which means that we have to display them in various places.
This is ugly; I'm not sure why I thought it was a good idea.

Anyway.  Add a project.inc option UNIQUE_USER_NAME.  If set:
- it won't let you create an account with a dup name,
    of change your name to a dup
- it doesn't show user IDs anywhere
- in places where you specify users, you use names

This is now the default for new projects.
Existing projects - which have lots of duplicate names -
can't use it unless they de-dup their names somehow
(and this might anger users).

Also some minor code cleanup.  sprintf() is our friend.
