### PR TITLE
[Manager] Add wrap function to server message

### DIFF
--- a/clientgui/CompletionErrorPage.cpp
+++ b/clientgui/CompletionErrorPage.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -13,7 +13,7 @@
 // See the GNU Lesser General Public License for more details.
 //
 // You should have received a copy of the GNU Lesser General Public License
-// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+// along with BOINC.  If not, see <https://www.gnu.org/licenses/>.
 //
 #if defined(__GNUG__) && !defined(__APPLE__)
 #pragma implementation "CompletionErrorPage.h"
@@ -233,6 +233,9 @@ void CCompletionErrorPage::OnPageChanged( wxWizardExEvent& event ) {
         m_pServerMessagesDescriptionCtrl->SetLabel(
             _("Messages from server:")
         );
+        const wxSize page_width = this->GetClientSize();
+        const int minimum_size = page_width.x - 15;  // 15 seems to be needed to keep the right border visible.
+        m_pServerMessagesCtrl->Wrap(minimum_size);
         m_pServerMessagesDescriptionCtrl->Show();
         m_pServerMessagesCtrl->Show();
     }


### PR DESCRIPTION
Fixes #3055 

**Description of the Change**
In the add project wizard under the CompletionErrorPage, if a server message is provided it is wrapped to the width of the wizard page.

Example:
![3055-Completion Error Page Fix](https://github.com/user-attachments/assets/97976afb-5827-429a-9b3f-7f5522f32f13)

Please note, if the server sends a message that has a long word (such as an URL), the wrap function does not work beyond that word.  I believe this is a function of wxWidgets that we cannot bypass.

**Alternate Designs**
None considered.

**Release Notes**
[Manager] Under "Add project" wizard, message from server for a failed project attempt now wraps to the wizard window.
