### PR TITLE
Consistent DB `enum` function

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -204,6 +204,11 @@ class BoincUser {
         $db = BoincDb::get();
         return $db->update($this, 'user', $clause);
     }
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincUser>
+     */
     static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
         return $db->enum('user', 'BoincUser', $where_clause, $order_clause);
@@ -258,6 +263,11 @@ class BoincTeam {
         $db = BoincDb::get();
         return $db->update($this, 'team', $clause);
     }
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincTeam>
+     */
     static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
         return $db->enum('team', 'BoincTeam', $where_clause, $order_clause);
@@ -297,9 +307,14 @@ class BoincTeamDelta {
         $db = BoincDb::get();
         return $db->insert('team_delta', $clause);
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincTeamDelta>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('team_delta', 'BoincTeamDelta', $where_clause);
+        return $db->enum('team_delta', 'BoincTeamDelta', $where_clause, $order_clause);
     }
     static function delete_for_user($user_id) {
         $db = BoincDb::get();
@@ -321,6 +336,11 @@ class BoincHost {
         $db = BoincDb::get();
         return $db->delete($this, 'host');
     }
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincHost>
+     */
     static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
         return $db->enum('host', 'BoincHost', $where_clause, $order_clause);
@@ -358,9 +378,14 @@ class BoincResult {
         $db = BoincDb::get();
         return $db->count('result', $clause);
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincResult>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('result', 'BoincResult', $where_clause);
+        return $db->enum('result', 'BoincResult', $where_clause, $order_clause);
     }
 	static function enum_fields($fields, $where_clause, $order_clause) {
         $db = BoincDb::get();
@@ -405,9 +430,14 @@ class BoincWorkunit {
         if (!$ret) return $ret;
         return $db->insert_id();
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincWorkunit>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('workunit', 'BoincWorkunit', $where_clause);
+        return $db->enum('workunit', 'BoincWorkunit', $where_clause, $order_clause);
     }
     function update($clause) {
         $db = BoincDb::get();
@@ -433,9 +463,14 @@ class BoincApp {
         $db = BoincDb::get();
         return $db->lookup('app', 'BoincApp', $clause);
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincApp>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('app', 'BoincApp', $where_clause);
+        return $db->enum('app', 'BoincApp', $where_clause, $order_clause);
     }
     static function insert($clause) {
         $db = BoincDb::get();
@@ -455,9 +490,14 @@ class BoincApp {
 
 #[AllowDynamicProperties]
 class BoincAppVersion {
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincAppVersion>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('app_version', 'BoincAppVersion', $where_clause);
+        return $db->enum('app_version', 'BoincAppVersion', $where_clause, $order_clause);
     }
     static function lookup($clause) {
         $db = BoincDb::get();
@@ -505,6 +545,11 @@ class BoincProfile {
         $db = BoincDb::get();
         return $db->insert('profile', $clause);
     }
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincProfile>
+     */
     static function enum($where_clause=null, $order_clause=null) {
         $db = BoincDb::get();
         return $db->enum('profile', 'BoincProfile', $where_clause, $order_clause);
@@ -529,9 +574,14 @@ class BoincTeamAdmin {
         $db = BoincDb::get();
         return $db->insert('team_admin', $clause);
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincTeamAdmin>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('team_admin', 'BoincTeamAdmin', $where_clause);
+        return $db->enum('team_admin', 'BoincTeamAdmin', $where_clause, $order_clause);
     }
     static function delete($clause) {
         $db = BoincDb::get();
@@ -553,9 +603,14 @@ class BoincPrivateMessage {
         $db = BoincDb::get();
         return $db->update($this, 'private_messages', $clause);
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincPrivateMessage>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('private_messages', 'BoincPrivateMessage', $where_clause);
+        return $db->enum('private_messages', 'BoincPrivateMessage', $where_clause, $order_clause);
     }
     static function insert($clause) {
         $db = BoincDb::get();
@@ -579,9 +634,14 @@ class BoincPrivateMessage {
 
 #[AllowDynamicProperties]
 class BoincPlatform {
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincPlatform>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('platform', 'BoincPlatform', $where_clause);
+        return $db->enum('platform', 'BoincPlatform', $where_clause, $order_clause);
     }
     static function lookup_id($id) {
         $db = BoincDb::get();
@@ -603,9 +663,14 @@ class BoincPlatform {
 
 #[AllowDynamicProperties]
 class BoincHostAppVersion {
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincHostAppVersion>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('host_app_version', 'BoincHostAppVersion', $where_clause);
+        return $db->enum('host_app_version', 'BoincHostAppVersion', $where_clause, $order_clause);
     }
     static function lookup($host_id, $app_version_id) {
         $db = BoincDb::get();
@@ -663,9 +728,14 @@ function latest_avs_app($appid) {
 
 #[AllowDynamicProperties]
 class BoincBadge {
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincBadge>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('badge', 'BoincBadge', $where_clause);
+        return $db->enum('badge', 'BoincBadge', $where_clause, $order_clause);
     }
     static function insert($clause) {
         $db = BoincDb::get();
@@ -693,9 +763,14 @@ class BoincBadge {
 
 #[AllowDynamicProperties]
 class BoincBadgeUser {
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincBadgeUser>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('badge_user', 'BoincBadgeUser', $where_clause);
+        return $db->enum('badge_user', 'BoincBadgeUser', $where_clause, $order_clause);
     }
     static function insert($clause) {
         $db = BoincDb::get();
@@ -723,9 +798,14 @@ class BoincBadgeUser {
 
 #[AllowDynamicProperties]
 class BoincBadgeTeam {
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincBadgeTeam>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('badge_team', 'BoincBadgeTeam', $where_clause);
+        return $db->enum('badge_team', 'BoincBadgeTeam', $where_clause, $order_clause);
     }
     static function insert($clause) {
         $db = BoincDb::get();
@@ -757,9 +837,14 @@ class BoincCreditUser {
         $db = BoincDb::get();
         return $db->lookup('credit_user', 'BoincCreditUser', $clause);
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincCreditUser>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('credit_user', 'BoincCreditUser', $where_clause);
+        return $db->enum('credit_user', 'BoincCreditUser', $where_clause, $order_clause);
     }
     static function sum($field, $clause) {
         $db = BoincDb::get();
@@ -774,7 +859,7 @@ class BoincCreditUser {
         $db->delete_aux('credit_user', "userid=$user->id");
     }
     static function get_list($where_clause, $order_clause, $limit) {
-        $db = BoincDB::get();
+        $db = BoincDb::get();
         return $db->get_list('user', 'credit_user', 'id', 'userid', 'BoincCreditUser', '*', $where_clause, $order_clause, $limit);
     }
 }
@@ -785,9 +870,14 @@ class BoincCreditTeam {
         $db = BoincDb::get();
         return $db->lookup('credit_team', 'BoincCreditTeam', $clause);
     }
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincCreditTeam>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('credit_team', 'BoincCreditTeam', $where_clause);
+        return $db->enum('credit_team', 'BoincCreditTeam', $where_clause, $order_clause);
     }
     static function sum($field, $clause) {
         $db = BoincDb::get();
@@ -798,7 +888,7 @@ class BoincCreditTeam {
         return $db->update_aux('credit_team', $clause);
     }
     static function get_list($where_clause, $order_clause, $limit) {
-        $db = BoincDB::get();
+        $db = BoincDb::get();
         return $db->get_list('team', 'credit_team', 'id', 'teamid', 'BoincCreditTeam', '*', $where_clause, $order_clause, $limit);
     }
 }
@@ -819,9 +909,14 @@ class BoincToken {
         return self::lookup("userid=$userid and token='$token' and expire_time > $now and type = '$type'");
     }
 
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincToken>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('token', 'BoincToken', $where_clause);
+        return $db->enum('token', 'BoincToken', $where_clause, $order_clause);
     }
 
     static function insert($clause) {
@@ -830,7 +925,7 @@ class BoincToken {
     }
 
     static function get_list($where_clause, $order_clause, $limit) {
-        $db = BoincDB::get();
+        $db = BoincDb::get();
         return $db->get_list('token', 'userid', 'type', 'create_time', 'expire_time', 'BoincToken', '*', $where_clause, $order_clause, $limit);
     }
 
@@ -899,9 +994,14 @@ class BoincConsent {
         return $db->lookup('consent', 'BoincConsent', $clause);
     }
 
-    static function enum($where_clause) {
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincConsent>
+     */
+    static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
-        return $db->enum('consent', 'BoincConsent', $where_clause);
+        return $db->enum('consent', 'BoincConsent', $where_clause, $order_clause);
     }
 
     static function insert ($clause) {
@@ -934,6 +1034,11 @@ class BoincConsentType {
         return $db->lookup('consent_type', 'BoincConsentType', $clause);
     }
 
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincConsentType>
+     */
     static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
         return $db->enum('consent_type', 'BoincConsentType', $where_clause, $order_clause);
@@ -970,6 +1075,11 @@ class BoincLatestConsent {
         return $db->lookup('latest_consent', 'BoincLatestConsent', $clause);
     }
 
+    /**
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<BoincLatestConsent>
+     */
     static function enum($where_clause, $order_clause=null) {
         $db = BoincDb::get();
         return $db->enum('latest_consent', 'BoincLatestConsent', $where_clause, $order_clause);

--- a/html/inc/db_conn.inc
+++ b/html/inc/db_conn.inc
@@ -114,6 +114,12 @@ class DbConn {
         return $this->lookup($table, $classname, "id=$id");
     }
 
+    /**
+     * @template T
+     * @param class-string<T> $classname
+     * @param string $query
+     * @return list<T>
+     */
     function enum_general($classname, $query) {
         $result = $this->do_query($query);
         if (!$result) return [];
@@ -125,10 +131,18 @@ class DbConn {
         return $x;
     }
 
+    /**
+     * @template T
+     * @param string $table
+     * @param class-string<T> $classname
+     * @param string $fields
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<T>
+     */
     function enum_fields(
         $table, $classname, $fields, $where_clause, $order_clause
     ) {
-        $x = array();
         if ($where_clause) {
             $where_clause = "where $where_clause";
         }
@@ -136,6 +150,14 @@ class DbConn {
         return $this->enum_general($classname, $query);
     }
 
+    /**
+     * @template T
+     * @param string $table
+     * @param class-string<T> $classname
+     * @param string|null $where_clause
+     * @param string|null $order_clause
+     * @return list<T>
+     */
     function enum($table, $classname, $where_clause=null, $order_clause=null) {
         return self::enum_fields(
             $table, $classname, '*', $where_clause, $order_clause

--- a/html/ops/create_forums.php
+++ b/html/ops/create_forums.php
@@ -29,7 +29,7 @@ require_once("../inc/util_ops.inc");
 
 function create_category($orderID, $name, $is_helpdesk) {
     $q = "(orderID, lang, name, is_helpdesk) values ($orderID, 1, '$name', $is_helpdesk)";
-    $db = BoincDB::get();
+    $db = BoincDb::get();
     $result = $db->insert("category", $q);
     if (!$result) {
         $cat = BoincCategory::lookup("name='$name' and is_helpdesk=$is_helpdesk");
@@ -43,7 +43,7 @@ function create_category($orderID, $name, $is_helpdesk) {
 
 function create_forum($category, $orderID, $title, $description, $is_dev_blog=0) {
     $q = "(category, orderID, title, description, is_dev_blog) values ($category, $orderID, '$title', '$description', $is_dev_blog)";
-    $db = BoincDB::get();
+    $db = BoincDb::get();
     $result = $db->insert("forum",$q);
     if (!$result) {
         $forum = BoincForum::lookup("category=$category and title='$title'");

--- a/html/user/get_project_config.php
+++ b/html/user/get_project_config.php
@@ -32,7 +32,7 @@ xml_header();
 function show_platforms() {
     $xmlFragment = unserialize(get_cached_data(3600, "project_config_platform_xml"));
     if ($xmlFragment==false){
-        $platforms = BoincDB::get()->enum_fields("platform, DBNAME.app_version, DBNAME.app", "BoincPlatform", "platform.name, platform.user_friendly_name, plan_class", "app_version.platformid = platform.id and app_version.appid = app.id and app_version.deprecated=0 and app.deprecated=0 group by platform.name, plan_class", "");
+        $platforms = BoincDb::get()->enum_fields("platform, DBNAME.app_version, DBNAME.app", "BoincPlatform", "platform.name, platform.user_friendly_name, plan_class", "app_version.platformid = platform.id and app_version.appid = app.id and app_version.deprecated=0 and app.deprecated=0 group by platform.name, plan_class", "");
         $xmlFragment = "    <platforms>";
         foreach ($platforms as $platform){
             $xmlFragment .= "

--- a/html/user/server_status.php
+++ b/html/user/server_status.php
@@ -414,7 +414,7 @@ function get_job_status() {
     $s = new StdClass;
     $apps = BoincApp::enum("deprecated=0");
     foreach ($apps as $app) {
-        $info = BoincDB::get()->lookup_fields("result", "stdClass",
+        $info = BoincDb::get()->lookup_fields("result", "stdClass",
             "ceil(avg(elapsed_time)/3600*100)/100 as avg,
             ceil(min(elapsed_time)/3600*100)/100 as min,
             ceil(max(elapsed_time)/3600*100)/100 as max,
@@ -440,7 +440,7 @@ function get_job_status() {
     $s->wus_need_validate = BoincWorkunit::count("need_validate=1");
     $s->wus_need_assimilate = BoincWorkunit::count("assimilate_state=1");
     $s->wus_need_file_delete = BoincWorkunit::count("file_delete_state=1");
-    $x = BoincDB::get()->lookup_fields("workunit", "stdClass", "MIN(transition_time) as min", "TRUE");
+    $x = BoincDb::get()->lookup_fields("workunit", "stdClass", "MIN(transition_time) as min", "TRUE");
     $gap = (time() - $x->min)/3600;
     if (($gap < 0) || ($x->min == 0)) {
         $gap = 0;


### PR DESCRIPTION
Fixes #1813

**Description of the Change**
Make all DB `enum` functions consistent

About the following requirement from the task:
> In addition a third argument for limit clauses should be added to the basic functions and the class implementations

Should I just update the `DbConn::enum` and `DbConn::enum_fields`?

**Release Notes**
N/A
