### PR TITLE
remove useless redirect

### DIFF
--- a/html/user/user_agreetermsofuse.php
+++ b/html/user/user_agreetermsofuse.php
@@ -35,9 +35,6 @@ $next_url = urldecode($next_url);
 $next_url = sanitize_local_url($next_url);
 $next_url = urlencode($next_url);
 
-$u = "user_agreetermsofuse.php?next_url=".$next_url;
-redirect_to_secure_url($u);
-
 page_head(tra("Agree to our Terms of Use."));
 
 user_agreetermsofuse_form($next_url);


### PR DESCRIPTION
**Description of the Change**
Remove useless call to `redirect_to_secure_url`.

The call is already made in a file that is included:
https://github.com/BOINC/boinc/blob/c67393e6d11e4dafe11b54fd9470fa254f3b1c36/html/inc/util.inc#L1167

Also, the function `redirect_to_secure_url` requires 0 parameter, here we were providing one:
https://github.com/BOINC/boinc/blob/c67393e6d11e4dafe11b54fd9470fa254f3b1c36/html/inc/util.inc#L1156

**Release Notes**
N/A
