### PR TITLE
web: the BBCode processor has [github] tags.

### DIFF
--- a/html/inc/text_transform.inc
+++ b/html/inc/text_transform.inc
@@ -224,7 +224,7 @@ function bb2html($text, $export=false) {
             "<a href=\"mailto:\\1\">\\1</a>",
             "<a href=\"mailto:\\1\">\\1</a>",
             "<a href=\"https://github.com/BOINC/boinc/issues/\\1\">#\\1</a>",
-            "<a href=\"https://github.com/BOINC/boinc-dev-doc/wiki/\\1\">\\1</a>",
+            "<a href=\"https://github.com/BOINC/boinc/wiki/\\1\">\\1</a>",
         );
     } else {
         $htmltags = array (
@@ -251,7 +251,7 @@ function bb2html($text, $export=false) {
             "<a href=\"mailto:\\1\">\\1</a>",
             "<a href=\"mailto:\\1\">\\1</a>",
             "<a href=\"https://github.com/BOINC/boinc/issues/\\1\">#\\1</a>",
-            "<a href=\"https://github.com/BOINC/boinc-dev-doc/wiki/\\1\">\\1</a>",
+            "<a href=\"https://github.com/BOINC/boinc/wiki/\\1\">\\1</a>",
         );
     }
     


### PR DESCRIPTION
These probably don't need to exist but at least
they should point to the right place.