### PR TITLE
[WIP] Mac: Fix bugs in Mac installer

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -163,8 +163,11 @@ int use_sandbox, int isManager, char* path_to_error, int len
 
 #ifdef __APPLE__
     char DataDirPath[MAXPATHLEN];
+#ifdef _MAC_INSTALLER
+    strlcpy(DataDirPath, dataPath, sizeof(dir_path));  // Installer
+#else
     getcwd(DataDirPath, sizeof(DataDirPath));
-
+#endif
     snprintf(full_path, sizeof(full_path),
         "%s/%s", DataDirPath, FIX_BOINC_USERS_FILENAME
     );

--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -50,7 +50,6 @@
 #include "ViewProjects.h"
 #include "ViewWork.h"
 #include "ViewTransfers.h"
-#include "ViewMessages.h"
 #include "ViewStatistics.h"
 #include "ViewResources.h"
 #include "DlgAbout.h"
@@ -1567,6 +1566,7 @@ void CAdvancedFrame::OnRefreshView(CFrameEvent& WXUNUSED(event)) {
     if (IsShown()) {
         CMainDocument*  pDoc = wxGetApp().GetDocument();
         CBOINCBaseView* pView = NULL;
+        wxTimerEvent    timerEvent;
         wxString        strTabTitle = wxEmptyString;
         int             iCount = 0;
         static int      iLastCount = 0;
@@ -1996,6 +1996,7 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
     CBOINCBaseView* theView = NULL;;
     CBOINCListCtrl* theListCtrl = NULL;
     long bottomItem;
+    wxTimerEvent    timerEvent;
     int currentPage = _GetCurrentViewPage();
 
     StopTimers();

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2024 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -123,6 +123,7 @@ protected:
     int                 m_iDisplayAnotherInstanceRunningDialog;
 #ifdef __WXMAC__
     int                 m_iHideMenuBarIcon;
+    int                 m_iWasShutDownBySystem;
 #endif
 
     bool                m_bGUIVisible;
@@ -202,6 +203,8 @@ public:
                                                     { return m_iHideMenuBarIcon; }
     void                SetBOINCMGRHideMenuBarIcon(int iHideMenuBarIcon)
                                                     { m_iHideMenuBarIcon = iHideMenuBarIcon; }
+    void                 SetBOINCMGRWasShutDownBySystem(int val)
+                                                    { m_iWasShutDownBySystem = val; }
 #endif
 
     bool                GetRunDaemon()

--- a/clientgui/mac/BOINCGUIApp.mm
+++ b/clientgui/mac/BOINCGUIApp.mm
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2016 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -218,6 +218,14 @@ OSErr QuitAppleEventHandler( const AppleEvent *appleEvt, AppleEvent* reply, UInt
             if (([bundleID compare:@"com.apple.dock"] != NSOrderedSame)
                     && ([bundleID compare:@"edu.berkeley.boinc"] != NSOrderedSame)) {
                 s_bSkipExitConfirmation = true; // Not from our app, our dock icon or our taskbar icon
+                if ([ NSApp isHidden ]) {
+                // If Manager was hidden and was shut down by system when user last logged
+                // out, MacOS's "Reopen windows when logging in" functionality may relaunch
+                // us visible before our LaunchAgent launches us with the "autostart" arg.
+                // Set the WasShutDownBySystem in our configuraiton file to tell us to
+                // treat this as an autostart and launch hidden.
+                    wxGetApp().SetBOINCMGRWasShutDownBySystem(1);
+                }
                 // The following may no longer be needed under wxCocoa-3.0.0
                 wxGetApp().ExitMainLoop();  // Prevents wxMac from issuing events to closed frames
             }


### PR DESCRIPTION
This PR fixes several bugs in the Mac installe. While I'm not sure, I suspect they might have been caused by changes in behavior of the MacOS. Among the issues fixed:
 - The BOINC Manager was being launched prematurely,before our install had completed setting things up.
 -  The installer opened BOINC Manager in a strange state,  especially if it was set to open in Simple View (which is the default for a virgin install), causing missing menus and the windows to not be shown.
 -  After a log out, the next time the user logged in, the BOINC Manager was launched in the foreground instead of hidden.