### PR TITLE
Update is_extpack_installed

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -1770,7 +1770,7 @@ bool VBOX_VM::is_extpack_installed() {
     command = "list extpacks";
 
     if (vbm_popen(command, output, "extpack detection", false, false) == 0) {
-        if ((output.find("Oracle VM VirtualBox Extension Pack") != string::npos) && (output.find("VBoxVRDP") != string::npos)) {
+        if ((output.find("VirtualBox Extension Pack") != string::npos) && (output.find("VBoxVRDP") != string::npos)) {
             return true;
         }
     }


### PR DESCRIPTION
For many years and across a couple of major VirtualBox versions vboxwrapper was looking for "Oracle VM VirtualBox Extension Pack" to test whether the Extension Pack is present.
With VirtualBox version 7.1 Oracle changed the string to "Oracle VirtualBox Extension Pack".

Reported by an experienced volunteer at LHC@home.

To make vboxwrapper work with old as well as with recent VirtualBox versions the test string needs to be modified.
