### PR TITLE
web: fix bug that hid GPUs in host page

### DIFF
--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -291,7 +291,7 @@ function gpu_desc($x, $detail=true) {
         //print_r($d);
         if ($d[0] == "BOINC") continue;
         if ($d[0] == "vbox") continue;
-        if (count($d) < 5) continue;
+        if (count($d) < 4) continue;
         if ($str) $str .= "<p>";
         if ($d[2]!="" && $d[2]!="1") $str .= "[".$d[2]."] ";
         if ($d[0] == "CUDA") {


### PR DESCRIPTION
The PHP code (gpu_desc()) skipped GPUs with < 5 description fields. Older clients return only 4 fields.