### PR TITLE
boinccmd: clarify old tasks output

### DIFF
--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -502,8 +502,8 @@ void OLD_RESULT::print() {
         "   app name: %s\n"
         "   exit status: %d\n"
         "   elapsed time: %f sec\n"
-        "   completed time: %s\n"
-        "   reported time: %s\n",
+        "   task completed: %s\n"
+        "   acked by project: %s\n",
         result_name,
         project_url,
         app_name,


### PR DESCRIPTION
Instead of 'reported time:', say 'acked by project:', which is more or less accurate.

Fixes #2268
