### PR TITLE
Add docker_wrapper and associated client/server changes

### DIFF
--- a/client/Makefile.linux
+++ b/client/Makefile.linux
@@ -140,7 +140,7 @@ clean:
 LIBS = ../lib/boinc.a \
     -L /usr/local/lib/ \
     -lpthread \
-    -lX11 -lXss \
+    -lX11 \
     -lcurl -lssl -lcrypto \
     -lz -ldl
 

--- a/client/app_test.cpp
+++ b/client/app_test.cpp
@@ -43,9 +43,11 @@
 
 #include "client_state.h"
 
-// set to 0 to enable app test
+#define APP_NONE            0
+#define APP_WSL_WRAPPER     0
+#define APP_DOCKER_WRAPPER  1
 
-#if 1
+#if APP_NONE
 void CLIENT_STATE::app_test_init() {}
 #else
 
@@ -163,6 +165,7 @@ void CLIENT_STATE::app_test_init() {
 #endif
 
     APP_VERSION *av = make_app_version(app);
+#if APP_WSL_WRAPPER
     av->app_files.push_back(
         *make_file(app->project, "wsl_wrapper.exe", NULL, MAIN_PROG, false)
     );
@@ -172,6 +175,20 @@ void CLIENT_STATE::app_test_init() {
     av->app_files.push_back(
         *make_file(app->project, "worker", NULL, INPUT_FILE, false)
     );
+#elif APP_DOCKER_WRAPPER
+    av->app_files.push_back(
+        *make_file(app->project, "docker_wrapper.exe", NULL, MAIN_PROG, false)
+    );
+    av->app_files.push_back(
+        *make_file(app->project, "job.toml", NULL, INPUT_FILE, true)
+    );
+    av->app_files.push_back(
+        *make_file(app->project, "Dockerfile", NULL, INPUT_FILE, true)
+    );
+    av->app_files.push_back(
+        *make_file(app->project, "worker", NULL, INPUT_FILE, true)
+    );
+#endif
 
     // can put other stuff here like
 #if 0
@@ -181,15 +198,20 @@ void CLIENT_STATE::app_test_init() {
 #endif
 
     WORKUNIT *wu = make_workunit(av);
-#if 1
+#if APP_WSL_WRAPPER
     //wu->command_line = "--nsecs 60";
     wu->input_files.push_back(
         *make_file(proj, "infile", "in", INPUT_FILE, false)
     );
 #endif
+#if APP_DOCKER_WRAPPER
+    wu->input_files.push_back(
+        *make_file(proj, "infile", "in", INPUT_FILE, true)
+    );
+#endif
 
     RESULT *result = make_result(av, wu);
-#if 1
+#if APP_WSL_WRAPPER || APP_DOCKER_WRAPPER
     result->output_files.push_back(
         *make_file(proj, "outfile", "out", OUTPUT_FILE, false)
     );

--- a/client/app_test.cpp
+++ b/client/app_test.cpp
@@ -218,10 +218,10 @@ void CLIENT_STATE::app_test_init() {
         *make_file(app->project, "worker", NULL, INPUT_FILE, true)
     );
     av->app_files.push_back(
-        *make_file(app->project, "job_copy.toml", NULL, INPUT_FILE, true)
+        *make_file(app->project, "job_copy.toml", "job.toml", INPUT_FILE, true)
     );
     av->app_files.push_back(
-        *make_file(app->project, "Dockerfile_copy", NULL, INPUT_FILE, true)
+        *make_file(app->project, "Dockerfile_copy", "Dockerfile", INPUT_FILE, true)
     );
 #endif
 
@@ -259,7 +259,7 @@ void CLIENT_STATE::app_test_init() {
 #endif
 #ifdef APP_DOCKER_WRAPPER_COPY
     result->output_files.push_back(
-        *make_file(proj, "outfile", "out", OUTPUT_FILE, false)
+        *make_file(proj, "outfile", "out", OUTPUT_FILE, true)
     );
 #endif
 

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -268,7 +268,7 @@ void CLIENT_STATE::show_host_info() {
                     docker_type_str(wsl.docker_type)
                 );
             }
-            if (!wsl.docker_composer_version) {
+            if (!wsl.docker_compose_version.empty()) {
                 msg_printf(NULL, MSG_INFO, "-      Docker compose version %s (%s)",
                     wsl.docker_compose_version.c_str(),
                     docker_type_str(wsl.docker_compose_type)

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -262,14 +262,16 @@ void CLIENT_STATE::show_host_info() {
                 "-      OS: %s (%s)",
                 wsl.os_name.c_str(), wsl.os_version.c_str()
             );
-            if (wsl.is_docker_available) {
-                msg_printf(NULL, MSG_INFO, "-      Docker version %s",
-                    wsl.docker_version.c_str()
+            if (!wsl.docker_version.empty()) {
+                msg_printf(NULL, MSG_INFO, "-      Docker version %s (%s)",
+                    wsl.docker_version.c_str(),
+                    docker_type_str(wsl.docker_type)
                 );
             }
-            if (wsl.is_docker_compose_available) {
-                msg_printf(NULL, MSG_INFO, "-      Docker compose version %s",
-                    wsl.docker_compose_version.c_str()
+            if (!wsl.docker_composer_version) {
+                msg_printf(NULL, MSG_INFO, "-      Docker compose version %s (%s)",
+                    wsl.docker_compose_version.c_str(),
+                    docker_type_str(wsl.docker_compose_type)
                 );
             }
         }
@@ -292,12 +294,12 @@ void CLIENT_STATE::show_host_info() {
     }
 
 #ifndef _WIN64
-    if (host_info.docker_available && strlen(host_info.docker_version)) {
+    if (strlen(host_info.docker_version)) {
         msg_printf(NULL, MSG_INFO, "Docker version %s found",
             host_info.docker_version
         );
     }
-    if (host_info.docker_compose_available && strlen(host_info.docker_compose_version)) {
+    if (strlen(host_info.docker_compose_version)) {
         msg_printf(NULL, MSG_INFO, "Docker compose version %s found",
             host_info.docker_compose_version
         );

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -295,13 +295,15 @@ void CLIENT_STATE::show_host_info() {
 
 #ifndef _WIN64
     if (strlen(host_info.docker_version)) {
-        msg_printf(NULL, MSG_INFO, "Docker version %s found",
-            host_info.docker_version
+        msg_printf(NULL, MSG_INFO, "Docker: version %s (%s)",
+            host_info.docker_version,
+            docker_type_str(host_info.docker_type)
         );
     }
     if (strlen(host_info.docker_compose_version)) {
-        msg_printf(NULL, MSG_INFO, "Docker compose version %s found",
-            host_info.docker_compose_version
+        msg_printf(NULL, MSG_INFO, "Docker compose: version %s (%s)",
+            host_info.docker_compose_version,
+            docker_type_str(host_info.docker_compose_type)
         );
     }
 #endif

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -141,6 +141,9 @@ int CLIENT_STATE::make_scheduler_request(PROJECT* p) {
         g_use_sandbox?1:0,
         p->dont_request_more_work?1:0
     );
+    if (cc_config.dont_use_docker) {
+        fprintf(f, "    <dont_use_docker/>\n");
+    }
     work_fetch.write_request(f, p);
 
     // write client capabilities

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1238,8 +1238,8 @@ int HOST_INFO::get_virtualbox_version() {
 //
 bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
     bool ret = false;
-    const char *cmd = get_docker_version_command(type);
-    FILE* f = popen(cmd, "r");
+    string cmd = string(docker_cli_prog(type)) + " --version";
+    FILE* f = popen(cmd.c_str(), "r");
     if (f) {
         char buf[256];
         fgets(buf, 256, f);
@@ -1269,7 +1269,8 @@ bool HOST_INFO::get_docker_version(){
 //
 bool HOST_INFO::get_docker_compose_version_aux(DOCKER_TYPE type){
     bool ret = false;
-    FILE* f = popen(get_docker_compose_version_command(type), "r");
+    string cmd = string(docker_cli_prog(type)) + " compose version";
+    FILE* f = popen(cmd.c_str(), "r");
     if (f) {
         char buf[256];
         fgets(buf, 256, f);

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -215,7 +215,7 @@ int get_wsl_information(
 
         // try running 'lsb_release -a'
         //
-        if (!rs.run_command(wd.distro_name, command_lsbrelease)) {
+        if (!rs.run_program_in_wsl(wd.distro_name, command_lsbrelease)) {
             read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);
             HOST_INFO::parse_linux_os_info(
                 reply, lsbrelease,
@@ -230,7 +230,7 @@ int get_wsl_information(
         //
         if (!got_both(wd)) {
             const std::string command_osrelease = "cat " + std::string(file_osrelease);
-            if (!rs.run_command( wd.distro_name, command_osrelease)) {
+            if (!rs.run_program_in_wsl( wd.distro_name, command_osrelease)) {
                 read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);
                 HOST_INFO::parse_linux_os_info(
                     reply, osrelease,
@@ -246,7 +246,7 @@ int get_wsl_information(
         //
         if (!got_both(wd)) {
             const std::string command_redhatrelease = "cat " + std::string(file_redhatrelease);
-            if (!rs.run_command(
+            if (!rs.run_program_in_wsl(
                 wd.distro_name, command_redhatrelease
             )) {
                 read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);
@@ -267,7 +267,7 @@ int get_wsl_information(
         //
         if (!got_both(wd)) {
             const std::string command_sysctl = "sysctl -a";
-            if (!rs.run_command(
+            if (!rs.run_program_in_wsl(
                 wd.distro_name, command_sysctl
             )) {
                 read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);
@@ -284,7 +284,7 @@ int get_wsl_information(
         //
         if (!got_both(wd)) {
             const std::string command_uname_s = "uname -s";
-            if (!rs.run_command(
+            if (!rs.run_program_in_wsl(
                 wd.distro_name, command_uname_s
             )) {
                 read_from_pipe(rs.out_read, rs.proc_handle, os_name_str, CMD_TIMEOUT);
@@ -298,7 +298,7 @@ int get_wsl_information(
         //
         if (!got_both(wd)) {
             const std::string command_uname_r = "uname -r";
-            if (!rs.run_command(
+            if (!rs.run_program_in_wsl(
                 wd.distro_name, command_uname_r
             )) {
                 read_from_pipe(rs.out_read, rs.proc_handle, os_version_str, CMD_TIMEOUT);
@@ -314,7 +314,7 @@ int get_wsl_information(
         // see if Docker is installed in the distro
         //
         if (detect_docker) {
-            if (!rs.run_command(
+            if (!rs.run_program_in_wsl(
                 wd.distro_name, command_get_docker_version
             )) {
                 read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);
@@ -327,7 +327,7 @@ int get_wsl_information(
                 }
                 CloseHandle(rs.proc_handle);
             }
-            if (!rs.run_command(
+            if (!rs.run_program_in_wsl(
                 wd.distro_name, command_get_docker_compose_version
             )) {
                 read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -330,9 +330,8 @@ int get_wsl_information(
 static bool get_docker_version_aux(WSL_CMD &rs, WSL_DISTRO &wd, DOCKER_TYPE type) {
     bool ret = false;
     string reply;
-    if (!rs.run_program_in_wsl(
-        wd.distro_name, get_docker_version_command(type)
-    )) {
+    string cmd = string(docker_cli_prog(type)) + " --version";
+    if (!rs.run_program_in_wsl(wd.distro_name, cmd.c_str())) {
         read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);
         string version;
         if (HOST_INFO::get_docker_version_string(type, reply.c_str(), version)) {
@@ -353,9 +352,8 @@ static void get_docker_version(WSL_CMD &rs, WSL_DISTRO &wd) {
 static bool get_docker_compose_version_aux(WSL_CMD &rs, WSL_DISTRO &wd, DOCKER_TYPE type) {
     bool ret = false;
     string reply;
-    if (!rs.run_program_in_wsl(
-        wd.distro_name, get_docker_compose_version_command(type)
-    )) {
+    string cmd = string(docker_cli_prog(type)) + " compose version";
+    if (!rs.run_program_in_wsl(wd.distro_name, cmd.c_str())) {
         read_from_pipe(rs.out_read, rs.proc_handle, reply, CMD_TIMEOUT);
         string version;
         if (HOST_INFO::get_docker_compose_version_string(

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -423,4 +423,7 @@ struct DEVICE_STATUS {
 #define LINUX_DEFAULT_DATA_DIR      "/var/lib/boinc"
 #endif
 
+// impementations of Docker
+enum DOCKER_TYPE {NONE, DOCKER, PODMAN};
+
 #endif

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -335,24 +335,19 @@ int HOST_INFO::write_cpu_benchmarks(FILE* out) {
     return 0;
 }
 
-const char* get_docker_version_command(DOCKER_TYPE type) {
+// name of CLI program
+//
+const char* docker_cli_prog(DOCKER_TYPE type) {
     switch (type) {
-    case DOCKER: return "docker --version";
-    case PODMAN: return "podman --version";
+    case DOCKER: return "docker";
+    case PODMAN: return "podman";
     default: break;
     }
-    return "";
+    return "unknown";
 }
 
-const char* get_docker_compose_version_command(DOCKER_TYPE type) {
-    switch (type) {
-    case DOCKER: return "docker compose version";
-    case PODMAN: return "podman compose version";
-    default: break;
-    }
-    return "";
-}
-
+// display name
+//
 const char* docker_type_str(DOCKER_TYPE type) {
     switch (type) {
     case DOCKER: return "Docker";

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -240,7 +240,7 @@ int HOST_INFO::write(
     if (strlen(docker_version)) {
         out.printf(
             "    <docker_version>%s</docker_version>\n"
-            "    <docker_type>%s</docker_type>\n",
+            "    <docker_type>%d</docker_type>\n",
             docker_version,
             docker_type
         );
@@ -248,7 +248,7 @@ int HOST_INFO::write(
     if (strlen(docker_compose_version)) {
         out.printf(
             "    <docker_compose_version>%s</docker_compose_version>\n"
-            "    <docker_compose_type>%s</docker_compose_type>\n",
+            "    <docker_compose_type>%d</docker_compose_type>\n",
             docker_compose_version,
             docker_compose_type
         );

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -50,8 +50,10 @@ enum LINUX_OS_INFO_PARSER {
 const char command_lsbrelease[] = "/usr/bin/lsb_release -a 2>&1";
 const char file_osrelease[] = "/etc/os-release";
 const char file_redhatrelease[] = "/etc/redhat-release";
-const char command_get_docker_version[] = "docker --version";
-const char command_get_docker_compose_version[] = "docker compose version";
+
+extern const char* get_docker_version_command(DOCKER_TYPE type);
+extern const char* get_docker_compose_version_command(DOCKER_TYPE type);
+extern const char* docker_type_str(DOCKER_TYPE type);
 
 // if you add fields, update clear_host_info()
 
@@ -89,11 +91,10 @@ public:
     // on Windows, Docker info is per WSL_DISTRO, not global
     WSL_DISTROS wsl_distros;
 #else
-    bool docker_available;
-        // Docker is present and allowed by config
-    bool docker_compose_available;
-    char docker_version[256];
+    char docker_version[256]; // null if not present
+    DOCKER_TYPE docker_type;
     char docker_compose_version[256];
+    DOCKER_TYPE docker_compose_type;
 #endif
 
     char product_name[256];       // manufacturer and/or model of system
@@ -136,8 +137,10 @@ public:
     int get_virtualbox_version();
 #ifndef _WIN64
     // on Windows, Docker info is per WSL_DISTRO, not global
-    bool get_docker_info();
-    bool get_docker_compose_info();
+    bool get_docker_version();
+    bool get_docker_version_aux(DOCKER_TYPE);
+    bool get_docker_compose_version();
+    bool get_docker_compose_version_aux(DOCKER_TYPE);
 #endif
     void make_random_string(const char* salt, char* out);
     void generate_host_cpid();
@@ -157,8 +160,12 @@ public:
         char* os_name, const int os_name_size, char* os_version,
         const int os_version_size
     );
-    static bool get_docker_version_string(std::string raw, std::string& parsed);
-    static bool get_docker_compose_version_string(std::string raw, std::string& parsed);
+    static bool get_docker_version_string(
+        DOCKER_TYPE type, const char* raw, std::string& version
+    );
+    static bool get_docker_compose_version_string(
+        DOCKER_TYPE type, const char* raw, std::string& version
+    );
 #ifdef _WIN32
     void win_get_processor_info();
 #endif

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -51,8 +51,7 @@ const char command_lsbrelease[] = "/usr/bin/lsb_release -a 2>&1";
 const char file_osrelease[] = "/etc/os-release";
 const char file_redhatrelease[] = "/etc/redhat-release";
 
-extern const char* get_docker_version_command(DOCKER_TYPE type);
-extern const char* get_docker_compose_version_command(DOCKER_TYPE type);
+extern const char* docker_cli_prog(DOCKER_TYPE type);
 extern const char* docker_type_str(DOCKER_TYPE type);
 
 // if you add fields, update clear_host_info()

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -372,7 +372,7 @@ int run_command(char *cmd, vector<string> &out) {
 
 // run the program, and return handles to write to and read from it
 //
-int run_command_pipe(
+int run_program_pipe(
     char *cmd, HANDLE &write_handle, HANDLE &read_handle, HANDLE &proc_handle
 ) {
     HANDLE in_read, in_write, out_read, out_write;

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -337,9 +337,6 @@ int run_command(char *cmd, vector<string> &out) {
     DWORD count, nread;
     PeekNamedPipe(pipe_read, NULL, NULL, NULL, &count, NULL);
     if (count == 0) {
-        if (verbose) {
-            fprintf(stderr, "No response from command\n");
-        }
         return 0;
     }
     char* buf = (char*)malloc(count+1);

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -355,6 +355,7 @@ int run_command(char *cmd, vector<string> &out) {
     }
     free(buf);
 #else
+#ifndef _USING_FCGI_
     char buf[256];
     FILE* fp = popen(cmd, "r");
     if (!fp) {
@@ -364,6 +365,7 @@ int run_command(char *cmd, vector<string> &out) {
     while (fgets(buf, 256, fp)) {
         out.push_back(buf);
     }
+#endif
 #endif
     return 0;
 }

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -285,11 +285,8 @@ int run_program(
 // Unix: if you want stderr too, add 2>&1 to command
 // Return error if command failed
 //
-int run_command(char *cmd, vector<string> &out, bool verbose) {
+int run_command(char *cmd, vector<string> &out) {
     out.clear();
-    if (verbose) {
-        fprintf(stderr, "running command: %s\n", cmd);
-    }
 #ifdef _WIN32
     HANDLE pipe_read, pipe_write;
     SECURITY_ATTRIBUTES sa;
@@ -362,9 +359,6 @@ int run_command(char *cmd, vector<string> &out, bool verbose) {
     free(buf);
 #else
     char buf[256];
-    if (verbose) {
-        fprintf(stderr, "run_command(): %s\n", cmd);
-    }
     FILE* fp = popen(cmd, "r");
     if (!fp) {
         fprintf(stderr, "popen() failed: %s\n", cmd);
@@ -372,12 +366,6 @@ int run_command(char *cmd, vector<string> &out, bool verbose) {
     }
     while (fgets(buf, 256, fp)) {
         out.push_back(buf);
-    }
-    if (verbose) {
-        fprintf(stderr, "output:\n");
-        for (string line: out) {
-            fprintf(stderr, "%s", line.c_str());
-        }
     }
 #endif
     return 0;

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -362,9 +362,12 @@ int run_command(char *cmd, vector<string> &out, bool verbose) {
     free(buf);
 #else
     char buf[256];
+    if (verbose) {
+        fprintf(stderr, "run_command(): %s\n", cmd);
+    }
     FILE* fp = popen(cmd, "r");
     if (!fp) {
-        fprintf(stderr, "can't run command %s\n", cmd);
+        fprintf(stderr, "popen() failed: %s\n", cmd);
         return ERR_FOPEN;
     }
     while (fgets(buf, 256, fp)) {

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -337,8 +337,10 @@ int run_command(char *cmd, vector<string> &out, bool verbose) {
     DWORD count;
     PeekNamedPipe(pipe_read, NULL, NULL, NULL, &count, NULL);
     if (count == 0) {
-        fprintf(stderr, "No response\n");
-        return -1;
+        if (verbose) {
+            fprintf(stderr, "No response from command\n");
+        }
+        return 0;
     }
     char* buf = (char*)malloc(count+1);
     buf[count] = 0;
@@ -367,8 +369,8 @@ int run_command(char *cmd, vector<string> &out, bool verbose) {
             fprintf(stderr, "%s", line.c_str());
         }
     }
-    return 0;
 #endif
+    return 0;
 }
 
 #ifdef _WIN32

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -279,7 +279,10 @@ int run_program(
 }
 #endif
 
-// Run command and return output as vector of lines.
+// Run command, wait for exit.
+// Return its output as vector of lines.
+// Win: output includes stdout and stderr
+// Unix: if you want stderr too, add 2>&1 to command
 // Return error if command failed
 //
 int run_command(char *cmd, vector<string> &out, bool verbose) {

--- a/lib/util.h
+++ b/lib/util.h
@@ -101,6 +101,15 @@ extern int run_program(
     char *const argv[],     // cmdline args, UNIX-style
     PROCESS_REF&             // ID of child process
 );
+
+#ifdef _WIN32
+// run program, return handles to read and write to it
+//
+extern int run_program(
+    char *cmd, HANDLE &write_handle, HANDLE &read_handle, HANDLE &proc_handle
+);
+#endif
+
 extern int kill_process(PROCESS_REF);
 extern int get_exit_status(PROCESS_REF, int& status, double dt);
     // get exit code of process

--- a/lib/util.h
+++ b/lib/util.h
@@ -111,7 +111,8 @@ extern int get_exit_status(PROCESS_REF, int& status, double dt);
     // Note: to see if a process has exited:
     // get_exit_status(pid, status, 0) == 0
 
-// Run command and return output as vector of lines.
+// Run command.
+// Wait for exit, and return output as vector of lines.
 // Return error if command failed
 //
 extern int run_command(

--- a/lib/util.h
+++ b/lib/util.h
@@ -115,9 +115,7 @@ extern int get_exit_status(PROCESS_REF, int& status, double dt);
 // Wait for exit, and return output as vector of lines.
 // Return error if command failed
 //
-extern int run_command(
-    char *cmd, std::vector<std::string> &out, bool verbose=false
-);
+extern int run_command(char *cmd, std::vector<std::string> &out);
 
 // get the path of the calling process's executable
 //

--- a/lib/util.h
+++ b/lib/util.h
@@ -105,7 +105,7 @@ extern int run_program(
 #ifdef _WIN32
 // run program, return handles to read and write to it
 //
-extern int run_program(
+extern int run_program_pipe(
     char *cmd, HANDLE &write_handle, HANDLE &read_handle, HANDLE &proc_handle
 );
 #endif

--- a/lib/util.h
+++ b/lib/util.h
@@ -89,6 +89,11 @@ extern int kill_process_with_status(int, int exit_code=0);
 #endif
 
 extern bool process_exists(PROCESS_REF);
+
+// chdir into the given directory, and run a program there.
+// Don't wait for it to exit.
+// argv is Unix-style, i.e. argv[0] is the program name
+//
 extern int run_program(
     const char* dir,        // directory to run program in; NULL if current dir
     const char* file,       // path of executable
@@ -106,6 +111,15 @@ extern int get_exit_status(PROCESS_REF, int& status, double dt);
     // Note: to see if a process has exited:
     // get_exit_status(pid, status, 0) == 0
 
+// Run command and return output as vector of lines.
+// Return error if command failed
+//
+extern int run_command(
+    char *cmd, std::vector<std::string> &out, bool verbose=false
+);
+
+// get the path of the calling process's executable
+//
 extern int get_real_executable_path(char* path, size_t max_len);
 
 #ifdef GCL_SIMULATOR

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -227,7 +227,7 @@ int WSL_CMD::setup() {
 int WSL_CMD::setup_root(const char* distro_name) {
     char cmd[1024];
     sprintf(cmd, "wsl -d %s -u root", distro_name);
-    int retval = run_command_pipe(cmd, in_write, out_read, proc_handle);
+    int retval = run_program_pipe(cmd, in_write, out_read, proc_handle);
     if (retval) return retval;
     return 0;
 }

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -224,7 +224,7 @@ int WSL_CMD::setup() {
     return 0;
 }
 
-int WSL_CMD::run_command(
+int WSL_CMD::run_program_in_wsl(
     const string distro_name, const string command, bool use_cwd
 ) {
     HRESULT ret = pWslLaunch(

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -224,6 +224,14 @@ int WSL_CMD::setup() {
     return 0;
 }
 
+int WSL_CMD::setup_root(const char* distro_name) {
+    char cmd[1024];
+    sprintf(cmd, "wsl -d %s -u root", distro_name);
+    int retval = run_command_pipe(cmd, in_write, out_read, proc_handle);
+    if (retval) return retval;
+    return 0;
+}
+
 int WSL_CMD::run_program_in_wsl(
     const string distro_name, const string command, bool use_cwd
 ) {

--- a/lib/win_util.h
+++ b/lib/win_util.h
@@ -50,7 +50,14 @@ struct WSL_CMD {
         if (out_write) CloseHandle(out_write);
     }
 
+    // Use WslLaunch() to run a shell in the WSL container
+    // The shell will run as the default user
+    //
     int setup();
+
+    // Use wsl.exe to run a shell as root in the WSL container
+    //
+    int setup_root();
 
     // run command, direct both stdout and stderr to the out pipe
     // Use read_from_pipe() to get the output.

--- a/lib/win_util.h
+++ b/lib/win_util.h
@@ -28,7 +28,13 @@ extern char* windows_format_error_string(
     unsigned long dwError, char* pszBuf, int iSize ...
 );
 
-// struct for running a WSL command, connected via pipes
+// struct for running a program in a WSL, connected via pipes.
+// This can be a one-time command,
+// or a shell to which you send a sequence of commands via the pipe.
+// In the latter case:
+//  - write to the input pipe to run commands from the shell
+//  - the output of each command should end with 'EOM'
+//      so that you know when you've read the complete output.
 //
 struct WSL_CMD {
     HANDLE in_read = NULL;
@@ -47,8 +53,9 @@ struct WSL_CMD {
     int setup();
 
     // run command, direct both stdout and stderr to the out pipe
+    // Use read_from_pipe() to get the output.
     //
-    int run_command(
+    int run_program_in_wsl(
         const std::string distro_name, const std::string command,
         bool use_cwd = false
     );

--- a/lib/win_util.h
+++ b/lib/win_util.h
@@ -57,7 +57,7 @@ struct WSL_CMD {
 
     // Use wsl.exe to run a shell as root in the WSL container
     //
-    int setup_root();
+    int setup_root(const char* distro_name);
 
     // run command, direct both stdout and stderr to the out pipe
     // Use read_from_pipe() to get the output.

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -126,3 +126,12 @@ WSL_DISTRO* WSL_DISTROS::find_match(
     }
     return NULL;
 }
+
+WSL_DISTRO* WSL_DISTROS::find_docker() {
+    for (WSL_DISTRO &wd: distros) {
+        if (wd.is_docker_available) {
+            return &wd;
+        }
+    }
+    return NULL;
+}

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -15,8 +15,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// write and parse WSL_DISTRO structs,
+// which describe WSL distros and their possible Docker contents
+
 #include <regex>
 
+#include "common_defs.h"
 #include "wslinfo.h"
 
 void WSL_DISTRO::clear() {
@@ -25,8 +29,6 @@ void WSL_DISTRO::clear() {
     os_version = "";
     is_default = false;
     wsl_version = 1;
-    is_docker_available = false;
-    is_docker_compose_available = false;
     docker_version = "";
     docker_compose_version = "";
 }
@@ -42,25 +44,36 @@ void WSL_DISTRO::write_xml(MIOFILE& f) {
         "            <os_name>%s</os_name>\n"
         "            <os_version>%s</os_version>\n"
         "            <is_default>%d</is_default>\n"
-        "            <wsl_version>%d</wsl_version>\n"
-        "            <is_docker_available>%d</is_docker_available>\n"
-        "            <is_docker_compose_available>%d</is_docker_compose_available>\n"
-        "            <docker_version>%s</docker_version>\n"
-        "            <docker_compose_version>%s</docker_compose_version>\n"
-        "        </distro>\n",
+        "            <wsl_version>%d</wsl_version>\n",
         dn,
         n,
         v,
         is_default ? 1 : 0,
-        wsl_version,
-        is_docker_available ? 1 : 0,
-        is_docker_compose_available ? 1 : 0,
-        docker_version.c_str(),
-        docker_compose_version.c_str()
+        wsl_version
+    );
+    if (!docker_version.empty()) {
+        f.printf(
+            "            <docker_version>%s</docker_version>\n"
+            "            <docker_type>%d</docker_type>\n",
+            docker_version.c_str(),
+            docker_type
+        );
+    }
+    if (!docker_compose_version.empty()) {
+        f.printf(
+            "            <docker_compose_version>%s</docker_compose_version>\n"
+            "            <docker_compose_type>%d</docker_compose_type>\n",
+            docker_compose_version.c_str(),
+            docker_compose_type
+        );
+    }
+    f.printf(
+        "        </distro>\n"
     );
 }
 
 int WSL_DISTRO::parse(XML_PARSER& xp) {
+    int i;
     clear();
     while (!xp.get_tag()) {
         if (xp.match_tag("/distro")) {
@@ -71,10 +84,16 @@ int WSL_DISTRO::parse(XML_PARSER& xp) {
         if (xp.parse_string("os_version", os_version)) continue;
         if (xp.parse_bool("is_default", is_default)) continue;
         if (xp.parse_int("wsl_version", wsl_version)) continue;
-        if (xp.parse_bool("is_docker_available", is_docker_available)) continue;
-        if (xp.parse_bool("is_docker_compose_available", is_docker_compose_available)) continue;
         if (xp.parse_string("docker_version", docker_version)) continue;
+        if (xp.parse_int("docker_type", i)) {
+            docker_type = (DOCKER_TYPE) i;
+            continue;
+        }
         if (xp.parse_string("docker_compose_version", docker_compose_version)) continue;
+        if (xp.parse_int("docker_compose_type", i)) {
+            docker_compose_type = (DOCKER_TYPE) i;
+            continue;
+        }
     }
     return ERR_XML_PARSE;
 }
@@ -129,7 +148,7 @@ WSL_DISTRO* WSL_DISTROS::find_match(
 
 WSL_DISTRO* WSL_DISTROS::find_docker() {
     for (WSL_DISTRO &wd: distros) {
-        if (wd.is_docker_available) {
+        if (!wd.docker_version.empty()) {
             return &wd;
         }
     }

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -68,6 +68,8 @@ struct WSL_DISTROS {
     WSL_DISTRO *find_match(
         const char *os_name_regexp, const char *os_version_regexp
     );
+    WSL_DISTRO *find_docker();
+        // find a distro containing Docker
 };
 
 #endif

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -25,8 +25,10 @@
 
 #include "miofile.h"
 #include "parse.h"
+#include "common_defs.h"
 
-// describes a WSL (Windows Subsystem for Linux) distro
+// describes a WSL (Windows Subsystem for Linux) distro,
+// and its Docker features
 //
 struct WSL_DISTRO {
     std::string distro_name;
@@ -39,14 +41,13 @@ struct WSL_DISTRO {
         // version of WSL (currently 1 or 2)
     bool is_default;
         // this is the default distro
-    bool is_docker_available;
-        // Docker is present and allowed by config
-    bool is_docker_compose_available;
-        // Docker Compose is present and allowed by config
     std::string docker_version;
-        // version of Docker
+        // version of Docker (or podman)
+        // empty if not present
+    DOCKER_TYPE docker_type;
     std::string docker_compose_version;
-        // version of Docker Compose
+        // version of Docker Compose; empty if none
+    DOCKER_TYPE docker_compose_type;
 
     WSL_DISTRO(){
         clear();

--- a/samples/docker_wrapper/Dockerfile
+++ b/samples/docker_wrapper/Dockerfile
@@ -1,6 +1,0 @@
-FROM debian
-WORKDIR /app
-COPY worker /app
-COPY in /app
-RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/*
-CMD ./worker in out

--- a/samples/docker_wrapper/Dockerfile
+++ b/samples/docker_wrapper/Dockerfile
@@ -1,0 +1,6 @@
+FROM debian
+WORKDIR /app
+COPY worker /app
+COPY in /app
+RUN apt-get update && apt-get install -y procps && rm -rf /var/lib/apt/lists/*
+CMD ./worker in out

--- a/samples/docker_wrapper/Makefile
+++ b/samples/docker_wrapper/Makefile
@@ -1,0 +1,10 @@
+all: docker_wrapper
+
+CXXFLAGS = -g -I../../lib -I../../api\
+    -L../../lib -L../../api \
+    -Wformat-overflow=0
+
+docker_wrapper: docker_wrapper.cpp
+	g++ $(CXXFLAGS) docker_wrapper.cpp \
+	-lboinc_api -lboinc \
+    -o docker_wrapper

--- a/samples/docker_wrapper/Makefile
+++ b/samples/docker_wrapper/Makefile
@@ -6,5 +6,5 @@ CXXFLAGS = -g -I../../lib -I../../api\
 
 docker_wrapper: docker_wrapper.cpp
 	g++ $(CXXFLAGS) docker_wrapper.cpp \
-	-lboinc_api -lboinc \
+	-lboinc_api -lboinc -lpthread \
     -o docker_wrapper

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -1,0 +1,471 @@
+// docker_wrapper
+// runs in a directory (normally slot dir) containing
+//
+// Dockerfile
+// job.toml
+//      optional job config file
+// files added to contrainer via Dockerfile
+// other input files
+//
+// For now all files must be <copy_file>
+//
+// If the container already exists
+//      this is a restart of the job
+//      start the container if it's stopped
+// else
+//      this is the first run of the job
+//      if the image doesn't already exist
+//          build image with 'docker build'
+//      (need a log around the above?)
+//      create the container image with -v to mount slot, project dirs
+//      copy input files as needed
+// loop: handle msgs from client, check for container exit
+// on successful exit
+//      copy output files as needed
+
+// Names:
+// image name: name:tag
+//      name: lower case letters, digits, separators (. _ -); max 4096 chars
+//      tag: max 128 chars
+//      we'll use: boinc_proj_appname_planclass:version
+//
+// container name:
+//      letters, numbers, _
+//      max 255 chars
+//      we'll use: boinc_proj_resultname
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "toml.h"
+    // from https://github.com/mayah/tinytoml
+
+#include "util.h"
+#include "boinc_api.h"
+
+using std::string;
+using std::vector;
+
+#define POLL_PERIOD 1.0
+#define CONFIG_FILE_NAME "job.toml"
+
+enum JOB_STATUS {JOB_IN_PROGRESS, JOB_SUCCESS, JOB_FAIL};
+
+struct RSC_USAGE {
+    double cpu_time;
+    double wss;
+    void clear() {
+        cpu_time = 0;
+        wss = 0;
+    }
+};
+
+struct FILE_COPY {
+    string src;
+    string dst;
+};
+
+// parsed version of job.toml
+//
+struct CONFIG {
+    string slot_dir_mount;
+        // mount slot dir here
+    string project_dir_mount;
+        // mount project dir here
+    vector<FILE_COPY> copy_to_container;
+    vector<FILE_COPY> copy_from_container;
+    void print() {
+        printf("slot: %s\n", slot_dir_mount.c_str());
+        printf("proj: %s\n", project_dir_mount.c_str());
+        for (FILE_COPY c:copy_to_container) {
+            printf("to src %s dst %s\n", c.src.c_str(), c.dst.c_str());
+        }
+        for (FILE_COPY c:copy_from_container) {
+            printf("from src %s dst %s\n", c.src.c_str(), c.dst.c_str());
+        }
+    }
+};
+
+char image_name[512];
+char container_name[512];
+APP_INIT_DATA aid;
+CONFIG config;
+bool running;
+bool verbose = true;
+
+// parse a list of file copy specs
+//
+int parse_config_copies(const toml::Value *x, vector<FILE_COPY> &copies) {
+    const toml::Array& ar = x->as<toml::Array>();
+    for (const toml::Value& a : ar) {
+        FILE_COPY copy;
+        const toml::Value *b = a.find("src");
+        if (!b) return -1;
+        copy.src = b->as<string>();
+        const toml::Value *c = a.find("dst");
+        if (!c) return -1;
+        copy.dst = c->as<string>();
+        copies.push_back(copy);
+    }
+    return 0;
+}
+
+// parse job config file
+//
+int parse_config_file(CONFIG& config) {
+    int retval;
+    std::ifstream ifs(CONFIG_FILE_NAME);
+    toml::ParseResult r = toml::parse(ifs);
+    if (!r.valid()) {
+        fprintf(stderr, "TOML error: %s\n", r.errorReason.c_str());
+        return 1;
+    }
+    const toml::Value &v = r.value;
+    const toml::Value *x;
+    x = v.find("slot_dir_mount");
+    if (x) {
+        config.slot_dir_mount = x->as<string>();
+    }
+    x = v.find("project_dir_mount");
+    if (x) {
+        config.project_dir_mount = x->as<string>();
+    }
+    x = v.find("copy_to_container");
+    if (x) {
+        retval = parse_config_copies(x, config.copy_to_container);
+        if (retval) return retval;
+    }
+    x = v.find("copy_from_container");
+    if (x) {
+        retval = parse_config_copies(x, config.copy_from_container);
+        if (retval) return retval;
+    }
+
+    return 0;
+}
+
+
+// Run command and return output as vector of lines.
+// Return error if command failed
+//
+int run_command(char *cmd, vector<string> &out) {
+    out.clear();
+    if (verbose) {
+        fprintf(stderr, "running command: %s\n", cmd);
+    }
+#ifdef _WIN32
+#else
+    char buf[256];
+    FILE* fp = popen(cmd, "r");
+    if (!fp) {
+        fprintf(stderr, "can't run command %s\n", cmd);
+        return ERR_FOPEN;
+    }
+    while (fgets(buf, 256, fp)) {
+        out.push_back(buf);
+    }
+    if (verbose) {
+        fprintf(stderr, "output:\n");
+        for (string line: out) {
+            fprintf(stderr, "%s", line.c_str());
+        }
+    }
+    return 0;
+#endif
+}
+
+// See if command output includes "Error"
+//
+int error_output(vector<string> &out) {
+    for (string line: out) {
+        if (strstr(line.c_str(), "Error")) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+//////////  IMAGE  ////////////
+
+void get_image_name() {
+    char *p = strchr(aid.project_dir, '/');
+    sprintf(image_name, "boinc_%s_%s_%s:%d",
+        p+1, aid.app_name, aid.plan_class, aid.app_version
+    );
+}
+
+int image_exists(bool &exists) {
+    char cmd[256];
+    vector<string> out;
+
+    sprintf(cmd, "docker images 2>&1");
+    int retval = run_command(cmd, out);
+    if (retval) return retval;
+    for (string line: out) {
+        if (line.find(image_name) != string::npos) {
+            exists = true;
+            return 0;
+        }
+    }
+    exists = false;
+    return 0;
+}
+
+int build_image() {
+    char cmd[256];
+    vector<string> out;
+    sprintf(cmd, "docker build . -t %s 2>&1", image_name);
+    int retval = run_command(cmd, out);
+    if (retval) return retval;
+    return 0;
+}
+
+// build image if needed
+//
+int get_image() {
+    bool exists;
+    int retval;
+
+    retval = image_exists(exists);
+    if (retval) {
+        fprintf(stderr, "image_exists() failed: %d\n", retval);
+        exit(1);
+    }
+    if (!exists) {
+        if (verbose) printf("building image\n");
+        retval = build_image();
+        if (retval) {
+            fprintf(stderr, "build_image() failed: %d\n", retval);
+            exit(1);
+        }
+    }
+    return 0;
+}
+
+//////////  CONTAINER  ////////////
+
+void get_container_name() {
+    sprintf(container_name, "boinc_%s", aid.result_name);
+}
+
+int container_exists(bool &exists) {
+    char cmd[1024];
+    int retval;
+    vector<string> out;
+
+    sprintf(cmd, "docker ps --filter \"name=%s\"",
+        container_name
+    );
+    retval = run_command(cmd, out);
+    if (retval) return retval;
+    for (string line: out) {
+        if (strstr(line.c_str(), container_name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int create_container() {
+    char cmd[1024];
+    char slot_cmd[256], project_cmd[256];
+    vector<string> out;
+    int retval;
+
+    retval = get_image();
+    if (retval) return retval;
+
+    if (config.slot_dir_mount.empty()) {
+        slot_cmd[0] = 0;
+    } else {
+        sprintf(slot_cmd, " -v %s/slots/%d:%s",
+            aid.boinc_dir, aid.slot, config.slot_dir_mount.c_str()
+        );
+    }
+    if (config.project_dir_mount.empty()) {
+        project_cmd[0] = 0;
+    } else {
+        sprintf(project_cmd, " -v %s:%s",
+            aid.project_dir, config.project_dir_mount.c_str()
+        );
+    }
+    sprintf(cmd, "docker create --name %s %s %s %s",
+        container_name,
+        slot_cmd, project_cmd,
+        image_name
+    );
+    retval = run_command(cmd, out);
+    if (retval) return retval;
+    if (error_output(out)) return -1;
+
+    // copy files into container
+    //
+    for (FILE_COPY &c: config.copy_to_container) {
+        sprintf(cmd, "docker cp %s %s:%s",
+            c.src.c_str(), container_name, c.dst.c_str()
+        );
+        retval = run_command(cmd, out);
+        if (retval) return retval;
+        if (error_output(out)) return -1;
+    }
+    return 0;
+}
+
+int copy_files_from_container() {
+    char cmd[1024];
+    int retval;
+    vector<string> out;
+
+    for (FILE_COPY &c: config.copy_from_container) {
+        sprintf(cmd, "docker cp %s:%s %s",
+            container_name, c.src.c_str(), c.dst.c_str()
+        );
+        retval = run_command(cmd, out);
+        if (retval) return retval;
+    }
+    return 0;
+}
+
+int remove_container() {
+    char cmd[1024];
+    vector<string> out;
+    sprintf(cmd, "docker rm %s", container_name);
+    int retval = run_command(cmd, out);
+    return retval;
+}
+
+//////////  JOB CONTROL  ////////////
+
+int resume() {
+    char cmd[1024];
+    vector<string> out;
+    sprintf(cmd, "docker start %s", container_name);
+    int retval = run_command(cmd, out);
+    return retval;
+}
+
+int suspend() {
+    char cmd[1024];
+    vector<string> out;
+    sprintf(cmd, "docker stop %s", container_name);
+    int retval = run_command(cmd, out);
+    return retval;
+}
+
+void poll_client_msgs() {
+    BOINC_STATUS status;
+    boinc_get_status(&status);
+    if (status.no_heartbeat || status.quit_request || status.abort_request) {
+        fprintf(stderr, "got quit/abort from client\n");
+        suspend();
+        //remove_container();
+        exit(0);
+    }
+    if (status.suspended) {
+#if VERBOSE
+        fprintf(stderr, "suspended\n");
+#endif
+        if (running) suspend();
+    } else {
+#if VERBOSE
+        fprintf(stderr, "not suspended\n");
+#endif
+        if (!running) resume();
+    }
+}
+
+JOB_STATUS poll_app(RSC_USAGE &ru) {
+    char cmd[1024];
+    vector<string> out;
+    int retval;
+
+    sprintf(cmd, "docker ps -all -f \"name=%s\"", container_name);
+    retval = run_command(cmd, out);
+    if (retval) return JOB_FAIL;
+    for (string line: out) {
+        if (strstr(line.c_str(), container_name)) {
+            if (strstr(line.c_str(), "Exited")) {
+                return JOB_SUCCESS;
+            }
+            return JOB_IN_PROGRESS;
+        }
+    }
+    return JOB_FAIL;
+}
+
+int main(int argc, char** argv) {
+    BOINC_OPTIONS options;
+    int retval;
+    bool sporadic = false, exists;
+    RSC_USAGE ru;
+
+    for (int j=1; j<argc; j++) {
+        if (!strcmp(argv[j], "--sporadic")) {
+            sporadic = true;
+        } else if (!strcmp(argv[j], "--verbose")) {
+            verbose = true;
+        }
+    }
+
+    retval = parse_config_file(config);
+    if (retval) {
+        fprintf(stderr, "can't parse config file\n");
+        exit(1);
+    }
+    if (verbose) config.print();
+
+    memset(&options, 0, sizeof(options));
+    options.main_program = true;
+    options.check_heartbeat = true;
+    options.handle_process_control = true;
+
+    //boinc_init_options(&options);
+    boinc_get_init_data(aid);
+
+    if (boinc_is_standalone()) {
+        strcpy(image_name, "boinc_standalone");
+        strcpy(container_name, "boinc_test");
+        aid.slot = 0;
+        strcpy(aid.project_dir, ".");
+        strcpy(aid.boinc_dir, ".");
+    } else {
+        get_image_name();
+        get_container_name();
+    }
+
+    retval = container_exists(exists);
+    if (retval) {
+        fprintf(stderr, "container_exists() failed: %d\n", retval);
+        boinc_finish(1);
+    }
+    if (!exists) {
+        if (verbose) printf("creating container\n");
+        retval = create_container();
+        if (retval) {
+            fprintf(stderr, "create_container() failed: %d\n", retval);
+            boinc_finish(1);
+        }
+    }
+    retval = resume();
+    if (retval) {
+        fprintf(stderr, "resume() failed: %d\n", retval);
+        boinc_finish(1);
+    }
+    running = true;
+    while (1) {
+        poll_client_msgs();
+        switch(poll_app(ru)) {
+        case JOB_FAIL:
+            //remove_container();
+            boinc_finish(1);    // doesn't return
+            break;
+        case JOB_SUCCESS:
+            copy_files_from_container();
+            //remove_container();
+            boinc_finish(0);
+            break;
+        }
+        boinc_sleep(POLL_PERIOD);
+    }
+}

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -21,7 +21,7 @@
 // Unix:
 //      The host must have the Docker engine.
 //      The wrapper runs Docker commands using popen()
-//      
+//
 // Logic:
 // If the container already exists
 //      this is a restart of the job

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -383,7 +383,7 @@ void cleanup() {
             fprintf(stderr, "   %s\n", line.c_str());
         }
     }
-
+    return;
     sprintf(cmd, "%s container rm %s", cli_prog, container_name);
     run_docker_command(cmd, out);
 
@@ -486,12 +486,12 @@ int main(int argc, char** argv) {
     }
 
 #ifdef _WIN32
-#if 1
+#if 0
     SetCurrentDirectoryA("C:/ProgramData/BOINC/slots/test_docker_copy");
     config_file = "job_copy.toml";
     dockerfile = "Dockerfile_copy";
 #endif
-#if 0
+#if 1
     SetCurrentDirectoryA("C:/ProgramData/BOINC/slots/test_docker_mount");
     config_file = "job_mount.toml";
     dockerfile = "Dockerfile_mount";

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -51,8 +51,8 @@
 //      we'll use: boinc_<proj>_<resultname>
 
 // standalone mode:
-// image name: boinc_standalone
-// container name: boinc_test
+// image name: boinc
+// container name: boinc
 // slot dir: .
 // project dir: project/
 
@@ -222,7 +222,7 @@ inline int run_docker_command(char* cmd, vector<string> &out) {
     if (verbose) {
         fprintf(stderr, "output:\n");
         for (string line: out) {
-            fprintf(stderr, "%s", line.c_str());
+            fprintf(stderr, "%s\n", line.c_str());
         }
     }
     return 0;
@@ -393,7 +393,7 @@ void cleanup() {
             fprintf(stderr, "   %s\n", line.c_str());
         }
     }
-    return;
+
     sprintf(cmd, "%s container rm %s", cli_prog, container_name);
     run_docker_command(cmd, out);
 
@@ -515,9 +515,9 @@ int main(int argc, char** argv) {
     boinc_init_options(&options);
 
     if (boinc_is_standalone()) {
-        strcpy(image_name, "boinc_standalone");
-        strcpy(container_name, "boinc_test");
-        strcpy(aid.project_dir, "project");
+        strcpy(image_name, "boinc");
+        strcpy(container_name, "boinc");
+        strcpy(aid.project_dir, "./project");
     } else {
         boinc_get_init_data(aid);
         get_image_name();

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -198,7 +198,10 @@ int error_output(vector<string> &out) {
 }
 
 inline int run_docker_command(char* cmd, vector<string> &out) {
-    out.clear();
+    int retval;
+    if (verbose) {
+        fprintf(stderr, "running docker command: %s\n", cmd);
+    }
 #ifdef _WIN32
     // Win: run the command in the WSL container
 
@@ -207,15 +210,22 @@ inline int run_docker_command(char* cmd, vector<string> &out) {
 
     sprintf(buf, "%s; echo EOM\n", cmd);
     write_to_pipe(ctl_wc.in_write, buf);
-    int retval = read_from_pipe(
+    retval = read_from_pipe(
         ctl_wc.out_read, ctl_wc.proc_handle, output, TIMEOUT, "EOM"
     );
     if (retval) return retval;
     out = split(output, '\n');
-    return 0;
 #else
-    return run_command(cmd, out, verbose);
+    retval = run_command(cmd, out);
+    if (retval) return retval;
 #endif
+    if (verbose) {
+        fprintf(stderr, "output:\n");
+        for (string line: out) {
+            fprintf(stderr, "%s", line.c_str());
+        }
+    }
+    return 0;
 }
 
 //////////  IMAGE  ////////////

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -43,12 +43,12 @@
 //      name: lower case letters, digits, separators (. _ -); max 4096 chars
 //      tag: max 128 chars
 //      in the universal model, each WU has a different image
-//      so we'll use: boinc_<proj>_<wuname>
+//      so we'll use: boinc__<proj>__<wuname>
 //
 // container name:
 //      letters, numbers, _
 //      max 255 chars
-//      we'll use: boinc_<proj>_<resultname>
+//      we'll use: boinc__<proj>__<resultname>
 
 // standalone mode:
 // image name: boinc
@@ -230,8 +230,8 @@ inline int run_docker_command(char* cmd, vector<string> &out) {
 //////////  IMAGE  ////////////
 
 void get_image_name() {
-    char *p = strchr(aid.project_dir, '/');
-    sprintf(image_name, "boinc_%s_%s",
+    char *p = strrchr(aid.project_dir, '/');
+    sprintf(image_name, "boinc__%s__%s",
         p+1, aid.wu_name
     );
 }
@@ -287,8 +287,8 @@ int get_image() {
 //////////  CONTAINER  ////////////
 
 void get_container_name() {
-    char *p = strchr(aid.project_dir, '/');
-    sprintf(container_name, "boinc_%s_%s", p, aid.result_name);
+    char *p = strrchr(aid.project_dir, '/');
+    sprintf(container_name, "boinc__%s__%s", p+1, aid.result_name);
 }
 
 int container_exists(bool &exists) {
@@ -403,7 +403,7 @@ void cleanup() {
 int resume() {
     char cmd[1024];
     vector<string> out;
-    sprintf(cmd, "%s start %s", cli_prog, container_name);
+    sprintf(cmd, "%s unpause %s", cli_prog, container_name);
     int retval = run_docker_command(cmd, out);
     return retval;
 }
@@ -411,7 +411,7 @@ int resume() {
 int suspend() {
     char cmd[1024];
     vector<string> out;
-    sprintf(cmd, "%s stop %s", cli_prog, container_name);
+    sprintf(cmd, "%s pause %s", cli_prog, container_name);
     int retval = run_docker_command(cmd, out);
     return retval;
 }
@@ -425,14 +425,14 @@ void poll_client_msgs() {
         exit(0);
     }
     if (status.suspended) {
-#if VERBOSE
-        fprintf(stderr, "suspended\n");
-#endif
+        if (verbose) {
+            fprintf(stderr, "client: suspended\n");
+        }
         if (running) suspend();
     } else {
-#if VERBOSE
-        fprintf(stderr, "not suspended\n");
-#endif
+        if (verbose) {
+            fprintf(stderr, "client: not suspended\n");
+        }
         if (!running) resume();
     }
 }
@@ -497,12 +497,13 @@ int main(int argc, char** argv) {
     }
 
 #ifdef _WIN32
+    // standalone tests; comment out if using client
 #if 0
     SetCurrentDirectoryA("C:/ProgramData/BOINC/slots/test_docker_copy");
     config_file = "job_copy.toml";
     dockerfile = "Dockerfile_copy";
 #endif
-#if 1
+#if 0
     SetCurrentDirectoryA("C:/ProgramData/BOINC/slots/test_docker_mount");
     config_file = "job_mount.toml";
     dockerfile = "Dockerfile_mount";

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -145,36 +145,6 @@ int parse_config_file(CONFIG& config) {
     return 0;
 }
 
-
-// Run command and return output as vector of lines.
-// Return error if command failed
-//
-int run_command(char *cmd, vector<string> &out) {
-    out.clear();
-    if (verbose) {
-        fprintf(stderr, "running command: %s\n", cmd);
-    }
-#ifdef _WIN32
-#else
-    char buf[256];
-    FILE* fp = popen(cmd, "r");
-    if (!fp) {
-        fprintf(stderr, "can't run command %s\n", cmd);
-        return ERR_FOPEN;
-    }
-    while (fgets(buf, 256, fp)) {
-        out.push_back(buf);
-    }
-    if (verbose) {
-        fprintf(stderr, "output:\n");
-        for (string line: out) {
-            fprintf(stderr, "%s", line.c_str());
-        }
-    }
-    return 0;
-#endif
-}
-
 // See if command output includes "Error"
 //
 int error_output(vector<string> &out) {

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -39,15 +39,16 @@
 //      copy output files as needed
 
 // Names:
-// image name: name:tag
+// image name
 //      name: lower case letters, digits, separators (. _ -); max 4096 chars
 //      tag: max 128 chars
-//      we'll use: boinc_proj_appname_planclass:version
+//      in the universal model, each WU has a different image
+//      so we'll use: boinc_<proj>_<wuname>
 //
 // container name:
 //      letters, numbers, _
 //      max 255 chars
-//      we'll use: boinc_proj_resultname
+//      we'll use: boinc_<proj>_<resultname>
 
 #include <cstdio>
 #include <string>
@@ -67,7 +68,6 @@ using std::string;
 using std::vector;
 
 #define POLL_PERIOD 1.0
-#define CONFIG_FILE_NAME "job.toml"
 
 enum JOB_STATUS {JOB_IN_PROGRESS, JOB_SUCCESS, JOB_FAIL};
 
@@ -112,7 +112,8 @@ APP_INIT_DATA aid;
 CONFIG config;
 bool running;
 bool verbose = true;
-char* config_file = CONFIG_FILE_NAME;
+const char* config_file = "job.toml";
+const char* dockerfile = "Dockerfile";
 #ifdef _WIN32
 WSL_CMD ctl_wc;
 #endif
@@ -227,7 +228,7 @@ int image_exists(bool &exists) {
 int build_image() {
     char cmd[256];
     vector<string> out;
-    sprintf(cmd, "docker build . -t %s", image_name);
+    sprintf(cmd, "docker build . -t %s -f %s", image_name, dockerfile);
     int retval = run_command(cmd, out, verbose);
     if (retval) return retval;
     return 0;
@@ -435,6 +436,8 @@ int main(int argc, char** argv) {
             verbose = true;
         } else if (!strcmp(argv[j], "--config")) {
             config_file = argv[++j];
+        } else if (!strcmp(argv[j], "--dockerfile")) {
+            dockerfile = argv[++j];
         }
     }
 

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -139,7 +139,7 @@ int parse_config_copies(const toml::Value *x, vector<FILE_COPY> &copies) {
 //
 int parse_config_file() {
     int retval;
-    std::ifstream ifs(CONFIG_FILE_NAME);
+    std::ifstream ifs(config_file);
     toml::ParseResult r = toml::parse(ifs);
     if (!r.valid()) {
         fprintf(stderr, "TOML error: %s\n", r.errorReason.c_str());
@@ -203,8 +203,8 @@ inline int run_docker_command(char* cmd, vector<string> &out) {
 
 void get_image_name() {
     char *p = strchr(aid.project_dir, '/');
-    sprintf(image_name, "boinc_%s_%s_%s:%d",
-        p+1, aid.app_name, aid.plan_class, aid.app_version
+    sprintf(image_name, "boinc_%s_%s",
+        p+1, aid.wu_name
     );
 }
 
@@ -259,7 +259,8 @@ int get_image() {
 //////////  CONTAINER  ////////////
 
 void get_container_name() {
-    sprintf(container_name, "boinc_%s", aid.result_name);
+    char *p = strchr(aid.project_dir, '/');
+    sprintf(container_name, "boinc_%s_%s", p, aid.result_name);
 }
 
 int container_exists(bool &exists) {

--- a/samples/docker_wrapper/job.toml
+++ b/samples/docker_wrapper/job.toml
@@ -1,0 +1,7 @@
+#slot_dir_mount = "/foo/bar"
+
+copy_to_container = [
+]
+copy_from_container = [
+    {src="/app/out", dst="out"}
+]

--- a/samples/docker_wrapper/test_copy/Dockerfile_copy
+++ b/samples/docker_wrapper/test_copy/Dockerfile_copy
@@ -1,0 +1,4 @@
+FROM debian
+WORKDIR /app
+COPY in /app
+CMD ./worker in out

--- a/samples/docker_wrapper/test_copy/in
+++ b/samples/docker_wrapper/test_copy/in
@@ -1,0 +1,1 @@
+A screaming comes across the sky.

--- a/samples/docker_wrapper/test_copy/job_copy.toml
+++ b/samples/docker_wrapper/test_copy/job_copy.toml
@@ -1,6 +1,5 @@
-#slot_dir_mount = "/foo/bar"
-
 copy_to_container = [
+    {src="worker", dst="/app/worker"}
 ]
 copy_from_container = [
     {src="/app/out", dst="out"}

--- a/samples/docker_wrapper/test_mount/Dockerfile_mount
+++ b/samples/docker_wrapper/test_mount/Dockerfile_mount
@@ -1,3 +1,4 @@
 FROM debian
 WORKDIR /app
-CMD ./worker in out
+COPY main.sh /app
+CMD ./main.sh

--- a/samples/docker_wrapper/test_mount/Dockerfile_mount
+++ b/samples/docker_wrapper/test_mount/Dockerfile_mount
@@ -1,0 +1,3 @@
+FROM debian
+WORKDIR /app
+CMD ./worker in out

--- a/samples/docker_wrapper/test_mount/in
+++ b/samples/docker_wrapper/test_mount/in
@@ -1,0 +1,1 @@
+A screaming comes across the sky.

--- a/samples/docker_wrapper/test_mount/in
+++ b/samples/docker_wrapper/test_mount/in
@@ -1,1 +1,1 @@
-A screaming comes across the sky.
+<soft_link>../../projects/foobar/in</soft_link>

--- a/samples/docker_wrapper/test_mount/job_mount.toml
+++ b/samples/docker_wrapper/test_mount/job_mount.toml
@@ -1,0 +1,2 @@
+slot_dir_mount = "/slot"
+project_dir_mount = "/project"

--- a/samples/docker_wrapper/test_mount/job_mount.toml
+++ b/samples/docker_wrapper/test_mount/job_mount.toml
@@ -1,2 +1,2 @@
-slot_dir_mount = "/slot"
-project_dir_mount = "/project"
+slot_dir_mount = "/app/slot"
+project_dir_mount = "/app/project"

--- a/samples/docker_wrapper/test_mount/main.sh
+++ b/samples/docker_wrapper/test_mount/main.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+resolve () {
+    sed 's/<soft_link>..\/..\/projects\/[^\/]*\//project\//; s/<\/soft_link>//' $1 | tr -d '\r\n'
+}
+
+$(resolve slot/worker) --nsecs 1 $(resolve slot/in) slot/out

--- a/samples/docker_wrapper/test_mount/main_mount.sh
+++ b/samples/docker_wrapper/test_mount/main_mount.sh
@@ -1,0 +1,7 @@
+#! /bin/bash
+
+resolve () {
+    sed 's/<soft_link>//; s/<\/soft_link>//' $1 | tr -d '\r\n'
+}
+
+$(resolve worker) --nsecs 60 $(resolve in) $(resolve out)

--- a/samples/docker_wrapper/test_mount/main_mount.sh
+++ b/samples/docker_wrapper/test_mount/main_mount.sh
@@ -1,7 +1,0 @@
-#! /bin/bash
-
-resolve () {
-    sed 's/<soft_link>//; s/<\/soft_link>//' $1 | tr -d '\r\n'
-}
-
-$(resolve worker) --nsecs 60 $(resolve in) $(resolve out)

--- a/samples/docker_wrapper/test_mount/worker
+++ b/samples/docker_wrapper/test_mount/worker
@@ -1,0 +1,1 @@
+<soft_link>../../projects/test/worker</soft_link>

--- a/samples/docker_wrapper/toml.h
+++ b/samples/docker_wrapper/toml.h
@@ -1,0 +1,2049 @@
+#ifndef TINYTOML_H_
+#define TINYTOML_H_
+
+#include <algorithm>
+#include <cassert>
+#include <cctype>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <istream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace toml {
+
+// ----------------------------------------------------------------------
+// Declarations
+
+class Value;
+typedef std::chrono::system_clock::time_point Time;
+typedef std::vector<Value> Array;
+typedef std::map<std::string, Value> Table;
+
+namespace internal {
+template<typename T> struct call_traits_value {
+    typedef T return_type;
+};
+template<typename T> struct call_traits_ref {
+    typedef const T& return_type;
+};
+} // namespace internal
+
+template<typename T> struct call_traits;
+template<> struct call_traits<bool> : public internal::call_traits_value<bool> {};
+template<> struct call_traits<int> : public internal::call_traits_value<int> {};
+template<> struct call_traits<int64_t> : public internal::call_traits_value<int64_t> {};
+template<> struct call_traits<double> : public internal::call_traits_value<double> {};
+template<> struct call_traits<std::string> : public internal::call_traits_ref<std::string> {};
+template<> struct call_traits<Time> : public internal::call_traits_ref<Time> {};
+template<> struct call_traits<Array> : public internal::call_traits_ref<Array> {};
+template<> struct call_traits<Table> : public internal::call_traits_ref<Table> {};
+
+// A value is returned for std::vector<T>. Not reference.
+// This is because a fresh vector is made.
+template<typename T> struct call_traits<std::vector<T>> : public internal::call_traits_value<std::vector<T>> {};
+
+// Formatting flags
+enum FormatFlag {
+    FORMAT_NONE = 0,
+    FORMAT_INDENT = 1
+};
+
+class Value {
+public:
+    enum Type {
+        NULL_TYPE,
+        BOOL_TYPE,
+        INT_TYPE,
+        DOUBLE_TYPE,
+        STRING_TYPE,
+        TIME_TYPE,
+        ARRAY_TYPE,
+        TABLE_TYPE,
+    };
+
+    Value() : type_(NULL_TYPE), null_(nullptr) {}
+    Value(bool v) : type_(BOOL_TYPE), bool_(v) {}
+    Value(int v) : type_(INT_TYPE), int_(v) {}
+    Value(int64_t v) : type_(INT_TYPE), int_(v) {}
+    Value(double v) : type_(DOUBLE_TYPE), double_(v) {}
+    Value(const std::string& v) : type_(STRING_TYPE), string_(new std::string(v)) {}
+    Value(const char* v) : type_(STRING_TYPE), string_(new std::string(v)) {}
+    Value(const Time& v) : type_(TIME_TYPE), time_(new Time(v)) {}
+    Value(const Array& v) : type_(ARRAY_TYPE), array_(new Array(v)) {}
+    Value(const Table& v) : type_(TABLE_TYPE), table_(new Table(v)) {}
+    Value(std::string&& v) : type_(STRING_TYPE), string_(new std::string(std::move(v))) {}
+    Value(Array&& v) : type_(ARRAY_TYPE), array_(new Array(std::move(v))) {}
+    Value(Table&& v) : type_(TABLE_TYPE), table_(new Table(std::move(v))) {}
+
+    Value(const Value& v);
+    Value(Value&& v) noexcept;
+    Value& operator=(const Value& v);
+    Value& operator=(Value&& v) noexcept;
+
+    // Guards from unexpected Value construction.
+    // Someone might use a value like this:
+    //   toml::Value v = x->find("foo");
+    // But this is wrong. Without this constructor,
+    // value will be unexpectedly initialized with bool.
+    Value(const void* v) = delete;
+    ~Value();
+
+    // Retruns Value size.
+    // 0 for invalid value.
+    // The number of inner elements for array or table.
+    // 1 for other types.
+    size_t size() const;
+    bool empty() const;
+    Type type() const { return type_; }
+
+    bool valid() const { return type_ != NULL_TYPE; }
+    template<typename T> bool is() const;
+    template<typename T> typename call_traits<T>::return_type as() const;
+
+    friend bool operator==(const Value& lhs, const Value& rhs);
+    friend bool operator!=(const Value& lhs, const Value& rhs) { return !(lhs == rhs); }
+
+    // ----------------------------------------------------------------------
+    // For integer/floating value
+
+    // Returns true if the value is int or double.
+    bool isNumber() const;
+    // Returns number. Convert to double.
+    double asNumber() const;
+
+    // ----------------------------------------------------------------------
+    // For Time value
+
+    // Converts to time_t if the internal value is Time.
+    // We don't have as<std::time_t>(). Since time_t is basically signed long,
+    // it's something like a method to converting to (normal) integer.
+    std::time_t as_time_t() const;
+
+    // ----------------------------------------------------------------------
+    // For Table value
+    template<typename T> typename call_traits<T>::return_type get(const std::string&) const;
+    Value* set(const std::string& key, const Value& v);
+    // Finds a Value with |key|. |key| can contain '.'
+    // Note: if you would like to find a child value only, you need to use findChild.
+    const Value* find(const std::string& key) const;
+    Value* find(const std::string& key);
+    bool has(const std::string& key) const { return find(key) != nullptr; }
+    bool erase(const std::string& key);
+
+    Value& operator[](const std::string& key);
+
+    // Merge table. Returns true if succeeded. Otherwise, |this| might be corrupted.
+    // When the same key exists, it will be overwritten.
+    bool merge(const Value&);
+
+    // Finds a value with |key|. It searches only children.
+    Value* findChild(const std::string& key);
+    const Value* findChild(const std::string& key) const;
+    // Sets a value, and returns the pointer to the created value.
+    // When the value having the same key exists, it will be overwritten.
+    Value* setChild(const std::string& key, const Value& v);
+    Value* setChild(const std::string& key, Value&& v);
+    bool eraseChild(const std::string& key);
+
+    // ----------------------------------------------------------------------
+    // For Array value
+
+    template<typename T> typename call_traits<T>::return_type get(size_t index) const;
+    const Value* find(size_t index) const;
+    Value* find(size_t index);
+    Value* push(const Value& v);
+    Value* push(Value&& v);
+
+    // ----------------------------------------------------------------------
+    // Others
+
+    // Writer.
+    static std::string spaces(int num);
+    static std::string escapeKey(const std::string& key);
+
+    void write(std::ostream*, const std::string& keyPrefix = std::string(), int indent = -1) const;
+    void writeFormatted(std::ostream*, FormatFlag flags) const;
+
+    friend std::ostream& operator<<(std::ostream&, const Value&);
+
+private:
+    static const char* typeToString(Type);
+
+    template<typename T> void assureType() const;
+    Value* ensureValue(const std::string& key);
+
+    template<typename T> struct ValueConverter;
+
+    Type type_;
+    union {
+        void* null_;
+        bool bool_;
+        int64_t int_;
+        double double_;
+        std::string* string_;
+        Time* time_;
+        Array* array_;
+        Table* table_;
+    };
+
+    template<typename T> friend struct ValueConverter;
+};
+
+// parse() returns ParseResult.
+struct ParseResult {
+    ParseResult(toml::Value v, std::string er) :
+        value(std::move(v)),
+        errorReason(std::move(er)) {}
+
+    bool valid() const { return value.valid(); }
+
+    toml::Value value;
+    std::string errorReason;
+};
+
+// Parses from std::istream.
+ParseResult parse(std::istream&);
+// Parses a file.
+ParseResult parseFile(const std::string& filename);
+
+// ----------------------------------------------------------------------
+// Declarations for Implementations
+//   You don't need to understand the below to use this library.
+
+#if defined(_WIN32)
+// Windows does not have timegm but have _mkgmtime.
+inline time_t timegm(std::tm* timeptr)
+{
+    return _mkgmtime(timeptr);
+}
+
+// On Windows, Visual Studio does not define gmtime_r. However, mingw might
+// do (or might not do). See https://github.com/mayah/tinytoml/issues/25,
+#ifndef gmtime_r
+inline struct tm* gmtime_r(const time_t* t, struct tm* r)
+{
+    // gmtime is threadsafe in windows because it uses TLS
+    struct tm *theTm = gmtime(t);
+    if (theTm) {
+        *r = *theTm;
+        return r;
+    } else {
+        return 0;
+    }
+}
+#endif  // gmtime_r
+#endif  // _WIN32
+
+namespace internal {
+
+enum class TokenType {
+    ERROR_TOKEN,
+    END_OF_FILE,
+    END_OF_LINE,
+    IDENT,
+    STRING,
+    MULTILINE_STRING,
+    BOOL,
+    INT,
+    DOUBLE,
+    TIME,
+    COMMA,
+    DOT,
+    EQUAL,
+    LBRACKET,
+    RBRACKET,
+    LBRACE,
+    RBRACE,
+};
+
+class Token {
+public:
+    explicit Token(TokenType tokenType) : type_(tokenType) {}
+    Token(TokenType tokenType, const std::string& v) : type_(tokenType), str_value_(v) {}
+    Token(TokenType tokenType, bool v) : type_(tokenType), int_value_(v) {}
+    Token(TokenType tokenType, std::int64_t v) : type_(tokenType), int_value_(v) {}
+    Token(TokenType tokenType, double v) : type_(tokenType), double_value_(v) {}
+    Token(TokenType tokenType, std::chrono::system_clock::time_point tp) : type_(tokenType), time_value_(tp) {}
+
+    TokenType type() const { return type_; }
+    const std::string& strValue() const { return str_value_; }
+    bool boolValue() const { return int_value_ != 0; }
+    std::int64_t intValue() const { return int_value_; }
+    double doubleValue() const { return double_value_; }
+    std::chrono::system_clock::time_point timeValue() const { return time_value_; }
+
+private:
+    TokenType type_;
+    std::string str_value_;
+    std::int64_t int_value_;
+    double double_value_;
+    std::chrono::system_clock::time_point time_value_;
+};
+
+class Lexer {
+public:
+    explicit Lexer(std::istream& is) : is_(is), lineNo_(1) {}
+
+    Token nextKeyToken();
+    Token nextValueToken();
+
+    int lineNo() const { return lineNo_; }
+
+    // Skips if UTF8BOM is found.
+    // Returns true if success. Returns false if intermediate state is left.
+    bool skipUTF8BOM();
+
+private:
+    bool current(char* c);
+    void next();
+    bool consume(char c);
+
+    Token nextToken(bool isValueToken);
+
+    void skipUntilNewLine();
+
+    Token nextStringDoubleQuote();
+    Token nextStringSingleQuote();
+
+    Token nextKey();
+    Token nextValue();
+
+    Token parseAsTime(const std::string&);
+
+    std::istream& is_;
+    int lineNo_;
+};
+
+class Parser {
+public:
+    explicit Parser(std::istream& is) : lexer_(is), token_(TokenType::ERROR_TOKEN)
+    {
+        if (!lexer_.skipUTF8BOM()) {
+            token_ = Token(TokenType::ERROR_TOKEN, std::string("Invalid UTF8 BOM"));
+        } else {
+            nextKey();
+        }
+    }
+
+    // Parses. If failed, value should be invalid value.
+    // You can get the error by calling errorReason().
+    Value parse();
+    const std::string& errorReason();
+
+private:
+    const Token& token() const { return token_; }
+    void nextKey() { token_ = lexer_.nextKeyToken(); }
+    void nextValue() { token_ = lexer_.nextValueToken(); }
+
+    void skipForKey();
+    void skipForValue();
+
+    bool consumeForKey(TokenType);
+    bool consumeForValue(TokenType);
+    bool consumeEOLorEOFForKey();
+
+    Value* parseGroupKey(Value* root);
+
+    bool parseKeyValue(Value*);
+    bool parseKey(std::string*);
+    bool parseValue(Value*);
+    bool parseBool(Value*);
+    bool parseNumber(Value*);
+    bool parseArray(Value*);
+    bool parseInlineTable(Value*);
+
+    void addError(const std::string& reason);
+
+    Lexer lexer_;
+    Token token_;
+    std::string errorReason_;
+};
+
+} // namespace internal
+
+// ----------------------------------------------------------------------
+// Implementations
+
+inline ParseResult parse(std::istream& is)
+{
+    if (!is) {
+        return ParseResult(toml::Value(), "stream is in bad state. file does not exist?");
+    }
+
+    internal::Parser parser(is);
+    toml::Value v = parser.parse();
+
+    if (v.valid())
+        return ParseResult(std::move(v), std::string());
+
+    return ParseResult(std::move(v), std::move(parser.errorReason()));
+}
+
+inline ParseResult parseFile(const std::string& filename)
+{
+    std::ifstream ifs(filename);
+    if (!ifs) {
+        return ParseResult(toml::Value(),
+                           std::string("could not open file: ") + filename);
+    }
+
+    return parse(ifs);
+}
+
+inline std::string format(std::stringstream& ss)
+{
+    return ss.str();
+}
+
+template<typename T, typename... Args>
+std::string format(std::stringstream& ss, T&& t, Args&&... args)
+{
+    ss << std::forward<T>(t);
+    return format(ss, std::forward<Args>(args)...);
+}
+
+// If you want to compile without exception,
+//   1. Define TOML_HAVE_FAILWITH_REPLACEMENT
+//   2. Define your own toml::failwith.
+// e.g. You can just abort here instead of exception.
+#ifndef TOML_HAVE_FAILWITH_REPLACEMENT
+
+template<typename... Args>
+#if defined(_MSC_VER)
+__declspec(noreturn)
+#else
+[[noreturn]]
+#endif
+void failwith(Args&&... args)
+{
+    std::stringstream ss;
+    throw std::runtime_error(format(ss, std::forward<Args>(args)...));
+}
+
+#endif
+
+namespace internal {
+
+inline std::string removeDelimiter(const std::string& s)
+{
+    std::string r;
+    for (char c : s) {
+        if (c == '_')
+            continue;
+        r += c;
+    }
+    return r;
+}
+
+inline std::string unescape(const std::string& codepoint)
+{
+    std::uint32_t x;
+    std::uint8_t buf[8];
+    std::stringstream ss(codepoint);
+
+    ss >> std::hex >> x;
+
+    if (x <= 0x7FUL) {
+        // 0xxxxxxx
+        buf[0] = 0x00 | ((x >> 0) & 0x7F);
+        buf[1] = '\0';
+    } else if (x <= 0x7FFUL) {
+        // 110yyyyx 10xxxxxx
+        buf[0] = 0xC0 | ((x >> 6) & 0xDF);
+        buf[1] = 0x80 | ((x >> 0) & 0xBF);
+        buf[2] = '\0';
+    } else if (x <= 0xFFFFUL) {
+        // 1110yyyy 10yxxxxx 10xxxxxx
+        buf[0] = 0xE0 | ((x >> 12) & 0xEF);
+        buf[1] = 0x80 | ((x >> 6) & 0xBF);
+        buf[2] = 0x80 | ((x >> 0) & 0xBF);
+        buf[3] = '\0';
+    } else if (x <= 0x10FFFFUL) {
+        // 11110yyy 10yyxxxx 10xxxxxx 10xxxxxx
+        buf[0] = 0xF0 | ((x >> 18) & 0xF7);
+        buf[1] = 0x80 | ((x >> 12) & 0xBF);
+        buf[2] = 0x80 | ((x >> 6) & 0xBF);
+        buf[3] = 0x80 | ((x >> 0) & 0xBF);
+        buf[4] = '\0';
+    } else {
+        buf[0] = '\0';
+    }
+
+    return reinterpret_cast<char*>(buf);
+}
+
+// Returns true if |s| is integer.
+// [+-]?\d+(_\d+)*
+inline bool isInteger(const std::string& s)
+{
+    if (s.empty())
+        return false;
+
+    std::string::size_type p = 0;
+    if (s[p] == '+' || s[p] == '-')
+        ++p;
+
+    while (p < s.size() && '0' <= s[p] && s[p] <= '9') {
+        ++p;
+        if (p < s.size() && s[p] == '_') {
+            ++p;
+            if (!(p < s.size() && '0' <= s[p] && s[p] <= '9'))
+                return false;
+        }
+    }
+
+    return p == s.size();
+}
+
+// Returns true if |s| is double.
+// [+-]? (\d+(_\d+)*)? (\.\d+(_\d+)*)? ([eE] [+-]? \d+(_\d+)*)?
+//       1-----------  2-------------  3----------------------
+// 2 or (1 and 3) should exist.
+inline bool isDouble(const std::string& s)
+{
+    if (s.empty())
+        return false;
+
+    std::string::size_type p = 0;
+    if (s[p] == '+' || s[p] == '-')
+        ++p;
+
+    bool ok = false;
+    while (p < s.size() && '0' <= s[p] && s[p] <= '9') {
+        ++p;
+        ok = true;
+
+        if (p < s.size() && s[p] == '_') {
+            ++p;
+            if (!(p < s.size() && '0' <= s[p] && s[p] <= '9'))
+                return false;
+        }
+    }
+
+    if (p < s.size() && s[p] == '.')
+        ++p;
+
+    while (p < s.size() && '0' <= s[p] && s[p] <= '9') {
+        ++p;
+        ok = true;
+
+        if (p < s.size() && s[p] == '_') {
+            ++p;
+            if (!(p < s.size() && '0' <= s[p] && s[p] <= '9'))
+                return false;
+        }
+    }
+
+    if (!ok)
+        return false;
+
+    ok = false;
+    if (p < s.size() && (s[p] == 'e' || s[p] == 'E')) {
+        ++p;
+        if (p < s.size() && (s[p] == '+' || s[p] == '-'))
+            ++p;
+        while (p < s.size() && '0' <= s[p] && s[p] <= '9') {
+            ++p;
+            ok = true;
+
+            if (p < s.size() && s[p] == '_') {
+                ++p;
+                if (!(p < s.size() && '0' <= s[p] && s[p] <= '9'))
+                    return false;
+            }
+        }
+        if (!ok)
+            return false;
+    }
+
+    return p == s.size();
+}
+
+// static
+inline std::string escapeString(const std::string& s)
+{
+    std::stringstream ss;
+    for (size_t i = 0; i < s.size(); ++i) {
+        switch (s[i]) {
+        case '\n': ss << "\\n"; break;
+        case '\r': ss << "\\r"; break;
+        case '\t': ss << "\\t"; break;
+        case '\"': ss << "\\\""; break;
+        case '\'': ss << "\\\'"; break;
+        case '\\': ss << "\\\\"; break;
+        default: ss << s[i]; break;
+        }
+    }
+
+    return ss.str();
+}
+
+} // namespace internal
+
+// ----------------------------------------------------------------------
+// Lexer
+
+namespace internal {
+
+inline bool Lexer::skipUTF8BOM()
+{
+    // Check [EF, BB, BF]
+
+    int x1 = is_.peek();
+    if (x1 != 0xEF) {
+        // When the first byte is not 0xEF, it's not UTF8 BOM.
+        // Just return true.
+        return true;
+    }
+
+    is_.get();
+    int x2 = is_.get();
+    if (x2 != 0xBB) {
+        return false;
+    }
+
+    int x3 = is_.get();
+    if (x3 != 0xBF) {
+        return false;
+    }
+
+    return true;
+}
+
+inline bool Lexer::current(char* c)
+{
+    int x = is_.peek();
+    if (x == EOF)
+        return false;
+    *c = static_cast<char>(x);
+    return true;
+}
+
+inline void Lexer::next()
+{
+    int x = is_.get();
+    if (x == '\n')
+        ++lineNo_;
+}
+
+inline bool Lexer::consume(char c)
+{
+    char x;
+    if (!current(&x))
+        return false;
+    if (x != c)
+        return false;
+    next();
+    return true;
+}
+
+inline void Lexer::skipUntilNewLine()
+{
+    char c;
+    while (current(&c)) {
+        if (c == '\n')
+            return;
+        next();
+    }
+}
+
+inline Token Lexer::nextStringDoubleQuote()
+{
+    if (!consume('"'))
+        return Token(TokenType::ERROR_TOKEN, std::string("string didn't start with '\"'"));
+
+    std::string s;
+    char c;
+    bool multiline = false;
+
+    if (current(&c) && c == '"') {
+        next();
+        if (!current(&c) || c != '"') {
+            // OK. It's empty string.
+            return Token(TokenType::STRING, std::string());
+        }
+
+        next();
+        // raw string literal started.
+        // Newline just after """ should be ignored.
+        while (current(&c) && (c == ' ' || c == '\t'))
+            next();
+        if (current(&c) && c == '\n')
+            next();
+        multiline = true;
+    }
+
+    while (current(&c)) {
+        next();
+        if (c == '\\') {
+            if (!current(&c))
+                return Token(TokenType::ERROR_TOKEN, std::string("string has unknown escape sequence"));
+            next();
+            switch (c) {
+            case 't': c = '\t'; break;
+            case 'n': c = '\n'; break;
+            case 'r': c = '\r'; break;
+            case 'u':
+            case 'U': {
+                int size = c == 'u' ? 4 : 8;
+                std::string codepoint;
+                for (int i = 0; i < size; ++i) {
+                  if (current(&c) && (('0' <= c && c <= '9') || ('A' <= c && c <= 'F') || ('a' <= c && c <= 'f'))) {
+                    codepoint += c;
+                    next();
+                  } else {
+                    return Token(TokenType::ERROR_TOKEN, std::string("string has unknown escape sequence"));
+                  }
+                }
+                s += unescape(codepoint);
+                continue;
+            }
+            case '"': c = '"'; break;
+            case '\'': c = '\''; break;
+            case '\\': c = '\\'; break;
+            case '\n':
+                while (current(&c) && (c == ' ' || c == '\t' || c == '\r' || c == '\n')) {
+                    next();
+                }
+                continue;
+            default:
+                return Token(TokenType::ERROR_TOKEN, std::string("string has unknown escape sequence"));
+            }
+        } else if (c == '"') {
+            if (multiline) {
+                if (current(&c) && c == '"') {
+                    next();
+                    if (current(&c) && c == '"') {
+                        next();
+                        return Token(TokenType::MULTILINE_STRING, s);
+                    } else {
+                        s += '"';
+                        s += '"';
+                        continue;
+                    }
+                } else {
+                    s += '"';
+                    continue;
+                }
+            } else {
+                return Token(TokenType::STRING, s);
+            }
+        }
+
+        s += c;
+    }
+
+    return Token(TokenType::ERROR_TOKEN, std::string("string didn't end"));
+}
+
+inline Token Lexer::nextStringSingleQuote()
+{
+    if (!consume('\''))
+        return Token(TokenType::ERROR_TOKEN, std::string("string didn't start with '\''?"));
+
+    std::string s;
+    char c;
+
+    if (current(&c) && c == '\'') {
+        next();
+        if (!current(&c) || c != '\'') {
+            // OK. It's empty string.
+            return Token(TokenType::STRING, std::string());
+        }
+        next();
+        // raw string literal started.
+        // Newline just after """ should be ignored.
+        if (current(&c) && c == '\n')
+            next();
+
+        while (current(&c)) {
+            if (c == '\'') {
+                next();
+                if (current(&c) && c == '\'') {
+                    next();
+                    if (current(&c) && c == '\'') {
+                        next();
+                        return Token(TokenType::MULTILINE_STRING, s);
+                    } else {
+                        s += '\'';
+                        s += '\'';
+                        continue;
+                    }
+                } else {
+                    s += '\'';
+                    continue;
+                }
+            }
+
+            next();
+            s += c;
+        }
+
+        return Token(TokenType::ERROR_TOKEN, std::string("string didn't end with '\'\'\'' ?"));
+    }
+
+    while (current(&c)) {
+        next();
+        if (c == '\'') {
+            return Token(TokenType::STRING, s);
+        }
+
+        s += c;
+    }
+
+    return Token(TokenType::ERROR_TOKEN, std::string("string didn't end with '\''?"));
+}
+
+inline Token Lexer::nextKey()
+{
+    std::string s;
+    char c;
+    while (current(&c) && (isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')) {
+        s += c;
+        next();
+    }
+
+    if (s.empty())
+        return Token(TokenType::ERROR_TOKEN, std::string("Unknown key format"));
+
+    return Token(TokenType::IDENT, s);
+}
+
+inline Token Lexer::nextValue()
+{
+    std::string s;
+    char c;
+
+    if (current(&c) && isalpha(static_cast<unsigned char>(c))) {
+        s += c;
+        next();
+        while (current(&c) && isalpha(static_cast<unsigned char>(c))) {
+            s += c;
+            next();
+        }
+
+        if (s == "true")
+            return Token(TokenType::BOOL, true);
+        if (s == "false")
+            return Token(TokenType::BOOL, false);
+        return Token(TokenType::ERROR_TOKEN, std::string("Unknown ident: ") + s);
+    }
+
+    while (current(&c) && (('0' <= c && c <= '9') || c == '.' || c == 'e' || c == 'E' ||
+                           c == 'T' || c == 'Z' || c == '_' || c == ':' || c == '-' || c == '+')) {
+        next();
+        s += c;
+    }
+
+    if (isInteger(s)) {
+        std::stringstream ss(removeDelimiter(s));
+        std::int64_t x;
+        ss >> x;
+        return Token(TokenType::INT, x);
+    }
+
+    if (isDouble(s)) {
+        std::stringstream ss(removeDelimiter(s));
+        double d;
+        ss >> d;
+        return Token(TokenType::DOUBLE, d);
+    }
+
+    return parseAsTime(s);
+}
+
+inline Token Lexer::parseAsTime(const std::string& str)
+{
+    const char* s = str.c_str();
+
+    int n;
+    int YYYY, MM, DD;
+#if defined(_MSC_VER)
+    if (sscanf_s(s, "%d-%d-%d%n", &YYYY, &MM, &DD, &n) != 3)
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+#else
+    if (sscanf(s, "%d-%d-%d%n", &YYYY, &MM, &DD, &n) != 3)
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+#endif
+
+    if (!(1 <= MM && MM <= 12)) {
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+    }
+    if (YYYY < 1900) {
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+    }
+
+    if (s[n] == '\0') {
+        std::tm t;
+        t.tm_sec = 0;
+        t.tm_min = 0;
+        t.tm_hour = 0;
+        t.tm_mday = DD;
+        t.tm_mon = MM - 1;
+        t.tm_year = YYYY - 1900;
+        auto tp = std::chrono::system_clock::from_time_t(timegm(&t));
+        return Token(TokenType::TIME, tp);
+    }
+
+    if (s[n] != 'T')
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+
+    s = s + n + 1;
+
+    int hh, mm;
+    double ss; // double for fraction
+#if defined(_MSC_VER)
+    if (sscanf_s(s, "%d:%d:%lf%n", &hh, &mm, &ss, &n) != 3)
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+#else
+    if (sscanf(s, "%d:%d:%lf%n", &hh, &mm, &ss, &n) != 3)
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+#endif
+
+    std::tm t;
+    t.tm_sec = static_cast<int>(ss);
+    t.tm_min = mm;
+    t.tm_hour = hh;
+    t.tm_mday = DD;
+    t.tm_mon = MM - 1;
+    t.tm_year = YYYY - 1900;
+    auto tp = std::chrono::system_clock::from_time_t(timegm(&t));
+    ss -= static_cast<int>(ss);
+    // TODO(mayah): workaround GCC 4.9.3 on cygwin does not have std::round, but round().
+    tp += std::chrono::microseconds(static_cast<std::int64_t>(round(ss * 1000000)));
+
+    if (s[n] == '\0')
+        return Token(TokenType::TIME, tp);
+
+    if (s[n] == 'Z' && s[n + 1] == '\0')
+        return Token(TokenType::TIME, tp);
+
+    s = s + n;
+    // offset
+    // [+/-]%d:%d
+    char pn;
+    int oh, om;
+#if defined(_MSC_VER)
+    if (sscanf_s(s, "%c%d:%d", &pn, static_cast<unsigned>(sizeof(pn)), &oh, &om) != 3)
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+#else
+    if (sscanf(s, "%c%d:%d", &pn, &oh, &om) != 3)
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+#endif
+
+    if (pn != '+' && pn != '-')
+        return Token(TokenType::ERROR_TOKEN, std::string("Invalid token"));
+
+    if (pn == '+') {
+        tp -= std::chrono::hours(oh);
+        tp -= std::chrono::minutes(om);
+    } else {
+        tp += std::chrono::hours(oh);
+        tp += std::chrono::minutes(om);
+    }
+
+    return Token(TokenType::TIME, tp);
+}
+
+inline Token Lexer::nextKeyToken()
+{
+    return nextToken(false);
+}
+
+inline Token Lexer::nextValueToken()
+{
+    return nextToken(true);
+}
+
+inline Token Lexer::nextToken(bool isValueToken)
+{
+    char c;
+    while (current(&c)) {
+        if (c == ' ' || c == '\t' || c == '\r') {
+            next();
+            continue;
+        }
+
+        if (c == '#') {
+            skipUntilNewLine();
+            continue;
+        }
+
+        switch (c) {
+        case '\n':
+            next();
+            return Token(TokenType::END_OF_LINE);
+        case '=':
+            next();
+            return Token(TokenType::EQUAL);
+        case '{':
+            next();
+            return Token(TokenType::LBRACE);
+        case '}':
+            next();
+            return Token(TokenType::RBRACE);
+        case '[':
+            next();
+            return Token(TokenType::LBRACKET);
+        case ']':
+            next();
+            return Token(TokenType::RBRACKET);
+        case ',':
+            next();
+            return Token(TokenType::COMMA);
+        case '.':
+            next();
+            return Token(TokenType::DOT);
+        case '\"':
+            return nextStringDoubleQuote();
+        case '\'':
+            return nextStringSingleQuote();
+        default:
+            if (isValueToken) {
+                return nextValue();
+            } else {
+                return nextKey();
+            }
+        }
+    }
+
+    return Token(TokenType::END_OF_FILE);
+}
+
+} // namespace internal
+
+// ----------------------------------------------------------------------
+
+// static
+inline const char* Value::typeToString(Value::Type type)
+{
+    switch (type) {
+    case NULL_TYPE:   return "null";
+    case BOOL_TYPE:   return "bool";
+    case INT_TYPE:    return "int";
+    case DOUBLE_TYPE: return "double";
+    case STRING_TYPE: return "string";
+    case TIME_TYPE:   return "time";
+    case ARRAY_TYPE:  return "array";
+    case TABLE_TYPE:  return "table";
+    default:          return "unknown";
+    }
+}
+
+inline Value::Value(const Value& v) :
+    type_(v.type_)
+{
+    switch (v.type_) {
+    case NULL_TYPE: null_ = v.null_; break;
+    case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
+    case DOUBLE_TYPE: double_ = v.double_; break;
+    case STRING_TYPE: string_ = new std::string(*v.string_); break;
+    case TIME_TYPE: time_ = new Time(*v.time_); break;
+    case ARRAY_TYPE: array_ = new Array(*v.array_); break;
+    case TABLE_TYPE: table_ = new Table(*v.table_); break;
+    default:
+        assert(false);
+        type_ = NULL_TYPE;
+        null_ = nullptr;
+    }
+}
+
+inline Value::Value(Value&& v) noexcept :
+    type_(v.type_)
+{
+    switch (v.type_) {
+    case NULL_TYPE: null_ = v.null_; break;
+    case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
+    case DOUBLE_TYPE: double_ = v.double_; break;
+    case STRING_TYPE: string_ = v.string_; break;
+    case TIME_TYPE: time_ = v.time_; break;
+    case ARRAY_TYPE: array_ = v.array_; break;
+    case TABLE_TYPE: table_ = v.table_; break;
+    default:
+        assert(false);
+        type_ = NULL_TYPE;
+        null_ = nullptr;
+    }
+
+    v.type_ = NULL_TYPE;
+    v.null_ = nullptr;
+}
+
+inline Value& Value::operator=(const Value& v)
+{
+    if (this == &v)
+        return *this;
+
+    this->~Value();
+
+    type_ = v.type_;
+    switch (v.type_) {
+    case NULL_TYPE: null_ = v.null_; break;
+    case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
+    case DOUBLE_TYPE: double_ = v.double_; break;
+    case STRING_TYPE: string_ = new std::string(*v.string_); break;
+    case TIME_TYPE: time_ = new Time(*v.time_); break;
+    case ARRAY_TYPE: array_ = new Array(*v.array_); break;
+    case TABLE_TYPE: table_ = new Table(*v.table_); break;
+    default:
+        assert(false);
+        type_ = NULL_TYPE;
+        null_ = nullptr;
+    }
+
+    return *this;
+}
+
+inline Value& Value::operator=(Value&& v) noexcept
+{
+    if (this == &v)
+        return *this;
+
+    this->~Value();
+
+    type_ = v.type_;
+    switch (v.type_) {
+    case NULL_TYPE: null_ = v.null_; break;
+    case BOOL_TYPE: bool_ = v.bool_; break;
+    case INT_TYPE: int_ = v.int_; break;
+    case DOUBLE_TYPE: double_ = v.double_; break;
+    case STRING_TYPE: string_ = v.string_; break;
+    case TIME_TYPE: time_ = v.time_; break;
+    case ARRAY_TYPE: array_ = v.array_; break;
+    case TABLE_TYPE: table_ = v.table_; break;
+    default:
+        assert(false);
+        type_ = NULL_TYPE;
+        null_ = nullptr;
+    }
+
+    v.type_ = NULL_TYPE;
+    v.null_ = nullptr;
+    return *this;
+}
+
+inline Value::~Value()
+{
+    switch (type_) {
+    case STRING_TYPE:
+        delete string_;
+        break;
+    case TIME_TYPE:
+        delete time_;
+        break;
+    case ARRAY_TYPE:
+        delete array_;
+        break;
+    case TABLE_TYPE:
+        delete table_;
+        break;
+    default:
+        break;
+    }
+}
+
+inline size_t Value::size() const
+{
+    switch (type_) {
+    case NULL_TYPE:
+        return 0;
+    case ARRAY_TYPE:
+        return array_->size();
+    case TABLE_TYPE:
+        return table_->size();
+    default:
+        return 1;
+    }
+}
+
+inline bool Value::empty() const
+{
+    return size() == 0;
+}
+
+template<> struct Value::ValueConverter<bool>
+{
+    bool is(const Value& v) { return v.type() == Value::BOOL_TYPE; }
+    bool to(const Value& v) { v.assureType<bool>(); return v.bool_; }
+
+};
+template<> struct Value::ValueConverter<int64_t>
+{
+    bool is(const Value& v) { return v.type() == Value::INT_TYPE; }
+    int64_t to(const Value& v) { v.assureType<int64_t>(); return v.int_; }
+};
+template<> struct Value::ValueConverter<int>
+{
+    bool is(const Value& v) { return v.type() == Value::INT_TYPE; }
+    int to(const Value& v) { v.assureType<int>(); return static_cast<int>(v.int_); }
+};
+template<> struct Value::ValueConverter<double>
+{
+    bool is(const Value& v) { return v.type() == Value::DOUBLE_TYPE; }
+    double to(const Value& v) { v.assureType<double>(); return v.double_; }
+};
+template<> struct Value::ValueConverter<std::string>
+{
+    bool is(const Value& v) { return v.type() == Value::STRING_TYPE; }
+    const std::string& to(const Value& v) { v.assureType<std::string>(); return *v.string_; }
+};
+template<> struct Value::ValueConverter<Time>
+{
+    bool is(const Value& v) { return v.type() == Value::TIME_TYPE; }
+    const Time& to(const Value& v) { v.assureType<Time>(); return *v.time_; }
+};
+template<> struct Value::ValueConverter<Array>
+{
+    bool is(const Value& v) { return v.type() == Value::ARRAY_TYPE; }
+    const Array& to(const Value& v) { v.assureType<Array>(); return *v.array_; }
+};
+template<> struct Value::ValueConverter<Table>
+{
+    bool is(const Value& v) { return v.type() == Value::TABLE_TYPE; }
+    const Table& to(const Value& v) { v.assureType<Table>(); return *v.table_; }
+};
+
+template<typename T>
+struct Value::ValueConverter<std::vector<T>>
+{
+    bool is(const Value& v)
+    {
+        if (v.type() != Value::ARRAY_TYPE)
+            return false;
+        const Array& array = v.as<Array>();
+        if (array.empty())
+            return true;
+        return array.front().is<T>();
+    }
+
+    std::vector<T> to(const Value& v)
+    {
+        const Array& array = v.as<Array>();
+        if (array.empty())
+            return std::vector<T>();
+        array.front().assureType<T>();
+
+        std::vector<T> result;
+        for (const auto& element : array) {
+            result.push_back(element.as<T>());
+        }
+
+        return result;
+    }
+};
+
+namespace internal {
+template<typename T> inline const char* type_name();
+template<> inline const char* type_name<bool>() { return "bool"; }
+template<> inline const char* type_name<int>() { return "int"; }
+template<> inline const char* type_name<int64_t>() { return "int64_t"; }
+template<> inline const char* type_name<double>() { return "double"; }
+template<> inline const char* type_name<std::string>() { return "string"; }
+template<> inline const char* type_name<toml::Time>() { return "time"; }
+template<> inline const char* type_name<toml::Array>() { return "array"; }
+template<> inline const char* type_name<toml::Table>() { return "table"; }
+} // namespace internal
+
+template<typename T>
+inline void Value::assureType() const
+{
+    if (!is<T>())
+        failwith("type error: this value is ", typeToString(type_), " but ", internal::type_name<T>(), " was requested");
+}
+
+template<typename T>
+inline bool Value::is() const
+{
+    return ValueConverter<T>().is(*this);
+}
+
+template<typename T>
+inline typename call_traits<T>::return_type Value::as() const
+{
+    return ValueConverter<T>().to(*this);
+}
+
+inline bool Value::isNumber() const
+{
+    return is<int>() || is<double>();
+}
+
+inline double Value::asNumber() const
+{
+    if (is<int>())
+        return as<int>();
+    if (is<double>())
+        return as<double>();
+
+    failwith("type error: this value is ", typeToString(type_), " but number is requested");
+}
+
+inline std::time_t Value::as_time_t() const
+{
+    return std::chrono::system_clock::to_time_t(as<Time>());
+}
+
+inline std::string Value::spaces(int num)
+{
+    if (num <= 0)
+        return std::string();
+
+    return std::string(num, ' ');
+}
+
+inline std::string Value::escapeKey(const std::string& key)
+{
+    auto position = std::find_if(key.begin(), key.end(), [](char c) -> bool {
+        if (std::isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '-')
+            return false;
+        return true;
+    });
+
+    if (position != key.end()) {
+        std::string escaped = "\"";
+        for (const char& c : key) {
+            if (c == '\\' || c  == '"')
+                escaped += '\\';
+            escaped += c;
+        }
+        escaped += "\"";
+
+        return escaped;
+    }
+
+    return key;
+}
+
+inline void Value::write(std::ostream* os, const std::string& keyPrefix, int indent) const
+{
+    switch (type_) {
+    case NULL_TYPE:
+        failwith("null type value is not a valid value");
+        break;
+    case BOOL_TYPE:
+        (*os) << (bool_ ? "true" : "false");
+        break;
+    case INT_TYPE:
+        (*os) << int_;
+        break;
+    case DOUBLE_TYPE: {
+        (*os) << std::fixed << std::showpoint << double_;
+        break;
+    }
+    case STRING_TYPE:
+        (*os) << '"' << internal::escapeString(*string_) << '"';
+        break;
+    case TIME_TYPE: {
+        time_t tt = std::chrono::system_clock::to_time_t(*time_);
+        std::tm t;
+        gmtime_r(&tt, &t);
+        char buf[256];
+        snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02dZ", t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec);
+        (*os) << buf;
+        break;
+    }
+    case ARRAY_TYPE:
+        (*os) << '[';
+        for (size_t i = 0; i < array_->size(); ++i) {
+            if (i)
+                (*os) << ", ";
+            (*array_)[i].write(os, keyPrefix, -1);
+        }
+        (*os) << ']';
+        break;
+    case TABLE_TYPE:
+        for (const auto& kv : *table_) {
+            if (kv.second.is<Table>())
+                continue;
+            if (kv.second.is<Array>() && kv.second.size() > 0 && kv.second.find(0)->is<Table>())
+                continue;
+            (*os) << spaces(indent) << escapeKey(kv.first) << " = ";
+            kv.second.write(os, keyPrefix, indent >= 0 ? indent + 1 : indent);
+            (*os) << '\n';
+        }
+        for (const auto& kv : *table_) {
+            if (kv.second.is<Table>()) {
+                std::string key(keyPrefix);
+                if (!keyPrefix.empty())
+                    key += ".";
+                key += escapeKey(kv.first);
+                (*os) << "\n" << spaces(indent) << "[" << key << "]\n";
+                kv.second.write(os, key, indent >= 0 ? indent + 1 : indent);
+            }
+            if (kv.second.is<Array>() && kv.second.size() > 0 && kv.second.find(0)->is<Table>()) {
+                std::string key(keyPrefix);
+                if (!keyPrefix.empty())
+                    key += ".";
+                key += escapeKey(kv.first);
+                for (const auto& v : kv.second.as<Array>()) {
+                    (*os) << "\n" << spaces(indent) << "[[" << key << "]]\n";
+                    v.write(os, key, indent >= 0 ? indent + 1 : indent);
+                }
+            }
+        }
+        break;
+    default:
+        failwith("writing unknown type");
+        break;
+    }
+}
+
+inline void Value::writeFormatted(std::ostream* os, FormatFlag flags) const
+{
+    int indent = flags & FORMAT_INDENT ? 0 : -1;
+
+    write(os, std::string(), indent);
+}
+
+// static
+inline FormatFlag operator|(FormatFlag lhs, FormatFlag rhs)
+{
+    return static_cast<FormatFlag>(static_cast<int>(lhs) | static_cast<int>(rhs));
+}
+
+// static
+inline std::ostream& operator<<(std::ostream& os, const toml::Value& v)
+{
+    v.write(&os);
+    return os;
+}
+
+// static
+inline bool operator==(const Value& lhs, const Value& rhs)
+{
+    if (lhs.type() != rhs.type())
+        return false;
+
+    switch (lhs.type()) {
+    case Value::Type::NULL_TYPE:
+        return true;
+    case Value::Type::BOOL_TYPE:
+        return lhs.bool_ == rhs.bool_;
+    case Value::Type::INT_TYPE:
+        return lhs.int_ == rhs.int_;
+    case Value::Type::DOUBLE_TYPE:
+        return lhs.double_ == rhs.double_;
+    case Value::Type::STRING_TYPE:
+        return *lhs.string_ == *rhs.string_;
+    case Value::Type::TIME_TYPE:
+        return *lhs.time_ == *rhs.time_;
+    case Value::Type::ARRAY_TYPE:
+        return *lhs.array_ == *rhs.array_;
+    case Value::Type::TABLE_TYPE:
+        return *lhs.table_ == *rhs.table_;
+    default:
+        failwith("unknown type");
+    }
+}
+
+template<typename T>
+inline typename call_traits<T>::return_type Value::get(const std::string& key) const
+{
+    if (!is<Table>())
+        failwith("type must be table to do get(key).");
+
+    const Value* obj = find(key);
+    if (!obj)
+        failwith("key ", key, " was not found.");
+
+    return obj->as<T>();
+}
+
+inline const Value* Value::find(const std::string& key) const
+{
+    if (!is<Table>())
+        return nullptr;
+
+    std::istringstream ss(key);
+    internal::Lexer lexer(ss);
+
+    const Value* current = this;
+    while (true) {
+        internal::Token t = lexer.nextKeyToken();
+        if (!(t.type() == internal::TokenType::IDENT || t.type() == internal::TokenType::STRING))
+            return nullptr;
+
+        std::string part = t.strValue();
+        t = lexer.nextKeyToken();
+        if (t.type() == internal::TokenType::DOT) {
+            current = current->findChild(part);
+            if (!current || !current->is<Table>())
+                return nullptr;
+        } else if (t.type() == internal::TokenType::END_OF_FILE) {
+            return current->findChild(part);
+        } else {
+            return nullptr;
+        }
+    }
+}
+
+inline Value* Value::find(const std::string& key)
+{
+    return const_cast<Value*>(const_cast<const Value*>(this)->find(key));
+}
+
+inline bool Value::merge(const toml::Value& v)
+{
+    if (this == &v)
+        return true;
+    if (!is<Table>() || !v.is<Table>())
+        return false;
+
+    for (const auto& kv : *v.table_) {
+        if (Value* tmp = find(kv.first)) {
+            // If both are table, we merge them.
+            if (tmp->is<Table>() && kv.second.is<Table>()) {
+                if (!tmp->merge(kv.second))
+                    return false;
+            } else {
+                setChild(kv.first, kv.second);
+            }
+        } else {
+            setChild(kv.first, kv.second);
+        }
+    }
+
+    return true;
+}
+
+inline Value* Value::set(const std::string& key, const Value& v)
+{
+    Value* result = ensureValue(key);
+    *result = v;
+    return result;
+}
+
+inline Value* Value::setChild(const std::string& key, const Value& v)
+{
+    if (!valid())
+        *this = Value((Table()));
+
+    if (!is<Table>())
+        failwith("type must be table to do set(key, v).");
+
+    (*table_)[key] = v;
+    return &(*table_)[key];
+}
+
+inline Value* Value::setChild(const std::string& key, Value&& v)
+{
+    if (!valid())
+        *this = Value((Table()));
+
+    if (!is<Table>())
+        failwith("type must be table to do set(key, v).");
+
+    (*table_)[key] = std::move(v);
+    return &(*table_)[key];
+}
+
+inline bool Value::erase(const std::string& key)
+{
+    if (!is<Table>())
+        return false;
+
+    std::istringstream ss(key);
+    internal::Lexer lexer(ss);
+
+    Value* current = this;
+    while (true) {
+        internal::Token t = lexer.nextKeyToken();
+        if (!(t.type() == internal::TokenType::IDENT || t.type() == internal::TokenType::STRING))
+            return false;
+
+        std::string part = t.strValue();
+        t = lexer.nextKeyToken();
+        if (t.type() == internal::TokenType::DOT) {
+            current = current->findChild(part);
+            if (!current || !current->is<Table>())
+                return false;
+        } else if (t.type() == internal::TokenType::END_OF_FILE) {
+            return current->eraseChild(part);
+        } else {
+            return false;
+        }
+    }
+}
+
+inline bool Value::eraseChild(const std::string& key)
+{
+    if (!is<Table>())
+        failwith("type must be table to do erase(key).");
+
+    return table_->erase(key) > 0;
+}
+
+inline Value& Value::operator[](const std::string& key)
+{
+    if (!valid())
+        *this = Value((Table()));
+
+    if (Value* v = findChild(key))
+        return *v;
+
+    return *setChild(key, Value());
+}
+
+template<typename T>
+inline typename call_traits<T>::return_type Value::get(size_t index) const
+{
+    if (!is<Array>())
+        failwith("type must be array to do get(index).");
+
+    if (array_->size() <= index)
+        failwith("index out of bound");
+
+    return (*array_)[index].as<T>();
+}
+
+inline const Value* Value::find(size_t index) const
+{
+    if (!is<Array>())
+        return nullptr;
+    if (index < array_->size())
+        return &(*array_)[index];
+    return nullptr;
+}
+
+inline Value* Value::find(size_t index)
+{
+    return const_cast<Value*>(const_cast<const Value*>(this)->find(index));
+}
+
+inline Value* Value::push(const Value& v)
+{
+    if (!valid())
+        *this = Value((Array()));
+    else if (!is<Array>())
+        failwith("type must be array to do push(Value).");
+
+    array_->push_back(v);
+    return &array_->back();
+}
+
+inline Value* Value::push(Value&& v)
+{
+    if (!valid())
+        *this = Value((Array()));
+    else if (!is<Array>())
+        failwith("type must be array to do push(Value).");
+
+    array_->push_back(std::move(v));
+    return &array_->back();
+}
+
+inline Value* Value::ensureValue(const std::string& key)
+{
+    if (!valid())
+        *this = Value((Table()));
+    if (!is<Table>()) {
+        failwith("encountered non table value");
+    }
+
+    std::istringstream ss(key);
+    internal::Lexer lexer(ss);
+
+    Value* current = this;
+    while (true) {
+        internal::Token t = lexer.nextKeyToken();
+        if (!(t.type() == internal::TokenType::IDENT || t.type() == internal::TokenType::STRING)) {
+            failwith("invalid key");
+        }
+
+        std::string part = t.strValue();
+        t = lexer.nextKeyToken();
+        if (t.type() == internal::TokenType::DOT) {
+            if (Value* candidate = current->findChild(part)) {
+                if (!candidate->is<Table>())
+                    failwith("encountered non table value");
+
+                current = candidate;
+            } else {
+                current = current->setChild(part, Table());
+            }
+        } else if (t.type() == internal::TokenType::END_OF_FILE) {
+            if (Value* v = current->findChild(part))
+                return v;
+            return current->setChild(part, Value());
+        } else {
+            failwith("invalid key");
+        }
+    }
+}
+
+inline Value* Value::findChild(const std::string& key)
+{
+    assert(is<Table>());
+
+    auto it = table_->find(key);
+    if (it == table_->end())
+        return nullptr;
+
+    return &it->second;
+}
+
+inline const Value* Value::findChild(const std::string& key) const
+{
+    assert(is<Table>());
+
+    auto it = table_->find(key);
+    if (it == table_->end())
+        return nullptr;
+
+    return &it->second;
+}
+
+// ----------------------------------------------------------------------
+
+namespace internal {
+
+inline void Parser::skipForKey()
+{
+    while (token().type() == TokenType::END_OF_LINE)
+        nextKey();
+}
+
+inline void Parser::skipForValue()
+{
+    while (token().type() == TokenType::END_OF_LINE)
+        nextValue();
+}
+
+inline bool Parser::consumeForKey(TokenType type)
+{
+    if (token().type() == type) {
+        nextKey();
+        return true;
+    }
+
+    return false;
+}
+
+inline bool Parser::consumeForValue(TokenType type)
+{
+    if (token().type() == type) {
+        nextValue();
+        return true;
+    }
+
+    return false;
+}
+
+inline bool Parser::consumeEOLorEOFForKey()
+{
+    if (token().type() == TokenType::END_OF_LINE || token().type() == TokenType::END_OF_FILE) {
+        nextKey();
+        return true;
+    }
+
+    return false;
+}
+
+inline void Parser::addError(const std::string& reason)
+{
+    if (!errorReason_.empty())
+        return;
+
+    std::stringstream ss;
+    ss << "Error: line " << lexer_.lineNo() << ": " << reason;
+    errorReason_ = ss.str();
+}
+
+inline const std::string& Parser::errorReason()
+{
+    return errorReason_;
+}
+
+inline Value Parser::parse()
+{
+    Value root((Table()));
+    Value* currentValue = &root;
+
+    while (true) {
+        skipForKey();
+        if (token().type() == TokenType::END_OF_FILE)
+            break;
+        if (token().type() == TokenType::LBRACKET) {
+            currentValue = parseGroupKey(&root);
+            if (!currentValue) {
+                addError("error when parsing group key");
+                return Value();
+            }
+            continue;
+        }
+
+        if (!parseKeyValue(currentValue)) {
+            addError("error when parsing key Value");
+            return Value();
+        }
+    }
+    return root;
+}
+
+inline Value* Parser::parseGroupKey(Value* root)
+{
+    if (!consumeForKey(TokenType::LBRACKET))
+        return nullptr;
+
+    bool isArray = false;
+    if (token().type() == TokenType::LBRACKET) {
+        nextKey();
+        isArray = true;
+    }
+
+    Value* currentValue = root;
+    while (true) {
+        if (token().type() != TokenType::IDENT && token().type() != TokenType::STRING)
+            return nullptr;
+
+        std::string key = token().strValue();
+        nextKey();
+
+        if (token().type() == TokenType::DOT) {
+            nextKey();
+            if (Value* candidate = currentValue->findChild(key)) {
+                if (candidate->is<Array>() && candidate->size() > 0)
+                    candidate = candidate->find(candidate->size() - 1);
+                if (!candidate->is<Table>())
+                    return nullptr;
+                currentValue = candidate;
+            } else {
+                currentValue = currentValue->setChild(key, Table());
+            }
+            continue;
+        }
+
+        if (token().type() == TokenType::RBRACKET) {
+            nextKey();
+            if (Value* candidate = currentValue->findChild(key)) {
+                if (isArray) {
+                    if (!candidate->is<Array>())
+                        return nullptr;
+                    currentValue = candidate->push(Table());
+                } else {
+                    if (candidate->is<Array>() && candidate->size() > 0)
+                        candidate = candidate->find(candidate->size() - 1);
+                    if (!candidate->is<Table>())
+                        return nullptr;
+                    currentValue = candidate;
+                }
+            } else {
+                if (isArray) {
+                    currentValue = currentValue->setChild(key, Array());
+                    currentValue = currentValue->push(Table());
+                } else {
+                    currentValue = currentValue->setChild(key, Table());
+                }
+            }
+            break;
+        }
+
+        return nullptr;
+    }
+
+    if (isArray) {
+        if (!consumeForKey(TokenType::RBRACKET))
+            return nullptr;
+    }
+
+    if (!consumeEOLorEOFForKey())
+        return nullptr;
+
+    return currentValue;
+}
+
+inline bool Parser::parseKeyValue(Value* current)
+{
+    std::string key;
+    if (!parseKey(&key)) {
+        addError("parse key failed");
+        return false;
+    }
+    if (!consumeForValue(TokenType::EQUAL)) {
+        addError("no equal?");
+        return false;
+    }
+
+    Value v;
+    if (!parseValue(&v))
+        return false;
+    if (!consumeEOLorEOFForKey())
+        return false;
+
+    if (current->has(key)) {
+        addError("Multiple same key: " + key);
+        return false;
+    }
+
+    current->setChild(key, std::move(v));
+    return true;
+}
+
+inline bool Parser::parseKey(std::string* key)
+{
+    key->clear();
+
+    if (token().type() == TokenType::IDENT || token().type() == TokenType::STRING) {
+        *key = token().strValue();
+        nextValue();
+        return true;
+    }
+
+    return false;
+}
+
+inline bool Parser::parseValue(Value* v)
+{
+    switch (token().type()) {
+    case TokenType::STRING:
+    case TokenType::MULTILINE_STRING:
+        *v = token().strValue();
+        nextValue();
+        return true;
+    case TokenType::LBRACKET:
+        return parseArray(v);
+    case TokenType::LBRACE:
+        return parseInlineTable(v);
+    case TokenType::BOOL:
+        *v = token().boolValue();
+        nextValue();
+        return true;
+    case TokenType::INT:
+        *v = token().intValue();
+        nextValue();
+        return true;
+    case TokenType::DOUBLE:
+        *v = token().doubleValue();
+        nextValue();
+        return true;
+    case TokenType::TIME:
+        *v = token().timeValue();
+        nextValue();
+        return true;
+    case TokenType::ERROR_TOKEN:
+        addError(token().strValue());
+        return false;
+    default:
+        addError("unexpected token");
+        return false;
+    }
+}
+
+inline bool Parser::parseBool(Value* v)
+{
+    if (token().strValue() == "true") {
+        nextValue();
+        *v = true;
+        return true;
+    }
+
+    if (token().strValue() == "false") {
+        nextValue();
+        *v = false;
+        return true;
+    }
+
+    return false;
+}
+
+inline bool Parser::parseArray(Value* v)
+{
+    if (!consumeForValue(TokenType::LBRACKET))
+        return false;
+
+    Array a;
+    while (true) {
+        skipForValue();
+
+        if (token().type() == TokenType::RBRACKET)
+            break;
+
+        skipForValue();
+        Value x;
+        if (!parseValue(&x))
+            return false;
+
+        if (!a.empty()) {
+            if (a.front().type() != x.type()) {
+                addError("type check failed");
+                return false;
+            }
+        }
+
+        a.push_back(std::move(x));
+        skipForValue();
+        if (token().type() == TokenType::RBRACKET)
+            break;
+        if (token().type() == TokenType::COMMA)
+            nextValue();
+    }
+
+    if (!consumeForValue(TokenType::RBRACKET))
+        return false;
+    *v = std::move(a);
+    return true;
+}
+
+inline bool Parser::parseInlineTable(Value* value)
+{
+    // For inline table, next is KEY, so use consumeForKey here.
+    if (!consumeForKey(TokenType::LBRACE))
+        return false;
+
+    Value t((Table()));
+    bool first = true;
+    while (true) {
+        if (token().type() == TokenType::RBRACE) {
+            break;
+        }
+
+        if (!first) {
+            if (token().type() != TokenType::COMMA) {
+                addError("inline table didn't have ',' for delimiter?");
+                return false;
+            }
+            nextKey();
+        }
+        first = false;
+
+        std::string key;
+        if (!parseKey(&key))
+            return false;
+        if (!consumeForValue(TokenType::EQUAL))
+            return false;
+        Value v;
+        if (!parseValue(&v))
+            return false;
+
+        if (t.has(key)) {
+            addError("inline table has multiple same keys: key=" + key);
+            return false;
+        }
+
+        t.set(key, v);
+    }
+
+    if (!consumeForValue(TokenType::RBRACE))
+        return false;
+    *value = std::move(t);
+    return true;
+}
+
+} // namespace internal
+} // namespace toml
+
+#endif // TINYTOML_H_

--- a/samples/wsl_wrapper/wsl_wrapper.cpp
+++ b/samples/wsl_wrapper/wsl_wrapper.cpp
@@ -76,15 +76,19 @@ int error(const char* where, int retval) {
     return retval;
 }
 
-// launch application and get process group ID
+// launch application (typically ./main) and get process group ID.
+// This doesn't wait for the application to finish.
 //
 int launch(const char* distro, const char* cmd) {
     char launch_cmd[256];
     sprintf(launch_cmd, "echo $$; %s; touch boinc_job_done\n", cmd);
     int retval = app_wc.setup();
     if (retval) return error("app setup", retval);
-    retval = app_wc.run_command(distro, launch_cmd, true);
-    if (retval) return error("app run_command", retval);
+    retval = app_wc.run_program_in_wsl(distro, launch_cmd, true);
+    if (retval) return error("app run_program_in_wsl", retval);
+
+    // get the process group ID
+    //
     string reply;
     retval = read_from_pipe(app_wc.out_read, app_wc.proc_handle, reply, CMD_TIMEOUT, "\n");
     if (retval) return error("app read_from_pipe", retval);
@@ -99,8 +103,9 @@ int launch(const char* distro, const char* cmd) {
     //
     retval = ctl_wc.setup();
     if (retval) return error("ctl setup", retval);
-    retval = ctl_wc.run_command(distro, "", true);
-    if (retval) return error("ctl run_command", retval);
+    retval = ctl_wc.run_program_in_wsl(distro, "", true);
+        // empty string means run shell
+    if (retval) return error("ctl run_program_in_wsl", retval);
     return 0;
 }
 

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -33,6 +33,7 @@ struct PLAN_CLASS_SPEC {
     bool opencl;
     bool virtualbox;
     bool wsl;
+    bool docker;
     bool is64bit;
     std::vector<std::string> cpu_features;
     double min_ncpus;

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -264,6 +264,7 @@ void SCHEDULER_REQUEST::clear() {
     strcpy(working_global_prefs_xml, "");
     strcpy(code_sign_key, "");
     dont_send_work = false;
+    dont_use_docker = false;
     strcpy(client_brand, "");
     global_prefs.defaults();
     strcpy(global_prefs_source_email_hash, "");
@@ -401,6 +402,7 @@ const char* SCHEDULER_REQUEST::parse(XML_PARSER& xp) {
         if (xp.parse_double("estimated_delay", cpu_estimated_delay)) continue;
         if (xp.parse_double("duration_correction_factor", host.duration_correction_factor)) continue;
         if (xp.parse_bool("dont_send_work", dont_send_work)) continue;
+        if (xp.parse_bool("dont_use_docker", dont_use_docker)) continue;
         if (xp.match_tag("global_preferences")) {
             safe_strcpy(global_prefs_xml, "<global_preferences>\n");
             char buf[BLOB_SIZE];

--- a/sched/sched_types.h
+++ b/sched/sched_types.h
@@ -339,6 +339,7 @@ struct SCHEDULER_REQUEST {
         // whether client uses account-based sandbox.  -1 = don't know
     int allow_multiple_clients;
         // whether client allows multiple clients per host, -1 don't know
+    bool dont_use_docker;
     bool using_weak_auth;
         // Request uses weak authenticator.
         // Don't modify user prefs or CPID

--- a/win_build/boinc.sln
+++ b/win_build/boinc.sln
@@ -132,6 +132,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example_app_sporadic", "spo
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "wsl_wrapper", "wsl_wrapper.vcxproj", "{97F092A0-AF80-4E60-89CB-D811F5AFA542}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "docker_wrapper", "docker_wrapper.vcxproj", "{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -442,6 +444,14 @@ Global
 		{97F092A0-AF80-4E60-89CB-D811F5AFA542}.Release|ARM64.Build.0 = Release|ARM64
 		{97F092A0-AF80-4E60-89CB-D811F5AFA542}.Release|x64.ActiveCfg = Release|x64
 		{97F092A0-AF80-4E60-89CB-D811F5AFA542}.Release|x64.Build.0 = Release|x64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Debug|ARM64.Build.0 = Debug|ARM64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Debug|x64.ActiveCfg = Debug|x64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Debug|x64.Build.0 = Debug|x64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Release|ARM64.ActiveCfg = Release|ARM64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Release|ARM64.Build.0 = Release|ARM64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Release|x64.ActiveCfg = Release|x64
+		{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/win_build/docker_wrapper.vcxproj
+++ b/win_build/docker_wrapper.vcxproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectName>docker_wrapper</ProjectName>
+    <ProjectGuid>{D6DDDD6C-BB00-43B8-B21D-DD76DD6A4E03}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="boinc.props" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>.;..;../api;../lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\samples\docker_wrapper\docker_wrapper.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\samples\docker_wrapper\toml.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="libboincapi.vcxproj">
+      <Project>{07bda8f7-4aaf-4a3b-b96e-ea72a143c5ae}</Project>
+    </ProjectReference>
+    <ProjectReference Include="libboinc.vcxproj">
+      <Project>{e8f6bd7e-461a-4733-b7d8-37b09a099ed8}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <Import Project="boinc_signing.targets" />
+</Project>


### PR DESCRIPTION
Support app versions that run jobs in Docker containers.
This also works with podman, an open-source and daemonless Docker equivalent.

Also: some changes to the client in terms of how Docker and podman are detected,
and the corresponding data structures.

Also: minor changes to the scheduler for parsing this info
(to be used by plan class specs).

Fixes #5825