### PR TITLE
Replace getcwd() with boinc_getcwd()

### DIFF
--- a/samples/vboxwrapper/vboxwrapper.cpp
+++ b/samples/vboxwrapper/vboxwrapper.cpp
@@ -508,7 +508,7 @@ int main(int argc, char** argv) {
     } else {
         project_dir_path = aid.project_dir;
     }
-    getcwd(path, sizeof(path));
+    boinc_getcwd(path);
     slot_dir_path = path;
 
     vboxlog_msg("BOINC client version: %d.%d.%d",


### PR DESCRIPTION
Compiling vboxwrapper with warnings enabled prints this:

```
vboxwrapper.cpp: In function ‘int main(int, char**)’:
vboxwrapper.cpp:511:11: warning: ignoring return value of ‘char* getcwd(char*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  511 |     getcwd(path, sizeof(path));
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~
```

To get rid of the warning replace getcwd() with boinc_getcwd().
