### PR TITLE
improve vboxwrapper network setup

### DIFF
--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -239,7 +239,7 @@ int VBOX_VM::create_vm() {
 
     // Tweak the VM's Graphics Controller Options
     //
-    vboxlog_msg("Setting Graphics Controller Options for VM.");
+    vboxlog_msg("Setting Graphics Controller Options for VM. (Driver: %s, %dMB)", vm_graphics_controller_type.c_str(), (int)vram_size_mb);
     snprintf(buf, sizeof(buf), "%d", (int)vram_size_mb);
 
     command  = "modifyvm \"" + vm_name + "\" ";

--- a/samples/vboxwrapper/vboxjob.cpp
+++ b/samples/vboxwrapper/vboxjob.cpp
@@ -118,8 +118,10 @@ void VBOX_JOB::clear() {
     enable_floppyio = false;
     enable_cache_disk = false;
     enable_isocontextualization = false;
+    vm_network_driver.clear();
     enable_network = false;
     network_bridged_mode = false;
+    enable_nat_dns_host_resolver = false;
     enable_remotedesktop = false;
     enable_gbac = false;
     enable_screenshots_on_error = false;
@@ -187,8 +189,10 @@ int VBOX_JOB::parse() {
         else if (xp.parse_string("temporary_exit_trigger_file", temporary_exit_trigger_file)) continue;
         else if (xp.parse_string("multiattach_vdi_file", multiattach_vdi_file)) continue;
         else if (xp.parse_bool("enable_cern_dataformat", enable_cern_dataformat)) continue;
+        else if (xp.parse_string("vm_network_driver", vm_network_driver)) continue;
         else if (xp.parse_bool("enable_network", enable_network)) continue;
         else if (xp.parse_bool("network_bridged_mode", network_bridged_mode)) continue;
+        else if (xp.parse_bool("enable_nat_dns_host_resolver", enable_nat_dns_host_resolver)) continue;
         else if (xp.parse_bool("enable_shared_directory", enable_shared_directory)) continue;
         else if (xp.parse_bool("enable_scratch_directory", enable_scratch_directory)) continue;
         else if (xp.parse_bool("share_slot_dir", share_slot_dir)) continue;

--- a/samples/vboxwrapper/vboxjob.h
+++ b/samples/vboxwrapper/vboxjob.h
@@ -97,10 +97,16 @@ struct VBOX_JOB {
         // add an extra cache disk for systems like uCernVM
     bool boot_iso;
         // put the iso as the first boot device
+    string vm_network_driver;
+        // name of the virtual network driver to be used
+        // see the VirtualBox manual for valid values
     bool enable_network;
         // allow network access
     bool network_bridged_mode;
         // use bridged mode for network
+    bool enable_nat_dns_host_resolver;
+        // specifies whether the NAT engine uses the host system's
+        // resolver mechanisms to handle DNS requests
     bool enable_shared_directory;
         // create slot/shared and share it as 'shared'
     bool enable_scratch_directory;


### PR DESCRIPTION
VirtualBox manual suggests `virtio` network driver to be the best choice for (recent) Linux guests.
Nonetheless, when a Linux VM is created without a driver is explicitly set, it configures an `Intel Pro` emulation, most likely for maximum compatibility.

Further information can be found here:
https://www.virtualbox.org/manual/topics/networkingdetails.html

This PR sets `virtio` as default driver if a Linux guest can be assumed.
Otherwise it keeps the default `Intel Pro`.

In addition it allows to manually overrride the selection using `<vm_network_driver>custom_name</vm_network_driver>` in `vbox_job.xml`.

Also added to `vbox_job.xml`:
An option `enable_nat_dns_host_resolver` which specifies whether the VirtualBox NAT engine uses the host system's resolver mechanisms to handle DNS requests.
