### PR TITLE
[linux] set default data directory location to '/var/lib/boinc'.

### DIFF
--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -420,7 +420,7 @@ struct DEVICE_STATUS {
 // You can define this in "configure" if you want.
 //
 #ifndef LINUX_DEFAULT_DATA_DIR
-#define LINUX_DEFAULT_DATA_DIR      "/var/lib/boinc-client"
+#define LINUX_DEFAULT_DATA_DIR      "/var/lib/boinc"
 #endif
 
 #endif

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -409,7 +409,7 @@ int RPC::parse_reply() {
 // Linux: look in:
 //  - current dir
 //  - a directory specified in /etc/boinc-client/config.properties
-//  - /var/lib/boinc-client
+//  - /var/lib/boinc
 //
 // Note: the Manager (on all platforms) has a -datadir cmdline option.
 // If present, it chdirs to that directory.


### PR DESCRIPTION
Official BOINC packages for Linux use '/var/lib/boinc' directory instead of '/var/lib/boinc-client'.

This fixes #5775.
