### PR TITLE
Mac Manager: fix response to -s or --systray argument

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -201,8 +201,9 @@ bool CBOINCGUIApp::OnInit() {
         // failed" error if we try to connect too soon, so delay a bit.
         sleep(10);
     }
+#else
+        m_bGUIVisible = IsApplicationVisible();
 #endif
-
 
     if (g_use_sandbox) {
         wxCHANGE_UMASK(2);  // Set file creation mask to be writable by both user and group
@@ -775,6 +776,9 @@ bool CBOINCGUIApp::OnCmdLineParsed(wxCmdLineParser &parser) {
 #if defined(__WXMSW__) || defined(__WXMAC__)
     if (parser.Found(wxT("systray"))) {
         m_bGUIVisible = false;
+#ifdef __WXMAC__
+        m_bBOINCMGRAutoStarted = true;
+#endif
     }
 #endif
     if (parser.Found(wxT("insecure"))) {

--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -201,8 +201,6 @@ bool CBOINCGUIApp::OnInit() {
         // failed" error if we try to connect too soon, so delay a bit.
         sleep(10);
     }
-#else
-        m_bGUIVisible = IsApplicationVisible();
 #endif
 
     if (g_use_sandbox) {
@@ -1145,6 +1143,7 @@ int CBOINCGUIApp::IdleTrackerDetach() {
 }
 
 
+// TODO: Does the Mac really need the OnActivateApp() routine?
 void CBOINCGUIApp::OnActivateApp(wxActivateEvent& event) {
     m_bProcessingActivateAppEvent = true;
 


### PR DESCRIPTION
On the Mac, BOINC Manager's implementation of the -s or --systray argument was broken. This fixes it.