### PR TITLE
fix typo in script to cancel WUs

### DIFF
--- a/html/inc/util_ops.inc
+++ b/html/inc/util_ops.inc
@@ -237,19 +237,32 @@ function current_versions($avs) {
 // - set the CANCELLED bit in workunit.error_mask
 //
 function cancel_wus($wuid1, $wuid2) {
-    $retval = BoincResult::update_aux("server_state=5, outcome=5 where server_state=2 and $wuid1<=workunitid and workunitid<=$wuid2");
+    $retval = BoincResult::update_aux(
+        sprintf(
+            'server_state=%d, outcome=%d where server_state=%d and workunitid>=%d and workunitid<=%d',
+            RESULT_SERVER_STATE_OVER,
+            RESULT_OUTECOME_DIDNT_NEED,
+            RESULT_SERVER_STATE_UNSENT,
+            $wuid1, $wuid2
+        )
+    );
     if (!$retval) {
         error_page("Result update failed");
     }
-    $retval = BoincWorkunit::update_aux("error_mask=error_mask|16 where $wuid1<=id and id<=$wuid2");
+
+    // mark WUs as cancelled and trigger the transitioner
+    //
+    $retval = BoincWorkunit::update_aux(
+        sprintf(
+            'error_mask=error_mask|%d, transition_time=%d where id>=%d and id<=%d',
+            WU_ERROR_CANCELLED,
+            time(),
+            $wuid1, $wuid2
+        )
+    );
     if (!$retval) {
         error_page("Workunit update failed");
     }
-
-    // trigger the transitioner (it will set file_delete_state)
-
-    $now = time();
-    $retval = BoincWorkunit::update_aux("transition_time=$now where $wuid1<=id and id<=$wuid2");
     return 0;
 }
 
@@ -259,9 +272,21 @@ function cancel_wus($wuid1, $wuid2) {
 function cancel_wus_if_unsent($id1, $id2) {
     $wus = BoincWorkunit::enum("id >= $id1 and id <= $id2");
     foreach ($wus as $wu) {
-        $results = BoincResult::enum("workunitid=$wu->id and server_state > 2");
+        $results = BoincResult::enum(
+            sprintf(
+                'workunitid=%d and server_state > %d',
+                $wu->id, RESULT_SERVER_STATE_UNSENT
+            )
+        );
         if (count($results)) continue;
-        $retval = BoincResult::update_aux("server_state=5, outcome=5 where workunitid=$wu->id");
+        $retval = BoincResult::update_aux(
+            sprintf(
+                'server_state=%d, outcome=%d where workunitid=%d',
+                RESULT_SERVER_STATE_OVER,
+                RESULT_OUTCOME_DIDNT_NEED,
+                $wu->id
+            )
+        );
         if (!$retval) {
             error_page("result update failed");
         }

--- a/html/inc/util_ops.inc
+++ b/html/inc/util_ops.inc
@@ -241,7 +241,7 @@ function cancel_wus($wuid1, $wuid2) {
         sprintf(
             'server_state=%d, outcome=%d where server_state=%d and workunitid>=%d and workunitid<=%d',
             RESULT_SERVER_STATE_OVER,
-            RESULT_OUTECOME_DIDNT_NEED,
+            RESULT_OUTCOME_DIDNT_NEED,
             RESULT_SERVER_STATE_UNSENT,
             $wuid1, $wuid2
         )

--- a/html/ops/cancel_workunits.php
+++ b/html/ops/cancel_workunits.php
@@ -36,7 +36,7 @@ if (!$limit || $limit==0) {
 $qclause = "";
 
 $minid = get_int('minid', true);
-$minid = get_int('maxid', true);
+$maxid = get_int('maxid', true);
 $list = get_str('list', true);
 $uclause = get_str('uclause', true);
 $clause = get_str('clause', true);


### PR DESCRIPTION
Don't use hardwired constants in DB queries.

Note: we have 2 scripts that do about the same thing ops/cancel_workunits.php
ops/cancel_wu_form.php
Both are linked to from ops page.  Remove one of them.

Fixes #5807