### PR TITLE
Merge the MRU computers list when saving

### DIFF
--- a/clientgui/BOINCBaseFrame.cpp
+++ b/clientgui/BOINCBaseFrame.cpp
@@ -730,8 +730,9 @@ bool CBOINCBaseFrame::SaveState() {
     wxString        strConfigLocation;
     wxString        strPreviousLocation;
     wxString        strBuffer;
-    int             iIndex;
-    int             iItemCount;
+    size_t          iIndex;
+    size_t          iItemCount;
+    wxArrayString   existingComputers;
 
 
     // An odd case happens every once and awhile where wxWidgets looses
@@ -757,8 +758,17 @@ bool CBOINCBaseFrame::SaveState() {
 
     pConfig->SetPath(strConfigLocation);
 
-    iItemCount = (int)m_aSelectedComputerMRU.GetCount() - 1;
-    for (iIndex = 0; iIndex <= iItemCount; iIndex++) {
+
+    // Retrieve existing computers in the config because
+    // some computers may have been added by other BOINC manager windows.
+    iIndex = 0;
+    strBuffer.Printf(wxT("%d"), iIndex);
+    while (pConfig->Exists(strBuffer)) {
+        existingComputers.Add(pConfig->Read(strBuffer, wxEmptyString));
+        strBuffer.Printf(wxT("%d"), ++iIndex);
+    }
+
+    for (iIndex = 0; iIndex < m_aSelectedComputerMRU.GetCount(); iIndex++) {
         strBuffer.Printf(wxT("%d"), iIndex);
         pConfig->Write(
             strBuffer,
@@ -766,9 +776,21 @@ bool CBOINCBaseFrame::SaveState() {
         );
     }
 
+    // Write existing computers that are not in the MRU list into the config.
+    for (auto computer : existingComputers) {
+        if (m_aSelectedComputerMRU.Index(computer) == wxNOT_FOUND) {
+            pConfig->Write(strBuffer, computer);
+            strBuffer.Printf(wxT("%d"), ++iIndex);
+        }
+    }
+
+    // Remove any remaining MRU computer entries in the config to avoid duplicates.
+    while (pConfig->Exists(strBuffer)) {
+        pConfig->DeleteEntry(strBuffer);
+        strBuffer.Printf(wxT("%d"), ++iIndex);
+    }
+
     pConfig->SetPath(strPreviousLocation);
-
-
     wxLogTrace(wxT("Function Start/End"), wxT("CBOINCBaseFrame::SaveState - Function End"));
     return true;
 }


### PR DESCRIPTION
This is to fix an issue causing duplicated or lost of MRU computers when multiple windows (instances) of BOINC manager are saving the MRU list into the state.

TODO before making this PR ready:
1. More details of description
2. Explore required items (e.g., tests) for the PR