### PR TITLE
DB: add indices on result(batch) and workunit(batch).

### DIFF
--- a/db/constraints.sql
+++ b/db/constraints.sql
@@ -39,6 +39,8 @@ alter table workunit
         -- file_deleter, db_purge
     add index wu_assim (appid, assimilate_state);
         -- assimilator
+    add index wu_batch(batch);
+        -- job submission web
 
 alter table result
     add unique(name),
@@ -66,8 +68,8 @@ alter table result
     add index res_hostid_id (hostid, id desc),
         -- html_user/results.php
 
-    add index res_wu_user (workunitid, userid);
-        -- scheduler (avoid sending mult results of same WU to one user)
+    add index res_batch (batch);
+        -- show batch status
 
 alter table msg_from_host
     add index message_handled (handled),

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1230,6 +1230,12 @@ SELECT userid,
     ");
 }
 
+function update_2_15_2025() {
+    do_query('alter table result drop index res_wu_user');
+    do_query('alter table workunit add index wu_batch(batch)');
+    do_query('alter table result add index res_batch(batch)');
+}
+
 // Updates are done automatically if you use "upgrade".
 //
 // If you need to do updates manually,
@@ -1289,7 +1295,8 @@ $db_updates = array (
     array(27025, "update_4_19_2018"),
     array(27026, "update_5_9_2018"),
     array(27027, "update_8_23_2018"),
-    array(27028, "update_9_12_2018")
+    array(27028, "update_9_12_2018"),
+    array(27029, "update_2_15_2025"),
 );
 
 ?>


### PR DESCRIPTION
These are needed for projects that use batch-oriented job submission (e.g. BUDA) and has little impact for projects that don't.

Also delete index on result(workunitid, userid).
Not needed.  result(workunitid) is enough

Fixes #6070