### PR TITLE
If using dynamic AM (like Science United) use prefs from the AM, not from projects

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -799,10 +799,18 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
         // process prefs if any
         //
         if (!global_prefs_xml.empty()) {
-            double mod_time = GLOBAL_PREFS::parse_mod_time(
-                global_prefs_xml.c_str()
-            );
-            if (mod_time > gstate.global_prefs.mod_time) {
+            bool use_am_prefs;
+            // if dynamic AM (like SU) its prefs are our net prefs
+            //
+            if (ami.dynamic) {
+                use_am_prefs = true;
+            } else {
+                double mod_time = GLOBAL_PREFS::parse_mod_time(
+                    global_prefs_xml.c_str()
+                );
+                use_am_prefs = mod_time > gstate.global_prefs.mod_time;
+            }
+            if (use_am_prefs) {
                 retval = gstate.save_global_prefs(
                     global_prefs_xml.c_str(), ami.master_url, ami.master_url
                 );

--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -84,6 +84,7 @@ struct ACCT_MGR_INFO : PROJ_AM {
         // This AM dynamically decides what projects to assign.
         // - send EC in AM RPCs
         // - send starvation info if idle resources
+        // - network preferences are those from AM
     USER_KEYWORDS user_keywords;
         // user's yes/no keywords.
         // These are conveyed to projects in scheduler requests

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -713,7 +713,7 @@ int CLIENT_STATE::handle_scheduler_reply(
         // BAM! currently has mixed http, https; trim off
         char* p = strchr(global_prefs.source_project, '/');
         char* q = strchr(gstate.acct_mgr_info.master_url, '/');
-        if (!global_prefs.override_file_present && gstate.acct_mgr_info.using_am() && p && q && !strcmp(p, q)) {
+        if (gstate.acct_mgr_info.using_am() && p && q && !strcmp(p, q)) {
             if (log_flags.sched_op_debug) {
                 msg_printf(project, MSG_INFO,
                     "[sched_op] ignoring prefs from project; using prefs from AM"

--- a/client/rr_sim.cpp
+++ b/client/rr_sim.cpp
@@ -682,14 +682,17 @@ void rr_simulation(const char* why) {
 }
 
 // Compute the number resources with > 0 idle instance
-// Put results in global state (rsc_work_fetch)
+// Put results in global state (rsc_work_fetch[].nidle_now)
 // This is called from the account manager logic,
 // to decide if we need to get new projects from the AM.
 //
 int n_idle_resources() {
-    int nidle_rsc = coprocs.n_rsc;
+    int nidle_rsc = 0;
+    coprocs.coprocs[0] = gstate.n_usable_cpus;
     for (int i=0; i<coprocs.n_rsc; i++) {
-        rsc_work_fetch[i].nidle_now = coprocs.coprocs[i].count;
+        int c = coprocs.coprocs[i].count;
+        rsc_work_fetch[i].nidle_now = c;
+        if (c > 0) nidle_rsc++;
     }
     for (unsigned int i=0; i<gstate.results.size(); i++) {
         RESULT* rp = gstate.results[i];


### PR DESCRIPTION
SU uses pre-made project accounts, which users can't log in to.