### PR TITLE
client: don't overwrite settings in app_config.xml

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -929,12 +929,10 @@ int CLIENT_STATE::handle_scheduler_reply(
             app, avpp.platform, avpp.version_num, avpp.plan_class
         );
         if (avp) {
-            // update app version attributes in case they changed on server
-            //
-            avp->resource_usage = avpp.resource_usage;
-            strlcpy(avp->api_version, avpp.api_version, sizeof(avp->api_version));
-            avp->dont_throttle = avpp.dont_throttle;
-            avp->needs_network = avpp.needs_network;
+            // don't copy resource usage info from avpp to avp.
+            // That would undo app_config.xml.
+            // App versions are immutable;
+            // if a project wants to change something, create a new one
 
             // if we had download failures, clear them
             //


### PR DESCRIPTION
When processing a scheduler reply, we were copying info (e.g. resource usage) from <app_version> elements
into the corresponding APP_VERSION objects.
This undoes any params specified in app_config.xml So I'm not sure that app_config.xml ever worked except initially.

The reason for this was in case projects tweaked app version parameters. But they're not supposed to do this.
App versions are immutable.
If you want to change something, make a new app version.

Fixes #6072 (hopefully)
