### PR TITLE
Missing items for Apple GPU support

### DIFF
--- a/api/boinc_opencl.cpp
+++ b/api/boinc_opencl.cpp
@@ -54,27 +54,23 @@ static int compareBOINCVersionTo(int toMajor, int toMinor, int toRelease);
 //
 int get_vendor(cl_device_id device_id, char* vendor, int len) {
     int retval = 0;
-
+    strlcpy(vendor, "", len);
     retval = clGetDeviceInfo(
         device_id, CL_DEVICE_VENDOR, len, vendor, NULL
     );
     if (retval != CL_SUCCESS) return retval;
     if (!strlen(vendor)) return CL_INVALID_DEVICE_TYPE;
-
     if ((strstr(vendor, "AMD")) ||
         (strstr(vendor, "Advanced Micro Devices, Inc."))
     ) {
         strlcpy(vendor, GPU_TYPE_ATI, len);       // "ATI"
-    }
-
-    if (strcasestr(vendor, "nvidia")) {
+    } else if (strcasestr(vendor, "nvidia")) {
         strlcpy(vendor, GPU_TYPE_NVIDIA, len);    // "NVIDIA"
-    }
-
-    if (strcasestr(vendor, "intel")) {
+    } else if (strcasestr(vendor, "intel")) {
         strlcpy(vendor, GPU_TYPE_INTEL, len);     // "intel_gpu"
+    } else if (strcasestr(vendor, "apple")) {
+        strlcpy(vendor, GPU_TYPE_APPLE, len);     // "intel_gpu"
     }
-
     return 0;
 }
 
@@ -154,8 +150,9 @@ int boinc_get_opencl_ids_aux(
 // This version is compatible with older clients.
 // Usage:
 // Pass the argc and argv received from the BOINC client
-// type: may be PROC_TYPE_NVIDIA_GPU, PROC_TYPE_AMD_GPU or PROC_TYPE_INTEL_GPU
-//       (it may also be 0, but then it will fail on older clients.)
+// type: may be PROC_TYPE_NVIDIA_GPU, PROC_TYPE_AMD_GPU,
+//      PROC_TYPE_INTEL_GPU or PROC_TYPE_APPLE_GPU
+//      (it may also be 0, but then it will fail on older clients.)
 //
 // The argc, argv and type arguments are ignored for 6.13.3 or later clients.
 //
@@ -194,6 +191,9 @@ int boinc_get_opencl_ids(
             break;
         case PROC_TYPE_INTEL_GPU:
             gpu_type = (char *)GPU_TYPE_INTEL;
+            break;
+        case PROC_TYPE_APPLE_GPU:
+            gpu_type = (char *)GPU_TYPE_APPLE;
             break;
         }
     }

--- a/client/project.cpp
+++ b/client/project.cpp
@@ -300,6 +300,8 @@ int PROJECT::parse_state(XML_PARSER& xp) {
             if (btemp) handle_no_rsc_ams(this, "CPU");
             continue;
         }
+
+        // the following 3 deprecated; use no_rsc_ams instead
         if (xp.parse_bool("no_cuda_ams", btemp)) {
             if (btemp) handle_no_rsc_ams(this, GPU_TYPE_NVIDIA);
             continue;
@@ -312,6 +314,7 @@ int PROJECT::parse_state(XML_PARSER& xp) {
             if (btemp) handle_no_rsc_ams(this, GPU_TYPE_INTEL);
             continue;
         }
+
         if (xp.parse_str("no_rsc_ams", buf, sizeof(buf))) {
             handle_no_rsc_ams(this, buf);
             continue;

--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -345,6 +345,12 @@ void CDlgItemProperties::renderInfos(PROJECT* project_in) {
                 project->rsc_desc_intel_gpu
             );
         }
+        if (pDoc->state.host_info.coprocs.have_apple_gpu()) {
+            show_rsc(
+                wxString(proc_type_name(PROC_TYPE_APPLE_GPU), wxConvUTF8),
+                project->rsc_desc_apple_gpu
+            );
+        }
         double dcf = project->duration_correction_factor;
         // if it's exactly 1, it's not being used
         //

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -396,6 +396,10 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
             ignore_gpu_instance[PROC_TYPE_INTEL_GPU].push_back(n);
             continue;
         }
+        if (xp.parse_int("ignore_apple_dev", n)) {
+            ignore_gpu_instance[PROC_TYPE_APPLE_GPU].push_back(n);
+            continue;
+        }
         if (xp.parse_int("max_event_log_lines", max_event_log_lines)) continue;
         if (xp.parse_int("max_file_xfers", max_file_xfers)) continue;
         if (xp.parse_int("max_file_xfers_per_project", max_file_xfers_per_project)) continue;


### PR DESCRIPTION
API: get_vendor() and boinc_get_opencl_ids() were missing Apple case,
    causing missing device IDs
Manager:
    show Apple GPU info in project properties
GUI RPC client: parse <ignore_apple_dev> in client config
    (e.g. so that Manager shows if Apple GPU is ignored)

Fixes #5738