### PR TITLE
Cleanup 'launch_vboxsvc' associated code

### DIFF
--- a/samples/vboxwrapper/vbox_common.cpp
+++ b/samples/vboxwrapper/vbox_common.cpp
@@ -107,11 +107,9 @@ VBOX_BASE::VBOX_BASE() : VBOX_JOB() {
     headless = true;
     log_pointer = 0;
     vm_pid = 0;
-    vboxsvc_pid = 0;
 
 #ifdef _WIN32
     vm_pid_handle = 0;
-    vboxsvc_pid_handle = 0;
 #endif
 }
 
@@ -125,10 +123,6 @@ VBOX_BASE::~VBOX_BASE() {
     if (vm_pid_handle) {
         CloseHandle(vm_pid_handle);
         vm_pid_handle = NULL;
-    }
-    if (vboxsvc_pid_handle) {
-        CloseHandle(vboxsvc_pid_handle);
-        vboxsvc_pid_handle = NULL;
     }
 #endif
 }

--- a/samples/vboxwrapper/vbox_common.h
+++ b/samples/vboxwrapper/vbox_common.h
@@ -163,7 +163,6 @@ struct VBOX_BASE : VBOX_JOB {
     std::streamoff log_pointer;
 
     int vm_pid;
-    int vboxsvc_pid;
 #ifdef _WIN32
     // the handle to the process for the VM
     // NOTE: we get a handle to the pid right after we parse it from the
@@ -172,9 +171,6 @@ struct VBOX_BASE : VBOX_JOB {
     //   handle to the process, the OS is free to reuse the pid for some other
     //   executable.
     HANDLE vm_pid_handle;
-
-    // the handle to the vboxsvc process created by us in the sandbox'ed environment
-    HANDLE vboxsvc_pid_handle;
 #endif
 
     void dump_vmguestlog_entries();

--- a/samples/vboxwrapper/vbox_vboxmanage.cpp
+++ b/samples/vboxwrapper/vbox_vboxmanage.cpp
@@ -1131,9 +1131,6 @@ int VBOX_VM::poll(bool log_state) {
     // Is our environment still sane?
     //
 #ifdef _WIN32
-    if (aid.using_sandbox && vboxsvc_pid_handle && !process_exists(vboxsvc_pid_handle)) {
-        vboxlog_msg("Status Report: vboxsvc.exe is no longer running.");
-    }
     if (started_successfully && vm_pid_handle && !process_exists(vm_pid_handle)) {
         vboxlog_msg("Status Report: virtualbox.exe/vboxheadless.exe is no longer running.");
     }
@@ -1258,9 +1255,6 @@ int VBOX_VM::poll2(bool log_state) {
     // Is our environment still sane?
     //
 #ifdef _WIN32
-    if (aid.using_sandbox && vboxsvc_pid_handle && !process_exists(vboxsvc_pid_handle)) {
-        vboxlog_msg("Status Report: vboxsvc.exe is no longer running.");
-    }
     if (started_successfully && vm_pid_handle && !process_exists(vm_pid_handle)) {
         vboxlog_msg("Status Report: virtualbox.exe/vboxheadless.exe is no longer running.");
     }


### PR DESCRIPTION
With PR #6119 `launch_vboxsvc()` has been removed from vboxwrapper.
As a result code snippets using `vboxsvc_pid_handle` and `vboxsvc_pid` (which were set in that function) can also be removed.
