### PR TITLE
Added a placeholder install step

### DIFF
--- a/samples/condor/Makefile
+++ b/samples/condor/Makefile
@@ -59,3 +59,6 @@ boinc_gahp: boinc_gahp.cpp $(BOINC_SOURCE_LIB_DIR)/remote_submit.h $(BOINC_SOURC
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MINGW_FLAGS) -g -O3 \
 	-o boinc_gahp boinc_gahp.cpp $(BOINC_SOURCE_LIB_DIR)/remote_submit.cpp \
 	-lcurl -lssl -lcrypto -lboinc $(CURL_EXTRA_LDFLAGS) $(MAKEFILE_LDFLAGS) $(STDCPPTC)
+
+install:
+	echo "Install step"

--- a/samples/multi_thread/Makefile
+++ b/samples/multi_thread/Makefile
@@ -43,3 +43,6 @@ distclean:
 
 multi_thread: multi_thread.o $(MAKEFILE_STDLIB) $(BOINC_API_DIR)/libboinc_api.a $(BOINC_LIB_DIR)/libboinc.a
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o multi_thread multi_thread.o $(MAKEFILE_LDFLAGS) -lboinc_api -lboinc $(STDCPPTC)
+
+install:
+	echo "Install step"


### PR DESCRIPTION
Fixes ##5690

**Description of the Change**
Added a **install** rule for the following Makefiles:
- condor
- multi_thread

**Release Notes**
`make install` no longer fails for samples.