### PR TITLE
client, server, web: enable BUDA GPU apps

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -285,7 +285,7 @@ int ACTIVE_TASK::init(RESULT* rp) {
     result = rp;
     wup = rp->wup;
     app_version = rp->avp;
-    max_elapsed_time = rp->wup->rsc_fpops_bound/rp->avp->flops;
+    max_elapsed_time = rp->wup->rsc_fpops_bound/rp->resource_usage.flops;
     if (max_elapsed_time < MIN_TIME_BOUND) {
         msg_printf(wup->project, MSG_INFO,
             "Elapsed time limit %f < %f; setting to %f",
@@ -790,7 +790,7 @@ int ACTIVE_TASK::write_gui(MIOFILE& fout) {
     //
     double fd = fraction_done;
     if (((fd<=0)||(fd>1)) && elapsed_time > 60) {
-        double est_time = wup->rsc_fpops_est/app_version->flops;
+        double est_time = wup->rsc_fpops_est/result->resource_usage.flops;
         double x = elapsed_time/est_time;
         fd = 1 - exp(-x);
     }

--- a/client/app_config.cpp
+++ b/client/app_config.cpp
@@ -56,9 +56,9 @@ int APP_CONFIGS::config_app_versions(PROJECT* p, bool show_warnings) {
         for (unsigned int j=0; j<gstate.app_versions.size(); j++) {
             APP_VERSION* avp = gstate.app_versions[j];
             if (avp->app != app) continue;
-            if (!avp->gpu_usage.rsc_type) continue;
-            avp->gpu_usage.usage = ac.gpu_gpu_usage;
-            avp->avg_ncpus = ac.gpu_cpu_usage;
+            if (!avp->resource_usage.rsc_type) continue;
+            avp->resource_usage.coproc_usage = ac.gpu_gpu_usage;
+            avp->resource_usage.avg_ncpus = ac.gpu_cpu_usage;
         }
     }
     for (i=0; i<app_version_configs.size(); i++) {
@@ -79,13 +79,13 @@ int APP_CONFIGS::config_app_versions(PROJECT* p, bool show_warnings) {
             if (strcmp(avp->plan_class, avc.plan_class)) continue;
             found = true;
             if (cmdline_len) {
-                safe_strcpy(avp->cmdline, avc.cmdline);
+                safe_strcpy(avp->resource_usage.cmdline, avc.cmdline);
             }
             if (avc.avg_ncpus) {
-                avp->avg_ncpus = avc.avg_ncpus;
+                avp->resource_usage.avg_ncpus = avc.avg_ncpus;
             }
             if (avc.ngpus) {
-                avp->gpu_usage.usage = avc.ngpus;
+                avp->resource_usage.coproc_usage = avc.ngpus;
             }
         }
         if (!found) {

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -351,11 +351,11 @@ static void limbo_message(ACTIVE_TASK& at) {
 // that use the GPU type, in case they're waiting for GPU RAM
 //
 static void clear_schedule_backoffs(ACTIVE_TASK* atp) {
-    int rt = atp->result->avp->rsc_type();
+    int rt = atp->result->resource_usage.rsc_type;
     if (rt == RSC_TYPE_CPU) return;
     for (unsigned int i=0; i<gstate.results.size(); i++) {
         RESULT* rp = gstate.results[i];
-        if (rp->avp->rsc_type() == rt) {
+        if (rp->resource_usage.rsc_type == rt) {
             rp->schedule_backoff = 0;
         }
     }
@@ -895,7 +895,7 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
             snprintf(buf, sizeof(buf), "exceeded elapsed time limit %.2f (%.2fG/%.2fG)",
                 atp->max_elapsed_time,
                 atp->result->wup->rsc_fpops_bound/1e9,
-                atp->result->avp->flops/1e9
+                atp->result->resource_usage.flops/1e9
             );
             msg_printf(atp->result->project, MSG_INFO,
                 "Aborting task %s: %s", atp->result->name, buf

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -767,12 +767,12 @@ int ACTIVE_TASK::start() {
 
     snprintf(cmdline, sizeof(cmdline),
         "%s %s %s",
-        exec_path, wup->command_line.c_str(), app_version->cmdline
+        exec_path, wup->command_line.c_str(), result->resource_usage.cmdline
     );
     if (!app_version->api_version_at_least(7, 5)) {
-        int rt = app_version->gpu_usage.rsc_type;
+        int rt = result->resource_usage.rsc_type;
         if (rt) {
-            coproc_cmdline(rt, result, app_version->gpu_usage.usage, cmdline, sizeof(cmdline));
+            coproc_cmdline(rt, result, result->resource_usage.coproc_usage, cmdline, sizeof(cmdline));
         }
     }
 

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -233,7 +233,7 @@ void ACTIVE_TASK::init_app_init_data(APP_INIT_DATA& aid) {
     aid.rsc_memory_bound = wup->rsc_memory_bound;
     aid.rsc_disk_bound = wup->rsc_disk_bound;
     aid.computation_deadline = result->computation_deadline();
-    int rt = app_version->gpu_usage.rsc_type;
+    int rt = result->resource_usage.rsc_type;
     if (rt) {
         COPROC& cp = coprocs.coprocs[rt];
         if (coproc_type_name_to_num(cp.type) >= 0) {
@@ -252,14 +252,14 @@ void ACTIVE_TASK::init_app_init_data(APP_INIT_DATA& aid) {
         }
         aid.gpu_device_num = cp.device_nums[k];
         aid.gpu_opencl_dev_index = cp.opencl_device_indexes[k];
-        aid.gpu_usage = app_version->gpu_usage.usage;
+        aid.gpu_usage = result->resource_usage.coproc_usage;
     } else {
         safe_strcpy(aid.gpu_type, "");
         aid.gpu_device_num = -1;
         aid.gpu_opencl_dev_index = -1;
         aid.gpu_usage = 0;
     }
-    aid.ncpus = app_version->avg_ncpus;
+    aid.ncpus = result->resource_usage.avg_ncpus;
     aid.vbox_window = cc_config.vbox_window;
     aid.checkpoint_period = gstate.global_prefs.disk_interval;
     aid.fraction_done_start = 0;
@@ -671,8 +671,8 @@ int ACTIVE_TASK::start() {
     // - is a wrapper
     //
     high_priority = false;
-    if (app_version->rsc_type()) high_priority = true;
-    if (app_version->avg_ncpus < 1) high_priority = true;
+    if (result->resource_usage.rsc_type) high_priority = true;
+    if (result->resource_usage.avg_ncpus < 1) high_priority = true;
     if (app_version->is_wrapper) high_priority = true;
 
     current_cpu_time = checkpoint_cpu_time;
@@ -968,13 +968,13 @@ int ACTIVE_TASK::start() {
 
     snprintf(cmdline, sizeof(cmdline),
         "%s %s",
-        wup->command_line.c_str(), app_version->cmdline
+        wup->command_line.c_str(), result->resource_usage.cmdline
     );
 
     if (!app_version->api_version_at_least(7, 5)) {
-        int rt = app_version->gpu_usage.rsc_type;
+        int rt = result->resource_usage.rsc_type;
         if (rt) {
-            coproc_cmdline(rt, result, app_version->gpu_usage.usage, cmdline, sizeof(cmdline));
+            coproc_cmdline(rt, result, result->resource_usage.coproc_usage, cmdline, sizeof(cmdline));
         }
     }
 

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -713,17 +713,17 @@ int CLIENT_STATE::init() {
     //
     for (i=0; i<app_versions.size(); i++) {
         APP_VERSION* avp = app_versions[i];
-        if (!avp->flops) {
-            if (!avp->avg_ncpus) {
-                avp->avg_ncpus = 1;
+        if (!avp->resource_usage.flops) {
+            if (!avp->resource_usage.avg_ncpus) {
+                avp->resource_usage.avg_ncpus = 1;
             }
-            avp->flops = avp->avg_ncpus * host_info.p_fpops;
+            avp->resource_usage.flops = avp->resource_usage.avg_ncpus * host_info.p_fpops;
 
             // for GPU apps, use conservative estimate:
             // assume GPU runs at 10X peak CPU speed
             //
-            if (avp->gpu_usage.rsc_type) {
-                avp->flops += avp->gpu_usage.usage * 10 * host_info.p_fpops;
+            if (avp->resource_usage.rsc_type) {
+                avp->resource_usage.flops += avp->resource_usage.coproc_usage * 10 * host_info.p_fpops;
             }
         }
     }

--- a/client/coproc_sched.cpp
+++ b/client/coproc_sched.cpp
@@ -292,10 +292,9 @@ void assign_coprocs(vector<RESULT*>& jobs) {
     //
     for (i=0; i<jobs.size(); i++) {
         RESULT* rp = jobs[i];
-        APP_VERSION* avp = rp->avp;
-        int rt = avp->gpu_usage.rsc_type;
+        int rt = rp->resource_usage.rsc_type;
         if (rt) {
-            usage = avp->gpu_usage.usage;
+            usage = rp->resource_usage.coproc_usage;
             cp = &coprocs.coprocs[rt];
         } else {
             continue;
@@ -311,10 +310,9 @@ void assign_coprocs(vector<RESULT*>& jobs) {
     job_iter = jobs.begin();
     while (job_iter != jobs.end()) {
         RESULT* rp = *job_iter;
-        APP_VERSION* avp = rp->avp;
-        int rt = avp->gpu_usage.rsc_type;
+        int rt = rp->resource_usage.rsc_type;
         if (rt) {
-            usage = avp->gpu_usage.usage;
+            usage = rp->resource_usage.coproc_usage;
             cp = &coprocs.coprocs[rt];
         } else {
             ++job_iter;

--- a/client/coproc_sched.h
+++ b/client/coproc_sched.h
@@ -54,14 +54,13 @@ struct SPORADIC_RESOURCES {
             return false;
         }
         RESULT *rp = atp->result;
-        APP_VERSION *avp = rp->avp;
-        if (ncpus_used + avp->avg_ncpus > ncpus_max) {
+        if (ncpus_used + rp->resource_usage.avg_ncpus > ncpus_max) {
             return false;
         }
-        int rt = avp->gpu_usage.rsc_type;
+        int rt = rp->resource_usage.rsc_type;
         bool found = false;
         if (rt) {
-            double u = avp->gpu_usage.usage;
+            double u = rp->resource_usage.coproc_usage;
             COPROC& cp = sr_coprocs.coprocs[rt];
             for (int i=0; i<cp.count; i++) {
                 if (gpu_excluded(rp->app, cp, i)) continue;
@@ -78,12 +77,11 @@ struct SPORADIC_RESOURCES {
     // reserve resources for the task
     void reserve(ACTIVE_TASK *atp) {
         RESULT *rp = atp->result;
-        APP_VERSION *avp = rp->avp;
         mem_used += atp->procinfo.working_set_size_smoothed;
-        ncpus_used+= avp->avg_ncpus;
-        int rt = avp->gpu_usage.rsc_type;
+        ncpus_used+= rp->resource_usage.avg_ncpus;
+        int rt = rp->resource_usage.rsc_type;
         if (rt) {
-            double u = avp->gpu_usage.usage;
+            double u = rp->resource_usage.coproc_usage;
             COPROC& cp = sr_coprocs.coprocs[rt];
             for (int i=0; i<cp.count; i++) {
                 if (gpu_excluded(rp->app, cp, i)) continue;

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -276,7 +276,7 @@ bool check_coprocs_usable() {
             for (i=0; i<gstate.results.size(); i++) {
                 RESULT* rp = gstate.results[i];
                 if (rp->resource_usage.rsc_type) {
-                    rp->coproc_missing = true;
+                    rp->resource_usage.missing_coproc = true;
                 }
             }
             msg_printf(NULL, MSG_INFO,
@@ -290,7 +290,7 @@ bool check_coprocs_usable() {
             for (i=0; i<gstate.results.size(); i++) {
                 RESULT* rp = gstate.results[i];
                 if (rp->resource_usage.rsc_type) {
-                    rp->coproc_missing = false;
+                    rp->resource_usage.missing_coproc = false;
                 }
             }
             msg_printf(NULL, MSG_INFO,

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -292,18 +292,18 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
                     safe_strcpy(avp->platform, get_primary_platform());
                 }
             }
-            if (avp->missing_coproc) {
-                if (strstr(avp->missing_coproc_name, "Apple ")) {
+            if (avp->resource_usage.missing_coproc) {
+                if (strstr(avp->resource_usage.missing_coproc_name, "Apple ")) {
                     msg_printf(project, MSG_INFO,
                         "App version uses deprecated GPU type '%s' - discarding",
-                        avp->missing_coproc_name
+                        avp->resource_usage.missing_coproc_name
                     );
                     delete avp;
                     continue;
                 } else {
                     msg_printf(project, MSG_INFO,
                         "App version uses missing GPU '%s'",
-                        avp->missing_coproc_name
+                        avp->resource_usage.missing_coproc_name
                     );
                 }
             }
@@ -394,11 +394,11 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
                 delete rp;
                 continue;
             }
-            if (rp->avp->missing_coproc) {
+            rp->init_resource_usage();
+            if (rp->resource_usage.missing_coproc) {
                 msg_printf(project, MSG_INFO,
                     "Missing coprocessor for task %s", rp->name
                 );
-                rp->coproc_missing = true;
             }
             rp->wup->version_num = rp->version_num;
             results.push_back(rp);

--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -770,8 +770,8 @@ void process_gpu_exclusions() {
 
     for (i=0; i<gstate.app_versions.size(); i++) {
         APP_VERSION* avp = gstate.app_versions[i];
-        if (avp->missing_coproc) continue;
-        int rt = avp->gpu_usage.rsc_type;
+        if (avp->resource_usage.missing_coproc) continue;
+        int rt = avp->resource_usage.rsc_type;
         if (!rt) continue;
         COPROC& cp = coprocs.coprocs[rt];
         bool found = false;
@@ -782,12 +782,11 @@ void process_gpu_exclusions() {
             }
         }
         if (found) continue;
-        avp->missing_coproc = true;
-        safe_strcpy(avp->missing_coproc_name, "");
+        avp->resource_usage.missing_coproc = true;
+        safe_strcpy(avp->resource_usage.missing_coproc_name, "");
         for (j=0; j<gstate.results.size(); j++) {
             RESULT* rp = gstate.results[j];
             if (rp->avp != avp) continue;
-            rp->coproc_missing = true;
             msg_printf(avp->project, MSG_INFO,
                 "marking %s as coproc missing",
                 rp->name

--- a/client/project.cpp
+++ b/client/project.cpp
@@ -698,7 +698,7 @@ void PROJECT::get_task_durs(double& not_started_dur, double& in_progress_dur) {
         RESULT* rp = gstate.results[i];
         if (rp->project != this) continue;
         double d = rp->estimated_runtime_remaining();
-        d /= gstate.time_stats.availability_frac(rp->avp->gpu_usage.rsc_type);
+        d /= gstate.time_stats.availability_frac(rp->resource_usage.rsc_type);
         if (rp->is_not_started()) {
             not_started_dur += d;
         } else {
@@ -827,7 +827,7 @@ bool PROJECT::runnable(int rsc_type) {
         RESULT* rp = gstate.results[i];
         if (rp->project != this) continue;
         if (rsc_type != RSC_TYPE_ANY) {
-            if (rp->avp->gpu_usage.rsc_type != rsc_type) {
+            if (rp->resource_usage.rsc_type != rsc_type) {
                 continue;
             }
         }
@@ -981,7 +981,7 @@ void PROJECT::check_no_apps() {
     for (unsigned int i=0; i<gstate.app_versions.size(); i++) {
         APP_VERSION* avp = gstate.app_versions[i];
         if (avp->project != this) continue;
-        no_rsc_apps[avp->gpu_usage.rsc_type] = false;
+        no_rsc_apps[avp->resource_usage.rsc_type] = false;
     }
 }
 

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -78,7 +78,6 @@ void RESULT::clear() {
     exit_status = 0;
     stderr_out.clear();
     suspended_via_gui = false;
-    coproc_missing = false;
     report_immediately = false;
     not_started = false;
     name_md5.clear();
@@ -389,7 +388,7 @@ int RESULT::write_gui(MIOFILE& out, bool check_resources) {
     if (project->suspended_via_gui) out.printf("    <project_suspended_via_gui/>\n");
     if (report_immediately) out.printf("    <report_immediately/>\n");
     if (edf_scheduled) out.printf("    <edf_scheduled/>\n");
-    if (coproc_missing) out.printf("    <coproc_missing/>\n");
+    if (resource_usage.missing_coproc) out.printf("    <coproc_missing/>\n");
     if (schedule_backoff > gstate.now) {
         out.printf("    <scheduler_wait/>\n");
         if (strlen(schedule_backoff_reason)) {
@@ -405,35 +404,35 @@ int RESULT::write_gui(MIOFILE& out, bool check_resources) {
         atp->write_gui(out);
     }
     if (!strlen(resources) || check_resources) { // update resource string only when zero or when app_config is updated.
-        if (avp->gpu_usage.rsc_type) {
-            if (avp->gpu_usage.usage == 1) {
+        if (resource_usage.rsc_type) {
+            if (resource_usage.coproc_usage == 1) {
                 snprintf(resources, sizeof(resources),
                     "%.3g %s + 1 %s",
-                    avp->avg_ncpus,
-                    cpu_string(avp->avg_ncpus),
-                    rsc_name_long(avp->gpu_usage.rsc_type)
+                    resource_usage.avg_ncpus,
+                    cpu_string(resource_usage.avg_ncpus),
+                    rsc_name_long(resource_usage.rsc_type)
                 );
             } else {
                 snprintf(resources, sizeof(resources),
                     "%.3g %s + %.3g %ss",
-                    avp->avg_ncpus,
-                    cpu_string(avp->avg_ncpus),
-                    avp->gpu_usage.usage,
-                    rsc_name_long(avp->gpu_usage.rsc_type)
+                    resource_usage.avg_ncpus,
+                    cpu_string(resource_usage.avg_ncpus),
+                    resource_usage.coproc_usage,
+                    rsc_name_long(resource_usage.rsc_type)
                 );
             }
-        } else if (avp->missing_coproc) {
+        } else if (resource_usage.missing_coproc) {
             snprintf(resources, sizeof(resources),
                 "%.3g %s + %.12s GPU (missing)",
-                avp->avg_ncpus,
-                cpu_string(avp->avg_ncpus),
-                avp->missing_coproc_name
+                resource_usage.avg_ncpus,
+                cpu_string(resource_usage.avg_ncpus),
+                resource_usage.missing_coproc_name
             );
-        } else if (!project->non_cpu_intensive && (avp->avg_ncpus != 1)) {
+        } else if (!project->non_cpu_intensive && (resource_usage.avg_ncpus != 1)) {
             snprintf(resources, sizeof(resources),
                 "%.3g %s",
-                avp->avg_ncpus,
-                cpu_string(avp->avg_ncpus)
+                resource_usage.avg_ncpus,
+                cpu_string(resource_usage.avg_ncpus)
             );
         } else {
             safe_strcpy(resources, " ");
@@ -444,13 +443,13 @@ int RESULT::write_gui(MIOFILE& out, bool check_resources) {
         char buf[256];
         safe_strcpy(buf, "");
         if (atp && atp->scheduler_state == CPU_SCHED_SCHEDULED) {
-            if (avp->gpu_usage.rsc_type) {
-                COPROC& cp = coprocs.coprocs[avp->gpu_usage.rsc_type];
+            if (resource_usage.rsc_type) {
+                COPROC& cp = coprocs.coprocs[resource_usage.rsc_type];
                 if (cp.count > 1) {
                     // if there are multiple GPUs of this type,
                     // show the user which one(s) are being used
                     //
-                    int n = (int)ceil(avp->gpu_usage.usage);
+                    int n = (int)ceil(resource_usage.coproc_usage);
                     safe_strcpy(buf, n>1?" (devices ":" (device ");
                     for (int i=0; i<n; i++) {
                         char buf2[256];
@@ -591,7 +590,7 @@ bool RESULT::runnable() {
     if (suspended_via_gui) return false;
     if (project->suspended_via_gui) return false;
     if (state() != RESULT_FILES_DOWNLOADED) return false;
-    if (coproc_missing) return false;
+    if (resource_usage.missing_coproc) return false;
     if (schedule_backoff > gstate.now) return false;
     if (avp->needs_network && gstate.file_xfers_suspended) {
         // check file_xfers_suspended rather than network_suspended;
@@ -618,7 +617,7 @@ bool RESULT::nearly_runnable() {
     default:
         return false;
     }
-    if (coproc_missing) return false;
+    if (resource_usage.missing_coproc) return false;
     if (schedule_backoff > gstate.now) return false;
     return true;
 }
@@ -635,7 +634,7 @@ bool RESULT::downloading() {
 }
 
 double RESULT::estimated_runtime_uncorrected() {
-    return wup->rsc_fpops_est/avp->flops;
+    return wup->rsc_fpops_est/resource_usage.flops;
 }
 
 // estimate how long a result will take on this host

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -664,7 +664,7 @@ double RESULT::estimated_runtime_remaining() {
 
     if (atp) {
 #ifdef SIM
-        return sim_flops_left/avp->flops;
+        return sim_flops_left/resource_usage.flops;
 #else
         return atp->est_dur() - atp->elapsed_time;
 #endif

--- a/client/sim_util.cpp
+++ b/client/sim_util.cpp
@@ -141,7 +141,7 @@ int ACTIVE_TASK::init(RESULT* rp) {
     result = rp;
     wup = rp->wup;
     app_version = rp->avp;
-    max_elapsed_time = rp->wup->rsc_fpops_bound/result->avp->flops;
+    max_elapsed_time = rp->wup->rsc_fpops_bound/result->resource_usage.flops;
     max_disk_usage = rp->wup->rsc_disk_bound;
     max_mem_usage = rp->wup->rsc_memory_bound;
     _task_state = PROCESS_UNINITIALIZED;

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -15,6 +15,10 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// structures corresponding to various DB tables.
+// In some cases the structures have extra fields,
+// used by the server code but not stored in the DB
+
 #ifndef _BOINC_DB_TYPES_
 #define _BOINC_DB_TYPES_
 

--- a/html/inc/app_types.inc
+++ b/html/inc/app_types.inc
@@ -1,0 +1,73 @@
+<?php
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2024 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// code to get list of app types (CPU/GPU) supported by project
+
+require_once("../inc/boinc_db.inc");
+
+// return a structure indicating whether project can use
+// various resource types, and a count of apps.
+// Include both non-deprecated app versions and BUDA app variants.
+//
+function get_app_types() {
+    $t = new StdClass;
+    $t->cpu = false;
+    $t->cuda = false;
+    $t->ati = false;
+    $t->intel_gpu = false;
+    $t->apple_gpu = false;
+    $t->count = 0;
+
+    $avs = BoincAppVersion::enum("deprecated=0");
+    foreach ($avs as $av) {
+        do_plan_class($av->plan_class, $t);
+    }
+
+    $pcs = file('../../buda_plan_classes');
+    foreach ($pcs as $pc) {
+        do_plan_class($pc, $t);
+    }
+    return $t;
+}
+
+function do_plan_class($plan_class, &$t) {
+    if (strstr($plan_class, "ati")) {
+        $t->ati = true;
+        $t->count++;
+    } else if (strstr($plan_class, "amd")) {
+        $t->ati = true;
+        $t->count++;
+    } else if (strstr($plan_class, "cuda")) {
+        $t->cuda = true;
+        $t->count++;
+    } else if (strstr($plan_class, "nvidia")) {
+        $t->cuda = true;
+        $t->count++;
+    } else if (strstr($plan_class, "intel_gpu")) {
+        $t->intel_gpu = true;
+        $t->count++;
+    } else if (strstr($plan_class, "apple_gpu")) {
+        $t->apple_gpu = true;
+        $t->count++;
+    } else {
+        $t->cpu = true;
+        $t->count++;
+    }
+}
+
+?>

--- a/html/inc/prefs_project.inc
+++ b/html/inc/prefs_project.inc
@@ -44,6 +44,7 @@
 // (send_email and show_hosts) that are treated as project preferences
 
 include_once("../inc/prefs_util.inc");
+include_once("../inc/app_types.inc");
 include_once("../project/project_specific_prefs.inc");
 
 global $app_types;
@@ -70,7 +71,7 @@ if (!empty($accelerate_gpu_apps_pref)) {
 
 if ($app_types->cpu) {
     $project_pref_descs[] = new PREF_BOOL (
-        tra("Use CPU"),
+        tra("Allow CPU-only tasks"),
         "Request CPU-only tasks from this project.",
         "no_cpu",
         false,

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -17,7 +17,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// server-side utility functions for remote job submissions and control
+// server-side utility functions for remote job submission and control
 
 require_once("../inc/submit_db.inc");
 
@@ -368,6 +368,43 @@ function parse_info_file($path) {
         return null;
     }
     return [$md5, $size];
+}
+
+///////////////// TEMPLATE CREATION //////////////
+
+function file_ref_in($fname) {
+    return(sprintf(
+'      <file_ref>
+         <open_name>%s</open_name>
+         <copy_file/>
+      </file_ref>
+',
+        $fname
+    ));
+}
+function file_info_out($i) {
+    return sprintf(
+'    <file_info>
+        <name><OUTFILE_%d/></name>
+        <generated_locally/>
+        <upload_when_present/>
+        <max_nbytes>5000000</max_nbytes>
+        <url><UPLOAD_URL/></url>
+    </file_info>
+',
+        $i
+    );
+}
+
+function file_ref_out($i, $fname) {
+    return sprintf(
+'        <file_ref>
+            <file_name><OUTFILE_%d/></file_name>
+            <open_name>%s</open_name>
+            <copy_file/>
+        </file_ref>
+',      $i, $fname
+    );
 }
 
 ?>

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -1018,46 +1018,6 @@ function db_init($try_replica=false) {
     return 0;
 }
 
-// return a structure indicating whether project has non-deprecated
-// apps versions for various resource types,
-// and with a count of app versions
-//
-function get_app_types() {
-    $t = new StdClass;
-    $t->cpu = false;
-    $t->cuda = false;
-    $t->ati = false;
-    $t->intel_gpu = false;
-    $t->apple_gpu = false;
-    $t->count = 0;
-    $avs = BoincAppVersion::enum("deprecated=0");
-    foreach ($avs as $av) {
-        if (strstr($av->plan_class, "ati")) {
-            $t->ati = true;
-            $t->count++;
-        } else if (strstr($av->plan_class, "amd")) {
-            $t->ati = true;
-            $t->count++;
-        } else if (strstr($av->plan_class, "cuda")) {
-            $t->cuda = true;
-            $t->count++;
-        } else if (strstr($av->plan_class, "nvidia")) {
-            $t->cuda = true;
-            $t->count++;
-        } else if (strstr($av->plan_class, "intel_gpu")) {
-            $t->intel_gpu = true;
-            $t->count++;
-        } else if (strstr($av->plan_class, "apple_gpu")) {
-            $t->apple_gpu = true;
-            $t->count++;
-        } else {
-            $t->cpu = true;
-            $t->count++;
-        }
-    }
-    return $t;
-}
-
 // Functions to sanitize GET and POST args
 
 // "next_url" arguments (must be local, not full URLs)

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -29,6 +29,32 @@ display_errors();
 
 $buda_root = "../../buda_apps";
 
+// scan BUDA apps and variants, and write a file 'buda_plan_classes' 
+// in the project dir with list of plan classes
+//
+function write_plan_class_file() {
+    $pcs = [];
+    global $buda_root;
+    if (is_dir($buda_root)) {
+        $apps = scandir($buda_root);
+        foreach ($apps as $app) {
+            if ($app[0] == '.') continue;
+            if (!is_dir("$buda_root/$app")) continue;
+            $vars = scandir("$buda_root/$app");
+            foreach ($vars as $var) {
+                if ($var[0] == '.') continue;
+                if (!is_dir("$buda_root/$app/$var")) continue;
+                $pcs[] = $var;
+            }
+        }
+    }
+    $pcs = array_unique($pcs);
+    file_put_contents(
+        "../../buda_plan_classes",
+        implode("\n", $pcs)."\n"
+    );
+}
+
 // show list of BUDA apps and variants,
 // w/ buttons for adding and deleting
 //
@@ -394,9 +420,13 @@ case 'variant_view':
 case 'variant_form':
     variant_form($user); break;
 case 'variant_action':
-    variant_action($user); break;
+    variant_action($user);
+    write_plan_class_file();
+    break;
 case 'variant_delete':
-    variant_delete(); break;
+    variant_delete();
+    write_plan_class_file();
+    break;
 case 'view_file':
     view_file(); break;
 case null:

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -165,6 +165,48 @@ function copy_and_stage_file($user, $fname, $dir, $app, $variant) {
     return $phys_name;
 }
 
+// create templates and put them in variant dir
+//
+function create_templates($variant, $variant_desc, $dir) {
+    // input template
+    //
+    $x = "<input_template>\n";
+    $ninfiles = 1 + count($variant_desc->input_file_names) + count($variant_desc->app_files);
+    for ($i=0; $i<$ninfiles; $i++) {
+        $x .= "   <file_info>\n      <no_delete/>\n   </file_info>\n";
+    }
+    $x .= "   <workunit>\n";
+    $x .= file_ref_in($variant_desc->dockerfile);
+    foreach ($variant_desc->app_files as $fname) {
+        $x .= file_ref_in($fname);
+    }
+    foreach ($variant_desc->input_file_names as $fname) {
+        $x .= file_ref_in($fname);
+    }
+    if ($variant == 'cpu') {
+        $x .= "      <plan_class></plan_class>\n";
+    } else {
+        $x .= "      <plan_class>$variant</plan_class>\n";
+    }
+    $x .= "   </workunit>\n<input_template>\n";
+    file_put_contents("$dir/template_in", $x);
+
+    // output template
+    //
+    $x = "<output_template>\n";
+    $i = 0;
+    foreach ($variant_desc->output_file_names as $fname) {
+        $x .= file_info_out($i++);
+    }
+    $x .= "   <result>\n";
+    $i = 0;
+    foreach ($variant_desc->output_file_names as $fname) {
+        $x .= file_ref_out($i++, $fname);
+    }
+    $x .= "   </result>\n</output_template>\n";
+    file_put_contents("$dir/template_out", $x);
+}
+
 // create variant
 //
 function variant_action($user) {
@@ -218,6 +260,8 @@ function variant_action($user) {
         "$dir/variant.json",
         json_encode($desc, JSON_PRETTY_PRINT)
     );
+
+    create_templates($variant, $desc, $dir);
 
     // Note: we don't currently allow indirect file access.
     // If we did, we'd need to create job.toml to mount project dir

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -29,7 +29,7 @@ display_errors();
 
 $buda_root = "../../buda_apps";
 
-// scan BUDA apps and variants, and write a file 'buda_plan_classes' 
+// scan BUDA apps and variants, and write a file 'buda_plan_classes'
 // in the project dir with list of plan classes
 //
 function write_plan_class_file() {

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -47,7 +47,7 @@ function get_batch() {
     $batch_id = get_str('batch_id');
     $dir = "../../results/$batch_id";
     $name = "batch_$batch_id.zip";
-    $cmd = "cd $dir; rm -f $name; zip $name *";
+    $cmd = "cd $dir; rm -f $name; zip -q $name *";
     system($cmd);
     do_download("$dir/$name");
 }

--- a/sched/plan_class_spec.xml.sample
+++ b/sched/plan_class_spec.xml.sample
@@ -29,7 +29,6 @@
         <gpu_type>              nvidia      </gpu_type>
         <cuda/>
         <min_nvidia_compcap>    100         </min_nvidia_compcap>
-        <max_nvidia_compcap>    200         </max_nvidia_compcap>
         <min_cuda_version>      3000        </min_cuda_version>
         <min_driver_version>    17700       </min_driver_version>
         <min_gpu_ram_mb>        254         </min_gpu_ram_mb>

--- a/sched/sched_array.cpp
+++ b/sched/sched_array.cpp
@@ -323,11 +323,15 @@ recheck:
             //
             result.id = wu_result.resultid;
             if (result_still_sendable(result, wu)) {
+                bool is_buda, is_ok;
                 HOST_USAGE hu;
-                if (!handle_wu_plan_class(wu, bavp, hu)) {
-                    continue;
+                check_buda_plan_class(wu, hu, is_buda, is_ok);
+                if (is_buda) {
+                    if (!is_ok) continue;
+                } else {
+                    hu = bavp->host_usage;
                 }
-                add_result_to_reply(result, wu, bavp, hu, false);
+                add_result_to_reply(result, wu, bavp, hu, is_buda, false);
 
                 // add_result_to_reply() fails only in pathological cases -
                 // e.g. we couldn't update the DB record or modify XML fields.

--- a/sched/sched_array.cpp
+++ b/sched/sched_array.cpp
@@ -323,7 +323,11 @@ recheck:
             //
             result.id = wu_result.resultid;
             if (result_still_sendable(result, wu)) {
-                add_result_to_reply(result, wu, bavp, false);
+                HOST_USAGE hu;
+                if (!handle_wu_plan_class(wu, bavp, hu)) {
+                    continue;
+                }
+                add_result_to_reply(result, wu, bavp, hu, false);
 
                 // add_result_to_reply() fails only in pathological cases -
                 // e.g. we couldn't update the DB record or modify XML fields.

--- a/sched/sched_assign.cpp
+++ b/sched/sched_assign.cpp
@@ -154,7 +154,15 @@ static int send_assigned_job(ASSIGNMENT& asg) {
     DB_ID_TYPE result_id = boinc_db.insert_id();
     SCHED_DB_RESULT result;
     retval = result.lookup_id(result_id);
-    add_result_to_reply(result, wu, bavp, bavp->host_usage, false);
+    bool is_buda, is_ok;
+    HOST_USAGE hu;
+    check_buda_plan_class(wu, hu, is_buda, is_ok);
+    if (is_buda) {
+        if (!is_ok) return -1;
+    } else {
+        hu = bavp->host_usage;
+    }
+    add_result_to_reply(result, wu, bavp, hu, is_buda, false);
 
     if (config.debug_assignment) {
         log_messages.printf(MSG_NORMAL,

--- a/sched/sched_assign.cpp
+++ b/sched/sched_assign.cpp
@@ -154,7 +154,7 @@ static int send_assigned_job(ASSIGNMENT& asg) {
     DB_ID_TYPE result_id = boinc_db.insert_id();
     SCHED_DB_RESULT result;
     retval = result.lookup_id(result_id);
-    add_result_to_reply(result, wu, bavp, false);
+    add_result_to_reply(result, wu, bavp, bavp->host_usage, false);
 
     if (config.debug_assignment) {
         log_messages.printf(MSG_NORMAL,

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -981,7 +981,11 @@ bool app_plan(
 
     if (config.debug_version_select) {
         log_messages.printf(MSG_NORMAL,
-            "[version] Checking plan class '%s'\n", plan_class
+            "[version] Checking plan class '%s' check %d have %d bad %d\n",
+            plan_class,
+            check_plan_class_spec,
+            have_plan_class_spec,
+            bad_plan_class_spec
         );
     }
 

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -959,15 +959,21 @@ static inline bool app_plan_vbox(
     return true;
 }
 
-static inline bool app_plan_wsl(SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu) {
+static inline bool app_plan_wsl(
+    SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu
+) {
     // no additional checks at the moment, just return true
     return true;
 }
 
-// app planning function.
+// if host can handle the plan class, populate host usage and return true
+//
 // See https://github.com/BOINC/boinc/wiki/AppPlan
 //
-bool app_plan(SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu, const WORKUNIT* wu) {
+bool app_plan(
+    SCHEDULER_REQUEST& sreq, char* plan_class, HOST_USAGE& hu,
+    const WORKUNIT* wu
+) {
     char buf[256];
     static bool check_plan_class_spec = true;
     static bool have_plan_class_spec = false;

--- a/sched/sched_locality.cpp
+++ b/sched/sched_locality.cpp
@@ -332,7 +332,11 @@ static int possibly_send_result(SCHED_DB_RESULT& result) {
         if (count > 0) return ERR_WU_USER_RULE;
     }
 
-    return add_result_to_reply(result, wu, bavp, true);
+    HOST_USAGE hu;
+    if (!handle_wu_plan_class(wu, bavp, hu)) {
+        return false;
+    }
+    return add_result_to_reply(result, wu, bavp, hu, true);
 }
 
 // Retrieves and returns a trigger instance identified by the given

--- a/sched/sched_locality.cpp
+++ b/sched/sched_locality.cpp
@@ -336,7 +336,7 @@ static int possibly_send_result(SCHED_DB_RESULT& result) {
     HOST_USAGE hu;
     check_buda_plan_class(wu, hu, is_buda, is_ok);
     if (is_buda) {
-        if (!is_ok) ERR_NO_APP_VERSION;
+        if (!is_ok) return ERR_NO_APP_VERSION;
     } else {
         hu = bavp->host_usage;
     }

--- a/sched/sched_locality.cpp
+++ b/sched/sched_locality.cpp
@@ -332,11 +332,15 @@ static int possibly_send_result(SCHED_DB_RESULT& result) {
         if (count > 0) return ERR_WU_USER_RULE;
     }
 
+    bool is_buda, is_ok;
     HOST_USAGE hu;
-    if (!handle_wu_plan_class(wu, bavp, hu)) {
-        return false;
+    check_buda_plan_class(wu, hu, is_buda, is_ok);
+    if (is_buda) {
+        if (!is_ok) ERR_NO_APP_VERSION;
+    } else {
+        hu = bavp->host_usage;
     }
-    return add_result_to_reply(result, wu, bavp, hu, true);
+    return add_result_to_reply(result, wu, bavp, hu, is_buda, false);
 }
 
 // Retrieves and returns a trigger instance identified by the given

--- a/sched/sched_nci.cpp
+++ b/sched/sched_nci.cpp
@@ -94,7 +94,7 @@ static int send_job_for_app(APP& app) {
                     "Sending non-CPU-intensive job: %s\n", wu.name
                 );
             }
-            add_result_to_reply(result, wu, bavp, bavp->host_usage, false);
+            add_result_to_reply(result, wu, bavp, bavp->host_usage, false, false);
             return 0;
         }
         log_messages.printf(MSG_NORMAL,

--- a/sched/sched_nci.cpp
+++ b/sched/sched_nci.cpp
@@ -94,7 +94,7 @@ static int send_job_for_app(APP& app) {
                     "Sending non-CPU-intensive job: %s\n", wu.name
                 );
             }
-            add_result_to_reply(result, wu, bavp, false);
+            add_result_to_reply(result, wu, bavp, bavp->host_usage, false);
             return 0;
         }
         log_messages.printf(MSG_NORMAL,

--- a/sched/sched_resend.cpp
+++ b/sched/sched_resend.cpp
@@ -249,13 +249,15 @@ bool resend_lost_work() {
             );
             g_reply->insert_message(warning_msg, "low");
         } else {
-            HOST_USAGE host_usage;
-            if (!handle_wu_plan_class(wu, bavp, host_usage)) {
-                continue;
+            bool is_buda, is_ok;
+            HOST_USAGE hu;
+            check_buda_plan_class(wu, hu, is_buda, is_ok);
+            if (is_buda) {
+                if (!is_ok) continue;
+            } else {
+                hu = bavp->host_usage;
             }
-            retval = add_result_to_reply(
-                result, wu, bavp, host_usage, false
-            );
+            retval = add_result_to_reply(result, wu, bavp, hu, is_buda, false);
             if (retval) {
                 log_messages.printf(MSG_CRITICAL,
                     "[HOST#%lu] failed to send [RESULT#%lu]\n",

--- a/sched/sched_resend.cpp
+++ b/sched/sched_resend.cpp
@@ -249,7 +249,13 @@ bool resend_lost_work() {
             );
             g_reply->insert_message(warning_msg, "low");
         } else {
-            retval = add_result_to_reply(result, wu, bavp, false);
+            HOST_USAGE host_usage;
+            if (!handle_wu_plan_class(wu, bavp, host_usage)) {
+                continue;
+            }
+            retval = add_result_to_reply(
+                result, wu, bavp, host_usage, false
+            );
             if (retval) {
                 log_messages.printf(MSG_CRITICAL,
                     "[HOST#%lu] failed to send [RESULT#%lu]\n",

--- a/sched/sched_score.cpp
+++ b/sched/sched_score.cpp
@@ -50,6 +50,10 @@ static int get_size_class(APP& app, double es) {
     return app.n_size_classes - 1;
 }
 
+JOB::JOB() {
+    memset(this, 0, sizeof(JOB));
+}
+
 // Assign a score to this job,
 // representing the value of sending the job to this host.
 // Also do some initial screening,
@@ -226,8 +230,15 @@ void send_work_score_type(int rt) {
 
         // check WU plan class (for BUDA jobs)
         //
-        if (!handle_wu_plan_class(wu, job.bavp, job.host_usage)) {
-            continue;
+        bool is_buda, is_ok;
+        HOST_USAGE hu;
+        check_buda_plan_class(wu, hu, is_buda, is_ok);
+        if (is_buda) {
+            if (!is_ok) continue;
+            job.host_usage = hu;
+            job.is_buda = true;
+        } else {
+            job.host_usage = job.bavp->host_usage;
         }
 
         job.index = i;
@@ -357,7 +368,11 @@ void send_work_score_type(int rt) {
             SCHED_DB_RESULT result;
             result.id = wu_result.resultid;
             if (result_still_sendable(result, wu)) {
-                add_result_to_reply(result, wu, job.bavp, job.host_usage, false);
+                add_result_to_reply(
+                    result, wu, job.bavp, job.host_usage,
+                    job.is_buda,
+                    false   // locality scheduling
+                );
 
                 // add_result_to_reply() fails only in pathological cases -
                 // e.g. we couldn't update the DB record or modify XML fields.

--- a/sched/sched_score.cpp
+++ b/sched/sched_score.cpp
@@ -202,6 +202,7 @@ void send_work_score_type(int rt) {
         }
         WORKUNIT wu = wu_result.workunit;
         JOB job;
+
         job.app = ssp->lookup_app(wu.appid);
         if (job.app->non_cpu_intensive) {
             if (config.debug_send_job) {
@@ -220,6 +221,12 @@ void send_work_score_type(int rt) {
                     wu_result.resultid
                 );
             }
+            continue;
+        }
+
+        // check WU plan class (for BUDA jobs)
+        //
+        if (!handle_wu_plan_class(wu, job.bavp, job.host_usage)) {
             continue;
         }
 
@@ -350,7 +357,7 @@ void send_work_score_type(int rt) {
             SCHED_DB_RESULT result;
             result.id = wu_result.resultid;
             if (result_still_sendable(result, wu)) {
-                add_result_to_reply(result, wu, job.bavp, false);
+                add_result_to_reply(result, wu, job.bavp, job.host_usage, false);
 
                 // add_result_to_reply() fails only in pathological cases -
                 // e.g. we couldn't update the DB record or modify XML fields.

--- a/sched/sched_score.h
+++ b/sched/sched_score.h
@@ -23,8 +23,12 @@ struct JOB {
     double score;
     APP* app;
     BEST_APP_VERSION* bavp;
+    bool is_buda;
     HOST_USAGE host_usage;
+        // if is_buda, usage returned by WU plan class
+        // else a copy of bavp->host_usage
 
+    JOB();
     bool get_score(int);
 };
 

--- a/sched/sched_score.h
+++ b/sched/sched_score.h
@@ -23,6 +23,7 @@ struct JOB {
     double score;
     APP* app;
     BEST_APP_VERSION* bavp;
+    HOST_USAGE host_usage;
 
     bool get_score(int);
 };

--- a/sched/sched_send.cpp
+++ b/sched/sched_send.cpp
@@ -896,14 +896,19 @@ static bool wu_has_plan_class(WORKUNIT &wu, char* buf) {
     return true;
 }
 
-// if workunit has a plan class (e.g. BUDA), check it
-// in any case, fill in the HOST_USAGE
+// If workunit has a plan class (e.g. BUDA), check it.
+// In any case, fill in the HOST_USAGE
 //
 bool handle_wu_plan_class(
     WORKUNIT &wu, BEST_APP_VERSION *bavp, HOST_USAGE &hu
 ) {
     char plan_class[256];
     if (wu_has_plan_class(wu, plan_class)) {
+        if (config.debug_version_select) {
+            log_messages.printf(MSG_NORMAL,
+                "[version] plan class: %s\n", plan_class
+            );
+        }
         if (strlen(plan_class)) {
             if (!app_plan(*g_request, plan_class, hu, &wu)) {
                 if (config.debug_version_select) {

--- a/sched/sched_send.h
+++ b/sched/sched_send.h
@@ -33,7 +33,14 @@ extern void send_work();
 
 extern int add_result_to_reply(
     SCHED_DB_RESULT& result, WORKUNIT& wu, BEST_APP_VERSION* bavp,
+    HOST_USAGE&,
     bool locality_scheduling
+);
+
+// if WU has plan class, get corresponding host_usage
+//
+extern bool handle_wu_plan_class(
+    WORKUNIT &wu, BEST_APP_VERSION *bavp, HOST_USAGE &host_usage
 );
 
 inline bool is_anonymous(PLATFORM* platform) {

--- a/sched/sched_send.h
+++ b/sched/sched_send.h
@@ -34,13 +34,14 @@ extern void send_work();
 extern int add_result_to_reply(
     SCHED_DB_RESULT& result, WORKUNIT& wu, BEST_APP_VERSION* bavp,
     HOST_USAGE&,
+    bool is_buda,
     bool locality_scheduling
 );
 
-// if WU has plan class, get corresponding host_usage
+// if WU has plan class, check host, and get corresponding host_usage
 //
-extern bool handle_wu_plan_class(
-    WORKUNIT &wu, BEST_APP_VERSION *bavp, HOST_USAGE &host_usage
+extern void check_buda_plan_class(
+    WORKUNIT &wu, HOST_USAGE &host_usage, bool &is_buda, bool &is_ok
 );
 
 inline bool is_anonymous(PLATFORM* platform) {

--- a/sched/sched_shmem.cpp
+++ b/sched/sched_shmem.cpp
@@ -113,7 +113,7 @@ void get_buda_plan_classes(vector<string> &pcs) {
     FILE *f = boinc::fopen("../buda_plan_classes", "r");
     if (!f) return;
     char buf[256];
-    while (fgets(buf, 256, f)) {
+    while (boinc::fgets(buf, 256, f)) {
         strip_whitespace(buf);
         pcs.push_back(buf);
     }

--- a/sched/sched_types.h
+++ b/sched/sched_types.h
@@ -61,6 +61,11 @@ struct USER_MESSAGE {
     USER_MESSAGE(const char* m, const char*p);
 };
 
+// The resource usage (CPU, GPU, RAM) of a job,
+// and estimates of its speed
+// Populated by plan-class functions if have plan class,
+// else by HOST_USAGE::sequential_app()
+//
 struct HOST_USAGE {
     int proc_type;
     double gpu_usage;

--- a/sched/sched_types.h
+++ b/sched/sched_types.h
@@ -63,13 +63,13 @@ struct USER_MESSAGE {
 
 // The resource usage (CPU, GPU, RAM) of a job,
 // and estimates of its speed
-// Populated by plan-class functions if have plan class,
+// Populated by plan-class functions if there's a plan class,
 // else by HOST_USAGE::sequential_app()
 //
 struct HOST_USAGE {
     int proc_type;
     double gpu_usage;
-    double gpu_ram;
+    double gpu_ram;     // not currently used by client
     double avg_ncpus;
     double mem_usage;
         // mem usage if specified by the plan class
@@ -439,7 +439,7 @@ struct WORK_REQ_BASE {
         req_instances[proc_type] = 0;
     }
 
-    // older clients send send a single number, the requested duration of jobs
+    // older clients send a single number, the requested duration of jobs
     //
     double seconds_to_fill;
 

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -982,4 +982,3 @@ BEST_APP_VERSION* get_app_version(
     }
     return bavp;
 }
-

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -761,12 +761,14 @@ BEST_APP_VERSION* get_app_version(
                 }
             }
 
+            // if app version has plan class, make sure host can handle it
+            //
             if (strlen(av.plan_class)) {
                 if (!app_plan(*g_request, av.plan_class, host_usage, &wu)) {
                     if (config.debug_version_select) {
                         log_messages.printf(MSG_NORMAL,
-                            "[version] [AV#%lu] app_plan() returned false\n",
-                            av.id
+                            "[version] [AV#%lu] app_plan(%s) returned false\n",
+                            av.id, av.plan_class
                         );
                     }
                     continue;


### PR DESCRIPTION
With BUDA, the (BOINC) app version has just the docker wrapper.
Everything else (Dockerfile, executables) is part of the workunit,
along with the input files.

We want to support GPU applications in BUDA.
That implies that:
- The plan class (saying what GPU type and driver are needed)
    is part of the workunit rather than the app version
- The resource usage (GPU, fraction of CPU) is part of
    the workunit that's sent to and stored on the client.

This required changes to both scheduler and client
(and to a small extent web).
Fortunately I was able to keep the changes fairly simple.

DB:
    When we create a BUDA workunit, we stores its plan class
    as an element of its xml_doc, where the scheduler can see it.

Scheduler:
    If a workunit has a plan class,
    call the plan class function to see if we can send it to the host
    and if so to get the usage info.
    Include the usage info in the <workunit> element in the scheduler reply.

Feeder:
    It makes a list of GPU types the project can use;
    this is used in scheduler replies.
    This list now must reflect not only APP_VERSION plan classes,
    but also BUDA app variants.
    We do this using a file 'buda_plan_classes'
    that's maintained by the web code.

Client:
    A new struct RESOURCE_USAGE has GPU/CPU usage info.
    APP_VERSION and WORKUNIT (for BUDA jobs) both have one.
    The appropriate one is copied to RESULT when it's created.
    Scheduling and work fetch code references this copy.

Scheduler protocol:
    <workunit> now can include plan class and resource usage info
