### PR TITLE
server: use correct DB connection in create_work()

### DIFF
--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -377,7 +377,7 @@ int create_work2(
             );
             return retval;
         }
-        wu.id = boinc_db.insert_id();
+        wu.id = wu.db->insert_id();
     }
 
     return 0;


### PR DESCRIPTION
A work generator can create and use its own DB connection.
Fix a bug in create_work() that incorrectly used the boinc_db connection
(which might not even be initialized).

Fixes #4032