### PR TITLE
[Client] [Windows]  Move location of FreeConsole within init_core_client

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -13,7 +13,7 @@
 // See the GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+// along with BOINC.  If not, see <https://www.gnu.org/licenses/>.
 
 // command-line version of the BOINC client
 
@@ -216,6 +216,13 @@ static void init_core_client(int argc, char** argv) {
             BOINC_DIAG_REDIRECTSTDOUT;
     }
 
+    // Win32 - detach from console if requested
+#ifdef _WIN32
+    if (gstate.detach_console) {
+        FreeConsole();
+    }
+#endif
+
     diagnostics_init(flags, "stdoutdae", "stderrdae");
 
 #ifdef _WIN32
@@ -239,13 +246,6 @@ static void init_core_client(int argc, char** argv) {
     if (read_nvc_config_file()) {
        // msg_printf(NULL, MSG_INFO, "nvc_config.xml not found - using defaults");
     }
-
-    // Win32 - detach from console if requested
-#ifdef _WIN32
-    if (gstate.detach_console) {
-        FreeConsole();
-    }
-#endif
 
     // Unix: install signal handlers
 #ifndef _WIN32


### PR DESCRIPTION
**Description of the Change**
Per Microsoft's notes on setvbuf:

> The setvbuf function allows the program to control both buffering and buffer size for stream. stream must refer to an open file that hasn't undergone an I/O operation since it was opened.

Source:  [https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf?view=msvc-170#remarks](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/setvbuf?view=msvc-170#remarks)

If a user were to run the Client from the command line and use both --redirectio and --detach_console, the current code would create the output log files.  However, after the console is detached, this causes an I/O operation, and therefore nothing else can be written to the log files.  By detaching the console before the diagnotic logs are initialized, this corrects the problem.

Fixes #5009

**Alternate Designs**
None considered.

**Release Notes**
[Client] [Windows] Fixed bug that prevented writing to stdoutae and sterrae when using --redirectio and --detach_console from the command line.
