### PR TITLE
[Manager] Add application name to task properties window

### DIFF
--- a/clientgui/DlgItemProperties.cpp
+++ b/clientgui/DlgItemProperties.cpp
@@ -453,6 +453,7 @@ void CDlgItemProperties::renderInfos(RESULT* result) {
     if (avp) {
         addProperty(_("Executable"), wxString(avp->exec_filename, wxConvUTF8));
         addProperty(_("Application Name"), wxString(avp->app_name, wxConvUTF8));
+        addProperty(_("Plan Class"), wxString(avp->plan_class, wxConvUTF8));
     }
     renderInfos();
 }


### PR DESCRIPTION
**Description of the Change**
As suggested by @RichardHaselgrove in #5827, this PR adds the plan class to the properties window.

![image](https://github.com/user-attachments/assets/2d8701ab-4579-49fa-8969-ea56534043af)

**Alternate Designs**
I considered having the plan class line only visible if there was one present, but if someone is expecting a plan class and doesn't see it, then this should at least indicate that one was not found.

**Release Notes**
[Manager] Added plan class name to task's properties window.
