### PR TITLE
Draft: windows on arm lib support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AC_SUBST(REV)
 AC_SUBST(RDATE)
 
 dnl Are we compiling for windows
-if echo $host_os | egrep '^mingw|^winnt' > /dev/null ; then
+if echo $host_os | egrep '^mingw|^winnt|^windows' > /dev/null ; then
   isWIN32=yes
 else
   isWIN32=no
@@ -1120,7 +1120,7 @@ fi
 AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep '^linux' > /dev/null])
 AM_CONDITIONAL(OS_FREEBSD, [echo $host_os | grep '^freebsd' > /dev/null])
 dnl In case anyone wants to try building the windows code using mingw!
-AM_CONDITIONAL(OS_WIN32, [echo $host_os | egrep '^mingw|^winnt' > /dev/null])
+AM_CONDITIONAL(OS_WIN32, [echo $host_os | egrep '^mingw|^winnt|^windows' > /dev/null])
 AM_CONDITIONAL(OS_WIN32_MINGW, [echo $host_os | grep '^mingw' > /dev/null])
 dnl or OS2
 AM_CONDITIONAL(OS_OS2, [echo $host_os | grep '^os2' > /dev/null])

--- a/lib/boinc_win.h
+++ b/lib/boinc_win.h
@@ -148,6 +148,8 @@
 #define SECURITY_WIN32
 #endif
 
+#include <cstddef>
+
 #if !defined(__CYGWIN32__) || defined(USE_WINSOCK)
 
 /* If we're not running under CYGWIN use windows networking */

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -75,7 +75,9 @@ void HOST_INFO::clear_host_info() {
     safe_strcpy(os_version, "");
 
 #ifdef _WIN64
+#if !defined(__aarch64__)
     wsl_distros.clear();
+#endif
 #else
     safe_strcpy(docker_version, "");
     safe_strcpy(docker_compose_version, "");
@@ -138,10 +140,12 @@ int HOST_INFO::parse(XML_PARSER& xp, bool static_items_only) {
         if (xp.parse_str("os_name", os_name, sizeof(os_name))) continue;
         if (xp.parse_str("os_version", os_version, sizeof(os_version))) continue;
 #ifdef _WIN64
+#if !defined(__aarch64__)
         if (xp.match_tag("wsl")) {
             this->wsl_distros.parse(xp);
             continue;
         }
+#endif
 #else
         if (xp.parse_str("docker_version", docker_version, sizeof(docker_version))) continue;
         if (xp.parse_str("docker_compose_version", docker_compose_version, sizeof(docker_compose_version))) continue;
@@ -235,7 +239,9 @@ int HOST_INFO::write(
         coprocs.ndevs()
     );
 #ifdef _WIN64
+#if !defined(__aarch64__)
     wsl_distros.write_xml(out);
+#endif
 #else
     if (strlen(docker_version)) {
         out.printf(

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -32,7 +32,7 @@
 #include "coproc.h"
 #include "common_defs.h"
 
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__aarch64__)
 #include "wslinfo.h"
 #endif
 
@@ -86,7 +86,7 @@ public:
     char os_name[256];
     char os_version[256];
 
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(__aarch64__)
     // on Windows, Docker info is per WSL_DISTRO, not global
     WSL_DISTROS wsl_distros;
 #else
@@ -173,7 +173,9 @@ public:
 extern void make_secure_random_string(char*);
 
 #ifdef _WIN64
+#if !defined(__aarch64__)
 extern int get_wsl_information(WSL_DISTROS &distros);
+#endif
 extern int get_processor_group(HANDLE);
 #endif
 

--- a/lib/stackwalker_win.cpp
+++ b/lib/stackwalker_win.cpp
@@ -745,6 +745,8 @@ static void ShowStackRM(HANDLE hThread, CONTEXT& Context)
         "cs=%.4x  ss=%.4x  ds=%.4x  es=%.4x  fs=%.4x  gs=%.4x             efl=%.8lx\n\n",
         Context.SegCs, Context.SegSs, Context.SegDs,  Context.SegEs,  Context.SegFs,  Context.SegGs, Context.EFlags
     );
+#elif defined(__aarch64__)
+    // not implemented
 #else
     fprintf(stderr,
         "eax=%.8lx ebx=%.8lx ecx=%.8lx edx=%.8lx esi=%.8lx edi=%.8lx\n",
@@ -780,6 +782,8 @@ static void ShowStackRM(HANDLE hThread, CONTEXT& Context)
     StackFrame.AddrPC.Mode = AddrModeFlat;
     StackFrame.AddrFrame.Offset = Context.Rbp;
     StackFrame.AddrFrame.Mode = AddrModeFlat;
+#elif defined(__aarch64__)
+    // not implemented
 #else
 	StackFrame.AddrPC.Offset = Context.Eip;
     StackFrame.AddrPC.Mode = AddrModeFlat;

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -154,7 +154,7 @@ char* windows_format_error_string(
     DWORD dwRet = 0;
     LPSTR lpszTemp = NULL;
 
-    va_list args = NULL;
+    va_list args;
     va_start(args, iSize);
     try {
         dwRet = FormatMessage(

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -18,6 +18,8 @@
 // write and parse WSL_DISTRO structs,
 // which describe WSL distros and their possible Docker contents
 
+#if !defined(__aarch64__)
+
 #include <regex>
 
 #include "common_defs.h"
@@ -183,3 +185,5 @@ WSL_DISTRO* WSL_DISTROS::find_docker() {
     }
     return NULL;
 }
+
+#endif

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -21,6 +21,8 @@
 #ifndef BOINC_WSLINFO_H
 #define BOINC_WSLINFO_H
 
+#if !defined(__aarch64__)
+
 #include <string>
 
 #include "miofile.h"
@@ -78,5 +80,7 @@ struct WSL_DISTROS {
     WSL_DISTRO *find_docker();
         // find a distro containing Docker
 };
+
+#endif
 
 #endif


### PR DESCRIPTION
Related to #4697

**Description of the Change**
this allows compiling BOINC libraries with https://github.com/Windows-on-ARM-Experiments/mingw-woarm64-build/ for cross-compilation. Windows on ARM will officially be supported in the upcoming GCC 15.

**Alternate Designs**
Visual Studio is an alternative, it allows ARM targets, but it doesn't support cross-compilation, so using a GCC is more convenient because there's no need to access the real hardware.

while this change fixes the build
_./configure --host="aarch64-windows" --with-boinc-platform="windows_aarch64" --disable-server --disable-manager --disable-client --disable-shared CXXFLAGS="-O3 "_

I'm not sure what the platform string should be... ? https://boinc.berkeley.edu/trac/wiki/BoincPlatforms

I also have to run more tests to ensure it works with apps, so it's a draft for now, but any feedback is welcome. Thanks!