### PR TITLE
database: make it work with utf8mb4

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -46,7 +46,7 @@
 create table platform (
     id                      integer         not null auto_increment,
     create_time             integer         not null,
-    name                    varchar(254)    not null,
+    name                    varchar(191)    not null,
     user_friendly_name      varchar(254)    not null,
     deprecated              tinyint         not null default 0,
     primary key (id)
@@ -55,7 +55,7 @@ create table platform (
 create table app (
     id                      integer         not null auto_increment,
     create_time             integer         not null,
-    name                    varchar(254)    not null,
+    name                    varchar(191)    not null,
     min_version             integer         not null default 0,
     deprecated              smallint        not null default 0,
     user_friendly_name      varchar(254)    not null,
@@ -83,7 +83,7 @@ create table app_version (
     min_core_version        integer         not null default 0,
     max_core_version        integer         not null default 0,
     deprecated              tinyint         not null default 0,
-    plan_class              varchar(254)    not null default '',
+    plan_class              varchar(128)    not null default '',
     pfc_n                   double          not null default 0,
     pfc_avg                 double          not null default 0,
     pfc_scale               double          not null default 0,
@@ -96,9 +96,9 @@ create table app_version (
 create table user (
     id                      integer         not null auto_increment,
     create_time             integer         not null,
-    email_addr              varchar(254)    not null,
-    name                    varchar(254),
-    authenticator           varchar(254),
+    email_addr              varchar(191)    not null,
+    name                    varchar(191),
+    authenticator           varchar(191),
     country                 varchar(254),
     postal_code             varchar(254),
     total_credit            double          not null,
@@ -139,7 +139,7 @@ create table team (
     id                      integer         not null auto_increment,
     create_time             integer         not null,
     userid                  integer         not null,
-    name                    varchar(254)    not null,
+    name                    varchar(191)    not null,
     name_lc                 varchar(254),
     url                     varchar(254),
     type                    integer         not null,
@@ -249,7 +249,7 @@ create table workunit (
     id                      integer         not null auto_increment,
     create_time             integer         not null,
     appid                   integer         not null,
-    name                    varchar(254)    not null,
+    name                    varchar(191)    not null,
     xml_doc                 blob,
     batch                   integer         not null,
     rsc_fpops_est           double          not null,
@@ -296,7 +296,7 @@ create table result (
     report_deadline         integer         not null,
     sent_time               integer         not null,
     received_time           integer         not null,
-    name                    varchar(254)    not null,
+    name                    varchar(191)    not null,
     cpu_time                double          not null,
     xml_doc_in              blob,
     xml_doc_out             blob,
@@ -381,7 +381,7 @@ create table user_submit_app (
 --
 create table job_file (
     id                      integer         not null auto_increment,
-    name                    varchar(255)    not null,
+    name                    varchar(191)    not null,
     create_time             double          not null,
     delete_time             double          not null,
     primary key (id)
@@ -456,7 +456,7 @@ create table category (
         -- order in which to display
     lang                    integer         not null,
         -- not used
-    name                    varchar(254) binary,
+    name                    varchar(180)    not null,
     is_helpdesk             smallint        not null,
     primary key (id)
 ) engine=InnoDB;
@@ -469,7 +469,7 @@ create table forum (
         -- ID of entity to which this forum is attached.
         -- The type (table) of the entity is determined by parent_type
     orderID                 integer         not null,
-    title                   varchar(254)    not null,
+    title                   varchar(175)    not null,
     description             varchar(254)    not null,
     timestamp               integer         not null default 0,
         -- time of last new or modified thread or post
@@ -786,7 +786,7 @@ create table credit_team (
 ) engine=InnoDB;
 
 create table token (
-    token                   varchar(255)    not null,
+    token                   varchar(64)     not null,
     userid                  integer         not null,
     type                    char            not null,
     create_time             integer         not null,
@@ -821,7 +821,7 @@ create table consent (
 
 create table consent_type (
     id                      integer         not null auto_increment,
-    shortname               varchar(255)    not null,
+    shortname               varchar(191)    not null,
     description             varchar(255)    not null,
     enabled                 integer         not null,
     project_specific        integer         not null,

--- a/py/Boinc/database.py
+++ b/py/Boinc/database.py
@@ -285,7 +285,7 @@ def create_database(srcdir, config = None, drop_first = False):
     cursor = dbcon.cursor()
     if drop_first:
         cursor.execute("drop database if exists %s"%config.db_name)
-    cursor.execute("create database %s"%config.db_name)
+    cursor.execute("create database %s character set utf8mb4 collate utf8mb4_unicode_ci"%config.db_name)
     cursor.execute("use %s"%config.db_name)
     for file in ['schema.sql', 'constraints.sql', 'content.sql']:
         _execute_sql_script(cursor, os.path.join(srcdir, 'db', file))


### PR DESCRIPTION
Going forward, BOINC databases should use char encoding utf8mb4
and collation utf8mb4-unicode-ci.
Each char can then be up to 4 bytes.
MariaDB/InnoDB has a limit of 767 bytes on index keys.
That means a limit of 191 chars on indexed fields.
Change the size of such fields from 255 to 191
(in some cases less, where indices involve other fields too).

Note: MySQL 8 doesn't have this issue.

make_project: use utf8mb4.

This change does not affect existing projects.

Fixes #4515