### PR TITLE
client: strip leading www. from master URLs

### DIFF
--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -201,11 +201,11 @@ void escape_url_readable(char *in, char* out) {
 
 
 // Canonicalize a master url.
-//   - Convert the first part of a URL (before the "://") to http://,
-// or prepend it
+//   - Prepend http:// if protocol missing
 //   - Remove double slashes in the rest
+//   - strip leading 'www.'
 //   - Add a trailing slash if necessary
-//   - Convert all alphabet characters to lower case
+//   - Convert all alphabetic characters to lower case
 //
 void canonicalize_master_url(char* url, int len) {
     char buf[1024];
@@ -218,6 +218,12 @@ void canonicalize_master_url(char* url, int len) {
         strlcpy(buf, p+3, sizeof(buf));
     } else {
         strlcpy(buf, url, sizeof(buf));
+    }
+
+    // strip leading www.
+    //
+    if (strstr(buf, "www.") == buf) {
+        strcpy(buf, buf+4);
     }
     while (1) {
         p = strstr(buf, "//");

--- a/sched/handle_request.cpp
+++ b/sched/handle_request.cpp
@@ -583,6 +583,10 @@ inline static const char* get_remote_addr() {
 static int modify_host_struct(HOST& host) {
     host.timezone = g_request->host.timezone;
     strlcpy(host.domain_name, g_request->host.domain_name, sizeof(host.domain_name));
+
+    // assemble a string with info about BOINC client, GPUs, VBox, and Docker
+    // store it in host.serialnum
+    //
     char buf[1024], buf2[1024];
     sprintf(buf, "[BOINC|%d.%d.%d",
         g_request->core_client_major_version,
@@ -594,8 +598,8 @@ static int modify_host_struct(HOST& host) {
         strcat(buf, g_request->client_brand);
     }
     strcat(buf, "]");
-    g_request->coprocs.summary_string(buf2, sizeof(buf2));
     strlcpy(host.serialnum, buf, sizeof(host.serialnum));
+    g_request->coprocs.summary_string(buf2, sizeof(buf2));
     strlcat(host.serialnum, buf2, sizeof(host.serialnum));
     if (strlen(g_request->host.virtualbox_version)) {
         sprintf(buf2, "[vbox|%s|%d|%d]",
@@ -605,6 +609,7 @@ static int modify_host_struct(HOST& host) {
         );
         strlcat(host.serialnum, buf2, sizeof(host.serialnum));
     }
+
     if (strcmp(host.last_ip_addr, g_request->host.last_ip_addr)) {
         strlcpy(
             host.last_ip_addr, g_request->host.last_ip_addr,


### PR DESCRIPTION
Fixes a bug where an account manager has an old URL with leading www;
causes duplicates of the project in the client.