### PR TITLE
web: use symbols rather than hardwired numbers for states in DB queries

### DIFF
--- a/html/inc/db_ops.inc
+++ b/html/inc/db_ops.inc
@@ -384,8 +384,7 @@ function link_results($n, $mq, $query, $clauses) {
     } else {
         if(strlen($clauses)) {
             return "<a href=\"db_action.php?table=result&query=$mq&$query&clauses=".urlencode($clauses)."&sort_by=mod_time&detail=low\">$n</a>";
-        }
-        else {
+        } else {
             return "<a href=\"db_action.php?table=result&query=$mq&$query&sort_by=mod_time&detail=low\">$n</a>";
         }
 
@@ -567,9 +566,9 @@ FROM result WHERE true
     start_table();
     echo "<tr valign=\"top\">";
     echo "<td><h2>" . link_results("$ntotal results", $urlquery, '', '') . "</h2></td>";
-    echo "<td><h2>" . link_results("'Over' results", $urlquery, "server_state=5", '') . "</h2></td>";
-    echo "<td><h2>" . link_results("'Success' results", $urlquery, "outcome=1", '') . "</h2></td>";
-    echo "<td><h2>" . link_results("'Client error' results", $urlquery, "outcome=3", '') . "</h2></td>";
+    echo "<td><h2>" . link_results("'Over' results", $urlquery, sprintf('server_state=%d', RESULT_SERVER_STATE_OVER), '') . "</h2></td>";
+    echo "<td><h2>" . link_results("'Success' results", $urlquery, sprintf('outcome=%d', RESULT_OUTCOME_SUCCESS), '') . "</h2></td>";
+    echo "<td><h2>" . link_results("'Client error' results", $urlquery, sprintf('outcome=%d', RESULT_OUTCOME_CLIENT_ERROR), '') . "</h2></td>";
     echo "</tr>";
     echo "<tr valign=\"top\">";
     echo "<td>";
@@ -579,7 +578,9 @@ FROM result WHERE true
         $res = new StdClass;
         $res->server_state = $ss;
         row2(result_server_state_string($res),
-             link_results("$server_state[$ss]",  $urlquery,"server_state=$ss", '')
+            link_results(
+                "$server_state[$ss]",  $urlquery, "server_state=$ss", ''
+            )
         );
     }
     end_table();
@@ -593,7 +594,9 @@ FROM result WHERE true
         $res = new StdClass;
         $res->outcome = $ro;
         $res->exit_status = 0;
-        c_row2($outcome[$ro]?outcome_color($ro):'', result_outcome_string($res),
+        c_row2(
+            $outcome[$ro]?outcome_color($ro):'',
+            result_outcome_string($res),
             link_results("$outcome[$ro]", $urlquery, "outcome=$ro", '')
         );
     }
@@ -607,19 +610,44 @@ FROM result WHERE true
         $res = new StdClass;
         $res->validate_state = $vs;
         $res->exit_status = 0;
-        c_row2($validate_state[$vs]?validate_color($vs):'', validate_state_str($res),
-        link_results("$validate_state[$vs]", $urlquery, "validate_state=$vs", "outcome=1"));
+        c_row2(
+            $validate_state[$vs]?validate_color($vs):'',
+            validate_state_str($res),
+            link_results(
+                "$validate_state[$vs]",
+                $urlquery,
+                "validate_state=$vs",
+                sprintf('outcome=%d', RESULT_OUTCOME_SUCCESS)
+            )
+        );
     }
     end_table();
     start_table('table-striped');
     echo "<tr><th>File Delete state</th><th># results</th></tr>\n";
 
     for ($fds=0; $fds<4; $fds++) {
-        row2(file_delete_state_str($fds),
-        link_results("$file_delete[$fds]", $urlquery, "outcome=1", "file_delete_state=$fds"));
+        row2(
+            file_delete_state_str($fds),
+            link_results(
+                "$file_delete[$fds]",
+                $urlquery,
+                sprintf('outcome=%d', RESULT_OUTCOME_SUCCESS),
+                "file_delete_state=$fds"
+            )
+        );
     }
