### PR TITLE
web: clarify 'banishment'

### DIFF
--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -589,9 +589,13 @@ function show_post(
     $is_posted_by_special = false;
     for ($i=0; $i<sizeof($special_user_bitfield);$i++) {
         if ($user->prefs && $user->prefs->privilege($keys[$i])) {
-            $fstatus.="<nobr>".$special_user_bitfield[$keys[$i]]."<nobr><br>";
+            $fstatus .= "<nobr>".$special_user_bitfield[$keys[$i]]."<nobr><br>";
             $is_posted_by_special = true;
         }
+    }
+
+    if (is_moderator($logged_in_user, $forum) && is_banished($user)) {
+        $fstatus .= '(banished)';
     }
 
     // Highlight special users if set in prefs;
@@ -810,13 +814,14 @@ function show_post_and_context($post, $thread, $forum, $options, $n) {
 }
 
 function is_banished($user) {
-    if (isset($user->prefs)) {
-        return ($user->prefs->banished_until > time());
-    } else {
-        return false;
-    }
+    BoincForumPrefs::lookup($user);
+    return ($user->prefs->banished_until > time());
 }
 
+// $user is the logged-in user.
+// They're trying to make a forum post or send a personal message.
+// If they're banished, don't allow it
+//
 function check_banished($user) {
     if (is_banished($user)) {
         error_page(

--- a/html/inc/profile.inc
+++ b/html/inc/profile.inc
@@ -196,10 +196,6 @@ function check_whether_to_show_profile($user, $logged_in_user) {
            tra("To prevent spam, profiles of users with an average credit of less than %1 are displayed only to logged-in users. We apologize for this inconvenience.", $min_credit)
         );
     }
-    if (is_banished($user)) {
-        error_page(tra("User is banished"));
-    }
-
 }
 
 // Displays a user's profile (if they have one);

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -339,9 +339,6 @@ function show_preference_links() {
 // their name, and profile picture if it exists
 //
 function friend_links($user) {
-    if (is_banished($user)) {
-        return "";
-    }
     $x = sprintf(
         '<a href="%s%s?userid=%d" style="%s">%s</a>',
         url_base(),
@@ -383,9 +380,6 @@ function user_links($user, $badge_height=0, $name_limit=0) {
         return;
     }
     BoincForumPrefs::lookup($user);
-    if (is_banished($user)) {
-        return "(banished: ID $user->id)";
-    }
     $x = "";
     if ($user->has_profile) {
         $img_url = url_base()."img/head_20.png";
@@ -418,6 +412,8 @@ function user_links($user, $badge_height=0, $name_limit=0) {
     return $name_limit?"<nobr>$x</nobr>":$x;
 }
 
+// show community links for the logged in user
+//
 function show_community_private($user) {
     show_badges_row(true, $user);
     if (!DISABLE_PROFILES) {
@@ -431,7 +427,17 @@ function show_community_private($user) {
     if (!DISABLE_FORUMS) {
         $tot = total_posts($user);
         if ($tot) {
-            row2(tra("Message boards"), "<a href=\"".url_base()."forum_user_posts.php?userid=$user->id\">".tra("%1 posts", $tot)."</a>");
+            if (is_banished($user)) {
+                row2(tra("Message boards"), tra('(banished)'));
+            } else {
+                row2(
+                    tra("Message boards"),
+                    sprintf(
+                        '<a href="%s/forum_user_posts.php?userid=%d">%s</a>',
+                        url_base(), $user->id, tra('%1 posts', $tot)
+                    )
+                );
+            }
         }
     }
 
@@ -573,7 +579,19 @@ function community_links($clo, $logged_in_user){
     }
     if (!DISABLE_FORUMS) {
         if ($tot) {
-            row2(tra("Message boards"), "<a href=\"".url_base()."forum_user_posts.php?userid=$user->id\">".tra("%1 posts", $tot)."</a>");
+            $link = sprintf(
+                '<a href="%s/forum_user_posts.php?userid=%d">%s</a>',
+                url_base(), $user->id, tra("%1 posts", $tot)
+            );
+            if (is_banished($user)) {
+                if (is_moderator($logged_in_user)) {
+                    row2(tra("Message boards"), $link.' (banished)');
+                } else {
+                    row2(tra("Message boards"), tra('(banished)'));
+                }
+            } else {
+                row2(tra("Message boards"), $link);
+            }
         }
     }
     if ($logged_in_user && $logged_in_user->id != $user->id) {

--- a/html/user/forum_forum.php
+++ b/html/user/forum_forum.php
@@ -199,6 +199,7 @@ function show_forum_threads($forum, $start, $sort_style, $user, $subs) {
     foreach ($threads as $thread) {
         $owner = BoincUser::lookup_id($thread->owner);
         if (!$owner) continue;
+        if (!$show_hidden && is_banished($owner)) continue;
         $unread = thread_is_unread($user, $thread);
 
         //if ($thread->status==1){

--- a/html/user/forum_user_posts.php
+++ b/html/user/forum_user_posts.php
@@ -35,6 +35,10 @@ $items_per_page = 20;
 $logged_in_user = get_logged_in_user(false);
 BoincForumPrefs::lookup($logged_in_user);
 
+if (!is_moderator($logged_in_user) && is_banished($user)) {
+    error_page('User is banished');
+}
+
 // Policy for what to show:
 // Team message board posts:
 //    if requesting user is a member of team

--- a/html/user/pm.php
+++ b/html/user/pm.php
@@ -187,6 +187,8 @@ function do_read($logged_in_user) {
     page_tail();
 }
 
+// form to send a personal message
+//
 function do_new($logged_in_user) {
     global $replyto, $userid;
     check_banished($logged_in_user);


### PR DESCRIPTION
If a user U is banished:
- no one can see U's forum posts
- no one can see U's forum threads (including the posts in those threads, even if they're by other users)
- the above includes forum searches
- the above includes U themselves
- Exception to the above: moderators can see U's posts and threads (but U is labeled as 'banished' in the user info box)

Also:
- U can't send private messages (but U's existing PMs are visible)

But:
- U's profile, if any, remains visible