### PR TITLE
server status page: show remote scheduler correctly

### DIFF
--- a/html/user/server_status.php
+++ b/html/user/server_status.php
@@ -356,17 +356,13 @@ function get_daemon_status() {
         $have_remote = true;
     }
 
-    // Scheduler is a daemon too
-    //
-    if ($sched_host == $main_host) {
-        $y = new StdClass;
-        $y->cmd = "Scheduler";
-        $y->host = $sched_host;
-        $y->status = !file_exists("../../stop_sched");;
-        $local_daemons[] = $y;
-    } else {
-        $have_remote = true;
-    }
+    // the scheduler is a CGI program, not a daemon;
+    // it doesn't have a PID.
+    $y = new StdClass;
+    $y->cmd = "Scheduler";
+    $y->host = $sched_host;
+    $y->status = !file_exists("../../stop_sched");;
+    $local_daemons[] = $y;
 
     foreach ($daemons->daemon as $d) {
         if ((int)$d->disabled != 0) {


### PR DESCRIPTION
The scheduler is a CGI program, not a daemon; it doesn't have a PID file.
So the only way we can see if it's 'running'
is to check the 'stop_sched' trigger file.
Do this whether the scheduler is local or remote.

Fixes #2209