### PR TITLE
Fix deprecated warning about wxTimerEvent::wxTimerEvent()

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2024 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -1567,7 +1567,6 @@ void CAdvancedFrame::OnRefreshView(CFrameEvent& WXUNUSED(event)) {
     if (IsShown()) {
         CMainDocument*  pDoc = wxGetApp().GetDocument();
         CBOINCBaseView* pView = NULL;
-        wxTimerEvent    timerEvent;
         wxString        strTabTitle = wxEmptyString;
         int             iCount = 0;
         static int      iLastCount = 0;
@@ -1613,7 +1612,7 @@ void CAdvancedFrame::OnRefreshView(CFrameEvent& WXUNUSED(event)) {
 
         // Update current tab contents
         pView = wxDynamicCast(m_pNotebook->GetPage(m_pNotebook->GetSelection()), CBOINCBaseView);
-        pView->FireOnListRender(timerEvent);
+        pView->FireOnListRender();
     }
 
     wxLogTrace(wxT("Function Start/End"), wxT("CAdvancedFrame::OnRefreshView - Function End"));
@@ -1997,7 +1996,6 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
     CBOINCBaseView* theView = NULL;;
     CBOINCListCtrl* theListCtrl = NULL;
     long bottomItem;
-    wxTimerEvent    timerEvent;
     int currentPage = _GetCurrentViewPage();
 
     StopTimers();
@@ -2026,7 +2024,7 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
     // Scroll the recreated list control to the same row as before
     if ((currentPage == VW_PROJ) || (currentPage == VW_TASK) || (currentPage == VW_XFER)) {
         theView = (CBOINCBaseView*)(m_pNotebook->GetPage(m_pNotebook->GetSelection()));
-        theView->FireOnListRender(timerEvent);
+        theView->FireOnListRender();
         theListCtrl = theView->GetListCtrl();
         if (theListCtrl->GetCountPerPage() < theListCtrl->GetItemCount()) {
             theListCtrl->EnsureVisible(bottomItem);

--- a/clientgui/BOINCBaseView.cpp
+++ b/clientgui/BOINCBaseView.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -208,8 +208,8 @@ int CBOINCBaseView::GetListRowCount() {
 }
 
 
-void CBOINCBaseView::FireOnListRender(wxTimerEvent& event) {
-    OnListRender(event);
+void CBOINCBaseView::FireOnListRender() {
+    OnListRender();
 }
 
 
@@ -233,7 +233,7 @@ int CBOINCBaseView::FireOnListGetItemImage(long item) const {
 }
 
 
-void CBOINCBaseView::OnListRender(wxTimerEvent& event) {
+void CBOINCBaseView::OnListRender() {
     if (!m_bProcessingListRenderEvent) {
         m_bProcessingListRenderEvent = true;
 
@@ -314,8 +314,6 @@ void CBOINCBaseView::OnListRender(wxTimerEvent& event) {
 
         m_bProcessingListRenderEvent = false;
     }
-
-    event.Skip();
 }
 
 

--- a/clientgui/BOINCBaseView.h
+++ b/clientgui/BOINCBaseView.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -107,7 +107,7 @@ public:
     bool                    FireOnRestoreState( wxConfigBase* pConfig );
 
     virtual int             GetListRowCount();
-    void                    FireOnListRender( wxTimerEvent& event );
+    void                    FireOnListRender();
     void                    FireOnListSelected( wxListEvent& event );
     void                    FireOnListDeselected( wxListEvent& event );
     wxString                FireOnListGetItemText( long item, long column ) const;
@@ -155,7 +155,7 @@ protected:
     virtual bool            OnSaveState( wxConfigBase* pConfig );
     virtual bool            OnRestoreState( wxConfigBase* pConfig );
 
-    virtual void            OnListRender( wxTimerEvent& event );
+    virtual void            OnListRender();
     virtual void            OnListSelected( wxListEvent& event );
     virtual void            OnListDeselected( wxListEvent& event );
     virtual void            OnCacheHint(wxListEvent& event);

--- a/clientgui/ViewNotices.cpp
+++ b/clientgui/ViewNotices.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -125,7 +125,7 @@ bool CViewNotices::OnRestoreState(wxConfigBase* WXUNUSED(pConfig)) {
 }
 
 
-void CViewNotices::OnListRender(wxTimerEvent& WXUNUSED(event)) {
+void CViewNotices::OnListRender() {
     wxLogTrace(wxT("Function Start/End"), wxT("CViewNotices::OnListRender - Function Begin"));
 
     static bool s_bInProgress = false;

--- a/clientgui/ViewNotices.h
+++ b/clientgui/ViewNotices.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -54,7 +54,7 @@ protected:
     virtual bool            OnSaveState( wxConfigBase* pConfig );
     virtual bool            OnRestoreState( wxConfigBase* pConfig );
 
-    virtual void            OnListRender( wxTimerEvent& event );
+    virtual void            OnListRender();
 };
 
 #endif

--- a/clientgui/ViewResources.cpp
+++ b/clientgui/ViewResources.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -168,7 +168,7 @@ bool CViewResources::OnRestoreState(wxConfigBase* /*pConfig*/) {
     return true;
 }
 
-void CViewResources::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
+void CViewResources::OnListRender() {
     CMainDocument* pDoc = wxGetApp().GetDocument();
     wxString diskspace;
 	static double project_total=0.0;

--- a/clientgui/ViewResources.h
+++ b/clientgui/ViewResources.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -60,7 +60,7 @@ protected:
 
     virtual bool            OnSaveState( wxConfigBase* pConfig );
     virtual bool            OnRestoreState( wxConfigBase* pConfig );
-	virtual void            OnListRender( wxTimerEvent& event );
+	virtual void            OnListRender();
 };
 
 #endif

--- a/clientgui/ViewStatistics.cpp
+++ b/clientgui/ViewStatistics.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -2350,7 +2350,7 @@ bool CViewStatistics::OnRestoreState(wxConfigBase* pConfig) {
     return true;
 }
 
-void CViewStatistics::OnListRender( wxTimerEvent& WXUNUSED(event) ) {
+void CViewStatistics::OnListRender() {
 	if (wxGetApp().GetDocument()->GetStatisticsCount()) {
 		m_PaintStatistics->m_full_repaint = true;
 		m_PaintStatistics->Refresh(false);

--- a/clientgui/ViewStatistics.h
+++ b/clientgui/ViewStatistics.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -243,7 +243,7 @@ protected:
     virtual bool            OnSaveState( wxConfigBase* pConfig );
     virtual bool            OnRestoreState( wxConfigBase* pConfig );
 
-    virtual void            OnListRender( wxTimerEvent& event );
+    virtual void            OnListRender();
 
     virtual void            UpdateSelection();
 };


### PR DESCRIPTION
Fixes #6098 (in part)

According to #6098, there is the following warning under the latest version of wxWidgets:
```
AdvancedFrame.cpp:1570:25: warning: ‘wxTimerEvent::wxTimerEvent()’ is deprecated: wxTimerEvent not supposed to be created by user code [-Wdeprecated-declarations]
 1570 |         wxTimerEvent    timerEvent;
```

Upon studying the code, I found that _CBOINCBaseView::FireOnListRender()_, _CBOINCBaseView::OnListRender()_, _CViewNotices::OnListRender()_, _CViewResources::OnListRender()_ and _CViewStatistics::OnListRender()_ are never called directly from a wxTimer event and so do not need the wxTimerEvent argument. I removed that argument, which eliminated the need for the `wxTimerEvent    timerEvent;` declarations in _CAdvancedFrame::OnRefreshView()_ and _CAdvancedFrame::OnDarkModeChanged_


**Release Notes**
N/A