### PR TITLE
Mac: Fix drawing of simple view buttons

### DIFF
--- a/clientgui/sg_CustomControls.cpp
+++ b/clientgui/sg_CustomControls.cpp
@@ -109,9 +109,10 @@ CTransparentButton::CTransparentButton(wxWindow* parent, wxWindowID id, const wx
 
 bool CTransparentButton::Create(wxWindow* parent, wxWindowID id, const wxString& label, const wxPoint& pos, const wxSize& size, long style, const wxValidator& validator, const wxString& name )
 {
+    SetBackgroundStyle(wxBG_STYLE_TRANSPARENT); // Must come before wxButton::Create()
+
     bool bRetVal = wxButton::Create(parent, id, label, pos, size, style|wxTRANSPARENT_WINDOW, validator, name);
 
-    SetBackgroundStyle(wxBG_STYLE_CUSTOM);
     SetBackgroundColour(parent->GetBackgroundColour());
     SetForegroundColour(parent->GetForegroundColour());
 


### PR DESCRIPTION
As described [here](https://github.com/BOINC/boinc/pull/6107#issuecomment-2676824859), on the Mac, the Simple View buttons Task Commands, Add Project (or Synchronize if using an account manager), Project Web Pages and Project Commands all have gray rectangles around them. As best as I can tell, this seems to be caused by a change in the Xcode compiler since I built BOINC 7.24.1. If I install the release version of BOINC 7.24.1, it does not have the issue, but if I recompile it with the current compiler the issue does appear.

Changing the button's Background Style from wxBG_STYLE_CUSTOM to wxBG_STYLE_TRANSPARENT fixes this on the Mac. Note that SetBackgroundStyle(wxBG_STYLE_TRANSPARENT); must come before the Create() call, as explained [here](https://docs.wxwidgets.org/3.2.6/classwx_window.html#af14f8fd2ed2d30a9bbb5d4f9fd6594ec).

**Alternate Designs**
Just using wxButton instead of the custom control CTransparentButton also fixes it on the Mac, but that may be more likely to cause problems on other platforms.

@Vulpine05: Pleas test this on Windows and Linux and let me know if this change causes any problems with drawing the Simple View buttons on those platforms. If it does, I will guard the changes with `#ifdef __WXMAC__` and `#ifndef __WXMAC__`.


**Release Notes**
Fixes a minor cosmetic issue drawing buttons in the Simple View