### PR TITLE
sched/db_purge: if a result fails to be deleted, don't purge the referencing workunit

### DIFF
--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -588,7 +588,12 @@ int purge_and_archive_results(DB_WORKUNIT& wu, int& number_results) {
             );
         } else {
             retval = result.delete_from_db();
-            if (retval) return retval;
+            if (retval) {
+                log_messages.printf(MSG_CRITICAL,
+                    "Couldn't delete result [%d] from database\n", result.id
+                );
+                return retval;
+            }
             log_messages.printf(MSG_DEBUG,
                 "Purged result [%lu] from database\n", result.id
             );
@@ -675,6 +680,10 @@ bool do_pass() {
         }
 
         retval = purge_and_archive_results(wu, n);
+        // if a result fails to be deleted, don't purge this workunit,
+        // or this result will be left orphaned and never get deleted
+        if (retval) continue;
+
         do_pass_purged_results += n;
 
         if (!no_archive) {


### PR DESCRIPTION
In db_purge, the return value of purge_and_archive_results() is never checked and not dealt with. If a result fails to be deleted from the DB (for whatever reason), the referencing workunit is still purged, leaving this result behind "orphaned", i.e. without reference. It will never get purged from the DB.

This change will skip this workunit in case of an error from purge_and_archive_results(), so the purger can have another try when it comes across that workunit again.
