### PR TITLE
Server: sched/validator: DON'T set assimilate_state by the validator.

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -2032,8 +2032,9 @@ int DB_VALIDATOR_ITEM_SET::update_workunit(WORKUNIT& wu) {
     char query[MAX_QUERY_LEN];
 
     sprintf(query,
-        "update workunit set need_validate=0, error_mask=%d, "
-        "assimilate_state=%d, transition_time=%d, "
+        "update workunit set need_validate=0, "
+        "error_mask=error_mask|%d, "
+        "transition_time=%d, "
         "target_nresults=%d, "
         "canonical_resultid=%lu, canonical_credit=%.15e "
         "where id=%lu",

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -685,7 +685,11 @@ int handle_wu(
                 );
                 wu.canonical_resultid = canonicalid;
                 wu.canonical_credit = credit;
-                wu.assimilate_state = ASSIMILATE_READY;
+
+                // DON'T modify assimilate_state here, under bad conditions the
+                // assimilator may have already started to work on this WU.
+                // Instead, let the transitioner decide what to do with it.
+                transition_time = IMMEDIATE;
 
                 // don't need to send any more results
                 //


### PR DESCRIPTION
- The assimilator may have already started to assimilate this WU. The validator may take quite some time to chew through a chunk of workunits. Resetting the assimilate_state after that may be harmful and override the update made by the assimilator. Instead, let the transitioner decide what to do with this workunit.

- Also too, avoid overriding a non-zero error mask that might have been set in the meantime by some other daemon

Fixes #5706