### PR TITLE
web: parse gd version number correctly

### DIFF
--- a/html/inc/profile.inc
+++ b/html/inc/profile.inc
@@ -136,8 +136,10 @@ function scale_image(
     }
 
     $gd_info = gd_info();
-    $newGD = (strstr($gd_info["GD Version"], "2.0")!="");
-    if ($newGD) {
+    $v = $gd_info["GD Version"];
+    $v = explode('.', $v);
+    $v = (int)$v[0];        // major version
+    if ($v >= 2) {
         // If you are using a modern PHP/GD installation that does
         // 'truecolor' images, this is what's needed.
         $newImage = ImageCreateTrueColor($destWidth, $destHeight);


### PR DESCRIPTION
We were checking specifically for '2.0'.
If you had a later version (like 2.2) it would think you had an old version, and use an old image conversion function that produces wrong-colored results.
