### PR TITLE
client: measure CPU time of VBox apps correctly

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -363,7 +363,7 @@ void ACTIVE_TASK_SET::get_memory_usage() {
     int retval;
     static bool first = true;
     double diff=0;
-    bool using_vbox = false;
+    bool vbox_app_running = false;
 
     if (!first) {
         diff = gstate.now - last_mem_time;
@@ -415,7 +415,7 @@ void ACTIVE_TASK_SET::get_memory_usage() {
         }
         procinfo_app(pi, v, pm, atp->app_version->graphics_exec_file);
         if (atp->app_version->is_vm_app) {
-            using_vbox = true;
+            vbox_app_running = true;
             // the memory of virtual machine apps is not reported correctly,
             // at least on Windows.  Use the VM size instead.
             //
@@ -540,7 +540,7 @@ void ACTIVE_TASK_SET::get_memory_usage() {
     static double last_nbrc=0;
     double total_cpu_time_now = total_cpu_time();
     if (total_cpu_time_now != 0.0) {    // total_cpu_time() returns 0.0 on error
-        double nbrc = total_cpu_time_now - boinc_related_cpu_time(pm, using_vbox);
+        double nbrc = total_cpu_time_now - boinc_related_cpu_time(pm, vbox_app_running);
         double delta_nbrc = nbrc - last_nbrc;
         if (delta_nbrc < 0) delta_nbrc = 0;
         last_nbrc = nbrc;

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -176,7 +176,7 @@ double boinc_related_cpu_time(PROC_MAP& pm, bool vbox_app_running) {
         if (
             p.is_boinc_app
             || p.is_low_priority
-            || (vbox_app_running && strcasestr(p.command, "vbox"))
+            || (vbox_app_running && strstr(p.command, "VBox"))
                 // if a VBox app is running,
                 // count VBox processes as BOINC-related
                 // e.g. VBoxHeadless.exe and VBoxSVC.exe on Win

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -165,7 +165,7 @@ void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
 // get CPU time of BOINC-related processes, low-priority processes,
 // and (if we're using Vbox) the Vbox daemon.
 //
-double boinc_related_cpu_time(PROC_MAP& pm, bool using_vbox) {
+double boinc_related_cpu_time(PROC_MAP& pm, bool vbox_app_running) {
     double sum = 0;
     PROC_MAP::iterator i;
     for (i=pm.begin(); i!=pm.end(); ++i) {
@@ -176,7 +176,10 @@ double boinc_related_cpu_time(PROC_MAP& pm, bool using_vbox) {
         if (
             p.is_boinc_app
             || p.is_low_priority
-            || (using_vbox && strstr(p.command, "VBoxSVC"))
+            || (vbox_app_running && strcasestr(p.command, "vbox"))
+                // if a VBox app is running,
+                // count VBox processes as BOINC-related
+                // e.g. VBoxHeadless.exe and VBoxSVC.exe on Win
         ) {
             sum += p.user_time;
         }

--- a/lib/procinfo.h
+++ b/lib/procinfo.h
@@ -87,7 +87,7 @@ extern double process_tree_cpu_time(int pid);
 extern double total_cpu_time();
     // total user-mode CPU time, as reported by OS
 
-extern double boinc_related_cpu_time(PROC_MAP&, bool using_vbox);
+extern double boinc_related_cpu_time(PROC_MAP&, bool vbox_app_running);
     // total CPU of current BOINC processes, low-priority processes,
-    // and (if using vbox) the Vbox daemon
+    // and (if a VBox app is running) VBox-related processes
 #endif


### PR DESCRIPTION
We were checking for VBoxSVC.exe and, if a VBox app is running, counting its CPU time as BOINC-related.
Should be 'VBoxHeadless.exe' on Win.
May be different on Mac/Linux, so use '*vbox*', case-insensitive

