### PR TITLE
Revert to 'ProtectSystem=strict' in boinc-client.service and make '/tmp' writable

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -7,9 +7,9 @@ After=vboxdrv.service network-online.target
 [Service]
 Type=simple
 ProtectHome=true
-ProtectSystem=full
+ProtectSystem=strict
 ProtectControlGroups=true
-ReadWritePaths=-/var/lib/boinc -/etc/boinc-client
+ReadWritePaths=-/var/lib/boinc -/etc/boinc-client -/tmp
 Nice=10
 User=boinc
 WorkingDirectory=/var/lib/boinc

--- a/tests/linux_package_integration_tests.py
+++ b/tests/linux_package_integration_tests.py
@@ -148,6 +148,7 @@ class IntegrationTests:
     def test_selected_values_from_boinc_client_service_file(self):
         ts = testset.TestSet("Test selected values from the '/usr/lib/systemd/system/boinc-client.service' file")
         data = self._get_key_value_pairs_from_file("/usr/lib/systemd/system/boinc-client.service")
+        ts.expect_equal(data["ProtectSystem"], "strict", "Test 'ProtectSystem' is correctly set")
         ts.expect_equal(data["ReadWritePaths"], "-/var/lib/boinc -/etc/boinc-client -/tmp", "Test 'ReadWritePaths' is correctly set")
         ts.expect_equal(data["User"], "boinc", "Test 'User' is correctly set")
         ts.expect_equal(data["WorkingDirectory"], "/var/lib/boinc", "Test 'WorkingDirectory' is correctly set")

--- a/tests/linux_package_integration_tests.py
+++ b/tests/linux_package_integration_tests.py
@@ -148,7 +148,7 @@ class IntegrationTests:
     def test_selected_values_from_boinc_client_service_file(self):
         ts = testset.TestSet("Test selected values from the '/usr/lib/systemd/system/boinc-client.service' file")
         data = self._get_key_value_pairs_from_file("/usr/lib/systemd/system/boinc-client.service")
-        ts.expect_equal(data["ReadWritePaths"], "-/var/lib/boinc -/etc/boinc-client", "Test 'ReadWritePaths' is correctly set")
+        ts.expect_equal(data["ReadWritePaths"], "-/var/lib/boinc -/etc/boinc-client -/tmp", "Test 'ReadWritePaths' is correctly set")
         ts.expect_equal(data["User"], "boinc", "Test 'User' is correctly set")
         ts.expect_equal(data["WorkingDirectory"], "/var/lib/boinc", "Test 'WorkingDirectory' is correctly set")
         ts.expect_equal(data["ExecStart"], "/usr/local/bin/boinc", "Test 'ExecStart' is correctly set")


### PR DESCRIPTION
BOINC volunteers running VirtualBox tasks on Linux occasionally report errors like this if BOINC runs as a systemd service:

```
2024-12-28 01:20:15 (16867): Detected: VirtualBox VboxManage Interface (Version: 7.0.12)
2024-12-28 01:20:20 (16867): Error in host info for VM: -182
Command:
VBoxManage -q list hostinfo 
Output:
VBoxManage: error: Failed to create the VirtualBox object!
VBoxManage: error: Code NS_ERROR_SOCKET_FAIL (0xC1F30200) - IPC daemon socket error (extended info not available)
VBoxManage: error: Most likely, the VirtualBox COM server is not running or failed to start.


2024-12-28 01:20:20 (16867): WARNING: Communication with VM Hypervisor failed.
2024-12-28 01:20:20 (16867): ERROR: VBoxManage list hostinfo failed
2024-12-28 01:20:20 (16867): called boinc_finish(1)
```

Usually this can be tracked down to a too restrictive setting in BOINC's systemd file:
`ProtectSystem=strict`

In most cases experienced volunteers suggest to replace `strict` with `full`, run `systemctl daemon-reload` and restart BOINC.
This works since - unlike `strict` - `full` leaves `/tmp` writable for BOINC and it's child processes.
The disadvantage is that it also leaves many other directories writable.
A better solution might be to leave `strict` and make `/tmp` writable which can be configured using `ReadWritePaths=`.


**Background details**

_From the systemd manual_

```
ProtectSystem=
Takes a boolean argument or the special values "full" or "strict". If true, mounts the /usr/ and the boot loader directories (/boot and /efi) read-only for processes invoked by this unit. If set to "full", the /etc/ directory is mounted read-only, too. If set to "strict" the entire file system hierarchy is mounted read-only, except for the API file system subtrees /dev/, /proc/ and /sys/ (...) If this option is used, ReadWritePaths= may be used to exclude specific directories from being made read-only.
```


_From the VirtualBox manual_

```
VBoxSVC IPC Issues
On Linux, Oracle VirtualBox makes use of a custom version of Mozilla XPCOM (cross platform component object model) for interprocess and intraprocess communication (IPC). (...) Communication between the various Oracle VirtualBox components and VBoxSVC is performed through a local domain socket residing in /tmp/.vbox-username-ipc. In case there are communication problems, such as an Oracle VirtualBox application cannot communicate with VBoxSVC, terminate the daemons and remove the local domain socket directory.
```
