### PR TITLE
[windows][installer] enable 'change'\'modify' and 'repair' options.

### DIFF
--- a/installer/boinc.json
+++ b/installer/boinc.json
@@ -9752,14 +9752,6 @@
             "Value": "https://boinc.berkeley.edu/"
         },
         {
-            "Property": "ARPNOMODIFY",
-            "Value": "1"
-        },
-        {
-            "Property": "ARPNOREPAIR",
-            "Value": "1"
-        },
-        {
             "Property": "ARPPRODUCTICON",
             "Value": "ARPPRODUCTICON.exe"
         },


### PR DESCRIPTION
I was not able to reproduce neither #1034 nor #1035, also it looks like the 'repair' option is not available anymore on Windows 11, and when selecting 'modify' it provides you two options: 'repair' and 'uninstall'. This looks valid to me, as if the user want to change something in the installation, it's always safer to uninstall and install again with the correct configuration, since it's a fast operation, and no user files are affected during it.

This fixes #1034 and #1035.
