### PR TITLE
client and docker_wrapper: get it to work on MacOS/podman

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -1280,14 +1280,13 @@ PROJECT* CLIENT_STATE::lookup_project(const char* master_url) {
     if (!p) return NULL;
     p += 2;
     if (strcasestr(p, "www.") == p) p += 4;
-    strcpy(buf, p);
 
     for (PROJECT *project: projects) {
         const char* q = strstr(project->master_url, "//");
         if (!q) continue;
         q += 2;
         if (strcasestr(q, "www.") == q) q += 4;
-        if (!strcasecmp(buf, q)) {
+        if (!strcasecmp(p, q)) {
             // note: canonicalize_master_url() doesn't lower-case
             return project;
         }

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1240,8 +1240,8 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
     bool ret = false;
 #ifdef __APPLE__
     if (type == PODMAN) {
-        system("podman machine init");
-        system("podman machine start");
+        system("podman machine init 2>/dev/null");
+        system("podman machine start 2>/dev/null");
     }
 #endif
     string cmd = string(docker_cli_prog(type)) + " --version 2>/dev/null";

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -366,29 +366,31 @@ int container_exists(bool &exists) {
 int create_container() {
     char cmd[1024];
     char slot_cmd[256], project_cmd[256], buf[256];
+    char cwd[MAXPATHLEN];
     vector<string> out;
     int retval;
 
     retval = get_image();
     if (retval) return retval;
 
-    sprintf(slot_cmd, " -v .:%s",
-        config.workdir.c_str()
-    );
+    // on MacOS/podman, you need the full path, not .
+    //
+    getcwd(cwd, sizeof(cwd));
+    snprintf(slot_cmd, sizeof(slot_cmd), " -v %s:%s", cwd, config.workdir.c_str());
     if (config.project_dir_mount.empty()) {
         project_cmd[0] = 0;
     } else {
         if (boinc_is_standalone()) {
-            sprintf(project_cmd, " -v %s:%s",
-                project_dir, config.project_dir_mount.c_str()
+            snprintf(project_cmd, sizeof(project_cmd), " -v %s/%s:%s",
+                cwd, project_dir, config.project_dir_mount.c_str()
             );
         } else {
-            sprintf(project_cmd, " -v ../../projects/%s:%s",
-                project_dir, config.project_dir_mount.c_str()
+            snprintf(project_cmd, sizeof(project_cmd), " -v %s/../../projects/%s:%s",
+                cwd, project_dir, config.project_dir_mount.c_str()
             );
         }
     }
-    sprintf(cmd, "create --name %s %s %s",
+    snprintf(cmd, sizeof(cmd), "create --name %s %s %s",
         container_name,
         slot_cmd, project_cmd
     );


### PR DESCRIPTION
- client: fix lookup_project() bug. Note to self: don't use strcpy on overlapping areas! It works on some libc but not others

- client: don't show output of 'podman machine' commands

- docker_wrapper: for -v host:guest args, the 'host' part needs to be a full path with Mac/podman
