### PR TITLE
Fix DockerWrapper compiler warnings

### DIFF
--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -424,7 +424,7 @@ int create_container() {
     // web graphics
     //
     if (config.web_graphics_guest_port) {
-        int host_port;
+        int host_port = 0;
         retval = boinc_get_port(false, host_port);
         if (retval) {
             fprintf(stderr, "can't allocated host port for web graphics\n");

--- a/samples/docker_wrapper/toml.h
+++ b/samples/docker_wrapper/toml.h
@@ -387,7 +387,7 @@ inline ParseResult parse(std::istream& is)
     if (v.valid())
         return ParseResult(std::move(v), std::string());
 
-    return ParseResult(std::move(v), parser.errorReason());
+    return ParseResult(std::move(v), std::move(parser.errorReason()));
 }
 
 inline ParseResult parseFile(const std::string& filename)

--- a/samples/docker_wrapper/toml.h
+++ b/samples/docker_wrapper/toml.h
@@ -387,7 +387,7 @@ inline ParseResult parse(std::istream& is)
     if (v.valid())
         return ParseResult(std::move(v), std::string());
 
-    return ParseResult(std::move(v), std::move(parser.errorReason()));
+    return ParseResult(std::move(v), parser.errorReason());
 }
 
 inline ParseResult parseFile(const std::string& filename)


### PR DESCRIPTION
Fixes warnings when DockerWrapper is compiled on Linux with gcc 14.2.1.

```
In file included from docker_wrapper.cpp:91:
toml.h: In function ‘toml::ParseResult toml::parse(std::istream&)’:
toml.h:390:47: warning: redundant move in initialization [-Wredundant-move]
  390 |     return ParseResult(std::move(v), std::move(parser.errorReason()));
      |                                      ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
toml.h:390:47: note: remove ‘std::move’ call
```

```
In function ‘fprintf’,
    inlined from ‘create_container’ at docker_wrapper.cpp:432:20:
/usr/include/bits/stdio2.h:111:24: warning: ‘host_port’ may be used uninitialized [-Wmaybe-uninitialized]
  111 |   return __fprintf_chk (__stream, __USE_FORTIFY_LEVEL - 1, __fmt,
      |                        ^
docker_wrapper.cpp: In function ‘create_container’:
docker_wrapper.cpp:427:13: note: ‘host_port’ was declared here
  427 |         int host_port;
      |             ^
```
