### PR TITLE
client: remove unused Docker images and containers on startup

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// client initialization and main loop
+
 #ifdef _WIN32
 #include "boinc_win.h"
 #else
@@ -728,6 +730,8 @@ int CLIENT_STATE::init() {
     }
 
     process_gpu_exclusions();
+
+    docker_cleanup();
 
     check_clock_reset();
 

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -378,6 +378,7 @@ struct CLIENT_STATE {
     int app_finished(ACTIVE_TASK&);
     bool handle_finished_apps();
     void check_overdue();
+    void docker_cleanup();
 
     ACTIVE_TASK* get_task(RESULT*);
 

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -486,7 +486,7 @@ void CLIENT_STATE::docker_cleanup() {
 #else
     if (strlen(host_info.docker_version)) {
         DOCKER_CONN dc;
-        dc.init(host_info.docker_type);
+        dc.init(host_info.docker_type, false);
         cleanup_docker(info, dc);
     }
 #endif

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -477,7 +477,7 @@ void CLIENT_STATE::docker_cleanup() {
     // BOINC images and containers not in the above lists
     //
 #ifdef _WIN32
-    for (WSL_DISTR &wd: hostinfo.wsl_distros.distros) {
+    for (WSL_DISTRO &wd: host_info.wsl_distros.distros) {
         if (wd.docker_version.empty()) continue;
         DOCKER_CONN dc;
         dc.init(wd.docker_type, wd.distro_name);

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -486,7 +486,7 @@ void CLIENT_STATE::docker_cleanup() {
 #else
     if (strlen(host_info.docker_version)) {
         DOCKER_CONN dc;
-        dc.init(host_info.docker_type, false);
+        dc.init(host_info.docker_type);
         cleanup_docker(info, dc);
     }
 #endif

--- a/client/hostinfo_linux.cpp
+++ b/client/hostinfo_linux.cpp
@@ -15,6 +15,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// Functions for getting the OS name and version of a Linux system.
+// This is included in the Windows build because the Win client
+// needs to get info on WSL distros.
+
 #if   defined(_WIN32) && !defined(__STDWX_H__)
 #include "boinc_win.h"
 #elif defined(_WIN32) && defined(__STDWX_H__)

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -18,7 +18,7 @@
 #ifndef BOINC_HOSTINFO_H
 #define BOINC_HOSTINFO_H
 
-// Description of a host's hardware and software.
+// struct HOST_INFO describes a host's hardware and software.
 // This is used a few places:
 // - it's part of the client's state file, client_state.xml
 // - it's passed in the reply to the get_host_info GUI RPC

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -725,6 +725,7 @@ int DOCKER_CONN::init(DOCKER_TYPE docker_type) {
 
 int DOCKER_CONN::command(const char* cmd, vector<string> out, bool verbose) {
     char buf[1024];
+    int retval;
     if (verbose) {
         fprintf(stderr, "running docker command: %s\n", cmd);
     }
@@ -743,7 +744,8 @@ int DOCKER_CONN::command(const char* cmd, vector<string> out, bool verbose) {
     out = split(output, '\n');
 #else
     sprintf(buf, "%s %s\n", cli_prog, cmd);
-    return run_command(buf, out);
+    retval = run_command(buf, out);
+    if (retval) return retval;
 #endif
     if (verbose) {
         fprintf(stderr, "output:\n");
@@ -751,6 +753,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> out, bool verbose) {
             fprintf(stderr, "%s\n", line.c_str());
         }
     }
+    return 0;
 }
 
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -646,7 +646,7 @@ bool process_exists(HANDLE h) {
     return false;
 }
 
-#else
+#else   // _WIN32
 
 // Unix: pthreads doesn't provide an API for getting per-thread CPU time,
 // so just get the process's CPU time
@@ -686,7 +686,9 @@ bool process_exists(int pid) {
     return true;
 }
 
-#endif
+#endif  // _WIN32
+
+#ifndef _USING_FCGI_
 
 string parse_ldd_libc(const char* input) {
     char *q = (char*)strchr(input, '\n');
@@ -811,3 +813,4 @@ string docker_container_name(
 bool docker_is_boinc_name(const char* name) {
     return strstr(name, "boinc__") == name;
 }
+#endif  // _USING_FCGI

--- a/lib/util.h
+++ b/lib/util.h
@@ -25,6 +25,7 @@
 #include <vector>
 #ifdef _WIN32
 #include "boinc_win.h"
+#include "win_util.h"
 #endif
 #include "common_defs.h"
 
@@ -159,6 +160,7 @@ struct DOCKER_CONN {
     int command(
         const char* cmd, std::vector<std::string> out, bool verbose=false
     );
+    static const int TIMEOUT = 10;    // timeout for docker commands
 
     // parse a line from "docker images" output; return name
     int parse_image_name(std::string line, std::string &name);

--- a/lib/util.h
+++ b/lib/util.h
@@ -26,6 +26,8 @@
 #ifdef _WIN32
 #include "boinc_win.h"
 #endif
+#include "common_defs.h"
+
 extern double dtime();
 extern double dday();
 extern void boinc_sleep(double);
@@ -141,5 +143,39 @@ extern std::string parse_ldd_libc(const char* input);
 extern double simtime;
 #define time(x) ((int)simtime)
 #endif
+
+// represents a connection to a Docker/Podman installation
+// used from docker_wrapper and the client
+//
+struct DOCKER_CONN {
+    DOCKER_TYPE type;
+    const char* cli_prog;
+#ifdef _WIN32
+    WSL_CMD ctl_wc;
+    int init(DOCKER_TYPE type, std::string distro_name);
+#else
+    int init(DOCKER_TYPE);
+#endif
+    int command(
+        const char* cmd, std::vector<std::string> out, bool verbose=false
+    );
+
+    // parse a line from "docker images" output; return name
+    int parse_image_name(std::string line, std::string &name);
+
+    // parse a line from "docker ps --all" output; return name
+    int parse_container_name(std::string line, std::string &name);
+};
+
+extern std::string docker_image_name(
+    const char* proj_url_esc,       // escaped project URL
+    const char* wu_name
+);
+extern std::string docker_container_name(
+    const char* proj_url_esc,       // escaped project URL
+    const char* result_name
+);
+// is the name (of a Docker image or container) a BOINC name?
+extern bool docker_is_boinc_name(const char* name);
 
 #endif

--- a/lib/util.h
+++ b/lib/util.h
@@ -154,9 +154,9 @@ struct DOCKER_CONN {
     bool verbose;
 #ifdef _WIN32
     WSL_CMD ctl_wc;
-    int init(DOCKER_TYPE type, std::string distro_name, bool verbose);
+    int init(DOCKER_TYPE type, std::string distro_name, bool verbose=false);
 #else
-    int init(DOCKER_TYPE, bool verbose);
+    int init(DOCKER_TYPE, bool verbose=false);
 #endif
     int command(const char* cmd, std::vector<std::string> &out);
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -151,15 +151,15 @@ extern double simtime;
 struct DOCKER_CONN {
     DOCKER_TYPE type;
     const char* cli_prog;
+    bool verbose;
 #ifdef _WIN32
     WSL_CMD ctl_wc;
-    int init(DOCKER_TYPE type, std::string distro_name);
+    int init(DOCKER_TYPE type, std::string distro_name, bool verbose);
 #else
-    int init(DOCKER_TYPE);
+    int init(DOCKER_TYPE, bool verbose);
 #endif
-    int command(
-        const char* cmd, std::vector<std::string> out, bool verbose=false
-    );
+    int command(const char* cmd, std::vector<std::string> &out);
+
     static const int TIMEOUT = 10;    // timeout for docker commands
 
     // parse a line from "docker images" output; return name

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -258,23 +258,23 @@ PIPE_READ_RET read_from_pipe(
         PeekNamedPipe(pipe, NULL, 0, NULL, &avail, NULL);
         if (avail) {
             ret = ReadFile(pipe, buf, sizeof(buf) - 1, &nread, NULL);
-            if (!ret) return READ_ERROR;
+            if (!ret) return ERR_READ;
             buf[nread] = 0;
             out += buf;
             if (eom) {
                 if (out.find(eom) != std::string::npos) {
-                    return GOT_EOM;
+                    return 0;
                 }
             }
         } else {
             if (exited) {
-                return PROC_DIED;
+                return ERR_CONNECT;
             }
             Sleep(200);
             if (timeout) {
                 elapsed += .2;
                 if (elapsed > timeout) {
-                    return TIMEOUT;
+                    return ERR_TIMEOUT;
                 }
             }
             if (proc_handle) {

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -244,7 +244,7 @@ int WSL_CMD::run_program_in_wsl(
     return (ret == S_OK)?0:-1;
 }
 
-PIPE_READ_RET read_from_pipe(
+int read_from_pipe(
     HANDLE pipe, HANDLE proc_handle, string& out, double timeout,
     const char* eom
 ) {

--- a/lib/win_util.h
+++ b/lib/win_util.h
@@ -68,8 +68,6 @@ struct WSL_CMD {
     );
 };
 
-enum PIPE_READ_RET {GOT_EOM, PROC_DIED, TIMEOUT, READ_ERROR};
-
 // read from the pipe until either
 // - we get the eom string (if any)
 //      If you want to read at least 1 line, use "\n"
@@ -77,7 +75,7 @@ enum PIPE_READ_RET {GOT_EOM, PROC_DIED, TIMEOUT, READ_ERROR};
 // - there's no more data and the given timeout (if any) is reached
 // - a read fails
 //
-extern PIPE_READ_RET read_from_pipe(
+extern int read_from_pipe(
     HANDLE pipe,
     HANDLE proc_handle,
     std::string& out,

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -483,7 +483,7 @@ int wsl_init() {
         distro_name = distro->distro_name;
         docker_type = distro->docker_type;
     }
-    return docker_conn.init (docker_type, distro_name);
+    return docker_conn.init(docker_type, distro_name, verbose);
 }
 #endif
 
@@ -555,7 +555,7 @@ int main(int argc, char** argv) {
     }
 #else
     docker_conn.init(
-        boinc_is_standalone()?DOCKER:aid.host_info.docker_type
+        boinc_is_standalone()?DOCKER:aid.host_info.docker_type, verbose
     );
 #endif
 


### PR DESCRIPTION
The names of images and containers created by docker_wrapper have a particular form:
boinc__<proj>__<wuname> and boinc__<proj>__<resultname>.

docker_wrapper normally cleans up after itself.
But if it crashes, these objects could hang around forever, taking up disk space.

So clean them up on client startup, as follows:
make lists of the image/container names for active Docker tasks.
Then go through the Docker images and containers.
Remove any that
- were created by Docker wrapper (i.e. have boinc__ names)
- aren't in the active-task lists

On Unix, do this on the host itself if it has Docker installed.
On Win, do it for every WSL distro that has Docker installed.
