### PR TITLE
lib/Makefile.mingw: add boinc_stdio.h to install headers

### DIFF
--- a/lib/Makefile.mingw
+++ b/lib/Makefile.mingw
@@ -21,6 +21,7 @@ HEADERS = $(BOINC_SRC)/version.h \
 	$(BOINC_SRC)/api/graphics2.h \
 	$(BOINC_SRC)/lib/app_ipc.h \
 	$(BOINC_SRC)/lib/boinc_win.h \
+	$(BOINC_SRC)/lib/boinc_stdio.h \
 	$(BOINC_SRC)/lib/url.h \
 	$(BOINC_SRC)/lib/common_defs.h \
 	$(BOINC_SRC)/lib/diagnostics.h \


### PR DESCRIPTION
boinc_stdio.h should be installed as well when doing a 'make -f lib/Makefile.mingw install'