### PR TITLE
create_work: clarify error message

### DIFF
--- a/html/inc/result.inc
+++ b/html/inc/result.inc
@@ -82,6 +82,9 @@ function app_version_string($result) {
         return anon_platform_string($result, tra("Apple GPU"));
     }
     $av = get_app_version($id);
+    if (!$av) {
+        return "missing app version $id";
+    }
     $app = get_app($av->appid);
     $platform = get_platform($av->platformid);
     $n = $app->user_friendly_name;

--- a/tools/process_input_template.cpp
+++ b/tools/process_input_template.cpp
@@ -468,8 +468,11 @@ static int process_workunit(
             }
             n_file_refs++;
         } else if (xp.parse_string("command_line", cmdline)) {
-            if (command_line) {
-                boinc::fprintf(stderr, "Can't specify command line twice\n");
+            if (strlen(command_line)) {
+                boinc::fprintf(stderr,
+                    "Can't specify command line %s; already specified as %s\n",
+                    cmdline.c_str(), command_line
+                );
                 return ERR_XML_PARSE;
             }
             out += "<command_line>\n";


### PR DESCRIPTION
You can't specify job cmdline args both in the input template and in the create_work command line.
Clarify this (at some point we could remove this restriction)
