### PR TITLE
Mac: update URL to download c-ares, which has moved to GitHub

### DIFF
--- a/mac_build/dependencyNames.sh
+++ b/mac_build/dependencyNames.sh
@@ -45,7 +45,7 @@ opensslURL="https://www.openssl.org/source/openssl-3.0.0.tar.gz"
 caresDirName="c-ares-1.17.2"
 caresBaseName="c-ares"
 caresFileName="c-ares-1.17.2.tar.gz"
-caresURL="https://c-ares.org/download/c-ares-1.17.2.tar.gz"
+caresURL="https://github.com/c-ares/c-ares/releases/download/cares-1_17_2/c-ares-1.17.2.tar.gz"
 
 curlDirName="curl-7.79.1"
 curlBaseName="curl"


### PR DESCRIPTION
When building the BOINC client for Macintosh, both GitHub Actions Ci and local builds download the third-party dependent libraries using the URLs in _mac_build/dependencyNames.sh_. The Mac uses the c-ares library to enable curl to do asynchronous file transfers. The developers of c-ares have announced:
> Any distributions that are currently pulling packages from https://c-ares.org/download/c-ares-X.Y.Z.tar.gz (or even the legacy https://c-ares.haxx.se/) are now broken.  Please update your packaging scripts to point to the github release assets, which is now the official repository for signed release packages.

This PR updates the URL for c-ares in _mac_build/dependencyNames.sh_ to the new URL.