### PR TITLE
client (Linux): check for podman only if BOINC data dir is not remote

### DIFF
--- a/client/hostinfo_linux.cpp
+++ b/client/hostinfo_linux.cpp
@@ -33,8 +33,12 @@
 #endif
 
 #include "str_replace.h"
+#include "util.h"
 
 #include "hostinfo.h"
+
+using std::vector;
+using std::string;
 
 // functions for getting Linux OS and version from various sources
 // (lsb_release -a, /etc/os-release, /etc/redhat-release)
@@ -206,4 +210,20 @@ bool HOST_INFO::parse_linux_os_info(
         strlcpy(os_name, dist_name, os_name_size);
     }
     return true;
+}
+
+int is_filesystem_remote(const char* path, bool &result) {
+    char cmd[256], buf[256];
+    vector<string> out;
+    result = false;
+    sprintf(cmd, "stat --file-system --format=%%T %s", path);
+    int retval = run_command(cmd, out);
+    if (retval) return retval;
+    if (out.empty()) return -1;
+    strcpy(buf, out[0].c_str());
+    strip_whitespace(buf);
+    if (!strcmp(buf, "nfs")) result = true;
+    else if (!strcmp(buf, "nfs4")) result = true;
+    else if (!strcmp(buf, "smb")) result = true;
+    return 0;
 }

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1255,12 +1255,21 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
 }
 
 bool HOST_INFO::get_docker_version(){
-    // podman doesn't work on Linux with remote FS, so don't check for it
-#if defined(__APPLE__) || defined(_WIN32)
-    if (get_docker_version_aux(PODMAN)) {
-        return true;
+    bool check_podman = true;
+#ifdef __linux__
+    // podman doesn't work on Linux with remote FS
+    bool remote;
+    int retval = is_filesystem_remote(".", remote);
+    if (!retval && remote) {
+        check_podman = false;
+        msg_printf(NULL, MSG_INFO, "Data dir is remote: not checking podman");
     }
 #endif
+    if (check_podman) {
+        if (get_docker_version_aux(PODMAN)) {
+            return true;
+        }
+    }
     if (get_docker_version_aux(DOCKER)) {
         return true;
     }

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -210,4 +210,8 @@ typedef double (*nxIdleTimeProc)(NXEventHandle handle);
 extern NXEventHandle gEventHandle;
 #endif
 
+// is the filesystem remote? (Linux only)
+//
+extern int is_filesystem_remote(const char* path, bool&);
+
 #endif


### PR DESCRIPTION
If it's remote, podman doesn't work without complex config changes