### PR TITLE
vboxwrapper: create the 'virtualbox home directory' in the project dir

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -112,12 +112,16 @@ int VBOX_VM::initialize() {
     if (p) {
         virtualbox_home_directory = p;
     } else {
-        // If not then make one in the BOINC data directory.
-        // Note: in a sandboxed config we're running as user 'boinc_project'.
-        // This user doesn't have write access to the (real user) home dir.
+        // If not then make one in the BOINC project directory.
+        // Notes:
+        // 1) we can't put it in the home dir;
+        //  in a sandboxed config we're running as user 'boinc_projects',
+        //  which doesn't have write access to the (real user) home dir.
+        // 2) we can't put it in the BOINC data dir.
+        //  boinc_projects can't write their either
         //
         virtualbox_home_directory = aid.boinc_dir;
-        virtualbox_home_directory += "/.VirtualBox";
+        virtualbox_home_directory += "/projects/VirtualBox";
 
         // create if not there already
         boinc_mkdir(virtualbox_home_directory.c_str());

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -101,14 +101,20 @@ int VBOX_VM::initialize() {
 #endif
 
     // Determine the 'VirtualBox home directory'.
+    // On Windows, we run VboxSVC.exe in this directory,
+    // and we look for its log file there.
+    // On other platforms I don't think this is used.
+    //
     // NOTE: I'm not sure this is relevant; see
     // https://docs.oracle.com/en/virtualization/virtualbox/6.1/admin/TechnicalBackground.html#3.1.3.-Summary-of-Configuration-Data-Locations
     //
     if (getenv("VBOX_USER_HOME")) {
         virtualbox_home_directory = getenv("VBOX_USER_HOME");
     } else {
-        // If the override environment variable isn't specified then
-        // it is based of the current users HOME directory.
+        // If not specified by environment variable then create it
+        // Win, Linux: under user home dir
+        // Mac: in BOINC data dir
+        //
         const char *home;
 #ifdef _WIN32
         home = getenv("USERPROFILE");
@@ -126,6 +132,7 @@ int VBOX_VM::initialize() {
 #endif
         virtualbox_home_directory = home;
         virtualbox_home_directory += "/.VirtualBox";
+        boinc_mkdir(virtualbox_home_directory.c_str());
     }
 
 #ifdef _WIN32

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -112,15 +112,11 @@ int VBOX_VM::initialize() {
     if (p) {
         virtualbox_home_directory = p;
     } else {
-        // If not then make one in the project dir.
-        // Note: in a sandboxed config (e.g. Mac) we're running
-        // as effective user 'boinc_project'.
-        // This user doesn't have write access to the (real user) home dir
-        // or the BOINC data directory.
-        // But it can write to slots/, slots/*/, projects/ and projects/*/.
-        // Use the latter.
+        // If not then make one in the BOINC data directory.
+        // Note: in a sandboxed config we're running as user 'boinc_project'.
+        // This user doesn't have write access to the (real user) home dir.
         //
-        virtualbox_home_directory = aid.project_dir;
+        virtualbox_home_directory = aid.boinc_dir;
         virtualbox_home_directory += "/.VirtualBox";
 
         // create if not there already


### PR DESCRIPTION
The 'VBox home directory' is where VBox writes log files
(which are read by vboxwrapper).
If this is not specified by the env var VBOX_USER_HOME,
we need to create it somewhere and set the env var to point there.

Previously we put it in <datadir>/projects.
That's no good because it's not a project, and the client erased it.

We also tried putting it in the (real) user's home dir.
That's no good because
1) we shouldn't mess with the home dir
2) in sandboxed configs we're running as user 'boinc_projects',
and don't have access to the home dir.

According to https://boinc.berkeley.edu/sandbox_design.php,
the only places 'boinc_projects' can write are
projects/, slots/, and their subdirectories.
So the logical places to put .VirtualBox are
this job's slot directory, or its project directory.
I chose the latter.