### PR TITLE
Remove OpenSSL engine support

### DIFF
--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -34,7 +34,6 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/conf.h>
-#include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/rsa.h>
 #include <openssl/bn.h>

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -51,7 +51,6 @@
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/conf.h>
-#include <openssl/engine.h>
 #include <openssl/err.h>
 
 #include "crypt.h"
@@ -347,7 +346,6 @@ int main(int argc, char** argv) {
         }
         OpenSSL_add_all_algorithms();
         ERR_load_crypto_strings();
-        ENGINE_load_builtin_engines();
         if (bio_err == NULL) {
             bio_err = BIO_new_fp(stdout, BIO_NOCLOSE);
         }


### PR DESCRIPTION
The ENGINE API is deprecated in OpenSSL 3.0; the intended replacement is the Provider API.

See also #5356, for which this addresses one (but not all) of the reported deprecation warnings.

This is also motivated by [F41 Change Proposal: OpenSSL Deprecate Engine (system-wide)](https://discussion.fedoraproject.org/t/f41-change-proposal-openssl-deprecate-engine-system-wide/111344). OpenSSL ENGINE API support has not been removed from Fedora, but there is an effort to identify packages that require it and gradually fix them. A similar change appears [in RHEL10](https://www.redhat.com/en/blog/openssl-3-providers-rhel-10).

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

This simply removes each instance of `#include <openssl/engine.h>` and the one function call to OpenSSL’s ENGINE API, `ENGINE_load_builtin_engines()`.

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

The call to `ENGINE_load_builtin_engines()` was added a very long time in 5ba9c007a57d331f013f918fa9589d664c548e7f as part of x.509 signature generation support. I’m making a guess in this PR that it can be removed without consequence, but it’s not immediately obvious to me how to test this properly. It’s possible that this breaks something important, and if that’s the case, then the [Provider API in OpenSSL 3.0](https://docs.openssl.org/master/man7/provider/) is the [intended replacement for the ENGINE API](https://wiki.openssl.org/index.php/OpenSSL_3.0#Engines_and_.22METHOD.22_APIs).

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->

Removed support for deprecated OpenSSL engines.