### PR TITLE
[vcpkg][linux] Add custom gdk-pixbuf and librsvg vcpkg ports

### DIFF
--- a/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
@@ -16,6 +16,12 @@
           "name": "wxwidgets",
           "default-features": false
         },
-        "freetype"
+        "freetype",
+        "librsvg",
+        {
+          "name": "gdk-pixbuf",
+          "features": ["jpeg", "png", "svg", "tiff", "others"],
+          "default-features": false
+        }
     ]
 }

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/add_optional_svg_support.patch
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/add_optional_svg_support.patch
@@ -1,0 +1,75 @@
+diff --git a/gdk-pixbuf/gdk-pixbuf-io.c b/gdk-pixbuf/gdk-pixbuf-io.c
+index e1df5900f..d7018da6e 100644
+--- a/gdk-pixbuf/gdk-pixbuf-io.c
++++ b/gdk-pixbuf/gdk-pixbuf-io.c
+@@ -592,7 +592,10 @@ gdk_pixbuf_init_modules (const char  *path,
+ 	g_free (filename);
+ 	return ret;
+ }
+-
++#ifdef INCLUDE_svg
++extern void _gdk_pixbuf__svg_fill_info   (GdkPixbufFormat *info) __attribute__((weak));
++extern void _gdk_pixbuf__svg_fill_vtable (GdkPixbufModule *module) __attribute__((weak));
++#endif
+ static void
+ gdk_pixbuf_io_init_builtin (void)
+ {
+@@ -659,6 +662,10 @@ gdk_pixbuf_io_init_builtin (void)
+         /* Except the gdip-png loader which normally isn't built at all even */
+         load_one_builtin_module (png);
+ #endif
++#ifdef INCLUDE_svg
++        if (_gdk_pixbuf__svg_fill_info && _gdk_pixbuf__svg_fill_vtable)
++                load_one_builtin_module (svg);
++#endif
+ 
+ #undef load_one_builtin_module
+ }
+@@ -777,6 +784,15 @@ gdk_pixbuf_load_module_unlocked (GdkPixbufModule *image_module,
+ #ifdef INCLUDE_qtif
+         try_module (qtif,qtif);
+ #endif
++#ifdef INCLUDE_svg
++if (fill_info == NULL &&
++           strcmp (image_module->module_name, "svg") == 0) {
++               if (_gdk_pixbuf__svg_fill_info && _gdk_pixbuf__svg_fill_vtable) {
++                        fill_info = _gdk_pixbuf__svg_fill_info;
++                        fill_vtable = _gdk_pixbuf__svg_fill_vtable;
++               }
++       }
++#endif
+ 
+ #undef try_module
+         
+diff --git a/meson.build b/meson.build
+index 3eb3fcc15..b11331239 100644
+--- a/meson.build
++++ b/meson.build
+@@ -280,6 +280,12 @@ if not gif_opt.disabled()
+   enabled_loaders += 'gif'
+ endif
+ 
++svg_opt = get_option('svg')
++if not svg_opt.disabled()
++  enabled_loaders += 'svg'
++  add_project_arguments([ '-DINCLUDE_svg' ], language: 'c')
++endif
++
+ others_opt = get_option('others')
+ if not others_opt.disabled()
+   # Keep sorted alphabetically
+diff --git a/meson_options.txt b/meson_options.txt
+index 74830154a..6961c9530 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -18,6 +18,10 @@ option('others',
+        description: 'Enable other loaders, which are weakly maintained',
+        type: 'feature',
+        value: 'disabled')
++option('svg',
++       description: 'Enable SVG loader',
++       type: 'feature',
++       value: 'disabled')
+ option('builtin_loaders',
+        description: 'Comma-separated list of loaders to build into gdk-pixbuf',
+        type: 'array',

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/fix-static-deps.patch
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/fix-static-deps.patch
@@ -1,0 +1,12 @@
+diff --git a/gdk-pixbuf/meson.build b/gdk-pixbuf/meson.build
+index d7aa127b48..c313dc272d 100644
+--- a/gdk-pixbuf/meson.build
++++ b/gdk-pixbuf/meson.build
+@@ -214,6 +214,7 @@ gdkpixbuf = library('gdk_pixbuf-2.0',
+                     dependencies: [
+                       gdk_pixbuf_deps,
+                       included_loaders_deps,
++                      loaders_deps
+                     ],
+                     install: true)
+ 

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/fix_build_error_windows.patch
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/fix_build_error_windows.patch
@@ -1,0 +1,19 @@
+--- a/meson.build
++++ b/meson.build
+@@ -90,8 +90,14 @@
+   gdk_pixbuf_conf.set('HAVE_ROUND', 1)
+ endif
+ 
+-if cc.has_function('lrint', dependencies: mathlib_dep)
+-  gdk_pixbuf_conf.set('HAVE_LRINT', 1)
++if cc.get_id() == 'msvc'
++    if cc.has_function('lrint', dependencies: mathlib_dep, args: '-Oi-')
++        gdk_pixbuf_conf.set('HAVE_LRINT', 1)
++    endif
++else
++    if cc.has_function('lrint', dependencies: mathlib_dep)
++      gdk_pixbuf_conf.set('HAVE_LRINT', 1)
++    endif
+ endif
+ 
+ intl_dep = cc.find_library('intl', required: false)

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/loaders-cache.patch
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/loaders-cache.patch
@@ -1,0 +1,20 @@
+diff --git a/gdk-pixbuf/meson.build b/gdk-pixbuf/meson.build
+index 54ff9dd..27f8512 100644
+--- a/gdk-pixbuf/meson.build
++++ b/gdk-pixbuf/meson.build
+@@ -348,7 +348,14 @@ foreach bin: gdkpixbuf_bin
+   set_variable(bin_name.underscorify(), bin)
+ endforeach
+ 
+-if not meson.is_cross_build()
++if dynamic_loaders.length() == 0
++  # skip tool invocation
++  cmake = find_program('cmake', required : true)
++  loaders_cache = custom_target('loaders.cache', output: 'loaders.cache', capture: true,
++                                command: [ cmake, '-E', 'echo', '# No dynamic loaders enabled at build time' ],
++                                build_by_default: true)
++  loaders_dep = declare_dependency(sources: [ loaders_cache ])
++elif not meson.is_cross_build()
+   # The 'loaders.cache' used for testing, so we don't accidentally
+   # load the installed cache; we always build it by default
+   loaders_cache = custom_target('loaders.cache',

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
@@ -1,0 +1,105 @@
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.gnome.org/
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO GNOME/gdk-pixbuf
+    REF "${VERSION}"
+    SHA512 f95c92974ed6efac9845790ef5c4ed74dd6e28b182ea3732013c46b016166e92f8bc10c1994358d79ff53e988c615c43cb1a2130c6ef531ef9d84c2fdcc87e52
+    HEAD_REF master
+    PATCHES
+        fix_build_error_windows.patch
+        loaders-cache.patch
+        use-libtiff-4-pkgconfig.patch
+        fix-static-deps.patch
+        add_optional_svg_support.patch
+)
+
+if("introspection" IN_LIST FEATURES)
+    list(APPEND OPTIONS_DEBUG -Dintrospection=disabled)
+    list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)
+else()
+    list(APPEND OPTIONS -Dintrospection=disabled)
+endif()
+
+if("png" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dpng=enabled)
+else()
+    list(APPEND OPTIONS -Dpng=disabled)
+endif()
+
+if("tiff" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dtiff=enabled)
+else()
+    list(APPEND OPTIONS -Dtiff=disabled)
+endif()
+
+if("jpeg" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Djpeg=enabled)
+else()
+    list(APPEND OPTIONS -Djpeg=disabled)
+endif()
+
+if("others" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dothers=enabled)
+else()
+    list(APPEND OPTIONS -Dothers=disabled)
+endif()
+
+if("svg" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dsvg=enabled)
+else()
+    list(APPEND OPTIONS -Dsvg=disabled)
+endif()
+
+if(CMAKE_HOST_WIN32 AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+    set(GIR_TOOL_DIR ${CURRENT_INSTALLED_DIR})
+else()
+    set(GIR_TOOL_DIR ${CURRENT_HOST_INSTALLED_DIR})
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    #list(APPEND OPTIONS -Dnative_windows_loaders=true) # Use Windows system components to handle BMP, EMF, GIF, ICO, JPEG, TIFF and WMF images, overriding jpeg and tiff.  To build this into gdk-pixbuf, pass in windows" with the other loaders to build in or use "all" with the builtin_loaders option
+endif()
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dman=false                 # Whether to generate man pages (requires xlstproc)
+        -Dgtk_doc=false             # Whether to generate the API reference (requires GTK-Doc)
+        -Ddocs=false
+        -Drelocatable=true          # Whether to enable application bundle relocation support
+        -Dtests=false
+        -Dinstalled_tests=false
+        -Dgio_sniffing=false        # Perform file type detection using GIO (Unused on MacOS and Windows)
+        -Dbuiltin_loaders=all       # since it is unclear where loadable plugins should be located;
+                                    # Comma-separated list of loaders to build into gdk-pixbuf, or "none", or "all" to build all buildable loaders into gdk-pixbuf
+        ${OPTIONS}
+    OPTIONS_DEBUG
+        ${OPTIONS_DEBUG}
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    ADDITIONAL_BINARIES
+        glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources'
+        glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'
+        glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'
+        g-ir-compiler='${CURRENT_HOST_INSTALLED_DIR}/tools/gobject-introspection/g-ir-compiler${VCPKG_HOST_EXECUTABLE_SUFFIX}'
+        g-ir-scanner='${GIR_TOOL_DIR}/tools/gobject-introspection/g-ir-scanner'
+)
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gdk-pixbuf-2.0.pc" [[${bindir}]] "\${prefix}/tools/${PORT}")
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gdk-pixbuf-2.0.pc" [[${bindir}]] "\${prefix}/../tools/${PORT}")
+endif()
+vcpkg_fixup_pkgconfig()
+
+set(TOOL_NAMES gdk-pixbuf-csource gdk-pixbuf-pixdata gdk-pixbuf-query-loaders)
+# gdk-pixbuf-thumbnailer is not compiled for cross-compiling
+# vcpkg-meson cross-build configuration differs from VCPKG_CROSSCOMPILING
+if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/gdk-pixbuf-thumbnailer${VCPKG_TARGET_EXECUTABLE_SUFFIX}")
+    list(APPEND TOOL_NAMES gdk-pixbuf-thumbnailer)
+endif()
+vcpkg_copy_pdbs()
+vcpkg_copy_tools(TOOL_NAMES ${TOOL_NAMES} AUTO_CLEAN)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/use-libtiff-4-pkgconfig.patch
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/use-libtiff-4-pkgconfig.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index b5280f3..4927ed5 100644
+--- a/meson.build
++++ b/meson.build
+@@ -333,7 +333,7 @@ tiff_opt = get_option('tiff')
+ if not tiff_opt.disabled() and not native_windows_loaders
+   # We currently don't have a fallback subproject, but this handles error
+   # reporting if tiff_opt is enabled.
+-  tiff_dep = dependency(is_msvc_like ? 'tiff' : 'libtiff-4', required: tiff_opt)
++  tiff_dep = dependency(false ? 'tiff' : 'libtiff-4', required: tiff_opt)
+ 
+   if tiff_dep.found()
+     enabled_loaders += 'tiff'

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
@@ -1,0 +1,68 @@
+{
+  "name": "gdk-pixbuf",
+  "version": "2.42.12",
+  "description": "Image loading library.",
+  "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!xbox",
+  "dependencies": [
+    {
+      "name": "gettext",
+      "host": true,
+      "features": [
+        "tools"
+      ]
+    },
+    "gettext-libintl",
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "jpeg",
+    "png",
+    "tiff"
+  ],
+  "features": {
+    "introspection": {
+      "description": "build with introspection",
+      "dependencies": [
+        "gobject-introspection"
+      ]
+    },
+    "jpeg": {
+      "description": "Enable JPEG loader (requires libjpeg)",
+      "dependencies": [
+        "libjpeg-turbo"
+      ]
+    },
+    "others": {
+      "description": "Enable other loaders, which are weakly maintained (ani, bmp, icns, ico, pnm, qtif, tga, xbm, xpm)"
+    },
+    "png": {
+      "description": "Enable PNG loader (requires libpng)",
+      "dependencies": [
+        "libpng"
+      ]
+    },
+    "svg": {
+      "description": "Enable SVG loader",
+      "supports": "!windows"
+    },
+    "tiff": {
+      "description": "Enable TIFF loader (requires libtiff)",
+      "dependencies": [
+        {
+          "name": "tiff",
+          "default-features": false
+        }
+      ]
+    }
+  }
+}

--- a/3rdParty/vcpkg_ports/ports/librsvg/CMakeLists.txt
+++ b/3rdParty/vcpkg_ports/ports/librsvg/CMakeLists.txt
@@ -1,0 +1,214 @@
+cmake_minimum_required(VERSION 3.11)
+project(librsvg C)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBCROCO libcroco-0.6 IMPORTED_TARGET)
+pkg_check_modules(GLIB2 glib-2.0 gobject-2.0 gmodule-2.0 gio-2.0 IMPORTED_TARGET)
+pkg_check_modules(CAIRO cairo IMPORTED_TARGET)
+pkg_check_modules(GDK_PIXBUF gdk-pixbuf-2.0 IMPORTED_TARGET)
+pkg_check_modules(PANGO pango pangocairo IMPORTED_TARGET)
+find_package(LibXml2 REQUIRED)
+
+if(CMAKE_SYSTEM_NAME MATCHES "Windows")
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
+else()
+    pkg_check_modules(PANGO2 pangoft2 pangofc IMPORTED_TARGET)
+    set(PANGO_FT2_LIB PkgConfig::PANGO2)
+endif()
+
+set(RSVG_API_MAJOR_VERSION 2)
+set(RSVG_API_VERSION "2.0")
+Set(VERSION "2.40.20")
+set(LIBRSVG_TARGET "rsvg-${RSVG_API_MAJOR_VERSION}")
+
+Set(prefix "${CMAKE_INSTALL_PREFIX}")
+Set(exec_prefix "\${prefix}")
+Set(libdir "\${prefix}/lib")
+Set(includedir "\${prefix}/include")
+
+# Public required modules (cf. headers and librsvg.pc)
+set(librsvg_pc_requires glib-2.0 gio-2.0 gdk-pixbuf-2.0 cairo)
+# Other required modules from configure.ac
+set(librsvg_pc_requires_private
+    libxml-2.0
+    pangocairo
+    pangoft2
+    cairo-png
+    libcroco-0.6
+    gthread-2.0
+    gmodule-2.0
+    gobject-2.0
+    gio-unix-2.0
+    fontconfig
+)
+if(WIN32)
+    string(REPLACE "gio-unix" "gio-windows" librsvg_pc_requires_private "${librsvg_pc_requires_private}")
+endif()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(LIBRSVG_LINK_PUBLIC ${librsvg_pc_requires} IMPORTED_TARGET REQUIRED)
+pkg_check_modules(LIBRSVG_LINK_PRIVATE ${librsvg_pc_requires_private} IMPORTED_TARGET REQUIRED)
+
+set(LIBRSVG_SOURCES
+    librsvg-features.c
+    rsvg-css.c
+    rsvg-css.h
+    rsvg-compat.h
+    rsvg-defs.c
+    rsvg-defs.h
+    rsvg-image.c
+    rsvg-image.h
+    rsvg-io.c
+    rsvg-io.h
+    rsvg-paint-server.c
+    rsvg-paint-server.h
+    rsvg-path.c
+    rsvg-path.h
+    rsvg-private.h
+    rsvg-base-file-util.c
+    rsvg-filter.c
+    rsvg-filter.h
+    rsvg-marker.c
+    rsvg-marker.h
+    rsvg-mask.c
+    rsvg-mask.h
+    rsvg-shapes.c
+    rsvg-shapes.h
+    rsvg-structure.c
+    rsvg-structure.h
+    rsvg-styles.c
+    rsvg-styles.h
+    rsvg-text.c
+    rsvg-text.h
+    rsvg-cond.c
+    rsvg-base.c
+    librsvg-enum-types.c
+    rsvg-cairo-draw.c
+    rsvg-cairo-draw.h
+    rsvg-cairo-render.c
+    rsvg-cairo-render.h
+    rsvg-cairo-clip.h
+    rsvg-cairo-clip.c
+    rsvg.c
+    rsvg-gobject.c
+    rsvg-file-util.c
+    rsvg-size-callback.c
+    rsvg-size-callback.h
+    rsvg-xml.c
+    rsvg-xml.h
+    rsvg.h
+    rsvg-cairo.h
+    librsvg-features.h
+    librsvg-enum-types.h
+)
+
+if(WIN32)
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.win32" "${CMAKE_CURRENT_BINARY_DIR}/config.h" COPYONLY)
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/rsvg.symbols" rsvg_symbols)
+    string(REGEX REPLACE "/[*][^*]*[*]/" "" rsvg_symbols "${rsvg_symbols}")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/rsvg.def" "EXPORTS\n${rsvg_symbols}")
+    list(APPEND LIBRSVG_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/rsvg.def")
+else()
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.h.linux" "${CMAKE_CURRENT_BINARY_DIR}/config.h" COPYONLY)
+    list(APPEND LIBRSVG_SOURCES rsvg.symbols)
+endif()
+
+add_library(${LIBRSVG_TARGET} ${LIBRSVG_SOURCES})
+target_compile_definitions(${LIBRSVG_TARGET} PRIVATE
+    -DRSVG_COMPILATION
+    -D_CRT_SECURE_NO_WARNINGS
+    -DSRCDIR="${CMAKE_CURRENT_SOURCE_DIR}"
+    -DGDK_PIXBUF_ENABLE_BACKEND
+    -DG_LOG_DOMAIN="libpixbufloader-svg"
+    -DSRCDIR=""
+    $<$<BOOL:${MINGW}>:HAVE_STRTOK_R>
+)
+
+target_link_libraries(${LIBRSVG_TARGET} PRIVATE
+    PkgConfig::GLIB2
+    ${LIBXML2_LIBRARIES}
+    PkgConfig::PANGO
+    PkgConfig::GDK_PIXBUF
+    ${PANGO_FT2_LIB}
+    PkgConfig::LIBCROCO
+)
+
+target_include_directories(${LIBRSVG_TARGET}
+    PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}"
+    PUBLIC
+        "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
+        "$<INSTALL_INTERFACE:include/librsvg-${RSVG_API_VERSION}>"
+)
+target_link_libraries(${LIBRSVG_TARGET}
+    PUBLIC
+        PkgConfig::LIBRSVG_LINK_PUBLIC
+    PRIVATE
+        PkgConfig::LIBRSVG_LINK_PRIVATE
+)
+install(TARGETS ${LIBRSVG_TARGET}
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+)
+install(
+    FILES
+        rsvg.h
+        rsvg-cairo.h
+        librsvg-features.h
+        librsvg-enum-types.h
+    DESTINATION include/librsvg-${RSVG_API_VERSION}/librsvg
+)
+
+set(gdk_pixbuf_pc_requires_private gdk-pixbuf-2.0)
+pkg_check_modules(GDK_PIXBUF ${gdk_pixbuf_pc_requires_private} IMPORTED_TARGET REQUIRED)
+pkg_get_variable(GDK_PIXBUF_MODULEDIR ${gdk_pixbuf_pc_requires_private} gdk_pixbuf_moduledir)
+
+set(PIXBUFLOADERSVG_SOURCES
+    gdk-pixbuf-loader/io-svg.c
+)
+
+if (BUILD_SHARED_LIBS)
+    add_library(pixbufloader-svg MODULE ${PIXBUFLOADERSVG_SOURCES})
+else()
+    add_library(pixbufloader-svg ${PIXBUFLOADERSVG_SOURCES})
+endif()
+target_include_directories(pixbufloader-svg
+    PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}"
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+target_compile_definitions(pixbufloader-svg PRIVATE
+    -DRSVG_COMPILATION
+    -D_CRT_SECURE_NO_WARNINGS
+    -DSRCDIR=""
+    -DGDK_PIXBUF_ENABLE_BACKEND
+    -DG_LOG_DOMAIN="libpixbufloader-svg"
+)
+target_link_libraries(pixbufloader-svg
+    PRIVATE
+        ${LIBRSVG_TARGET}
+        PkgConfig::GDK_PIXBUF
+)
+if (BUILD_SHARED_LIBS)
+    install(TARGETS pixbufloader-svg
+        RUNTIME DESTINATION "${GDK_PIXBUF_MODULEDIR}"
+        LIBRARY DESTINATION "${GDK_PIXBUF_MODULEDIR}"
+    )
+else()
+    install(TARGETS pixbufloader-svg
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+    )
+endif()
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/librsvg.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" @ONLY)
+file(READ "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" librsvg_pc)
+list(JOIN librsvg_pc_requires_private " " requires_private)
+string(REPLACE "Requires.private:" "Requires.private: ${requires_private}" librsvg_pc "${librsvg_pc}")
+if (NOT BUILD_SHARED_LIBS)
+    string(REPLACE "-lm" "-lpixbufloader-svg -lm" librsvg_pc "${librsvg_pc}")
+endif()
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" "${librsvg_pc}")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/librsvg.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" RENAME "librsvg-${RSVG_API_VERSION}.pc")

