### PR TITLE
vboxwrapper: virtualbox home directory fix MacOS

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -103,7 +103,7 @@ int VBOX_VM::initialize() {
     // Determine the 'VirtualBox home directory'.
     // NOTE: I'm not sure this is relevant; see
     // https://docs.oracle.com/en/virtualization/virtualbox/6.1/admin/TechnicalBackground.html#3.1.3.-Summary-of-Configuration-Data-Locations
-    //
+    // This is relevant for MacOS since ~ dir is strictly for the user.
     if (getenv("VBOX_USER_HOME")) {
         virtualbox_home_directory = getenv("VBOX_USER_HOME");
     } else {
@@ -126,6 +126,11 @@ int VBOX_VM::initialize() {
 #endif
         virtualbox_home_directory = home;
         virtualbox_home_directory += "/.VirtualBox";
+        // Set the environment variable after changing it since VirtualBox uses this as reference.
+        if (setenv("VBOX_USER_HOME", const_cast<char*>(virtualbox_home_directory.c_str()), 1)) {
+            vboxlog_msg("Failed to modify the home path.");
+        }
+        boinc_mkdir(virtualbox_home_directory.c_str());
     }
 
 #ifdef _WIN32


### PR DESCRIPTION
Directory was changed but not assigned to the environmental variable. Which caused a failure on MacOS.

Only change which need to be made for this pull request to work is create directory .VirtualBox by default or give boinc_project access to BOINC_data to be able to write the folder.

Related to #6016  and #6018 