### PR TITLE
html/inc/boinc_db.inc: fix $dbnum comparison in BoicDB::get()

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -105,7 +105,7 @@ class BoincDb {
     static function get($dbnum = 0) {
         global $generating_xml;
         if (isset(self::$instance)) {
-            if (self::$dbnum == $dbnum) {
+            if (intval(self::$dbnum) == intval($dbnum)) {
                 return self::$instance;
             }
             self::close();


### PR DESCRIPTION
In `BoicDB::get()` if `self::$dbnum` is currently 0 or 1, it is handled as a boolean value and thus the comparison with the new `$dbnum` is a boolean comparison. This works for 0 or 1, but not for other values (like 2, which is also boolean `true`). Therefore numeric values need to be specified explicitly.

Fixes a problem in #5697 that slipped through during original review/testing. I had that in my MR (#5695), though, to fix  the same problem.