--- a/3rdParty/vcpkg_ports/ports/librsvg/config.h.linux
+++ b/3rdParty/vcpkg_ports/ports/librsvg/config.h.linux
@@ -1,0 +1,89 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define if building universal (internal helper macro) */
+/* #undef AC_APPLE_UNIVERSAL_BUILD */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define if your <locale.h> file defines LC_MESSAGES. */
+#define HAVE_LC_MESSAGES 1
+
+/* Define to 1 if you have the <locale.h> header file. */
+#define HAVE_LOCALE_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Have the pangoft2 library */
+#define HAVE_PANGOFT2 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strtok_r' function. */
+#define HAVE_STRTOK_R 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "librsvg"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://bugzilla.gnome.org/enter_bug.cgi?product=librsvg"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "RSVG"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "RSVG 2.40.20"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "librsvg"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "2.40.20"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Version number of package */
+#define VERSION "2.40.20"
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+/* #  undef WORDS_BIGENDIAN */
+# endif
+#endif

--- a/3rdParty/vcpkg_ports/ports/librsvg/fix_io_svg_for_static_build.patch
+++ b/3rdParty/vcpkg_ports/ports/librsvg/fix_io_svg_for_static_build.patch
@@ -1,0 +1,43 @@
+diff --git a/gdk-pixbuf-loader/io-svg.c b/gdk-pixbuf-loader/io-svg.c
+index bcdfd0bb..4e8ede6d 100644
+--- a/gdk-pixbuf-loader/io-svg.c
++++ b/gdk-pixbuf-loader/io-svg.c
+@@ -43,8 +43,8 @@ typedef struct {
+         gpointer                    user_data;
+ } SvgContext;
+ 
+-G_MODULE_EXPORT void fill_vtable (GdkPixbufModule *module);
+-G_MODULE_EXPORT void fill_info (GdkPixbufFormat *info);
++// G_MODULE_EXPORT void fill_vtable (GdkPixbufModule *module);
++// G_MODULE_EXPORT void fill_info (GdkPixbufFormat *info);
+ 
+ enum {
+         ERROR_WRITING = 1,
+@@ -173,17 +173,23 @@ gdk_pixbuf__svg_image_stop_load (gpointer data, GError **error)
+         return result;
+ }
+ 
+-void
+-fill_vtable (GdkPixbufModule *module)
++#ifdef BUILD_SHARED_LIBS
++#define MODULE_ENTRY(function) G_MODULE_EXPORT void function
++#else
++#define MODULE_ENTRY(function) void _gdk_pixbuf__svg_ ## function
++#endif
++
++MODULE_ENTRY (fill_vtable) (GdkPixbufModule *module)
+ {
++        if (module == NULL) return;
+         module->begin_load     = gdk_pixbuf__svg_image_begin_load;
+         module->stop_load      = gdk_pixbuf__svg_image_stop_load;
+         module->load_increment = gdk_pixbuf__svg_image_load_increment;
+ }
+ 
+-void
+-fill_info (GdkPixbufFormat *info)
++MODULE_ENTRY (fill_info) (GdkPixbufFormat *info)
+ {
++        if (info == NULL) return;
+         static const GdkPixbufModulePattern signature[] = {
+                 {  " <svg",  "*    ", 100 },
+                 {  " <!DOCTYPE svg",  "*             ", 100 },

--- a/3rdParty/vcpkg_ports/ports/librsvg/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/librsvg/portfile.cmake
@@ -1,0 +1,42 @@
+# port update requires rust/cargo
+
+string(REGEX REPLACE "^([0-9]*[.][0-9]*)[.].*" "\\1" MAJOR_MINOR "${VERSION}")
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gnome.org/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
+         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
+    FILENAME "librsvg-${VERSION}.tar.xz"
+    SHA512 cdd8224deb4c3786e29f48ed02c32ed9dff5cb15aba574a5ef845801ad3669cfcc3eedb9d359c22213dc7a29de24c363248825adad5877c40abf73b3688ff12f
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        fix_io_svg_for_static_build.patch
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" "${CMAKE_CURRENT_LIST_DIR}/config.h.linux" DESTINATION "${SOURCE_PATH}")
+
+vcpkg_find_acquire_program(PKGCONFIG)
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+    file(GLOB_RECURSE pc_files "${CURRENT_PACKAGES_DIR}/*.pc")
+    foreach(pc_file IN LISTS pc_files)
+        vcpkg_replace_string("${pc_file}" " -lm" "")
+    endforeach()
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(COPY "${CURRENT_PORT_DIR}/unofficial-librsvg-config.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-librsvg")
+file(COPY "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/librsvg/unofficial-librsvg-config.cmake
+++ b/3rdParty/vcpkg_ports/ports/librsvg/unofficial-librsvg-config.cmake
@@ -1,0 +1,14 @@
+file(READ "${CMAKE_CURRENT_LIST_DIR}/../librsvg/usage" usage)
+message(WARNING "find_package(unofficial-librsvg) is deprecated.\n${usage}")
+
+include(CMakeFindDependencyMacro)
+find_dependency(PkgConfig)
+pkg_check_modules(VCPKG_LIBRSVG librsvg-2.0 IMPORTED_TARGET)
+if(NOT VCPKG_LIBRSVG_FOUND)
+    set(${CMAKE_FIND_PACKAGE_NAME}_FOUND 0)
+elseif(NOT TARGET unofficial::librsvg::rsvg-2)
+    add_library(unofficial::librsvg::rsvg-2 INTERFACE IMPORTED)
+    set_target_properties(unofficial::librsvg::rsvg-2 PROPERTIES
+        INTERFACE_LINK_LIBRARIES PkgConfig::VCPKG_LIBRSVG
+    )
+endif()

--- a/3rdParty/vcpkg_ports/ports/librsvg/usage
+++ b/3rdParty/vcpkg_ports/ports/librsvg/usage
@@ -1,0 +1,5 @@
+librsvg can be imported via CMake FindPkgConfig module:
+
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBRSVG librsvg-2.0 IMPORTED_TARGET REQUIRED)
+    target_link_libraries(main PRIVATE PkgConfig::LIBRSVG)

--- a/3rdParty/vcpkg_ports/ports/librsvg/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/librsvg/vcpkg.json
@@ -1,0 +1,24 @@
+{
+  "name": "librsvg",
+  "version": "2.40.20",
+  "port-version": 11,
+  "description": "A small library to render Scalable Vector Graphics (SVG)",
+  "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
+  "license": "LGPL-2.0-or-later",
+  "dependencies": [
+    "cairo",
+    "fontconfig",
+    "gdk-pixbuf",
+    "glib",
+    "libcroco",
+    {
+      "name": "libxml2",
+      "default-features": false
+    },
+    "pango",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    }
+  ]
+}

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -69,7 +69,33 @@ BEGIN_EVENT_TABLE (CBOINCGUIApp, wxApp)
 #endif
 END_EVENT_TABLE ()
 
+#if defined(__WXGTK__) && defined(BUILD_WITH_VCPKG)
+extern "C" {
+    void _gdk_pixbuf__svg_fill_info (void*);
+    void _gdk_pixbuf__svg_fill_vtable (void*);
+    unsigned int rsvg_error_quark (void);
+    void rsvg_handle_get_pixbuf (void*);
+}
+
+typedef void (*GdkPixbufFillInfo) (void*);
+typedef void (*GdkPixbufFillVtable) (void*);
+typedef unsigned int (*RsvgErrorQuark) (void);
+typedef void (*RsvgHandleGetPixbuf) (void*);
+#endif
+
 bool CBOINCGUIApp::OnInit() {
+#if defined(__WXGTK__) && defined(BUILD_WITH_VCPKG)
+    try {
+        GdkPixbufFillInfo fi = _gdk_pixbuf__svg_fill_info;
+        GdkPixbufFillVtable fv = _gdk_pixbuf__svg_fill_vtable;
+        RsvgErrorQuark eq = rsvg_error_quark;
+        RsvgHandleGetPixbuf hp = rsvg_handle_get_pixbuf;
+        fi(NULL);
+        fv(NULL);
+        eq();
+        hp(NULL);
+    } catch (...) {}
+#endif
     // Initialize globals
 #ifdef SANDBOX
     g_use_sandbox = true;

--- a/linux/ci_configure_manager.sh
+++ b/linux/ci_configure_manager.sh
@@ -50,4 +50,4 @@ linux/update_vcpkg_manager.sh
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 
-./configure --enable-vcpkg --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0" GTK_LIBS="$(pkg-config --libs gtk+-3.0)" $exec_prefix
+./configure --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0)" $exec_prefix


### PR DESCRIPTION
When BOINC for Linux is built with vcpkg, and links all the dependencies statically, gdk-pixbuf cannot load dynamically loaded modules (like SVG loader) during runtime. To fix thism we need to modify gdk-pixbuf in a way that it uses librsvg as a built-in format. However, librsvg internally requires gdk-pixbuf during build stage, that makes a circular dependency. To avoid this, we have to include necessary librsvg symbols into boincmgr binary manually and do some dummy calls to them to force linker to include them into the final binary.

This fixes: #5563.
