### PR TITLE
Extend support for WSL and Docker apps

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -262,6 +262,11 @@ void CLIENT_STATE::show_host_info() {
                 "-      OS: %s (%s)",
                 wsl.os_name.c_str(), wsl.os_version.c_str()
             );
+            if (!wsl.libc_version.empty()) {
+                msg_printf(NULL, MSG_INFO,
+                    "-      libc version: %s", wsl.libc_version.c_str()
+                );
+            }
             if (!wsl.docker_version.empty()) {
                 msg_printf(NULL, MSG_INFO, "-      Docker version %s (%s)",
                     wsl.docker_version.c_str(),

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -1666,23 +1666,19 @@ int HOST_INFO::get_host_info(bool init) {
         os_name, sizeof(os_name), os_version, sizeof(os_version)
     );
 #ifdef _WIN64
-    if (!cc_config.dont_use_wsl) {
-        OSVERSIONINFOEX osvi;
-        if (get_OSVERSIONINFO(osvi) && osvi.dwMajorVersion >= 10) {
-            retval = get_wsl_information(
-                cc_config.allowed_wsls, wsl_distros, !cc_config.dont_use_docker
+    OSVERSIONINFOEX osvi;
+    if (get_OSVERSIONINFO(osvi) && osvi.dwMajorVersion >= 10) {
+        retval = get_wsl_information(wsl_distros);
+        if (retval) {
+            msg_printf(0, MSG_INTERNAL_ERROR,
+                "get_wsl_information(): %s", boincerror(retval)
             );
-            if (retval) {
-                msg_printf(0, MSG_INTERNAL_ERROR,
-                    "get_wsl_information(): %s", boincerror(retval)
-                );
-            }
         }
     }
 #endif
-    if (!cc_config.dont_use_vbox) {
-        get_virtualbox_version();
-    }
+
+    get_virtualbox_version();
+
     get_processor_info(
         p_vendor, sizeof(p_vendor),
         p_model, sizeof(p_model),

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -24,6 +24,7 @@ using std::string;
 #include "str_replace.h"
 #include "client_msgs.h"
 #include "hostinfo.h"
+#include "util.h"
 
 // timeout for commands run in WSL container
 // If something goes wrong we don't want client to hang
@@ -320,7 +321,7 @@ int get_wsl_information(
         )) {
             string buf;
             read_from_pipe(rs.out_read, rs.proc_handle, buf, CMD_TIMEOUT);
-            wd.libc_version = parse_ldd_libc(buf);
+            wd.libc_version = parse_ldd_libc(buf.c_str());
         }
 
         // see if Docker is installed in the distro

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -319,8 +319,8 @@ int get_wsl_information(WSL_DISTROS &distros) {
         // see if distro is disallowed
         //
         vector<string> &dw = cc_config.disallowed_wsls;
-        if (std::find(dw.begin(), dw.end(), wd.distro_name,) != dw.end()) {
-            dw.disallowed = true;
+        if (std::find(dw.begin(), dw.end(), wd.distro_name) != dw.end()) {
+            wd.disallowed = true;
         }
         distros.distros.push_back(wd);
     }

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -314,6 +314,15 @@ int get_wsl_information(
         // in case nothing worked
         update_os(wd, "unknown", "unknown");
 
+        // get the libc version
+        if (!rs.run_program_in_wsl(
+            wd.distro_name, "ldd --version"
+        )) {
+            string buf;
+            read_from_pipe(rs.out_read, rs.proc_handle, buf, CMD_TIMEOUT);
+            wd.libc_version = parse_ldd_libc(buf);
+        }
+
         // see if Docker is installed in the distro
         //
         if (detect_docker) {
@@ -327,7 +336,9 @@ int get_wsl_information(
     return 0;
 }
 
-static bool get_docker_version_aux(WSL_CMD &rs, WSL_DISTRO &wd, DOCKER_TYPE type) {
+static bool get_docker_version_aux(
+    WSL_CMD &rs, WSL_DISTRO &wd, DOCKER_TYPE type
+) {
     bool ret = false;
     string reply;
     string cmd = string(docker_cli_prog(type)) + " --version";
@@ -349,7 +360,9 @@ static void get_docker_version(WSL_CMD &rs, WSL_DISTRO &wd) {
     get_docker_version_aux(rs, wd, DOCKER);
 }
 
-static bool get_docker_compose_version_aux(WSL_CMD &rs, WSL_DISTRO &wd, DOCKER_TYPE type) {
+static bool get_docker_compose_version_aux(
+    WSL_CMD &rs, WSL_DISTRO &wd, DOCKER_TYPE type
+) {
     bool ret = false;
     string reply;
     string cmd = string(docker_cli_prog(type)) + " compose version";

--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -195,16 +195,16 @@ void CC_CONFIG::show() {
     if (dont_use_vbox) {
         msg_printf(NULL, MSG_INFO, "Config: don't use VirtualBox");
     }
-    if (dont_use_wsl) {
-        msg_printf(NULL, MSG_INFO, "Config: don't use the Windows Subsystem for Linux");
-    }
-    for (string s: allowed_wsls) {
-        msg_printf(NULL, MSG_INFO,
-            "Config: allowed WSL distro: %s", s.c_str()
-        );
-    }
     if (dont_use_docker) {
-        msg_printf(NULL, MSG_INFO, "Config: don't use the Docker");
+        msg_printf(NULL, MSG_INFO, "Config: don't use Docker");
+    }
+    if (dont_use_wsl) {
+        msg_printf(NULL, MSG_INFO, "Config: don't use Windows Subsystem for Linux");
+    }
+    for (string s: disallowed_wsls) {
+        msg_printf(NULL, MSG_INFO,
+            "Config: disallowed WSL distro: %s", s.c_str()
+        );
     }
     for (i=0; i<alt_platforms.size(); i++) {
         msg_printf(NULL, MSG_INFO,
@@ -381,8 +381,8 @@ int CC_CONFIG::parse_options_client(XML_PARSER& xp) {
         if (xp.parse_bool("dont_suspend_nci", dont_suspend_nci)) continue;
         if (xp.parse_bool("dont_use_vbox", dont_use_vbox)) continue;
         if (xp.parse_bool("dont_use_wsl", dont_use_wsl)) continue;
-        if (xp.parse_string("allowed_wsl", s)) {
-            allowed_wsls.push_back(s);
+        if (xp.parse_string("disallowed_wsl", s)) {
+            disallowed_wsls.push_back(s);
             continue;
         }
         if (xp.parse_bool("dont_use_docker", dont_use_docker)) continue;

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -215,7 +215,7 @@ void CC_CONFIG::defaults() {
     dont_suspend_nci = false;
     dont_use_vbox = false;
     dont_use_wsl = false;
-    allowed_wsls.clear();
+    disallowed_wsls.clear();
     dont_use_docker = false;
     exclude_gpus.clear();
     exclusive_apps.clear();
@@ -351,8 +351,8 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
         if (xp.parse_bool("dont_use_vbox", dont_use_vbox)) continue;
         if (xp.parse_bool("dont_use_docker", dont_use_docker)) continue;
         if (xp.parse_bool("dont_use_wsl", dont_use_wsl)) continue;
-        if (xp.parse_string("allowed_wsl", s)) {
-            allowed_wsls.push_back(s);
+        if (xp.parse_string("disallowed_wsl", s)) {
+            disallowed_wsls.push_back(s);
             continue;
         }
         if (xp.match_tag("exclude_gpu")) {
@@ -584,10 +584,10 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         dont_use_docker
     );
 
-    for (i=0; i<allowed_wsls.size(); ++i) {
+    for (i=0; i<disallowed_wsls.size(); ++i) {
         out.printf(
-            "        <allowed_wsl>%s</allowed_wsl>\n",
-            allowed_wsls[i].c_str()
+            "        <disallowed_wsl>%s</disallowed_wsl>\n",
+            disallowed_wsls[i].c_str()
         );
     }
 

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -167,7 +167,7 @@ struct CC_CONFIG {
     bool dont_suspend_nci;
     bool dont_use_vbox;
     bool dont_use_wsl;
-    std::vector<std::string> allowed_wsls;
+    std::vector<std::string> disallowed_wsls;
     bool dont_use_docker;
     std::vector<EXCLUDE_GPU> exclude_gpus;
     std::vector<std::string> exclusive_apps;

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -173,11 +173,7 @@ public:
 extern void make_secure_random_string(char*);
 
 #ifdef _WIN64
-extern int get_wsl_information(
-    std::vector<std::string> &allowed_wsls,
-    WSL_DISTROS &usable_distros,
-    bool detect_docker
-);
+extern int get_wsl_information(WSL_DISTROS &distros);
 extern int get_processor_group(HANDLE);
 #endif
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -685,3 +685,13 @@ bool process_exists(int pid) {
 }
 
 #endif
+
+string parse_ldd_libc(const char* input) {
+    const char *p = strrchr(input, ' ');
+    if (!p) return "";
+    int maj, min;
+    if (sscanf(p, "%d.%d", &maj, &min) != 2) return "";
+    string s = (string)p;
+    strip_whitespace(s);
+    return s;
+}

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -687,6 +687,8 @@ bool process_exists(int pid) {
 #endif
 
 string parse_ldd_libc(const char* input) {
+    char *q = (char*)strchr(input, '\n');
+    if (q) *q = 0;
     const char *p = strrchr(input, ' ');
     if (!p) return "";
     int maj, min;

--- a/lib/util.h
+++ b/lib/util.h
@@ -130,6 +130,13 @@ extern int run_command(char *cmd, std::vector<std::string> &out);
 //
 extern int get_real_executable_path(char* path, size_t max_len);
 
+// given a string of the form
+// ldd (Ubuntu GLIBC 2.27-3ubuntu1.6) 2.27
+// return "2.27" (or empty string if can't parse)
+//
+
+extern std::string parse_ldd_libc(const char* input);
+
 #ifdef GCL_SIMULATOR
 extern double simtime;
 #define time(x) ((int)simtime)

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -27,6 +27,7 @@ void WSL_DISTRO::clear() {
     distro_name = "";
     os_name = "";
     os_version = "";
+    libc_version = "";
     is_default = false;
     wsl_version = 1;
     docker_version = "";
@@ -51,6 +52,12 @@ void WSL_DISTRO::write_xml(MIOFILE& f) {
         is_default ? 1 : 0,
         wsl_version
     );
+    if (!libc_version.empty()) {
+        f.printf(
+            "           <libc_version>%s</libc_version>\n",
+            libc_version.c_str()
+        );
+    }
     if (!docker_version.empty()) {
         f.printf(
             "            <docker_version>%s</docker_version>\n"
@@ -82,6 +89,7 @@ int WSL_DISTRO::parse(XML_PARSER& xp) {
         if (xp.parse_string("distro_name", distro_name)) continue;
         if (xp.parse_string("os_name", os_name)) continue;
         if (xp.parse_string("os_version", os_version)) continue;
+        if (xp.parse_string("libc_version", libc_version)) continue;
         if (xp.parse_bool("is_default", is_default)) continue;
         if (xp.parse_int("wsl_version", wsl_version)) continue;
         if (xp.parse_string("docker_version", docker_version)) continue;

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -28,8 +28,9 @@ void WSL_DISTRO::clear() {
     os_name = "";
     os_version = "";
     libc_version = "";
+    disallowed = false;
     is_default = false;
-    wsl_version = 1;
+    wsl_version = 0;
     docker_version = "";
     docker_compose_version = "";
 }
@@ -44,14 +45,22 @@ void WSL_DISTRO::write_xml(MIOFILE& f) {
         "            <distro_name>%s</distro_name>\n"
         "            <os_name>%s</os_name>\n"
         "            <os_version>%s</os_version>\n"
-        "            <is_default>%d</is_default>\n"
         "            <wsl_version>%d</wsl_version>\n",
         dn,
         n,
         v,
-        is_default ? 1 : 0,
         wsl_version
     );
+    if (is_default) {
+        f.printf(
+            "            <is_default/>\n"
+        );
+    }
+    if (disallowed) {
+        f.printf(
+            "            <disallowed/>\n"
+        );
+    }
     if (!libc_version.empty()) {
         f.printf(
             "           <libc_version>%s</libc_version>\n",
@@ -91,6 +100,7 @@ int WSL_DISTRO::parse(XML_PARSER& xp) {
         if (xp.parse_string("os_version", os_version)) continue;
         if (xp.parse_string("libc_version", libc_version)) continue;
         if (xp.parse_bool("is_default", is_default)) continue;
+        if (xp.parse_bool("disallowed", disallowed)) continue;
         if (xp.parse_int("wsl_version", wsl_version)) continue;
         if (xp.parse_string("docker_version", docker_version)) continue;
         if (xp.parse_int("docker_type", i)) {
@@ -104,6 +114,13 @@ int WSL_DISTRO::parse(XML_PARSER& xp) {
         }
     }
     return ERR_XML_PARSE;
+}
+
+int WSL_DISTRO::libc_version_int() {
+    int maj, min;
+    int n = sscanf(libc_version.c_str(), "%d.%d", &maj, &min);
+    if (n==2) return maj*100+min;
+    return 0;
 }
 
 WSL_DISTROS::WSL_DISTROS() {
@@ -139,7 +156,8 @@ int WSL_DISTROS::parse(XML_PARSER& xp) {
 }
 
 WSL_DISTRO* WSL_DISTROS::find_match(
-    const char *os_name_regexp, const char *os_version_regexp
+    const char *os_name_regexp, const char *os_version_regexp,
+    int min_libc_version
 ) {
     std::regex name_regex(os_name_regexp), version_regex(os_version_regexp);
     for (WSL_DISTRO &wd: distros) {
@@ -147,6 +165,9 @@ WSL_DISTRO* WSL_DISTROS::find_match(
             continue;
         }
         if (!std::regex_match(wd.os_version.c_str(), version_regex)) {
+            continue;
+        }
+        if (wd.libc_version_int() < min_libc_version) {
             continue;
         }
         return &wd;

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -43,6 +43,8 @@ struct WSL_DISTRO {
         // version of WSL (currently 1 or 2)
     bool is_default;
         // this is the default distro
+    bool disallowed;
+        // disallowed in cc_config.xml
     std::string docker_version;
         // version of Docker (or podman)
         // empty if not present
@@ -57,6 +59,7 @@ struct WSL_DISTRO {
     void clear();
     void write_xml(MIOFILE&);
     int parse(XML_PARSER&);
+    int libc_version_int();
 };
 
 // a set of WSL distros
@@ -69,7 +72,8 @@ struct WSL_DISTROS {
     void write_xml(MIOFILE&);
     int parse(XML_PARSER&);
     WSL_DISTRO *find_match(
-        const char *os_name_regexp, const char *os_version_regexp
+        const char *os_name_regexp, const char *os_version_regexp,
+        int min_libc_version
     );
     WSL_DISTRO *find_docker();
         // find a distro containing Docker

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -37,6 +37,8 @@ struct WSL_DISTRO {
         // name of the operating system
     std::string os_version;
         // version of the operating system
+    std::string libc_version;
+        // version of libc, as reported by ldd --version
     int wsl_version;
         // version of WSL (currently 1 or 2)
     bool is_default;

--- a/samples/wsl_wrapper/wsl_wrapper.cpp
+++ b/samples/wsl_wrapper/wsl_wrapper.cpp
@@ -214,6 +214,7 @@ void poll_client_msgs() {
 
 int main(int argc, char** argv) {
     const char *os_name_regexp=".*", *os_version_regexp=".*", *pass_thru="";
+    int min_libc_version = 0;
     for (int i=1; i<argc; i++) {
         if (!strcmp(argv[i], "--os_name_regexp")) {
             os_name_regexp = argv[++i];
@@ -221,6 +222,8 @@ int main(int argc, char** argv) {
             os_version_regexp = argv[++i];
         } else if (!strcmp(argv[i], "--pass_thru")) {
             pass_thru = argv[++i];
+        } else if (!strcmp(argv[i], "--min_libc_version")) {
+            min_libc_version = atoi(argv[++i]);
         } else {
             fprintf(stderr, "unknown option %s\n", argv[i]);
             exit(1);
@@ -240,7 +243,9 @@ int main(int argc, char** argv) {
         distro_name = "Ubuntu-22.04";
     } else {
         boinc_get_init_data(aid);
-        WSL_DISTRO *distro = aid.host_info.wsl_distros.find_match(os_name_regexp, os_version_regexp);
+        WSL_DISTRO *distro = aid.host_info.wsl_distros.find_match(
+            os_name_regexp, os_version_regexp, min_libc_version
+        );
         if (!distro) {
             fprintf(stderr, "can't find distro\n");
             exit(1);

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -54,6 +54,7 @@ struct PLAN_CLASS_SPEC {
     int min_android_version;
     int max_android_version;
     int min_libc_version;
+        // if WSL: applies to WSL distro
     char project_prefs_tag[256];
     bool have_project_prefs_regex;
     regex_t project_prefs_regex;
@@ -64,6 +65,7 @@ struct PLAN_CLASS_SPEC {
         // for non-compute-intensive, or override for GPU apps
     bool have_host_summary_regex;
     regex_t host_summary_regex;
+        // matched against host.serialnum
     int user_id;
     double infeasible_random;
     long min_wu_id;

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -264,6 +264,7 @@ void SCHEDULER_REQUEST::clear() {
     strcpy(working_global_prefs_xml, "");
     strcpy(code_sign_key, "");
     dont_send_work = false;
+    dont_use_wsl = false;
     dont_use_docker = false;
     strcpy(client_brand, "");
     global_prefs.defaults();
@@ -403,6 +404,7 @@ const char* SCHEDULER_REQUEST::parse(XML_PARSER& xp) {
         if (xp.parse_double("duration_correction_factor", host.duration_correction_factor)) continue;
         if (xp.parse_bool("dont_send_work", dont_send_work)) continue;
         if (xp.parse_bool("dont_use_docker", dont_use_docker)) continue;
+        if (xp.parse_bool("dont_use_wsl", dont_use_wsl)) continue;
         if (xp.match_tag("global_preferences")) {
             safe_strcpy(global_prefs_xml, "<global_preferences>\n");
             char buf[BLOB_SIZE];

--- a/sched/sched_types.h
+++ b/sched/sched_types.h
@@ -267,6 +267,9 @@ struct PLATFORM_LIST {
     std::vector<PLATFORM*> list;
 };
 
+// if you add anything:
+// - add it to clear()
+// - add it to parse()
 struct SCHEDULER_REQUEST {
     char authenticator[256];
     CLIENT_PLATFORM platform;
@@ -339,6 +342,7 @@ struct SCHEDULER_REQUEST {
         // whether client uses account-based sandbox.  -1 = don't know
     int allow_multiple_clients;
         // whether client allows multiple clients per host, -1 don't know
+    bool dont_use_wsl;
     bool dont_use_docker;
     bool using_weak_auth;
         // Request uses weak authenticator.


### PR DESCRIPTION
- New philosophy: always query the presence of software (WSL distros, Docker)
    even if client config doesn't allow its use.
    Send the config info to scheduler, and enforce it there.
- New philosophy: allow running jobs in any WSL distro
    except those disallowed in the config

- Add plan class support for WSL and Docker app versions

- client: query the libc version of WSL distros and report it in scheduler requests.
    The plan class entry for a WSL app version can specify a min libc version.

- wsl_wrapper: add --min_libc_version cmdline arg (should match plan class spec)
