### PR TITLE
[Manager] Add application name to task properties window

### DIFF
--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -452,6 +452,7 @@ void CDlgItemProperties::renderInfos(RESULT* result) {
     }
     if (avp) {
         addProperty(_("Executable"), wxString(avp->exec_filename, wxConvUTF8));
+        addProperty(_("Application Name"), wxString(avp->app_name, wxConvUTF8));
     }
     renderInfos();
 }


### PR DESCRIPTION
Provides the general application name.  This allows the user to easily identify the application that will run the task.  Helpful for finding which application to reference in app_config.xml.

Fixes #5166 

**Description of the Change**
Under the properties window, a wxString is added that displays the application name.

![image](https://github.com/user-attachments/assets/ea252dc3-a778-4fb0-9695-47a23c4c691f)

**Release Notes**
[Manager] Added application name to task's properties window.
