### PR TITLE
client: fix work fetch messages

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -282,6 +282,8 @@ void CLIENT_STATE::show_host_info() {
     }
 }
 
+// TODO: the following 3 should be members of COPROCS
+
 int rsc_index(const char* name) {
     const char* nm = strcmp(name, "CUDA")?name:GPU_TYPE_NVIDIA;
         // handle old state files

--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -1320,10 +1320,14 @@ const char* project_reason_string(PROJECT* p, char* buf, int len) {
             x = "don't need (";
             for (int i=0; i<coprocs.n_rsc; i++) {
                 char buf2[256];
+                RSC_REASON reason = p->rsc_pwf[i].rsc_project_reason;
+                if (!reason) {
+                    reason = rsc_work_fetch[i].dont_fetch_reason;
+                }
                 snprintf(buf2, sizeof(buf2),
                     "%s: %s",
                     rsc_name_long(i),
-                    rsc_reason_string(p->rsc_pwf[i].rsc_project_reason)
+                    rsc_reason_string(reason)
                 );
                 x += buf2;
                 if (i < coprocs.n_rsc-1) {

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -1171,6 +1171,7 @@ const char* proc_type_name(int pt) {
 // TODO: fix the function name
 //
 int coproc_type_name_to_num(const char* name) {
+    if (!strcmp(name, "CPU")) return PROC_TYPE_CPU;
     if (!strcmp(name, "CUDA")) return PROC_TYPE_NVIDIA_GPU;
     if (!strcmp(name, "NVIDIA")) return PROC_TYPE_NVIDIA_GPU;
     if (!strcmp(name, "ATI")) return PROC_TYPE_AMD_GPU;

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -1119,16 +1119,28 @@ void COPROC_APPLE::fake(double ram, double avail_ram, int n) {
 
 ///////////////////// END GPU TYPES ///////////////
 
-// used wherever a processor type is specified in XML, e.g.
-// <coproc>
-//    <type>xxx</type>
+// processor types (CPU and GPUs) are (confusingly) identified in various ways:
 //
-// Don't confuse this with the element names used for GPUS within <coprocs>,
-// namely:
-// coproc_cuda
-// coproc_ati
-// coproc_intel_gpu
-// coproc_apple_gpu
+// - proc_type (int):
+//      PROC_TYPE_NVIDIA_GPU etc.
+//      The processor types known to BOINC.
+//      -1 if unknown (e.g. returned by OpenCL GPU enumeration)
+// - rsc_type (int):
+//      index into the coproc.coprocs[] array
+//      0 is always CPU
+// - name (char*)
+//      XML name (like intel_gpu)
+//      e.g. <coproc><type>intel_gpu</type>...</coproc>
+//      also COPROC.type (confusing)
+// - user friendly name (char*)
+//      user-facing, e.g. 'Intel GPU'
+// - element name (char*)
+//      e.g. <coproc_cuda>
+//      used in client_state.xml,
+//      and within <coproc> elements in sched requests
+
+// proc_type to name
+// TODO: fix the function name
 //
 const char* proc_type_name_xml(int pt) {
     switch(pt) {
@@ -1141,6 +1153,9 @@ const char* proc_type_name_xml(int pt) {
     return "unknown";
 }
 
+// proc_type to user friendly name
+// TODO: fix the function name
+//
 const char* proc_type_name(int pt) {
     switch(pt) {
     case PROC_TYPE_CPU: return "CPU";
@@ -1152,6 +1167,9 @@ const char* proc_type_name(int pt) {
     return "unknown";
 }
 
+// name to proc_type
+// TODO: fix the function name
+//
 int coproc_type_name_to_num(const char* name) {
     if (!strcmp(name, "CUDA")) return PROC_TYPE_NVIDIA_GPU;
     if (!strcmp(name, "NVIDIA")) return PROC_TYPE_NVIDIA_GPU;

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -1139,6 +1139,9 @@ void COPROC_APPLE::fake(double ram, double avail_ram, int n) {
 //      used in client_state.xml,
 //      and within <coproc> elements in sched requests
 
+// TODO: move rsc_name() etc from client_state.cpp;
+// make them members of COPROCS
+
 // proc_type to name
 // TODO: fix the function name
 //


### PR DESCRIPTION
The client shows messages like
8/16/2024 8:13:47 PM | PrimeGrid | Not requesting tasks: don't need (CPU: ; NVIDIA GPU: ; Intel GPU: )
The reasons are missing.
This is because there are two levels of reason for not fetching a resource:
project-level (like it has no app versions that use the resource)
and global (like the buffer is full).
We were only looking at the project-level reason.
Look at both, to produce e.g.

8/16/2024 8:13:47 PM | PrimeGrid | Not requesting tasks: don't need (CPU: buffer full; NVIDIA GPU: buffer full; Intel GPU: buffer full)