### PR TITLE
C++ code: eliminate a source of potential bugs

### DIFF
--- a/client/client_types.h
+++ b/client/client_types.h
@@ -245,9 +245,9 @@ struct DAILY_STATS {
     double host_expavg_credit;
     double day;
 
-    DAILY_STATS(int){}
+    DAILY_STATS(DUMMY_TYPE){}
     void clear() {
-        static const DAILY_STATS x(0);
+        static const DAILY_STATS x(DUMMY);
         *this = x;
     }
     DAILY_STATS() {
@@ -299,9 +299,9 @@ struct APP {
     bool ignore;
 #endif
 
-    APP(int){}
+    APP(DUMMY_TYPE){}
     void clear() {
-        static const APP x(0);
+        static const APP x(DUMMY);
         *this = x;
     }
     APP(){

--- a/client/net_stats.h
+++ b/client/net_stats.h
@@ -55,9 +55,9 @@ public:
     NET_INFO up;
     NET_INFO down;
 
-    NET_STATS(int){}
+    NET_STATS(DUMMY_TYPE){}
     void clear() {
-        static const NET_STATS x(0);
+        static const NET_STATS x(DUMMY);
         *this = x;
     }
     NET_STATS() {

--- a/client/sim.h
+++ b/client/sim.h
@@ -34,9 +34,9 @@ struct SIM_RESULTS {
     double idle_frac;
     int nrpcs;
 
-    SIM_RESULTS(int){}
+    SIM_RESULTS(DUMMY_TYPE){}
     void clear() {
-        static const SIM_RESULTS x(0);
+        static const SIM_RESULTS x(DUMMY);
         *this = x;
     }
     SIM_RESULTS() {

--- a/client/work_fetch.h
+++ b/client/work_fetch.h
@@ -334,9 +334,9 @@ struct PROJECT_WORK_FETCH {
         // If we're uploading but a resource is idle, make a work request.
         // If this succeeds, clear the flag.
 
-    PROJECT_WORK_FETCH(int) {}
+    PROJECT_WORK_FETCH(DUMMY_TYPE) {}
     void clear() {
-        static const PROJECT_WORK_FETCH x(0);
+        static const PROJECT_WORK_FETCH x(DUMMY);
         *this = x;
     }
     PROJECT_WORK_FETCH() {

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -282,6 +282,14 @@ enum SPORADIC_AC_STATE {
 #define CREDIT_TYPE_NETWORK         2
 #define CREDIT_TYPE_PROJECT         3
 
+// An arg type for the 'dummy constructors' used to zero out structs.
+// Something that won't occur naturally, so that
+// COPROC c = 0;
+// will give a compile error, rather than creating a COPROC
+// using a dummy COPROC(int) constructor
+//
+typedef enum DUMMY_ENUM{DUMMY=0} DUMMY_TYPE;
+
 struct TIME_STATS {
     double now;
         // the client's current time of day

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -84,6 +84,7 @@
 #include "cal_boinc.h"
 #include "cl_boinc.h"
 #include "opencl_boinc.h"
+#include "common_defs.h"
 
 #define MAX_COPROC_INSTANCES 64
 #define MAX_RSC 8
@@ -205,9 +206,9 @@ struct COPROC {
 
     OPENCL_DEVICE_PROP opencl_prop;
 
-    COPROC(int){}
+    COPROC(DUMMY_TYPE){}
     inline void clear() {
-        static const COPROC x(0);
+        static const COPROC x(DUMMY);
         *this = x;
     }
     COPROC(){
@@ -284,9 +285,9 @@ struct CUDA_DEVICE_PROP {
     int   deviceOverlap;
     int   multiProcessorCount;
 
-    CUDA_DEVICE_PROP(int){}
+    CUDA_DEVICE_PROP(DUMMY_TYPE){}
     void clear() {
-        static const CUDA_DEVICE_PROP x(0);
+        static const CUDA_DEVICE_PROP x(DUMMY);
         *this = x;
     }
     CUDA_DEVICE_PROP() {

--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -19,6 +19,7 @@
 #define BOINC_OPENCL_BOINC_H
 
 #include "cl_boinc.h"
+#include "common_defs.h"
 #include "miofile.h"
 #include "parse.h"
 

--- a/lib/prefs.h
+++ b/lib/prefs.h
@@ -20,6 +20,7 @@
 
 #include <cstdio>
 
+#include "common_defs.h"
 #include "miofile.h"
 #include "parse.h"
 
@@ -74,9 +75,9 @@ struct GLOBAL_PREFS_MASK {
     bool work_buf_additional_days;
     bool work_buf_min_days;
 
-    GLOBAL_PREFS_MASK(int){}
+    GLOBAL_PREFS_MASK(DUMMY_TYPE){}
     void clear() {
-        static const GLOBAL_PREFS_MASK x(0);
+        static const GLOBAL_PREFS_MASK x(DUMMY);
         *this = x;
     }
     GLOBAL_PREFS_MASK() {


### PR DESCRIPTION
To create zero-filled structs, we use a method where we create a static struct using a 'dummy constructor' taking an (unused) int argument. The problem is that if you mistakenly have e.g.
    COPROC c = 1;
you don't get a compile error;
you get an uninitialized struct as if you had done
    COPROC c = COPROC(1);
I changed this so that we use a type DUMMY_TYPE
(guaranteed not to be convertible from anything)
as the arg type for the dummy constructors.
So now you get a compile error in the above case.