### PR TITLE
Removed newline from print logs

### DIFF
--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -489,7 +489,7 @@ void cleanup() {
     docker_conn.command(cmd, out);
     fprintf(stderr, "stderr from container:\n");
     for (string line : out) {
-        fprintf(stderr, "%s\n", line.c_str());
+        fprintf(stderr, "%s", line.c_str());
     }
     fprintf(stderr, "stderr end\n");
 


### PR DESCRIPTION
Fixes #6190


Removed newline from print logs in the cleanup function