### PR TITLE
Mac tweaks to installer, uninstaller

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -283,7 +283,7 @@ bool CBOINCGUIApp::OnInit() {
     // Detect where BOINC Manager executable name.
     DetectExecutableName();
 
-    // Detect where BOINC Manager was installed too.
+    // Detect where BOINC Manager was installed to.
     DetectRootDirectory();
 
     // Detect where the BOINC Data files are.

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -281,7 +281,8 @@ public:
     void                getDisplayNameForThisApp(char* pathBuf, size_t bufSize);
     void                SetActivationPolicyAccessory(bool hideDock);
     void                CheckPartialActivation();
-
+    long                GetBrandID();
+    
     // Override standard wxCocoa wxApp::CallOnInit() to allow Manager
     // to run properly when launched hidden on login via Login Item.
     bool                CallOnInit();

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -282,7 +282,7 @@ public:
     void                SetActivationPolicyAccessory(bool hideDock);
     void                CheckPartialActivation();
     long                GetBrandID();
-    
+
     // Override standard wxCocoa wxApp::CallOnInit() to allow Manager
     // to run properly when launched hidden on login via Login Item.
     bool                CallOnInit();

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -689,7 +689,7 @@ int DeleteReceipt()
                 continue;
             }
             if (strcmp(loginName, pw->pw_name) == 0) {
-                continue; // We've already launched for logged in user
+                continue; // We've already launched for this user (who is running the installer)
             }
 #ifdef SANDBOX
             launchForThisUser = false;
@@ -703,7 +703,7 @@ int DeleteReceipt()
 
             if (launchForThisUser) {
                 // Launch Manager hidden (in background, without opening windows)
-                sprintf(s, "su -l \"%s\" -c 'open -jg \"%s\" --args -s'", pw->pw_name, appPath[brandID]);
+                sprintf(s, "su -l \"%s\" -c 'open -jg \"%s\" --args --autostart'", pw->pw_name, appPath[brandID]);
                 err = callPosixSpawn(s);
                 if (err) {
                     REPORT_ERROR(true);
@@ -787,17 +787,19 @@ void CheckUserAndGroupConflicts()
             }
         }
     }
