### PR TITLE
Update docker_wrapper.cpp

### DIFF
--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -500,7 +500,7 @@ int main(int argc, char** argv) {
     options.check_heartbeat = true;
     options.handle_process_control = true;
     boinc_init_options(&options);
-
+    retval = parse_config_file();
     if (boinc_is_standalone()) {
         verbose = true;
         strcpy(image_name, "boinc");
@@ -512,7 +512,7 @@ int main(int argc, char** argv) {
         get_image_name();
         get_container_name();
     }
-    retval = parse_config_file();
+
     if (retval) {
         fprintf(stderr, "can't parse config file\n");
         exit(1);


### PR DESCRIPTION
Fixed bug:
the configuration file was parsed after image name was populated by  parse_config_file(); so every custom image name specified in the configuration file was ignored.

Fixes #

**Description of the Change**
I moved the   `retval = parse_config_file(); `line in the docker_wrapper main() before:
```
    if (boinc_is_standalone()) {
        verbose = true;
        strcpy(image_name, "boinc");
        strcpy(container_name, "boinc");
        project_dir = "project";
    } else {
        boinc_get_init_data(aid);
        project_dir = strrchr(aid.project_dir, '/')+1;
        get_image_name();
        get_container_name();
    }
```

**Alternate Designs**
Another possibility would have been to include the parsing of the config file in the else branch, so parsing the config file only when the wrapper is not run standalone. But considered that in this case image_name, container_name and project_dir get override, I think it can work also in this way so that eventually if there are other options in the toml they are going to be respected even in standalone mode (perhaps some future functionality)

**Release Notes**
N/A
