### PR TITLE
vboxwrapper: don't create projects/virtualbox

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -109,15 +109,20 @@ int VBOX_VM::initialize() {
     } else {
         // If the override environment variable isn't specified then
         // it is based of the current users HOME directory.
+        const char *home;
 #ifdef _WIN32
-        virtualbox_home_directory = getenv("USERPROFILE");
+        home = getenv("USERPROFILE");
+        if (home == NULL) {
+            vboxlog_msg("no USERPROFILE - exiting");
+            exit(1);
+        }
 #else
-        const char *home = getenv("HOME");
+        home = getenv("HOME");
         if (home == NULL) {
             home = getpwuid(getuid())->pw_dir;
         }
-        virtualbox_home_directory = home;
 #endif
+        virtualbox_home_directory = home;
         virtualbox_home_directory += "/.VirtualBox";
     }
 


### PR DESCRIPTION
If Vboxwrapper couldn't find the Vbox 'home dir' (normally ~/.VirtualBox) based on env vars, it would create one: projects/virtualbox (owned by boinc_projects, not boinc_master)

This is wrong because
1) on startup, the client deletes anything in projects/
    that's not a project directory
2) on Mac it causes installer error messages
    because the dir is not owned by boinc_master.

Fix: don't create projects/virtualbox.