### PR TITLE
client and docker_wrapper: bug fixes

### DIFF
--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -365,36 +365,33 @@ const char* docker_type_str(DOCKER_TYPE type) {
     return "unknown";
 }
 
+// parse a string like
+// Docker version 24.0.7, build 24.0.7-0ubuntu2~22.04.1
+// or
+// podman version 4.9.3
+// ... possibly with a \n at the end.
+// Return the version (24.0.7 or 4.9.3)
+//
 bool HOST_INFO::get_docker_version_string(
-    DOCKER_TYPE type, const char* raw, string &version
+    DOCKER_TYPE /*type*/, const char* raw, string &version
 ) {
     char *p, *q;
     const char *prefix;
-    switch (type) {
-    case DOCKER:
-        // Docker version 24.0.7, build 24.0.7-0ubuntu2~22.04.1
-        prefix = "Docker version ";
-        p = (char*)strstr(raw, prefix);
-        if (!p) return false;
-        p += strlen(prefix);
-        q = (char*)strstr(p, ",");
-        if (!q) return false;
-        *q = 0;
-        version = p;
-        return true;
-    case PODMAN:
-        // podman version 4.9.3
-        prefix = "podman version ";
-        p = (char*)strstr(raw, prefix);
-        if (!p) return false;
-        p += strlen(prefix);
-        q = (char*)strstr(p, "\n");
-        if (q) *q = 0;
-        version = p;
-        return true;
-    default: break;
+    prefix = "version ";
+    p = (char*)strstr(raw, prefix);
+    if (!p) return false;
+    p += strlen(prefix);
+    q = (char*)strstr(p, ",");
+    if (!q) {
+        q = (char*)strstr(p, " ");
     }
-    return false;
+    if (!q) {
+        q = (char*)strstr(p, "\n");
+    }
+    if (!q) return false;
+    *q = 0;
+    version = p;
+    return true;
 }
 
 bool HOST_INFO::get_docker_compose_version_string(

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -357,6 +357,7 @@ int run_command(char *cmd, vector<string> &out) {
 #else
 #ifndef _USING_FCGI_
     char buf[256];
+    errno = 0;
     FILE* fp = popen(cmd, "r");
     if (!fp) {
         fprintf(stderr, "popen() failed: %s\n", cmd);

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -754,7 +754,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     sprintf(buf, "%s %s; echo EOM\n", cli_prog, cmd);
     write_to_pipe(ctl_wc.in_write, buf);
     retval = read_from_pipe(
-        ctl_wc.out_read, ctl_wc.proc_handle, output, TIMEOUT, "EOM"
+        ctl_wc.out_read, ctl_wc.proc_handle, output, CMD_TIMEOUT, "EOM"
     );
     if (retval) {
         fprintf(stderr, "read_from_pipe() error: %s\n", boincerror(retval));

--- a/lib/util.h
+++ b/lib/util.h
@@ -160,7 +160,10 @@ struct DOCKER_CONN {
 #endif
     int command(const char* cmd, std::vector<std::string> &out);
 
-    static const int TIMEOUT = 10;    // timeout for docker commands
+    static const int CMD_TIMEOUT = 600;
+        // timeout for docker commands.
+        // This includes build commands that may have to download 
+        // a lot of big files, so make it fairly large.
 
     // parse a line from "docker images" output; return name
     int parse_image_name(std::string line, std::string &name);

--- a/lib/util.h
+++ b/lib/util.h
@@ -162,7 +162,7 @@ struct DOCKER_CONN {
 
     static const int CMD_TIMEOUT = 600;
         // timeout for docker commands.
-        // This includes build commands that may have to download 
+        // This includes build commands that may have to download
         // a lot of big files, so make it fairly large.
         // Note: this is enforced only on Win.
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -164,6 +164,7 @@ struct DOCKER_CONN {
         // timeout for docker commands.
         // This includes build commands that may have to download 
         // a lot of big files, so make it fairly large.
+        // Note: this is enforced only on Win.
 
     // parse a line from "docker images" output; return name
     int parse_image_name(std::string line, std::string &name);


### PR DESCRIPTION
Change timeout for Docker commands from 10s to 600s.  Build commands can take a while.

In parsing docker version, parse anything of the form '* version a.b.c*'

Fix bug in popen() error checking.  Set errno=0 first.