### PR TITLE
scheduler/client: add notion of 'strict memory bound' projects

### DIFF
--- a/client/project.cpp
+++ b/client/project.cpp
@@ -87,6 +87,7 @@ void PROJECT::init() {
     disk_share = 0.0;
     anonymous_platform = false;
     non_cpu_intensive = false;
+    strict_memory_bound = false;
     report_results_immediately = false;
     pwf.reset(this);
     send_time_stats_log = 0;
@@ -246,6 +247,7 @@ int PROJECT::parse_state(XML_PARSER& xp) {
         if (xp.parse_bool("send_full_workload", send_full_workload)) continue;
         if (xp.parse_bool("dont_use_dcf", dont_use_dcf)) continue;
         if (xp.parse_bool("non_cpu_intensive", non_cpu_intensive)) continue;
+        if (xp.parse_bool("strict_memory_bound", strict_memory_bound)) continue;
         if (xp.parse_bool("suspended_via_gui", suspended_via_gui)) continue;
         if (xp.parse_bool("dont_request_more_work", dont_request_more_work)) continue;
         if (xp.parse_bool("detach_when_done", detach_when_done)) continue;
@@ -422,7 +424,7 @@ int PROJECT::write_state(MIOFILE& out, bool gui_rpc) {
         "    <njobs_error>%d</njobs_error>\n"
         "    <elapsed_time>%f</elapsed_time>\n"
         "    <last_rpc_time>%f</last_rpc_time>\n"
-        "%s%s%s%s%s%s%s%s%s%s%s%s%s",
+        "%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
         master_url,
         project_name,
         symstore,
@@ -466,6 +468,7 @@ int PROJECT::write_state(MIOFILE& out, bool gui_rpc) {
         send_full_workload?"    <send_full_workload/>\n":"",
         dont_use_dcf?"    <dont_use_dcf/>\n":"",
         non_cpu_intensive?"    <non_cpu_intensive/>\n":"",
+        strict_memory_bound?"    <strict_memory_bound/>\n":"",
         suspended_via_gui?"    <suspended_via_gui/>\n":"",
         dont_request_more_work?"    <dont_request_more_work/>\n":"",
         detach_when_done?"    <detach_when_done/>\n":"",
@@ -605,6 +608,7 @@ void PROJECT::copy_state_fields(PROJECT& p) {
     send_full_workload = p.send_full_workload;
     dont_use_dcf = p.dont_use_dcf;
     non_cpu_intensive = p.non_cpu_intensive;
+    strict_memory_bound = p.strict_memory_bound;
     send_time_stats_log = p.send_time_stats_log;
     send_job_log = p.send_job_log;
     suspended_via_gui = p.suspended_via_gui;

--- a/client/project.h
+++ b/client/project.h
@@ -170,6 +170,13 @@ struct PROJECT : PROJ_AM {
     bool non_cpu_intensive;
         // The project has asserted (in sched reply) that
         // all its apps are non-CPU-intensive.
+    bool strict_memory_bound;
+        // assume that jobs from this project will have a WSS
+        // of wu.rsc_memory_bound,
+        // even if it's currently less.
+        // For example, CPDN jobs start small and get big later.
+        // If we run a lot of them (based on the small WSS)
+        // the system will run out of RAM and swap when they get big
     bool use_symlinks;
     bool report_results_immediately;
     bool sched_req_no_work[MAX_RSC];

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -594,7 +594,7 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
     MIOFILE mf;
     XML_PARSER xp(&mf);
     string delete_file_name;
-    bool ended = false;
+    bool ended = false, strict_memory_bound = false, non_cpu_intensive = false;
 
     mf.init_file(in);
     bool found_start_tag = false, btemp;
@@ -656,6 +656,8 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
             // If the scheduler reply didn't specify them, they're not set.
             //
             project->ended = ended;
+            project->non_cpu_intensive = non_cpu_intensive;
+            project->strict_memory_bound = strict_memory_bound;
             return 0;
         }
         else if (xp.parse_str("project_name", project->project_name, sizeof(project->project_name))) {
@@ -888,7 +890,9 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
             continue;
         } else if (xp.parse_bool("dont_use_dcf", dont_use_dcf)) {
             continue;
-        } else if (xp.parse_bool("non_cpu_intensive", project->non_cpu_intensive)) {
+        } else if (xp.parse_bool("non_cpu_intensive", non_cpu_intensive)) {
+            continue;
+        } else if (xp.parse_bool("strict_memory_bound", strict_memory_bound)) {
             continue;
         } else if (xp.parse_int("send_time_stats_log", send_time_stats_log)){
             continue;

--- a/sched/sched_config.cpp
+++ b/sched/sched_config.cpp
@@ -140,6 +140,7 @@ int SCHED_CONFIG::parse(FILE* f) {
         if (xp.parse_str("upload_url", upload_url, sizeof(upload_url))) continue;
         if (xp.parse_str("upload_dir", upload_dir, sizeof(upload_dir))) continue;
         if (xp.parse_bool("non_cpu_intensive", non_cpu_intensive)) continue;
+        if (xp.parse_bool("strict_memory_bound", strict_memory_bound)) continue;
         if (xp.parse_bool("verify_files_on_app_start", verify_files_on_app_start)) continue;
         if (xp.parse_int("homogeneous_redundancy", homogeneous_redundancy)) continue;
         if (xp.parse_bool("hr_class_static", hr_class_static)) continue;

--- a/sched/sched_config.h
+++ b/sched/sched_config.h
@@ -64,6 +64,7 @@ struct SCHED_CONFIG {
     double delete_delay;
     bool msg_to_host;
     bool non_cpu_intensive;
+    bool strict_memory_bound;
     bool verify_files_on_app_start;
     int homogeneous_redundancy;
     bool hr_allocate_slots;

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -1030,6 +1030,10 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
         boinc::fprintf(fout, "<non_cpu_intensive/>\n");
     }
 
+    if (config.strict_memory_bound) {
+        boinc::fprintf(fout, "<strict_memory_bound/>\n");
+    }
+
     if (config.verify_files_on_app_start) {
         boinc::fprintf(fout, "<verify_files_on_app_start/>\n");
     }


### PR DESCRIPTION
I recently changed the client so that its estimate of a job's WSS is at least wu.rsc_memory_bound.
This addressed a problem with CPDN apps,
which have small WSS for a while and then get big; the client would run too many of these at once
and when they get big the system would run out of RAM and/or swap.

However, some projects have rsc_memory_bound quite a bit larger than actual WSS,
and this change caused the client to run fewer of these jobs, causing idle CPUs in some cases.

Solution: have a per-project 'strict memory bound' flag, specified in config.xml.
For projects that set this (like CPDN) we'll estimate WSS the new way; otherwise we'll use the old way.