### PR TITLE
web: in PM send to multiple users, but names/IDs on separate lines

### DIFF
--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -165,10 +165,13 @@ function pm_form($replyto, $userid, $error = null) {
         sprintf('%s <br><small>%s</small>',
             tra("To"),
             UNIQUE_USER_NAME
-                ?tra('User names, separated with commas')
-                :tra("User IDs or unique usernames, separated with commas")
+                ?tra('User names, one per line')
+                :tra("User IDs or unique usernames, one per line")
         ),
-        "<input type=\"text\" class=\"form-control\" name=\"to\" value=\"$writeto\">",
+        sprintf(
+            '<textarea rows=2 class="form-control" name="to">%s</textarea>',
+            $writeto
+        ),
         null, '20%'
     );
     row2(

--- a/html/user/pm.php
+++ b/html/user/pm.php
@@ -262,25 +262,25 @@ function do_send($logged_in_user) {
         pm_form($replyto, $userid);
     }
     if (($to == null) || ($subject == null) || ($content == null)) {
-        pm_form($replyto, $userid, tra("You need to fill all fields to send a private message"));
+        pm_form(
+            $replyto, $userid,
+            tra("You need to fill all fields to send a private message")
+        );
         return;
     }
     if (!akismet_check($logged_in_user, $content)) {
-        pm_form($replyto, $userid, tra("Your message was flagged as spam
-            by the Akismet anti-spam system.
-            Please modify your text and try again.")
+        pm_form($replyto, $userid,
+            tra("Your message was flagged as spam by the Akismet anti-spam system.  Please modify your text and try again.")
         );
     }
-    $to = str_replace(", ", ",", $to); // Filter out spaces after separator
-    $users = explode(",", $to);
+    $users = explode("\n", $to);
 
     $userlist = array();
     $userids = array(); // To prevent from spamming a single user by adding it multiple times
 
     foreach ($users as $username) {
-        $user = explode(" ", $username);
-        if (is_numeric($user[0])) { // user ID is given
-            $userid = $user[0];
+        if (is_numeric($username)) {     // user ID is given
+            $userid = (int)$username;
             $user = BoincUser::lookup_id($userid);
             if ($user == null) {
                 pm_form($replyto, $userid, tra("Could not find user with id %1", $userid));


### PR DESCRIPTION
... rather than comma-separated.
User names can contain commas but not newlines.

Fixes #572