-    row2("Total files deleted",
-    link_results("$nfile_deleted", $urlquery, "outcome=1", "(file_delete_state=1 or file_delete_state=2 or file_delete_state=3)"));
+    row2(
+        "Total files deleted",
+        link_results(
+            "$nfile_deleted",
+            $urlquery,
+            sprintf('outcome=%d', RESULT_OUTCOME_SUCCESS),
+            sprintf(
+                '(file_delete_state=%d or file_delete_state=%d or file_delete_state=%d)',
+                FILE_DELETE_READY, FILE_DELETE_DONE, FILE_DELETE_ERROR
+            )
+        )
+    );
     end_table();
     echo "</td>";
 
@@ -631,13 +659,17 @@ FROM result WHERE true
         $res->client_state = $cs;
         $res->exit_status = 0;
         row2(result_client_state_string($res),
-            link_results("$client_state[$cs]", $urlquery, "client_state=$cs", "outcome=3")
+            link_results(
+                "$client_state[$cs]",
+                $urlquery,
+                "client_state=$cs",
+                sprintf('outcome=%d', RESULT_OUTCOME_CLIENT_ERROR)
+            )
         );
     }
     end_table();
     echo "</td>";
     end_table();
-
 }
 
 function server_state_select() {

--- a/html/inc/result.inc
+++ b/html/inc/result.inc
@@ -118,7 +118,7 @@ function result_granted_credit_string($result, $string_to_show) {
     }
 }
 
-// various states that we allow users to filter on
+// various result states that users can filter on
 
 define("STATE_ALL", 0);
 define("STATE_IN_PROGRESS", 1);
