### PR TITLE
db_dump: report encoding correctly ('utf-8' rather than 'iso-8859-1')

### DIFF
--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -365,7 +365,7 @@ public:
         }
 
         write(
-            "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<%s>\n", tag.c_str()
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<%s>\n", tag.c_str()
         );
     }
 


### PR DESCRIPTION
Fixes #1503