### PR TITLE
client and boinccmd: show some RAM/disk sizes in GB rather than MB

### DIFF
--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -177,8 +177,8 @@ void CLIENT_STATE::get_disk_shares() {
     double greedy_allowed = allowed - non_greedy_ddu;
     if (log_flags.disk_usage_debug) {
         msg_printf(0, MSG_INFO,
-            "[disk_usage] allowed %.2fMB used %.2fMB",
-            allowed/MEGA, total_disk_usage/MEGA
+            "[disk_usage] allowed %.2fGB used %.2fGB",
+            allowed/GIGA, total_disk_usage/GIGA
         );
     }
     for (i=0; i<projects.size(); i++) {
@@ -191,8 +191,8 @@ void CLIENT_STATE::get_disk_shares() {
         }
         if (log_flags.disk_usage_debug) {
             msg_printf(p, MSG_INFO,
-                "[disk_usage] usage %.2fMB share %.2fMB",
-                p->disk_usage/MEGA, p->disk_share/MEGA
+                "[disk_usage] usage %.2fGB share %.2fGB",
+                p->disk_usage/GIGA, p->disk_share/GIGA
             );
         }
     }

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -339,9 +339,9 @@ void COPROC_NVIDIA::description(char* buf, int buflen) {
         safe_strcpy(cuda_vers, "unknown");
     }
     snprintf(buf, buflen,
-        "%s (driver version %s, CUDA version %s, compute capability %d.%d, %.0fMB, %.0fMB available, %.0f GFLOPS peak)",
+        "%s (driver version %s, CUDA version %s, compute capability %d.%d, %.2fGB, %.2fGB available, %.0f GFLOPS peak)",
         prop.name, vers, cuda_vers, prop.major, prop.minor,
-        prop.totalGlobalMem/MEGA, available_ram/MEGA, peak_flops/1e9
+        prop.totalGlobalMem/GIGA, available_ram/GIGA, peak_flops/1e9
     );
 }
 
@@ -852,9 +852,9 @@ int COPROC_ATI::parse(XML_PARSER& xp) {
 
 void COPROC_ATI::description(char* buf, int buflen) {
     snprintf(buf, buflen,
-        "%s (CAL version %s, %uMB, %.0fMB available, %.0f GFLOPS peak)",
-        name, version, attribs.localRAM,
-        available_ram/MEGA, peak_flops/1.e9
+        "%s (CAL version %s, %.2fGB, %.2fGB available, %.0f GFLOPS peak)",
+        name, version, attribs.localRAM/1024.,
+        available_ram/GIGA, peak_flops/1.e9
     );
 }
 

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -72,7 +72,7 @@ void GUI_URL::print() {
 
 void PROJECT::print_disk_usage() {
     printf("   master URL: %s\n", master_url);
-    printf("   disk usage: %.2fMB\n", disk_usage/MEGA);
+    printf("   disk usage: %.2fGB\n", disk_usage/GIGA);
 }
 
 void PROJECT::print() {
@@ -96,7 +96,7 @@ void PROJECT::print() {
     printf("   ended: %s\n", ended?"yes":"no");
     printf("   suspended via GUI: %s\n", suspended_via_gui?"yes":"no");
     printf("   don't request more work: %s\n", dont_request_more_work?"yes":"no");
-    printf("   disk usage: %.2fMB\n", disk_usage/MEGA);
+    printf("   disk usage: %.2fGB\n", disk_usage/GIGA);
     time_t foo = (time_t)last_rpc_time;
     printf("   last RPC: %s\n", ctime(&foo));
     printf("   project files downloaded: %f\n", project_files_downloaded_time);
@@ -441,8 +441,8 @@ void PROJECTS::print_urls() {
 void DISK_USAGE::print() {
     unsigned int i;
     printf("======== Disk usage ========\n");
-    printf("total: %.2fMB\n", d_total/MEGA);
-    printf("free: %.2fMB\n", d_free/MEGA);
+    printf("total: %.2fGB\n", d_total/GIGA);
+    printf("free: %.2fGB\n", d_free/GIGA);
     for (i=0; i<projects.size(); i++) {
         printf("%d) -----------\n", i+1);
         projects[i]->print_disk_usage();

--- a/lib/opencl_boinc.cpp
+++ b/lib/opencl_boinc.cpp
@@ -263,10 +263,10 @@ void OPENCL_DEVICE_PROP::description(char* buf, int buflen, const char* type) {
     n = (int)strlen(s1) - 1;
     if ((n > 0) && (s1[n] == ' ')) s1[n] = '\0';
     snprintf(s2, sizeof(s2),
-        "%.64s (driver version %.64s, device version %.64s, %.0fMB, %.0fMB available, %.0f GFLOPS peak)",
+        "%.64s (driver version %.64s, device version %.64s, %.2fGB, %.2fGB available, %.0f GFLOPS peak)",
         name, opencl_driver_version,
-        s1, global_mem_size/MEGA,
-        opencl_available_ram/MEGA, peak_flops/1.e9
+        s1, global_mem_size/GIGA,
+        opencl_available_ram/GIGA, peak_flops/1.e9
     );
 
     switch(is_used) {


### PR DESCRIPTION
When showing a system size (total RAM or VRAM, disk, swap)
use GB (with %.2f) instead of MB.
When showing the RAM or disk usage of particular job, use MB.

Fixes #4832
