### PR TITLE
[Manager] Gray out projects in project wizard that are already attached

### DIFF
--- a/clientgui/ProjectInfoPage.cpp
+++ b/clientgui/ProjectInfoPage.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -818,36 +818,14 @@ void CProjectInfoPage::OnPageChanging( wxWizardExEvent& event ) {
 
 	std::string new_project_url = (const char*)m_strProjectURL.mb_str();
 	canonicalize_master_url(new_project_url);
-	// remove http(s):// at the beginning of project address
-	// there is no reason to connect to secure address project
-	// if we're already connected to the non-secure address
-	// or vice versa
-	// also clear last '/' character if present
-	size_t pos = new_project_url.find(http);
-	if (pos != std::string::npos) {
-		new_project_url.erase(pos, http.length());
-	}
-	else if ((pos = new_project_url.find(https)) != std::string::npos) {
-		new_project_url.erase(pos, https.length());
-	}
-	if (new_project_url.length() >= 1 && new_project_url[new_project_url.length() - 1] == '/') {
-		new_project_url.erase(new_project_url.length() - 1, 1);
-	}
+    TrimURL(new_project_url);
  	for (int i = 0; i < pDoc->GetProjectCount(); ++i) {
  	    PROJECT* project = pDoc->project(i);
         if (project) {
             std::string project_url = project->master_url;
 
             canonicalize_master_url(project_url);
-
-            if ((pos = project_url.find(http)) != std::string::npos) {
-                project_url.erase(pos, http.length());
-            } else if ((pos = project_url.find(https)) != std::string::npos) {
-                project_url.erase(pos, https.length());
-            }
-			if (project_url.length() >= 1 && project_url[project_url.length() - 1] == '/') {
-				project_url.erase(project_url.length() - 1, 1);
-			}
+            TrimURL(project_url);
 
             if (project_url == new_project_url) {
                 bAlreadyAttached = true;
@@ -913,4 +891,30 @@ void CProjectInfoPage::RefreshPage() {
     // Trigger initial event to populate the list control
     wxCommandEvent evtEvent(wxEVT_COMMAND_COMBOBOX_SELECTED, ID_CATEGORIES);
     ProcessEvent(evtEvent);
+}
+
+
+// Function to "trim" the URL of the http(s) prefix and the last slash.
+// Prior to running this function, the string should be canonicalized using
+// the canonicalize_master_url function.
+//
+void CProjectInfoPage::TrimURL(std::string& purl) {
+    const std::string http = "http://";
+    const std::string https = "https://";
+    // Remove http(s):// at the beginning of project address
+    // there is no reason to connect to secure address project
+    // if we're already connected to the non-secure address
+    // or vice versa
+    // also clear last '/' character if present
+    //
+    size_t pos = purl.find(http);
+    if (pos != std::string::npos) {
+        purl.erase(pos, http.length());
+    }
+    else if ((pos = purl.find(https)) != std::string::npos) {
+        purl.erase(pos, https.length());
+    }
+    if (purl.length() >= 1 && purl[purl.length() - 1] == '/') {
+        purl.erase(purl.length() - 1, 1);
+    }
 }

--- a/clientgui/ProjectInfoPage.cpp
+++ b/clientgui/ProjectInfoPage.cpp
@@ -645,7 +645,7 @@ void CProjectInfoPage::OnProjectSelected( wxListEvent& event ) {
             m_pProjectDetailsOrganizationCtrl->SetToolTip(pProjectInfo->m_strOrganization);
         }
     }
-    
+
     wxLogTrace(wxT("Function Start/End"), wxT("CProjectInfoPage::OnProjectSelected - Function End"));
 }
 

--- a/clientgui/ProjectInfoPage.h
+++ b/clientgui/ProjectInfoPage.h
@@ -129,6 +129,8 @@ private:
     std::vector<CProjectInfo*> m_Projects;
     bool m_bProjectSupported;
     bool m_bProjectListPopulated;
+    std::vector<std::string> m_pTrimmedURL;
+    std::vector<std::string> m_pTrimmedURL_attached;
 };
 
 #endif

--- a/clientgui/ProjectInfoPage.h
+++ b/clientgui/ProjectInfoPage.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2018 University of California
+// Copyright (C) 2024 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -90,6 +90,8 @@ public:
     void EllipseStringIfNeeded(wxString& s, wxWindow *win);
 
     void RefreshPage();
+
+    void TrimURL(std::string& purl);
 
 ////@begin CProjectInfoPage member variables
     wxStaticText* m_pTitleStaticCtrl;

--- a/clientgui/ProjectInfoPage.h
+++ b/clientgui/ProjectInfoPage.h
@@ -55,8 +55,8 @@ public:
     /// wxEVT_COMMAND_COMBOBOX_SELECTED event handler for ID_PROJECTCATEGORY
     void OnProjectCategorySelected( wxCommandEvent& event );
 
-    /// wxEVT_COMMAND_LISTBOX_SELECTED event handler for ID_PROJECTS
-    void OnProjectSelected( wxCommandEvent& event );
+    /// wxEVT_LIST_ITEM_SELECTED event handler for ID_PROJECTS
+    void OnProjectSelected( wxListEvent& event );
 
     /// wxEVT_WIZARD_PAGE_CHANGED event handler for ID_PROJECTINFOPAGE
     void OnPageChanged( wxWizardExEvent& event );
@@ -99,7 +99,7 @@ public:
     wxStaticText* m_pProjectCategoriesStaticCtrl;
     wxComboBox* m_pProjectCategoriesCtrl;
     wxStaticText* m_pProjectsStaticCtrl;
-    wxListBox* m_pProjectsCtrl;
+    wxListCtrl* m_pProjectsCtrl;
     wxStaticBox* m_pProjectDetailsStaticCtrl;
     wxTextCtrl* m_pProjectDetailsDescriptionCtrl;
     wxStaticText* m_pProjectDetailsResearchAreaStaticCtrl;


### PR DESCRIPTION
Fixes #1552 

**Description of the Change**
This PR adds a feature to the Add Project wizard that will change the text of a project to gray if the project is already added.  This is accomplished by storing a string array of all projects that are available in the wizard, another string array of all projects currently attached.  Each array is then canonicalized, then trimmed of "http", etc.  Arrays are then compared and if any match, the text is set to gray.  The ability to make the text gray was enabled by adding the property "wxLB_OWNERDRAW" to the wxListBox.

For a "simple" change, this is actually a bit more complicated.  A few design notes:
1. Adding the Ownerdraw property did more than provide the ability to change the text color.  The background color of the wxListBox, wherenever there is text, also changed to grey.  I discovered this was a bug and not a feature in wxWidgets, and have reported it [here.](https://github.com/wxWidgets/wxWidgets/issues/24917)  It is being fixed with [this pull request](https://github.com/wxWidgets/wxWidgets/pull/24918).  I haven't tested the fix yet (I'm not sure I have the skill set to change BOINC's wxWidgets dependency).  Therefore, if you were to built with this PR, it looks like this:
![image](https://github.com/user-attachments/assets/27a3483a-63d6-4fba-9ac5-e5794c02c76e)

     I had hard coded a white background before I noticed it was a bug with wxWidgets, and with that it looks like this:
     ![image](https://github.com/user-attachments/assets/7378472b-e192-4dd5-a032-af024bf0f1e8)
     Of course, that white background would be redundant once the wxWidgets PR is merged, so that hard coding is not in this PR.

2. I have not tested this in Linux nor MacOS.  I also have not reviewed the code for anything dark mode settings.  I will need someone to check on those platforms to see if I broke anything.  FWIW, I run Windows in dark mode.
3. I am not an expert in accessibility, but a 4.6:1 contrast ratio looked good to me.  I tried to get a 7:1 ratio, but the gray looked too close to black to me and was hard to notice the distinction.

From what I have worked on, I think this PR is ready, but I kindly request others to test this on other platforms, especially with dark mode, before merging.

**Alternate Designs**
Hiding the projects that are attached didn't seem like a good idea to me.  If someone wanted to find out the information of the project in this wizard, they would not be able to unless they removed the project.  By graying out the projects that are attached, the users is able to see which projects that are still active and they are attached to.

**Release Notes**
[Manager] Projects listed in Add a Project wizard that are already added are changed to grey.
