### PR TITLE
[Windows] Detect WSL version of enabled distros.

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -253,11 +253,11 @@ void CLIENT_STATE::show_host_info() {
             const WSL& wsl = host_info.wsls.wsls[i];
             if (wsl.is_default) {
                 msg_printf(NULL, MSG_INFO,
-                    "   [%s] (default): %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
+                    "   [%s] <v%s> (default): %s (%s)", wsl.distro_name.c_str(), wsl.wsl_version.c_str(), wsl.os_name.c_str(), wsl.os_version.c_str()
                 );
             } else {
                 msg_printf(NULL, MSG_INFO,
-                    "   [%s]: %s (%s)", wsl.distro_name.c_str(), wsl.name.c_str(), wsl.version.c_str()
+                    "   [%s] <v%s>: %s (%s)", wsl.distro_name.c_str(), wsl.wsl_version.c_str(), wsl.os_name.c_str(), wsl.os_version.c_str()
                 );
             }
         }

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -23,27 +23,30 @@ WSL::WSL() {
 
 void WSL::clear() {
     distro_name = "";
-    name = "";
-    version = "";
+    os_name = "";
+    os_version = "";
     is_default = false;
+    wsl_version = "1";
 }
 
 void WSL::write_xml(MIOFILE& f) {
     char dn[256], n[256], v[256];
     xml_escape(distro_name.c_str(), dn, sizeof(dn));
-    xml_escape(name.c_str(), n, sizeof(n));
-    xml_escape(version.c_str(), v, sizeof(v));
+    xml_escape(os_name.c_str(), n, sizeof(n));
+    xml_escape(os_version.c_str(), v, sizeof(v));
     f.printf(
         "        <distro>\n"
         "            <distro_name>%s</distro_name>\n"
-        "            <name>%s</name>\n"
-        "            <version>%s</version>\n"
+        "            <os_name>%s</os_name>\n"
+        "            <os_version>%s</os_version>\n"
         "            <is_default>%d</is_default>\n"
+        "            <wsl_version>%s</wsl_version>\n"
         "        </distro>\n",
         dn,
         n,
         v,
-        is_default ? 1 : 0
+        is_default ? 1 : 0,
+        wsl_version.c_str()
     );
 }
 
@@ -54,9 +57,10 @@ int WSL::parse(XML_PARSER& xp) {
             return 0;
         }
         if (xp.parse_string("distro_name", distro_name)) continue;
-        if (xp.parse_string("name", name)) continue;
-        if (xp.parse_string("version", version)) continue;
+        if (xp.parse_string("os_name", os_name)) continue;
+        if (xp.parse_string("os_version", os_version)) continue;
         if (xp.parse_bool("is_default", is_default)) continue;
+        if (xp.parse_string("wsl_version", wsl_version)) continue;
     }
     return ERR_XML_PARSE;
 }

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -23,10 +23,17 @@
 #include "miofile.h"
 #include "parse.h"
 
+// this structure describes the information about every WSL (Windows Subsystem for Linux) installation enabled on the host
 struct WSL {
+    // unique identifier of installed WSL distribution
     std::string distro_name;
-    std::string name;
-    std::string version;
+    // name of the operating system
+    std::string os_name;
+    // version of the operating system
+    std::string os_version;
+    // version of WSL (currently 1 or 2)
+    std::string wsl_version;
+    // flag indicating whether this is the default WSL distribution
     bool is_default;
 
     WSL();


### PR DESCRIPTION
In the most cases, WSL2 (currently the latest) is the recommended version, but there are some cases when WSL1 is more suitable. For example, WSL1 is faster in some cases (e.g. file operations), and it is the only option for Windows 10 Home users. More details here: https://docs.microsoft.com/en-us/windows/wsl/compare-versions
