### PR TITLE
subs should be empty by default, not null

### DIFF
--- a/html/user/forum_forum.php
+++ b/html/user/forum_forum.php
@@ -38,7 +38,7 @@ function forum_page($forum, $user, $msg=null) {
     $start = get_int("start", true);
     if (!$start) $start = 0;
 
-    $subs = null;
+    $subs = [];
     if ($user) {
         BoincForumPrefs::lookup($user);
         $subs = BoincSubscription::enum("userid=$user->id");


### PR DESCRIPTION
**Description of the Change**
Users not logged in get a 
```
Warning: foreach() argument must be of type array\|object, null given in /home/boinc/whatever/html/inc/forum.inc on line 1420
```
message because `subs` is `null`, not `[]` by default and it is called so in the foreach.

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->

fix warning when users are not logged in on the forums