### PR TITLE
swap calloc arguments

### DIFF
--- a/api/gutil.cpp
+++ b/api/gutil.cpp
@@ -470,7 +470,7 @@ void STARFIELD::build_stars(int sz, float sp) {
 	nstars=sz;
 
     if (stars) free(stars);
-    stars = (STAR*)calloc(sizeof(STAR), (long unsigned int)nstars);
+    stars = (STAR*)calloc((long unsigned int)nstars, sizeof(STAR));
     if (!stars) {
         fprintf(stderr, "out of mem in STARFIELD::build_stars");
         sz = 0;


### PR DESCRIPTION
Fixes a warning during compilation

**Description of the Change**
```
gutil.cpp: In member function 'void STARFIELD::build_stars(int, float)':
gutil.cpp:473:27: warning: 'void* calloc(size_t, size_t)' sizes specified with 'sizeof' in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  473 |     stars = (STAR*)calloc(sizeof(STAR), (long unsigned int)nstars);
      |                           ^~~~~~~~~~~~
gutil.cpp:473:27: note: earlier argument should specify number of elements, later size of each element
```

The calloc function takes two arguments: the number of elements and the size of each element. However, the arguments here are swapped.