### PR TITLE
web: facilitate unsubscription

### DIFF
--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -170,9 +170,9 @@ function show_forum_header($user) {
     ";
 }
 
-// Output the forum/thread title.
+// return forum/thread title, with links.
 //
-function show_forum_title($category, $forum, $thread, $link_thread=false) {
+function forum_title($category, $forum, $thread, $link_thread=false) {
     if ($category) {
         $is_helpdesk = $category->is_helpdesk;
     } else {
@@ -182,50 +182,57 @@ function show_forum_title($category, $forum, $thread, $link_thread=false) {
     $where = $is_helpdesk?tra("Questions and Answers"):tra("Message boards");
     $top_url = $is_helpdesk?"forum_help_desk.php":"forum_index.php";
 
+    $x = '';
     if (!$forum && !$thread) {
-        echo "<span class=\"title\">$where</span>\n";
-
+        $x .= $where;
     } else if ($forum && !$thread) {
-        echo "<span class=title>";
-        echo "<a href=\"$top_url\">$where</a> : ";
-        echo $forum->title;
-        echo "</span>";
+        $x .= sprintf('<a href="%s">%s</a> : %s',
+            $top_url,
+            $where,
+            $forum->title
+        );
     } else if ($forum && $thread) {
-        echo "<span class=title>
-            <a href=\"$top_url\">$where</a> :
-            <a href=\"forum_forum.php?id=".$forum->id."\">", $forum->title, "</a> :
-        ";
+        $x .= sprintf('<a href="%s">%s</a> :',
+            $top_url,
+            $where
+        );
+        $x .= sprintf('<a href="forum_forum.php?id=%d">%s</a> :',
+            $forum->id,
+            $forum->title
+        );
         if ($link_thread) {
-            echo "<a href=forum_thread.php?id=$thread->id>";
+            $x .= sprintf('<a href=forum_thread.php?id=%d>%s</a>',
+                $thread->id,
+                cleanup_title($thread->title)
+            );
+        } else {
+            $x .= cleanup_title($thread->title);
         }
-        echo cleanup_title($thread->title);
-        if ($link_thread) {
-            echo "</a>";
-        }
-        echo "</span>";
     } else {
-        echo "Invalid thread ID";
+        $x = "Invalid thread ID";
     }
+    return $x;
 }
 
-function show_team_forum_title($forum, $thread=null, $link_thread=false) {
+function team_forum_title($forum, $thread=null, $link_thread=false) {
     $team = BoincTeam::lookup_id($forum->category);
-    echo "<span class=title>
-        <a href=\"forum_index.php\">".tra("Message boards")."</a> :
-    ";
+    $x = sprintf('<a href="forum_index.php">%s</a> :',
+        tra("Message boards")
+    );
     if ($thread) {
-        echo "
-            <a href=team_forum.php?teamid=$team->id>".tra("%1 message board", $team->name)."</a>
-        ";
+        $x .= sprintf('<a href=team_forum.php?teamid=%d>%s</a>',
+            $team->id,
+            tra("%1 message board", $team->name)
+        );
         if ($link_thread) {
-            echo " : <a href=forum_thread.php?id=$thread->id>$thread->title</a>";
+            $x .= " : <a href=forum_thread.php?id=$thread->id>$thread->title</a>";
         } else {
-            echo " : $thread->title";
+            $x .= " : $thread->title";
         }
     } else {
-        echo tra("%1 message board", $team->name);
+        $x .= tra("%1 message board", $team->name);
     }
-    echo "</span>";
+    return $x;
 }
 
 // start a table of forum posts
@@ -782,10 +789,10 @@ function show_post_and_context($post, $thread, $forum, $options, $n) {
     switch ($forum->parent_type) {
     case 0:
         $category = BoincCategory::lookup_id($forum->category);
-        show_forum_title($category, $forum, $thread, true);
+        echo forum_title($category, $forum, $thread, true);
         break;
     case 1:
-        show_team_forum_title($forum);
+        echo team_forum_title($forum);
         break;
     }
     echo "
@@ -1349,43 +1356,63 @@ function is_moderator($user, $forum=null) {
     return false;
 }
 
-function show_thread_and_context_header() {
-    start_table('table-striped');
-    row_heading_array(array(
-        tra("Thread"),
-        tra("Posts"),
-        tra("Author"),
-        tra("Views"),
-        "<nobr>".tra("Last post")."</nobr>"
-    ));
+function thread_list_header($subscriptions=false) {
+    if ($subscriptions) {
+        $x = [
+            tra("Thread"),
+            tra("Author"),
+            "<nobr>".tra("Last post")."</nobr>",
+            'Unsubscribe'
+        ];
+    } else {
+        $x = [
+            tra("Thread"),
+            tra("Posts"),
+            tra("Author"),
+            tra("Views"),
+            "<nobr>".tra("Last post")."</nobr>"
+        ];
+    }
+    row_heading_array($x);
 }
 
 // show a 1-line summary of thread and its forum.
 // Used for search results and subscription list
 //
-function show_thread_and_context($thread, $user) {
+function thread_list_item($thread, $user, $subscriptions=false) {
     $thread_forum = BoincForum::lookup_id($thread->forum);
     if (!$thread_forum) return;
     if (!is_forum_visible_to_user($thread_forum, $user)) return;
     $owner = BoincUser::lookup_id($thread->owner);
     if (!$owner) return;
-    echo "<tr><td>\n";
     switch($thread_forum->parent_type) {
     case 0:
         $category = BoincCategory::lookup_id($thread_forum->category);
-        show_forum_title($category, $thread_forum, $thread, true);
+        $title = forum_title($category, $thread_forum, $thread, true);
         break;
     case 1:
-        show_team_forum_title($thread_forum, $thread);
+        $title = team_forum_title($thread_forum, $thread);
         break;
+    default:
+        $title = '???';
     }
-    echo '
-        </td><td class="numbers">'.($thread->replies+1).'</td>
-        <td>'.user_links($owner).'</td>
-        <td class="numbers">'.$thread->views.'</td>
-        <td class="lastpost">'.time_diff_str($thread->timestamp, time()).'</td>
-        </tr>
-    ';
+    if ($subscriptions) {
+        $x = [
+            $title,
+            user_links($owner),
+            time_diff_str($thread->timestamp, time()),
+            "<input type=checkbox name=unsub_thread_$thread->id>"
+        ];
+    } else {
+        $x = [
+            $title,
+            $thread->replies+1,
+            user_links($owner),
+            $thread->views,
+            time_diff_str($thread->timestamp, time())
+        ];
+    }
+    row_array($x);
 }
 
 // see if ID is in subscription list

--- a/html/user/forum_edit.php
+++ b/html/user/forum_edit.php
@@ -95,10 +95,10 @@ show_forum_header($logged_in_user);
 switch ($forum->parent_type) {
 case 0:
     $category = BoincCategory::lookup_id($forum->category);
-    show_forum_title($category, $forum, $thread);
+    echo forum_title($category, $forum, $thread);
     break;
 case 1:
-    show_team_forum_title($forum, $thread);
+    echo team_forum_title($forum, $thread);
     break;
 }
 

--- a/html/user/forum_forum.php
+++ b/html/user/forum_forum.php
@@ -74,14 +74,14 @@ function forum_page($forum, $user, $msg=null) {
         }
         if ($msg) echo "<p>$msg</p>\n";
         show_forum_header($user);
-        show_forum_title($category, $forum, NULL);
+        echo forum_title($category, $forum, NULL);
         break;
     case 1:
         $team = BoincTeam::lookup_id($forum->category);
         page_head(tra("Team message board for %1", $team->name));
         if ($msg) echo "<p>$msg</p>\n";
         show_forum_header($user);
-        show_team_forum_title($forum);
+        echo team_forum_title($forum);
         break;
     }
 

--- a/html/user/forum_help_desk.php
+++ b/html/user/forum_help_desk.php
@@ -39,7 +39,7 @@ $first = true;
 foreach ($categories as $category) {
     if ($first) {
         $first = false;
-        show_forum_title($category, null, null);
+        echo forum_title($category, null, null);
         echo "<p>";
         show_mark_as_read_button($user);
         start_table('table-striped');

--- a/html/user/forum_index.php
+++ b/html/user/forum_index.php
@@ -23,15 +23,6 @@ require_once('../inc/forum.inc');
 require_once('../inc/pm.inc');
 require_once('../inc/time.inc');
 
-check_get_args(array("read", "return", "tnow", "ttok"));
-
-$user = get_logged_in_user(false);
-BoincForumPrefs::lookup($user);
-
-if (DISABLE_FORUMS && !is_admin($user)) {
-    error_page("Forums are disabled");
-}
-
 // Process request to mark all posts as read
 //
 if ((get_int("read", true) == 1)) {
@@ -69,79 +60,151 @@ function show_forum_summary($forum) {
     </tr>";
 }
 
-page_head(tra("Message boards"));
+function main($user) {
+    page_head(tra("Message boards"));
 
-show_forum_header($user);
+    show_forum_header($user);
 
-if (defined('FORUM_QA_MERGED_MODE') && FORUM_QA_MERGED_MODE){
-    $categories = BoincCategory::enum("true order by orderID");
-} else {
-    echo "<p>"
-        .tra("If you have a question or problem, please use the %1 Questions & Answers %2 section of the message boards.", "<a href=\"forum_help_desk.php\">", "</a>")
-        ."</p>"
-    ;
-    $categories = BoincCategory::enum("is_helpdesk=0 order by orderID");
-}
-$first = true;
-foreach ($categories as $category) {
-    if ($first) {
-        $first = false;
-        echo "<p>";
-        show_forum_title($category, NULL, NULL);
-        echo "<p>";
-        show_mark_as_read_button($user);
-        start_table('table-striped');
-        row_heading_array(
-            array(
-                tra("Topic"),
-                tra("Threads"),
-                tra("Posts"),
-                tra("Last post")
-            ),
-            array("width=30%", "", "", "")
-        );
+    if (defined('FORUM_QA_MERGED_MODE') && FORUM_QA_MERGED_MODE){
+        $categories = BoincCategory::enum("true order by orderID");
+    } else {
+        echo "<p>"
+            .tra("If you have a question or problem, please use the %1 Questions & Answers %2 section of the message boards.", "<a href=\"forum_help_desk.php\">", "</a>")
+            ."</p>"
+        ;
+        $categories = BoincCategory::enum("is_helpdesk=0 order by orderID");
     }
-    if (strlen($category->name)) {
-        echo '
-            <tr>
-            <th class="info" colspan="4">'.$category->name.'</th>
-            </tr>
-        ';
-    }
-    $forums = BoincForum::enum("parent_type=0 and category=$category->id order by orderID");
-    foreach ($forums as $forum) {
-        show_forum_summary($forum);
-    }
-}
-
-if ($user && $user->teamid) {
-    $forum = BoincForum::lookup("parent_type=1 and category=$user->teamid");
-    if ($forum) {
-        show_forum_summary($forum);
-    }
-}
-end_table();
-
-if ($user) {
-    $subs = BoincSubscription::enum("userid=$user->id");
-    if (count($subs)) {
-        echo "<p><h3>".tra("Subscribed threads")."</h3><p>";
-        show_thread_and_context_header();
-        foreach ($subs as $sub) {
-            $thread = BoincThread::lookup_id($sub->threadid);
-            if (!$thread) {
-                BoincSubscription::delete($user->id, $sub->threadid);
-                continue;
-            }
-            if ($thread->hidden) continue;
-            show_thread_and_context($thread, $user);
+    $first = true;
+    foreach ($categories as $category) {
+        if ($first) {
+            $first = false;
+            echo "<p>";
+            echo forum_title($category, NULL, NULL);
+            echo "<p>";
+            show_mark_as_read_button($user);
+            start_table('table-striped');
+            row_heading_array(
+                array(
+                    tra("Forum"),
+                    tra("Threads"),
+                    tra("Posts"),
+                    tra("Last post")
+                ),
+                array("width=30%", "", "", "")
+            );
         }
-        end_table();
+        if (strlen($category->name)) {
+            echo '
+                <tr>
+                <th class="info" colspan="4">'.$category->name.'</th>
+                </tr>
+            ';
+        }
+        $forums = BoincForum::enum("parent_type=0 and category=$category->id order by orderID");
+        foreach ($forums as $forum) {
+            show_forum_summary($forum);
+        }
     }
+
+    if ($user && $user->teamid) {
+        $forum = BoincForum::lookup("parent_type=1 and category=$user->teamid");
+        if ($forum) {
+            show_forum_summary($forum);
+        }
+    }
+    end_table();
+
+    // show user's subscriptions (threads and forums)
+
+    if ($user) {
+        $subs = BoincSubscription::enum("userid=$user->id");
+        $thread_subs = [];
+        $forum_subs = [];
+        foreach ($subs as $sub) {
+            if ($sub->threadid > 0) {
+                $thread_subs[] = $sub;
+            } else {
+                $forum_subs[] = $sub;
+            }
+        }
+        if (count($subs)) {
+            echo '<form action=forum_index.php method=post>
+                <input type=hidden name=action value=unsub>
+            ';
+            echo "<p><h3>".tra("Subscriptions")."</h3><p>";
+            start_table('table-striped');
+        }
+        if (count($thread_subs)) {
+            thread_list_header(true);
+            foreach ($thread_subs as $sub) {
+                $thread = BoincThread::lookup_id($sub->threadid);
+                if (!$thread) {
+                    BoincSubscription::delete($user->id, $sub->threadid);
+                    continue;
+                }
+                if ($thread->hidden) continue;
+                thread_list_item($thread, $user, true);
+            }
+        }
+        if (count($forum_subs)) {
+            row_heading_array([
+                'Forum', '', 'Last post', 'Unsubscribe'
+            ]);
+            foreach ($forum_subs as $sub) {
+                $id = -$sub->threadid;
+                $forum = BoincForum::lookup_id($id);
+                if (!$forum) {
+                    BoincSubscription::delete($user->id, $sub->threadid);
+                    continue;
+                }
+                row_array([
+                    "$forum->title<br><small>$forum->description</small>",
+                    '',
+                    time_diff_str($forum->timestamp, time()),
+                    "<input type=checkbox name=unsub_forum_$id>"
+                ]);
+            }
+        }
+        if (count($subs)) {
+            end_table();
+            echo '
+                <input type=submit name=submit value="Unsubscribe from selected items">
+                </form>
+            ';
+        }
+    }
+
+    page_tail();
+    BoincForumLogging::cleanup();
 }
 
-page_tail();
-BoincForumLogging::cleanup();
+function do_unsubscribe($user) {
+    $subs = BoincSubscription::enum("userid=$user->id");
+    foreach ($subs as $sub) {
+        if ($sub->threadid > 0) {
+            $x = "unsub_thread_$sub->threadid";
+        } else {
+            $x = sprintf('unsub_forum_%d', -$sub->threadid);
+        }
+        if (post_str($x, true)) {
+            BoincSubscription::delete($user->id, $sub->threadid);
+        }
+    }
+    header('Location: forum_index.php');
+}
 
+$user = get_logged_in_user(false);
+BoincForumPrefs::lookup($user);
+
+if (DISABLE_FORUMS && !is_admin($user)) {
+    error_page("Forums are disabled");
+}
+
+$submit = post_str('submit', true);
+if ($submit) {
+    do_unsubscribe($user);
+} else {
+    main($user);
+}
 $cvs_version_tracker[]="\$Id$";  //Generated automatically - do not edit
 ?>

--- a/html/user/forum_post.php
+++ b/html/user/forum_post.php
@@ -88,10 +88,10 @@ if ($warning) {
 switch ($forum->parent_type) {
 case 0:
     $category = BoincCategory::lookup_id($forum->category);
-    show_forum_title($category, $forum, null);
+    echo forum_title($category, $forum, null);
     break;
 case 1:
-    show_team_forum_title($forum);
+    echo team_forum_title($forum);
     break;
 }
 

--- a/html/user/forum_reply.php
+++ b/html/user/forum_reply.php
@@ -102,10 +102,10 @@ if ($warning) {
 switch ($forum->parent_type) {
 case 0:
     $category = BoincCategory::lookup_id($forum->category);
-    show_forum_title($category, $forum, $thread);
+    echo forum_title($category, $forum, $thread);
     break;
 case 1:
-    show_team_forum_title($forum, $thread);
+    echo team_forum_title($forum, $thread);
     break;
 }
 echo "<p>";

--- a/html/user/forum_search_action.php
+++ b/html/user/forum_search_action.php
@@ -175,10 +175,11 @@ $threads = search_thread_titles($search_list, $forum, $user, $min_timestamp, rou
 //
 if (count($threads)){
     echo "<h3>" . tra("Thread titles matching your query:") . "</h3>";
-    show_thread_and_context_header();
+    start_table('table-striped');
+    thread_list_header();
     foreach ($threads as $thread){
         if ($thread->hidden) continue;
-        show_thread_and_context($thread, $logged_in_user);
+        thread_list_item($thread, $logged_in_user);
     }
     end_table();
     echo "<br /><br />";

--- a/html/user/forum_subscribe.php
+++ b/html/user/forum_subscribe.php
@@ -35,10 +35,10 @@ function show_title($forum, $thread) {
     switch ($forum->parent_type) {
     case 0:
         $category = BoincCategory::lookup_id($forum->category);
-        show_forum_title($category, $forum, $thread);
+        echo forum_title($category, $forum, $thread);
         break;
     case 1:
-        show_team_forum_title($forum, $thread);
+        echo team_forum_title($forum, $thread);
         break;
     }
 }

--- a/html/user/forum_thread.php
+++ b/html/user/forum_thread.php
@@ -109,10 +109,10 @@ echo "<p>";
 switch ($forum->parent_type) {
 case 0:
     $category = BoincCategory::lookup_id($forum->category);
-    show_forum_title($category, $forum, $thread);
+    echo forum_title($category, $forum, $thread);
     break;
 case 1:
-    show_team_forum_title($forum, $thread);
+    echo team_forum_title($forum, $thread);
     break;
 }
 echo "<br><small><a href=moderation.php>".tra("Message board moderation")."</a></small>
@@ -306,10 +306,10 @@ if ($reply_url) {
 echo "<p></p>";
 switch ($forum->parent_type) {
 case 0:
-    show_forum_title($category, $forum, $thread);
+    echo forum_title($category, $forum, $thread);
     break;
 case 1:
-    show_team_forum_title($forum, $thread);
+    echo team_forum_title($forum, $thread);
     break;
 }
 


### PR DESCRIPTION
On the main Forums page, show all subscriptions
(to both threads and forums) with checkboxes,
so you can unsubscribe to multiple items at once.

Modernize the forum code here and there.
- Get rid of <span>s - we don't do our own CSS anymore.
- Have functions return strings rather than printing text; it makes them more general.
- Use table_row() etc. instead of printing <td> etc.
- Move code from top level to functions
- start_table() and end_table() always at same code level

Fixes #2595

(though I chose to do this on Forums index page rather than Community Preferences)