+
     if ((boinc_master_gid < 501) || (entryCount > 1)) {
-        err = callPosixSpawn ("dscl . -delete /groups/boinc_master");
+        // Use of sudo here may help avoid a warning alert from MacOS
+        err = callPosixSpawn ("sudo dscl . -delete /groups/boinc_master");
         // User boinc_master must have group boinc_master as its primary group.
         // Since this group no longer exists, delete the user as well.
         if (err) {
-            fprintf(stdout, "dscl . -delete /groups/boinc_master returned %d\n", err);
+            fprintf(stdout, "sudo dscl . -delete /groups/boinc_master returned %d\n", err);
             fflush(stdout);
         }
-        err = callPosixSpawn ("dscl . -delete /users/boinc_master");
+        err = callPosixSpawn ("sudo dscl . -delete /users/boinc_master");
         if (err) {
-            fprintf(stdout, "dscl . -delete /users/boinc_master returned %d\n", err);
+            fprintf(stdout, "sudo dscl . -delete /users/boinc_master returned %d\n", err);
             fflush(stdout);
         }
         ResynchDSSystem();
@@ -825,16 +827,16 @@ void CheckUserAndGroupConflicts()
     }
 
     if ((boinc_project_gid < 501) || (entryCount > 1)) {
-        err = callPosixSpawn ("dscl . -delete /groups/boinc_project");
+        err = callPosixSpawn ("sudo dscl . -delete /groups/boinc_project");
         if (err) {
-            fprintf(stdout, "dscl . -delete /groups/boinc_project returned %d\n", err);
+            fprintf(stdout, "sudo dscl . -delete /groups/boinc_project returned %d\n", err);
             fflush(stdout);
         }
         // User boinc_project must have group boinc_project as its primary group.
         // Since this group no longer exists, delete the user as well.
-        err = callPosixSpawn ("dscl . -delete /users/boinc_project");
+        err = callPosixSpawn ("sudo dscl . -delete /users/boinc_project");
         if (err) {
-            fprintf(stdout, "dscl . -delete /users/boinc_project returned %d\n", err);
+            fprintf(stdout, "sudo dscl . -delete /users/boinc_project returned %d\n", err);
             fflush(stdout);
         }
         ResynchDSSystem();
@@ -865,10 +867,10 @@ void CheckUserAndGroupConflicts()
     }
 
     if (entryCount > 1) {
-        err = callPosixSpawn ("dscl . -delete /users/boinc_master");
+        err = callPosixSpawn ("sudo dscl . -delete /users/boinc_master");
         if (err) {
             REPORT_ERROR(true);
-            fprintf(stdout, "dscl . -delete /users/boinc_master returned %d\n", err);
+            fprintf(stdout, "sudo dscl . -delete /users/boinc_master returned %d\n", err);
             fflush(stdout);
         }
         ResynchDSSystem();
@@ -895,10 +897,10 @@ void CheckUserAndGroupConflicts()
     }
 
     if (entryCount > 1) {
-        err = callPosixSpawn ("dscl . -delete /users/boinc_project");
+        err = callPosixSpawn ("sudo dscl . -delete /users/boinc_project");
         if (err) {
             REPORT_ERROR(true);
-            fprintf(stdout, "dscl . -delete /users/boinc_project returned %d\n", err);
+            fprintf(stdout, "sudo dscl . -delete /users/boinc_project returned %d\n", err);
             fflush(stdout);
         }
         ResynchDSSystem();
@@ -1769,7 +1771,7 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                         pw->pw_name, boinc_master_group_name, BMGroupMembershipCount);
             fflush(stdout);
             if (BMGroupMembershipCount == 0) {
-                sprintf(cmd, "dscl . -merge /groups/%s GroupMembership \"%s\"", boinc_master_group_name, pw->pw_name);
+                sprintf(cmd, "sudo dscl . -merge /groups/%s GroupMembership \"%s\"", boinc_master_group_name, pw->pw_name);
                 err = callPosixSpawn(cmd);
                 REPORT_ERROR(err);
                 printf("[2] %s returned %d\n", cmd, err);
@@ -1778,7 +1780,7 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
             } else {
                 isBMGroupMember = true;
                 for (i=1; i<BMGroupMembershipCount; ++i) {
-                    sprintf(cmd, "dscl . -delete /groups/%s GroupMembership \"%s\"", boinc_master_group_name, pw->pw_name);
+                    sprintf(cmd, "sudo dscl . -delete /groups/%s GroupMembership \"%s\"", boinc_master_group_name, pw->pw_name);
                     err = callPosixSpawn(cmd);
                     REPORT_ERROR(err);
                     printf("[2] %s returned %d\n", cmd, err);
@@ -1791,14 +1793,14 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                    pw->pw_name, boinc_project_group_name, BPGroupMembershipCount);
             fflush(stdout);
             if (BPGroupMembershipCount == 0) {
-                sprintf(cmd, "dscl . -merge /groups/%s GroupMembership \"%s\"", boinc_project_group_name, pw->pw_name);
+                sprintf(cmd, "sudo dscl . -merge /groups/%s GroupMembership \"%s\"", boinc_project_group_name, pw->pw_name);
                 err = callPosixSpawn(cmd);
                 REPORT_ERROR(err);
                 printf("[2] %s returned %d\n", cmd, err);
                 fflush(stdout);
             } else {
                 for (i=1; i<BPGroupMembershipCount; ++i) {
-                    sprintf(cmd, "dscl . -delete /groups/%s GroupMembership \"%s\"", boinc_project_group_name, pw->pw_name);
+                    sprintf(cmd, "sudo dscl . -delete /groups/%s GroupMembership \"%s\"", boinc_project_group_name, pw->pw_name);
                     err = callPosixSpawn(cmd);
                     REPORT_ERROR(err);
                     printf("[2] %s returned %d\n", cmd, err);

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -71,6 +71,7 @@ int main(int argc, const char * argv[]) {
     bool                    isUninstall = false;
     int                     iBrandId = 0;
     bool                    calledFromInstaller = false;
+    struct stat             buf;
 
     // Wait until we are the active login (in case of fast user switching)
     userName = getenv("USER");
@@ -80,13 +81,18 @@ int main(int argc, const char * argv[]) {
 
     pw = getpwuid(getuid());
 
-
-    for (i=0; i<NUMBRANDS; i++) {
-        snprintf(cmd, sizeof(cmd), "osascript -e 'tell application \"System Events\" to delete login item \"%s\"'", appName[i]);
-        err = callPosixSpawn(cmd);
-        if (err) {
-            print_to_log_file("Command: %s\n", cmd);
-            print_to_log_file("Delete login item containing %s returned error %d\n", appName[i], err);
+    // Using "System Events" which can trigger an alert which the user may find alraming.
+    // If we previously set a login item launch agent,  we removed the old style login
+    // item at that time, so we can avoid that alert.
+    snprintf(cmd, sizeof(cmd), "/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist", pw->pw_name);
+    if (!stat(cmd, &buf)) {
+        for (i=0; i<NUMBRANDS; i++) {
+            snprintf(cmd, sizeof(cmd), "osascript -e 'tell application \"System Events\" to delete login item \"%s\"'", appName[i]);
+            err = callPosixSpawn(cmd);
+            if (err) {
+                print_to_log_file("Command: %s\n", cmd);
+                print_to_log_file("Delete login item containing %s returned error %d\n", appName[i], err);
+            }
         }
     }
 
@@ -113,7 +119,7 @@ int main(int argc, const char * argv[]) {
             print_to_log_file("killall %s returned error %d\n", appName[iBrandId], err);
         }
 
-        if (compareOSVersionTo(13, 0) >= 0) {
+        if (compareOSVersionTo(10, 13) >= 0) {
             snprintf(cmd, sizeof(cmd), "launchctl unload \"/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist\"", pw->pw_name);
             err = callPosixSpawn(cmd);
             if (err) {
@@ -129,7 +135,7 @@ int main(int argc, const char * argv[]) {
         }
 
     } else {
-        if (compareOSVersionTo(13, 0) >= 0) {
+        if (compareOSVersionTo(10, 13) >= 0) {
             bool success = MakeLaunchManagerLaunchAgent(iBrandId, pw);
             if (!success) {
                 print_to_log_file("Command: %s\n", cmd);
@@ -144,7 +150,7 @@ int main(int argc, const char * argv[]) {
             }
         }
 
-        if (compareOSVersionTo(13, 0) >= 0) {
+        if (compareOSVersionTo(10, 13) >= 0) {
             snprintf(cmd, sizeof(cmd), "launchctl unload \"/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist\"", pw->pw_name);
             err = callPosixSpawn(cmd);
             if (err) {

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -183,7 +183,7 @@ int main(int argc, const char * argv[]) {
     if (! calledFromManager) {
         FixLaunchServicesDataBase(iBrandId, isUninstall);
     }
-    
+
     if (! (calledFromInstaller || calledFromManager)) {
         snprintf(cmd, sizeof(cmd), "rm -f \"/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist\"", pw->pw_name);
         callPosixSpawn(cmd);

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -106,12 +106,12 @@ int main(int argc, char *argv[])
     FILE                        *pipe = NULL;
     OSStatus                    err = noErr;
 
-    FILE * stdout_file = freopen("/tmp/Uninstall_stdout", "w", stdout);
+    FILE * stdout_file = freopen("/tmp/BOINC_Uninstall_log.txt", "w", stdout);
     if (stdout_file) {
         setbuf(stdout_file, 0);
     }
 
-    FILE * stderr_file = freopen("/tmp/Uninstall_stderr", "w", stderr);
+    FILE * stderr_file = freopen("/tmp/BOINC_Uninstall_log.txt", "a", stderr);
     if (stderr_file) {
         setbuf(stderr_file, 0);
     }
@@ -544,10 +544,11 @@ fprintf(stdout, "Starting privileged tool\n");
     // Phase 6: step through all users and do user-specific cleanup
     CleanupAllVisibleUsers();
 
-    callPosixSpawn ("dscl . -delete /users/boinc_master");
-    callPosixSpawn ("dscl . -delete /groups/boinc_master");
-    callPosixSpawn ("dscl . -delete /users/boinc_project");
-    callPosixSpawn ("dscl . -delete /groups/boinc_project");
+    // Use of sudo here may help avoid a warning alert from MacOS
+    callPosixSpawn ("sudo dscl . -delete /users/boinc_master");
+    callPosixSpawn ("sudo dscl . -delete /groups/boinc_master");
+    callPosixSpawn ("sudo dscl . -delete /users/boinc_project");
+    callPosixSpawn ("sudo dscl . -delete /groups/boinc_project");
 
     return 0;
 }
@@ -772,10 +773,10 @@ static OSStatus CleanupAllVisibleUsers(void)
 #endif
 
         // Remove user from groups boinc_master and boinc_project
-        sprintf(s, "dscl . -delete /groups/boinc_master GroupMembership \"%s\"", pw->pw_name);
+        sprintf(s, "sudo dscl . -delete /groups/boinc_master GroupMembership \"%s\"", pw->pw_name);
         callPosixSpawn (s);
 
-        sprintf(s, "dscl . -delete /groups/boinc_project GroupMembership \"%s\"", pw->pw_name);
+        sprintf(s, "sudo dscl . -delete /groups/boinc_project GroupMembership \"%s\"", pw->pw_name);
         callPosixSpawn (s);
 
        // Set login item for this user


### PR DESCRIPTION
Mac installer, uninstaller:
 * Whenever possible use login item launch agent instead of old-style login item
 * Avoid  calling System Events so as not to display an alert "Installer wants to control your computer" that might alarm the user.

Previous versions of the Mac installer switched from the old style login items to using the newer launch agent method only for MacOS 13.0, when the old style ones stopped working. This version of the Mac installer uses the newer method for MacOS 10.13 or later.

If a previous BOINC install set a login item launch agent, it already removed the old style login item at that time, so we can avoid that alert.