### PR TITLE
clarify meaning of DEBUG in C++ code

### DIFF
--- a/api/ttfont.cpp
+++ b/api/ttfont.cpp
@@ -31,6 +31,8 @@
 
 // originally adapted by Carl Christensen
 
+//#define TTFONT_DEBUG
+
 #ifdef _WIN32
 #include "boinc_win.h"
 #endif
@@ -105,8 +107,8 @@ void ttf_load_fonts(
             //g_font[i] = new FTPolygonFont(vpath);
             g_font[i] = new FTTextureFont(vpath);
             if(!g_font[i]->Error()) {
-#ifdef _DEBUG
-               fprintf(stderr, "Successfully loaded '%s'...\n", vpath);
+#ifdef TTFONT_DEBUG
+                fprintf(stderr, "Successfully loaded '%s'...\n", vpath);
 #endif
                 int iScale = 30;
                 if (strScaleFont && !strcmp(strScaleFont, g_cstrFont[i])) iScale = iScaleFont;
@@ -121,7 +123,7 @@ void ttf_load_fonts(
                 g_iFont = i;
 
             }
-#ifdef _DEBUG
+#ifdef TTFONT_DEBUG
             else {
                 fprintf(stderr, "Failed to load '%s'...\n", vpath);
             }

--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -17,6 +17,7 @@
 
 // check_security.C
 
+//#define DEBUG_CHECK_SECURITY
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -83,7 +84,7 @@ int use_sandbox, int isManager, char* path_to_error, int len
     int                 isMacInstaller = 0;
 
     useFakeProjectUserAndGroup = ! use_sandbox;
-#ifdef _DEBUG
+#ifdef DEBUG_CHECK_SECURITY
 #ifdef DEBUG_WITH_FAKE_PROJECT_USER_AND_GROUP
     useFakeProjectUserAndGroup = 1;
 #endif
@@ -107,7 +108,7 @@ int use_sandbox, int isManager, char* path_to_error, int len
         return -1099;
     }
 #endif
-#endif      // _DEBUG
+#endif      // DEBUG_CHECK_SECURITY
 
 // GDB can't attach to applications which are running as a different user or group so
 //  it ignores the S_ISUID and S_ISGID permission bits when launching an application.
@@ -280,7 +281,7 @@ int use_sandbox, int isManager, char* path_to_error, int len
                 snprintf(full_path, sizeof(full_path), "/Library/Screen Savers/%s.saver/Contents/Resources/gfx_switcher", saverName[i]);
                 retval = stat(full_path, &sbuf);
                 if (! retval) {
-#ifdef _DEBUG
+#ifdef DEBUG_CHECK_SECURITY
                     if (sbuf.st_uid != boinc_master_uid)
                         return -1101;
 

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -51,6 +51,8 @@
 using std::string;
 using std::vector;
 
+//#define SHOW_MSGS
+
 RPC_CLIENT::RPC_CLIENT() {
     sock = -1;
     start_time = 0;
@@ -352,7 +354,7 @@ int RPC::do_rpc(const char* req) {
 
     //fprintf(stderr, "RPC::do_rpc rpc_client->sock = '%d'", rpc_client->sock);
     if (rpc_client->sock == -1) return ERR_CONNECT;
-#ifdef DEBUG
+#ifdef SHOW_MSGS
     puts(req);
 #endif
     retval = rpc_client->send_request(req);
@@ -360,7 +362,7 @@ int RPC::do_rpc(const char* req) {
     retval = rpc_client->get_reply(mbuf);
     if (retval) return retval;
     fin.init_buf_read(mbuf);
-#ifdef DEBUG
+#ifdef SHOW_MSGS
     puts(mbuf);
 #endif
     return 0;

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -134,6 +134,7 @@ void APP_VERSION::print() {
 }
 
 void WORKUNIT::print() {
+    printf("   project: %s\n", project->project_name.c_str());
     printf("   name: %s\n", name);
     printf("   FP estimate: %e\n", rsc_fpops_est);
     printf("   FP bound: %e\n", rsc_fpops_bound);
@@ -151,7 +152,11 @@ void WORKUNIT::print() {
 void RESULT::print() {
     printf("   name: %s\n", name);
     printf("   WU name: %s\n", wu_name);
-    printf("   project URL: %s\n", project_url);
+    if (project) {
+        printf("   project: %s\n", project->project_name.c_str());
+    } else {
+        printf("   project URL: %s\n", project_url);
+    }
     time_t foo = (time_t)received_time;
     printf("   received: %s", ctime(&foo));
     foo = (time_t)report_deadline;

--- a/lib/proc_control.cpp
+++ b/lib/proc_control.cpp
@@ -46,9 +46,9 @@
 
 using std::vector;
 
-//#define DEBUG
+//#define DEBUG_PROC_CONTROL
 
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
 #include <stdio.h>
 #endif
 
@@ -74,7 +74,7 @@ void get_descendants(int pid, vector<int>& pids) {
     retval = procinfo_setup(pm);
     if (retval) return;
     get_descendants_aux(pm, pid, pids);
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
     fprintf(stderr, "descendants of %d:\n", pid);
     for (unsigned int i=0; i<pids.size(); i++) {
         fprintf(stderr, "   %d\n", pids[i]);
@@ -107,7 +107,7 @@ int suspend_or_resume_threads(
     DWORD n;
     static vector<DWORD> suspended_threads;
 
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
     fprintf(stderr, "start: check_exempt %d %s\n", check_exempt, precision_time_to_string(dtime()));
     fprintf(stderr, "%s processes", resume?"resume":"suspend");
     for (unsigned int i=0; i<pids.size(); i++) {
@@ -135,12 +135,12 @@ int suspend_or_resume_threads(
 
     do {
         if (check_exempt && !diagnostics_is_thread_exempt_suspend(te.th32ThreadID)) {
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
             fprintf(stderr, "thread is exempt\n");
 #endif
             continue;
         }
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
         fprintf(stderr, "thread %d PID %d %s\n",
             te.th32ThreadID, te.th32OwnerProcessID,
             precision_time_to_string(dtime())
@@ -157,7 +157,7 @@ int suspend_or_resume_threads(
                 te.th32ThreadID
             ) != suspended_threads.end()) {
                 n = ResumeThread(thread);
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
                 fprintf(stderr, "ResumeThread returns %d\n", n);
 #endif
             } else {
@@ -166,7 +166,7 @@ int suspend_or_resume_threads(
         } else {
             n = SuspendThread(thread);
             suspended_threads.push_back(te.th32ThreadID);
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
             fprintf(stderr, "SuspendThread returns %d\n", n);
 #endif
         }
@@ -175,7 +175,7 @@ int suspend_or_resume_threads(
     } while (Thread32Next(threads, &te));
 
     CloseHandle (threads);
-#ifdef DEBUG
+#ifdef DEBUG_PROC_CONTROL
     fprintf(stderr, "end: %s\n", precision_time_to_string(dtime()));
 #endif
     return retval;


### PR DESCRIPTION
I was testing boinc_cmd and was surprised to see that it was
printing the GUI RPC XML messages.
Turned out this was because of a puts(req) conditioned on DEBUG,
which is set (globally) when you configure with --enable-debug.
I looked around and there were several other cases of
very specific debugging printf's enabled by DEBUG.

This isn't the right idea.
A global flag should do global things (like compile with -g).
Use specific #defines (like SHOW_MSGS for GUI RPCs).
