### PR TITLE
debug BUDA on Unix

### DIFF
--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -645,7 +645,11 @@ int FILE_INFO::merge_info(FILE_INFO& new_info) {
     // This deals with cases where somehow a file didn't
     // get protected right when it was initially downloaded.
     //
-    if (status == FILE_PRESENT && new_info.executable) {
+    if (status == FILE_PRESENT && !executable && new_info.executable) {
+        msg_printf(project, MSG_INTERNAL_ERROR,
+            "%s has changed to executable", name
+        );
+        executable = true;
         int retval = set_permissions();
         if (retval) {
             msg_printf(project, MSG_INTERNAL_ERROR,

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -199,7 +199,7 @@ function create_templates($variant, $variant_desc, $dir) {
     $x = "<input_template>\n";
     $ninfiles = 1 + count($variant_desc->input_file_names) + count($variant_desc->app_files);
     for ($i=0; $i<$ninfiles; $i++) {
-        $x .= "   <file_info>\n      <no_delete/>\n   </file_info>\n";
+        $x .= "   <file_info>\n      <no_delete/>\n      <executable/>\n   </file_info>\n";
     }
     $x .= "   <workunit>\n";
     $x .= file_ref_in($variant_desc->dockerfile);

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -89,6 +89,7 @@ void HOST_INFO::clear_host_info() {
 }
 
 int HOST_INFO::parse(XML_PARSER& xp, bool static_items_only) {
+    int i;
     clear_host_info();
     while (!xp.get_tag()) {
         if (xp.match_tag("/host_info")) return 0;
@@ -144,8 +145,15 @@ int HOST_INFO::parse(XML_PARSER& xp, bool static_items_only) {
         }
 #else
         if (xp.parse_str("docker_version", docker_version, sizeof(docker_version))) continue;
+        if (xp.parse_int("docker_type", i)) {
+            docker_type = (DOCKER_TYPE)i;
+            continue;
+        }
         if (xp.parse_str("docker_compose_version", docker_compose_version, sizeof(docker_compose_version))) continue;
-        if (xp.parse_str("docker_version", docker_version, sizeof(docker_version))) continue;
+        if (xp.parse_int("docker_compose_type", i)) {
+            docker_compose_type = (DOCKER_TYPE)i;
+            continue;
+        }
 #endif
         if (xp.parse_str("product_name", product_name, sizeof(product_name))) continue;
         if (xp.parse_str("virtualbox_version", virtualbox_version, sizeof(virtualbox_version))) continue;


### PR DESCRIPTION
BUDA: the user file sandbox system doesn't know about executable flags.
This is OK on Win because everything is executable, but on Unix BUDA apps were failing.
Fix this by making all BUDA application files executable.

client: fix bug when changing file to executable

BUDA variant creation: mark all app files as executable.

docker_wrapper, Linux: fix parsing of Docker type

Fixes #6141 (and others not reported yet)
