### PR TITLE
Set virtualbox vrde-property

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -800,6 +800,9 @@ int VBOX_VM::create_vm() {
             command += "--vrdeauthlibrary default ";
             command += "--vrdeauthtype null ";
             command += "--vrdeport " + string(buf) + " ";
+            if (is_virtualbox_version_newer(7, 0, 99)) {
+                command += "--vrde-property \"Security/Method=RDP\" ";
+            }
 
             retval = vbm_popen(command, output, "remote desktop");
             if (retval) return retval;


### PR DESCRIPTION
With version 7.1.0 VirtualBox changed the default behavior of RDP encryption if a user hasn't created own certificates.

See the VirtualBox changelog:

> VirtualBox 7.1.0 (released September 09 2024)
> VRDE: If user does not set up TLS with custom certificates, enable it with self-signed certificate, including issuing a new one before the old one expires

Old default:
VirtualBox used hard wired internal certificates or even no encryption.

Since the self-signed certificates are not known by the host the first RDP connection to a VM starts with a warning like this (provided by a volunteer from LHC@home):
![Certificate-RDP](https://github.com/user-attachments/assets/de9882a6-df8a-4af3-bcf7-632e9dedee79)


The VirtualBox manual gives a hint how the old behavior can be enabled:
https://www.virtualbox.org/manual/topics/remotevm.html#vrde-crypt

Vboxwrapper should configure VMs using standard RDP instead of TLS to avoid the warning message being presented for each fresh VM.
