### PR TITLE
web: on forum page, tell user they have to log in to post

### DIFF
--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -1226,12 +1226,16 @@ function is_admin($user) {
     return false;
 }
 
+// return
+// 'yes' if logged in and can post (show New thread button)
+// 'login' if could post if logged in (show login to post msg)
+// 'no' if can't post (don't show anythin)
+//
 function user_can_create_thread($user, $forum) {
-    if (!$user) return false;
-    if ($forum->is_dev_blog && !is_admin($user)) {
-        return false;
+    if ($forum->is_dev_blog) {
+        return is_admin($user)?'yes':'no';
     }
-    return true;
+    return $user ?'yes':'login';
 }
 
 function check_post_access($user, $forum) {

--- a/html/user/forum_forum.php
+++ b/html/user/forum_forum.php
@@ -95,10 +95,16 @@ echo '
     <td colspan=2>
 ';
 
-if (user_can_create_thread($user, $forum)) {
+
+switch (user_can_create_thread($user, $forum)) {
+case 'yes':
     show_button(
         "forum_post.php?id=$id", tra("New thread"), tra("Add a new thread to this forum")
     );
+    break;
+case 'login':
+    echo "To add a thread, you must <a href=login_form.php>log in</a>.";
+    break;
 }
 
 echo '</td>

--- a/html/user/forum_post.php
+++ b/html/user/forum_post.php
@@ -43,7 +43,7 @@ if (DISABLE_FORUMS && !is_admin($logged_in_user)) {
     error_page("Forums are disabled");
 }
 
-if (!user_can_create_thread($logged_in_user, $forum)) {
+if (user_can_create_thread($logged_in_user, $forum)=='no') {
     error_page(tra("Only project admins may create a thread here. However, you may reply to existing threads."));
 }
 check_post_access($logged_in_user, $forum);


### PR DESCRIPTION
Currently, if we direct someone to the "Questions and problems" forum, and they're not logged in, it's a dead end;
they aren't told that they need to log in
(and/or create an account) in order to post a question. Add this.
