### PR TITLE
docker_wrapper: support HTML graphics

### DIFF
--- a/samples/docker_wrapper/Makefile
+++ b/samples/docker_wrapper/Makefile
@@ -31,6 +31,11 @@ ifdef BUILD_APPS_WITH_VCPKG
     -L$(VCPKG_DIR)/lib
 endif
 
+ifdef BUILD_WITH_MINGW
+  MAKEFILE_LDFLAGS += \
+    -lws2_32
+endif
+
 all: docker_wrapper
 
 libstdc++.a:

--- a/win_build/docker_wrapper.vcxproj
+++ b/win_build/docker_wrapper.vcxproj
@@ -15,6 +15,7 @@
       <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
+      <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Add 'web_graphics_guest_port' option to job.toml config file. If set:
- allocate a host port
- tell Docker to map the guest port to host port
- tell the BOINC client to get HTML graphics at http:localhost:host_port

Fixes #6146
