### PR TITLE
fix email address checks

### DIFF
--- a/html/inc/email.inc
+++ b/html/inc/email.inc
@@ -145,27 +145,39 @@ Note:  Your password will need to be recovered after clicking this link";
     return send_email($user, $subject, $body_new) && send_email($user, $subject, $body_old, null, $user->previous_email_addr);
 }
 
-// a valid email address is of the form A@B.C
-// where A, B, C are nonempty,
-// A and B don't contain @ or .,
-// and C doesn't contain @ and is at least 2 chars
+// return true if the email address
+// - is syntactically valid according to filter_var()
+// - if configured, is OK with stopforumspam.com
 //
-function is_valid_email_addr($addr) {
-    if (defined("USE_STOPFORUMSPAM") && USE_STOPFORUMSPAM && array_key_exists('REMOTE_ADDR', $_SERVER)) {
+function is_valid_email_sfs($addr) {
+    if (!defined("USE_STOPFORUMSPAM")) return true;
+    if (!USE_STOPFORUMSPAM) return true;
+    $ip = '';
+    if (array_key_exists('REMOTE_ADDR', $_SERVER)) {
         $ip = $_SERVER['REMOTE_ADDR'];
-        // For obviously private IPs check just the email against SFS, otherwise check both IP and email
-        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-            $x = @file_get_contents("https://www.stopforumspam.com/api?ip=".$ip."&email=".$addr);
-        } else {
-            $x = @file_get_contents("https://www.stopforumspam.com/api?email=".$addr);
-        }
-        if (substr_count($x, '<appears>yes</appears>')) {
-            return false;
-        }
     }
-    $pattern = '/^([^@]+)@([^@\.]+)\.([^@]{2,})$/';
-    $match = preg_match($pattern, $addr);
-    return (bool) $match;
+    // For obviously private IPs check just the email against SFS,
+    // otherwise check both IP and email
+    if ($ip && filter_var(
+        $ip, FILTER_VALIDATE_IP,
+        FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+    )) {
+        $x = @file_get_contents("https://www.stopforumspam.com/api?ip=".$ip."&email=".$addr);
+    } else {
+        $x = @file_get_contents("https://www.stopforumspam.com/api?email=".$addr);
+    }
+    // could also look at 'frequency' and 'lastseen'
+    // see https://www.stopforumspam.com/usage
+    //
+    if (substr_count($x, '<appears>yes</appears>')) {
+        error_log("stopforumspam.com rejected email $addr, IP $ip");
+        return false;
+    }
+    return true;
+}
+
+function is_valid_email_syntax($addr) {
+    return filter_var($addr, FILTER_VALIDATE_EMAIL);
 }
 
 function send_confirm_delete_email($user) {

--- a/html/inc/user_util.inc
+++ b/html/inc/user_util.inc
@@ -110,7 +110,8 @@ function make_user(
     $email_addr, $name, $passwd_hash,
     $country=null, $postal_code=null, $project_prefs=null, $teamid=0
 ) {
-    if (!is_valid_email_addr($email_addr)) return null;
+    if (!is_valid_email_syntax($email_addr)) return null;
+        // caller generally has already checked
     if (is_banned_email_addr($email_addr)) return null;
 
     $authenticator = random_string();
@@ -251,13 +252,18 @@ function validate_post_make_user() {
     }
 
     $new_email_addr = strtolower(post_str("new_email_addr"));
-    if (!is_valid_email_addr($new_email_addr)) {
+    if (!is_valid_email_syntax($new_email_addr)) {
         show_error(tra("Invalid email address: please enter a valid address of the form name@xxx.yyy"));
     }
+    if (!is_valid_email_sfs($new_email_addr)) {
+        show_error("$new_email_addr was flagged by stopforumspam.com");
+    }
+
     $user = BoincUser::lookup_email_addr($new_email_addr);
     if ($user) {
         show_error(tra("There's already an account with that email address."));
     }
+
     $tmpuser = BoincUser::lookup_prev_email_addr($new_email_addr);
     if ($tmpuser) {
         show_error(tra("There's already an account with that email address."));

--- a/html/ops/mass_email_script.php
+++ b/html/ops/mass_email_script.php
@@ -189,7 +189,7 @@ function mail_type($user, $email_file) {
         echo $text;
     }
     if ($globals->send) {
-        if (is_valid_email_addr($user->email_addr)) {
+        if (is_valid_email_syntax($user->email_addr)) {
             send_email(
                 $user,
                 $email_file['subject'],

--- a/html/user/am_set_info.php
+++ b/html/user/am_set_info.php
@@ -159,8 +159,11 @@ if ($email_addr && $email_addr != $user->email_addr) {
         xml_error(ERR_BAD_EMAIL_ADDR, "Email address was changed within the past 7 days, please look for an email to $user->previous_email_addr if this email change is incorrect.");
     }
 
-    if (!is_valid_email_addr($email_addr)) {
+    if (!is_valid_email_syntax($email_addr)) {
         xml_error(ERR_BAD_EMAIL_ADDR, "Invalid email address");
+    }
+    if (!is_valid_email_sfs($email_addr)) {
+        xml_error(ERR_BAD_EMAIL_ADDR, "email address flagged by stopforumspam.com");
     }
     if (is_banned_email_addr($email_addr)) {
         xml_error(ERR_BAD_EMAIL_ADDR, "Invalid email address");

--- a/html/user/create_account.php
+++ b/html/user/create_account.php
@@ -71,10 +71,12 @@ if (!is_valid_user_name($user_name, $reason)) {
     xml_error(ERR_BAD_USER_NAME, $reason);
 }
 
-if (!is_valid_email_addr($email_addr)) {
+if (!is_valid_email_syntax($email_addr)) {
     xml_error(ERR_BAD_EMAIL_ADDR);
 }
-
+if (!is_valid_email_sfs($email_addr)) {
+    xml_error(ERR_BAD_EMAIL_ADDR, 'flagged by stopforumspam.com');
+}
 if (is_banned_email_addr($email_addr)) {
     xml_error(ERR_BAD_EMAIL_ADDR);
 }

--- a/html/user/edit_email_action.php
+++ b/html/user/edit_email_action.php
@@ -36,10 +36,12 @@ $passwd = post_str("passwd", true);
 
 page_head(tra("Change email address of account"));
 
-if (!is_valid_email_addr($email_addr)) {
+if (!is_valid_email_syntax($email_addr)) {
     echo tra("New email address '%1' is invalid.", $email_addr);
+} else if (!is_valid_email_sfs($email_addr)) {
+    echo tra("Email address '%1' is flagged by stopforumspam.com.", $email_addr);
 } else if (is_banned_email_addr($email_addr)) {
-    echo tra("New email address '%1' is invalid.", $email_addr);
+    echo tra("New email address '%1' is banned.", $email_addr);
 } else if ($email_addr == $user->email_addr) {
     echo tra("New email address is same as existing address. Nothing is changed.");
 } else if ($user->email_addr_change_time + 604800 > time()) {

--- a/html/user/edit_email_form.php
+++ b/html/user/edit_email_form.php
@@ -28,7 +28,7 @@ echo tra("Note: if you change your email address, your %1weak account key%2 will
 echo "<p>";
 
 $email_text = "";
-if (is_valid_email_addr($user->email_addr)) {
+if (is_valid_email_syntax($user->email_addr)) {
     $email_text = $user->email_addr;
 }
 

--- a/html/user/login_action.php
+++ b/html/user/login_action.php
@@ -191,7 +191,7 @@ if ($email_addr) {
 }
 $passwd = post_str("passwd", true);
 if ($email_addr && $passwd) {
-    if (LDAP_HOST && !is_valid_email_addr($email_addr)) {
+    if (LDAP_HOST && !is_valid_email_syntax($email_addr)) {
         login_with_ldap($email_addr, $passwd, $next_url, $perm);
     } else {
         login_with_email($email_addr, $passwd, $next_url, $perm);

--- a/html/user/openid_login.php
+++ b/html/user/openid_login.php
@@ -104,7 +104,7 @@ try {
         }
         $new_email_addr = $data['contact/email'];
         $new_email_addr = strtolower($new_email_addr);
-        if (!is_valid_email_addr($new_email_addr)) {
+        if (!is_valid_email_syntax($new_email_addr)) {
             show_error("Invalid email address:
                 you must enter a valid address of the form
                 name@domain"


### PR DESCRIPTION
There are two types of email address check:
1) syntax check
2) stopforumspam.com (SFS) check: enabled by USE_STOPFORUMSPAM in project.inc

- Separate these.  Sometimes it's appropriate to use just syntax check.
    When we do use SFS check, and the email is flagged,
    we should tell the user what happened;
    maybe they're incorrectly in the SFS DB.
- use PHP's filter_var() for the syntax check,
    rather than our own funky regexp.

Fixes #1828