### PR TITLE
[Windows] Set correct platform name when running BOINC client on Windows on ARM.

### DIFF
--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -386,8 +386,8 @@ int get_os_information(
                     }
                 } else {
                     if  (osvi.dwBuildNumber >= 26100) {
-			strlcat(os_name, "Windows Server 2025", os_name_size);
-		    } else if (osvi.dwBuildNumber >= 25398) {
+			            strlcat(os_name, "Windows Server 2025", os_name_size);
+		            } else if (osvi.dwBuildNumber >= 25398) {
                         strlcat(os_name, "Windows Server 23H2", os_name_size);
                     } else if (osvi.dwBuildNumber >= 20348) {
                         strlcat(os_name, "Windows Server 2022", os_name_size);

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -172,6 +172,12 @@ public:
 
 extern void make_secure_random_string(char*);
 
+#ifdef _WIN32
+#ifndef SIM
+extern BOOL get_OSVERSIONINFO(OSVERSIONINFOEX& osvi);
+#endif
+#endif
+
 #ifdef _WIN64
 extern int get_wsl_information(WSL_DISTROS &distros);
 extern int get_processor_group(HANDLE);


### PR DESCRIPTION
With this commit a new platform name 'windows_arm64' added. Also, according to the https://learn.microsoft.com/en-us/windows/arm/apps-on-arm-x86-emulation, Windows 10 on ARM supports x86 applications, and Windows 11 on ARM supports x64 applications. That is why we will be checking what version of Windows we are running on, and adding 'windows_intelx86' on Windows 10 and later (I suppose, this is will set always) and 'windows_x86_64' on Windows 11 and later (nothing later at the moment, but we are looking into the future!).

This fixes #5934.
