### PR TITLE
client: handle app_config.xml correctly

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -682,6 +682,17 @@ int CLIENT_STATE::init() {
     check_app_config();
     show_app_config();
 
+    // must go after check_app_config() and parse_state_file()
+    //
+    for (RESULT* rp: results) {
+        rp->init_resource_usage();
+        if (rp->resource_usage.missing_coproc) {
+            msg_printf(rp->project, MSG_INFO,
+                "Missing coprocessor for task %s", rp->name
+            );
+        }
+    }
+
     // this needs to go after parse_state_file() because
     // GPU exclusions refer to projects
     //

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -394,12 +394,6 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
                 delete rp;
                 continue;
             }
-            rp->init_resource_usage();
-            if (rp->resource_usage.missing_coproc) {
-                msg_printf(project, MSG_INFO,
-                    "Missing coprocessor for task %s", rp->name
-                );
-            }
             rp->wup->version_num = rp->version_num;
             results.push_back(rp);
             continue;


### PR DESCRIPTION
The BUDA changes copy resource usage (and cmdline) from either WU or APP_VERSION.
Need to do this after app_config files have been parsed, otherwise they'll have no effect.

Fixes #6072