### PR TITLE
web: in pages that take an ID as an arg, show error if not valid ID

### DIFF
--- a/html/user/forum_banishment_vote.php
+++ b/html/user/forum_banishment_vote.php
@@ -39,6 +39,7 @@ if (!$logged_in_user->prefs->privilege(S_MODERATOR)) {
 
 $userid = get_int('userid');
 $user = BoincUser::lookup_id($userid);
+if (!$user) error_page('No such user');
 
 page_head(tra("Banishment Vote"));
 

--- a/html/user/forum_banishment_vote_action.php
+++ b/html/user/forum_banishment_vote_action.php
@@ -48,6 +48,7 @@ if (!post_str('action', true)) {
 
 $userid = post_int('userid');
 $user=BoincUser::lookup_id($userid);
+if (!$user) error_page('No such user');
 
 if ($action!="start"){
     error_page("Unknown action");

--- a/html/user/forum_moderate_post.php
+++ b/html/user/forum_moderate_post.php
@@ -32,6 +32,7 @@ check_tokens($logged_in_user->authenticator);
 BoincForumPrefs::lookup($logged_in_user);
 $postid = get_int('id');
 $post = BoincPost::lookup_id($postid);
+if (!$post) error_page('No such post');
 $thread = BoincThread::lookup_id($post->thread);
 $forum = BoincForum::lookup_id($thread->forum);
 
@@ -74,10 +75,10 @@ if (get_str('action')=="hide") {
 } elseif (get_str('action')=="banish_user") {
     $userid = get_int('userid');
     $user = BoincUser::lookup_id($userid);
-    BoincForumPrefs::lookup($user);
     if (!$user) {
         error_page("no user found");
     }
+    BoincForumPrefs::lookup($user);
     $x = $user->prefs->banished_until;
     if ($x>time()) {
         error_page(tra("User is already banished"));

--- a/html/user/forum_moderate_thread.php
+++ b/html/user/forum_moderate_thread.php
@@ -32,6 +32,7 @@ if (!get_str('action')) {
     error_page("unknown action");
 }
 $thread = BoincThread::lookup_id(get_int('thread'));
+if (!$thread) error_page('No such thread');
 $forum = BoincForum::lookup_id($thread->forum);
 
 if (!is_moderator($logged_in_user, $forum)) {

--- a/html/user/forum_post.php
+++ b/html/user/forum_post.php
@@ -38,6 +38,7 @@ if (VALIDATE_EMAIL_TO_POST) {
 
 $forumid = get_int("id");
 $forum = BoincForum::lookup_id($forumid);
+if (!$forum) error_page('No such forum');
 
 if (DISABLE_FORUMS && !is_admin($logged_in_user)) {
     error_page("Forums are disabled");

--- a/html/user/forum_rate.php
+++ b/html/user/forum_rate.php
@@ -29,7 +29,7 @@ if (parse_bool($config, "no_forum_rating")) {
 }
 
 if (!empty($_GET['post'])) {
-    $postId = get_int('post');
+    $post_id = get_int('post');
     $choice = post_str('submit', true);
     $rating = post_int('rating', true);
     if (!$choice) $choice = get_str('choice', true);
@@ -46,7 +46,8 @@ if (!empty($_GET['post'])) {
         show_result_page(false, NULL, NULL, $choice);
     }
 
-    $post = BoincPost::lookup_id($postId);
+    $post = BoincPost::lookup_id($post_id);
+    if (!$post) error_page('No such post');
     $thread = BoincThread::lookup_id($post->thread);
     $forum = BoincForum::lookup_id($thread->forum);
 

--- a/html/user/forum_reply.php
+++ b/html/user/forum_reply.php
@@ -38,6 +38,7 @@ if (VALIDATE_EMAIL_TO_POST) {
 }
 
 $thread = BoincThread::lookup_id(get_int('thread'));
+if (!$thread) error_page('No such thread');
 $forum = BoincForum::lookup_id($thread->forum);
 
 $sort_style = get_str('sort', true);

--- a/html/user/forum_subscribe.php
+++ b/html/user/forum_subscribe.php
@@ -29,6 +29,7 @@ check_get_args(array("action", "thread", "tnow", "ttok"));
 $action = get_str('action');
 $threadid = get_int('thread');
 $thread = BoincThread::lookup_id($threadid);
+if (!$thread) error_page('No such thread');
 $forum = BoincForum::lookup_id($thread->forum);
 
 function show_title($forum, $thread) {

--- a/html/user/forum_thread_vote.php
+++ b/html/user/forum_thread_vote.php
@@ -27,6 +27,7 @@ check_get_args(array("id"));
 
 $threadid = get_int('id');
 $thread = BoincThread::lookup_id($threadid);
+if (!$thread) error_page('No such thread');
 $logged_in_user = get_logged_in_user();
 
 $posts = get_thread_posts($threadid, 0,true);

--- a/html/user/forum_user_posts.php
+++ b/html/user/forum_user_posts.php
@@ -26,12 +26,12 @@ if (DISABLE_FORUMS) error_page("Forums are disabled");
 check_get_args(array("userid", "offset"));
 
 $userid = get_int("userid");
+$user = BoincUser::lookup_id($userid);
+if (!$user) error_page('no such user');
 $offset = get_int("offset", true);
 if (!$offset) $offset=0;
 $items_per_page = 20;
 
-$user = BoincUser::lookup_id($userid);
-if (!$user) error_page('no such user');
 $logged_in_user = get_logged_in_user(false);
 BoincForumPrefs::lookup($logged_in_user);
 


### PR DESCRIPTION
don't just proceed with a null object
