### PR TITLE
client: don't delete unrecognized stuff in projects/

### DIFF
--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -111,14 +111,8 @@ int CLIENT_STATE::make_project_dirs() {
             continue;
         }
         msg_printf(0, MSG_INFO,
-            "%s is not a project dir - removing", path
+            "%s is not a project directory", path
         );
-        if (is_dir(path)) {
-            clean_out_dir(path);
-            boinc_rmdir(path);
-        } else {
-            boinc_delete_file(path);
-        }
     }
 
     return 0;


### PR DESCRIPTION
If someone runs the client in a directory (e.g. their home directory) that happens to contain a directory projects/, it deletes everything there! I don't know what I was thinking.
Print a message instead.

Fixes #6000

BTW: maybe we should have called it boinc_projects/ instead of projects/.
For now let's not change this.