### PR TITLE
[windows] when running installer, search for DLLs in the system directory only since the installer itself doesn't rely on any custom DLLs.

### DIFF
--- a/installer/installer_setup/main.cpp
+++ b/installer/installer_setup/main.cpp
@@ -177,6 +177,7 @@ void ShowWindow(HINSTANCE hInstance, int nCmdShow) {
 }
 
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE, LPSTR, int nCmdShow) {
+    SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32);
     ShowWindow(hInstance, nCmdShow);
     ExtractResourceAndExecute(IDB_MSI, "BOINC.msi");
     return 0;


### PR DESCRIPTION
This fixes #2482.