@@ -141,12 +141,35 @@ $state_name = array(
 
 $state_clause = array(
     "",
-    " and server_state=4 ",
-    " and server_state=5 and outcome=1 and validate_state=0 ",
-    " and server_state=5 and outcome=1 and validate_state=4 ",
-    " and server_state=5 and outcome=1 and validate_state=1 ",
-    " and server_state=5 and (outcome=6 or (outcome=1 and (validate_state=2 or validate_state=3 or validate_state=5))) ",
-    " and server_state=5 and (outcome=3 or outcome=4 or outcome=7) ",
+    sprintf(
+        ' and server_state=%d ',
+        RESULT_SERVER_STATE_IN_PROGRESS
+    ),
+    sprintf(
+        ' and server_state=%d and outcome=%d and validate_state=%d ',
+        RESULT_SERVER_STATE_OVER, RESULT_OUTCOME_SUCCESS, VALIDATE_STATE_INIT
+    ),
+    sprintf(
+        ' and server_state=%d and outcome=%d and validate_state=%d ',
+        RESULT_SERVER_STATE_OVER, RESULT_OUTCOME_SUCCESS,
+        VALIDATE_STATE_INCONCLUSIVE
+    ),
+    sprintf(
+        ' and server_state=%d and outcome=%d and validate_state=%d ',
+        RESULT_SERVER_STATE_OVER, RESULT_OUTCOME_SUCCESS, VALIDATE_STATE_VALID
+    ),
+    sprintf(
+        ' and server_state=%d and (outcome=%d or (outcome=%d and (validate_state=%d or validate_state=%d or validate_state=%d))) ',
+        RESULT_SERVER_STATE_OVER,
+        RESULT_OUTCOME_VALIDATE_ERROR, RESULT_OUTCOME_SUCCESS,
+        VALIDATE_STATE_INVALID, VALIDATE_STATE_NO_CHECK,
+        VALIDATE_STATE_TOO_LATE
+    ),
+    sprintf(
+        ' and server_state=%d and (outcome=%d or outcome=%d or outcome=%d) ',
+        RESULT_SERVER_STATE_OVER, RESULT_OUTCOME_CLIENT_ERROR,
+        RESULT_OUTCOME_NO_REPLY, RESULT_OUTCOME_CLIENT_DETACHED
+    )
 );
 
 function state_num($result) {

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -252,7 +252,7 @@ function abort_workunit($wu) {
         sprintf(
             'server_state=%d, outcome=%d where server_state=%d and workunitid=%d',
             RESULT_SERVER_STATE_OVER, RESULT_OUTCOME_DIDNT_NEED,
-            RESULT_SERVER_STATE_UNSENT, 
+            RESULT_SERVER_STATE_UNSENT,
             $wu->id
         )
     );

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -249,7 +249,12 @@ function get_outfile_paths($result) {
 
 function abort_workunit($wu) {
     BoincResult::update_aux(
-        "server_state=5, outcome=5 where server_state=2 and workunitid=$wu->id"
+        sprintf(
+            'server_state=%d, outcome=%d where server_state=%d and workunitid=%d',
+            RESULT_SERVER_STATE_OVER, RESULT_OUTCOME_DIDNT_NEED,
+            RESULT_SERVER_STATE_UNSENT, 
+            $wu->id
+        )
     );
     $wu->update("error_mask=error_mask|16");
 }
@@ -259,7 +264,9 @@ function abort_batch($batch) {
     foreach ($wus as $wu) {
         abort_workunit($wu);
     }
-    $batch->update("state=".BATCH_STATE_ABORTED);
+    $batch->update(
+        sprintf('state=%d', BATCH_STATE_ABORTED)
+    );
     return 0;
 }
 

--- a/html/inc/util_ops.inc
+++ b/html/inc/util_ops.inc
@@ -409,7 +409,10 @@ function in_rops() {
 
 function cancel_wus_where($clause) {
     $q1 = "CREATE TEMPORARY TABLE tmp SELECT id FROM workunit WHERE $clause;";
-    $q2 = "UPDATE result r INNER JOIN tmp t on r.workunitid=t.id SET server_state=5, outcome=5 WHERE server_state=2;";
+    $q2 = sprintf(
+        'UPDATE result r INNER JOIN tmp t on r.workunitid=t.id SET outcome=%d WHERE server_state=%d;',
+        RESULT_OUTCOME_DIDNT_NEED, RESULT_SERVER_STATE_UNSENT
+    );
     $q3 = "UPDATE workunit w INNER JOIN tmp t on w.id=t.id SET error_mask=error_mask|16, transition_time=0;";
     $q4 = "DROP TABLE tmp;";
 

--- a/html/user/server_status.php
+++ b/html/user/server_status.php
@@ -36,6 +36,7 @@ require_once("../inc/util.inc");
 require_once("../inc/xml.inc");
 require_once("../inc/boinc_db.inc");
 require_once("../inc/server_version.inc");
+require_once("../inc/common_defs.inc");
 
 if (!defined('STATUS_PAGE_TTL')) {
     define('STATUS_PAGE_TTL', 3600);
@@ -416,13 +417,17 @@ function get_job_status() {
     foreach ($apps as $app) {
         $info = BoincDB::get()->lookup_fields("result", "stdClass",
             "ceil(avg(elapsed_time)/3600*100)/100 as avg,
-            ceil(min(elapsed_time)/3600*100)/100 as min,
-            ceil(max(elapsed_time)/3600*100)/100 as max,
-            count(distinct userid) as users",
-            "appid = $app->id
-            AND validate_state=1
-            AND received_time > (unix_timestamp()-86400)
-            "
+                ceil(min(elapsed_time)/3600*100)/100 as min,
+                ceil(max(elapsed_time)/3600*100)/100 as max,
+                count(distinct userid) as users
+            ",
+            sprintf('appid=%d
+                AND validate_state=%d
+                AND received_time > (unix_timestamp()-86400)
+                ',
+                $app->id,
+                VALIDATE_STATE_VALID
+            )
         );
         // $info fields will be null if app has no results
         if ($info->avg) {
@@ -430,16 +435,34 @@ function get_job_status() {
         } else {
             $app->info = null;
         }
-        $app->unsent = BoincResult::count("appid=$app->id and server_state=2");
-        $app->in_progress = BoincResult::count("appid=$app->id and server_state=4");
+        $app->unsent = BoincResult::count(
+            sprintf('appid=%d and server_state=%d',
+                $app->id, RESULT_SERVER_STATE_UNSENT
+            )
+        );
+        $app->in_progress = BoincResult::count(
+            sprintf('appid=%d and server_state=%d',
+                $app->id, RESULT_SERVER_STATE_IN_PROGRESS
+            )
+        );
     }
     $s->apps = $apps;
-    $s->results_ready_to_send = BoincResult::count("server_state=2");
-    $s->results_in_progress = BoincResult::count("server_state=4");
-    $s->results_need_file_delete = BoincResult::count("file_delete_state=1");
+    $s->results_ready_to_send = BoincResult::count(
+        sprintf('server_state=%d', RESULT_SERVER_STATE_UNSENT)
+    );
+    $s->results_in_progress = BoincResult::count(
+        sprintf('server_state=%d', RESULT_SERVER_STATE_IN_PROGRESS)
+    );
+    $s->results_need_file_delete = BoincResult::count(
+        sprintf('file_delete_state=%d', FILE_DELETE_READY)
+    );
     $s->wus_need_validate = BoincWorkunit::count("need_validate=1");
-    $s->wus_need_assimilate = BoincWorkunit::count("assimilate_state=1");
-    $s->wus_need_file_delete = BoincWorkunit::count("file_delete_state=1");
+    $s->wus_need_assimilate = BoincWorkunit::count(
+        sprintf('assimilate_state=%d', ASSIMILATE_READY)
+    );
+    $s->wus_need_file_delete = BoincWorkunit::count(
+        sprintf('file_delete_state=%d', FILE_DELETE_READY)
+    );
     $x = BoincDB::get()->lookup_fields("workunit", "stdClass", "MIN(transition_time) as min", "TRUE");
     $gap = (time() - $x->min)/3600;
     if (($gap < 0) || ($x->min == 0)) {
@@ -468,12 +491,22 @@ function get_job_status() {
 function show_counts_xml() {
     xml_header();
     echo "<job_counts>\n";
-    item_xml('results_ready_to_send', BoincResult::count("server_state=2"));
-    item_xml('results_in_progress', BoincResult::count("server_state=4"));
-    item_xml('results_need_file_delete', BoincResult::count("file_delete_state=1"));
+    item_xml('results_ready_to_send', BoincResult::count(
+        sprintf('server_state=%d', RESULT_SERVER_STATE_UNSENT)
+    ));
+    item_xml('results_in_progress', BoincResult::count(
+        sprintf('server_state=%d', RESULT_SERVER_STATE_IN_PROGRESS)
+    ));
+    item_xml('results_need_file_delete', BoincResult::count(
+        sprintf('file_delete_state=%d', FILE_DELETE_READY)
+    ));
     item_xml('wus_need_validate', BoincWorkunit::count("need_validate=1"));
-    item_xml('wus_need_assimilate', BoincWorkunit::count("assimilate_state=1"));
-    item_xml('wus_need_file_delete', BoincWorkunit::count("file_delete_state=1"));
+    item_xml('wus_need_assimilate', BoincWorkunit::count(
+        sprintf('assimilate_state=%d', ASSIMILATE_READY)
+    ));
+    item_xml('wus_need_file_delete', BoincWorkunit::count(
+        sprintf('file_delete_state=%d', FILE_DELETE_READY)
+    ));
     echo "</job_counts>\n";
 }
 


### PR DESCRIPTION
Much of the db_ops code is substandard in various ways.
