### PR TITLE
web: minor fixes

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -109,8 +109,10 @@ if (!defined('SHOW_USER_PAGE')) {
 if (!defined('POST_MAX_LINKS')) {
     define('POST_MAX_LINKS', 0);
 }
+
+// support dark mode if user has selected it
 if (!defined('DARK_MODE')) {
-    define('DARK_MODE', false);
+    define('DARK_MODE', true);
 }
 if (!defined('VALIDATE_EMAIL_TO_POST')) {
     define('VALIDATE_EMAIL_TO_POST', false);

--- a/html/inc/util_basic.inc
+++ b/html/inc/util_basic.inc
@@ -227,4 +227,8 @@ function is_valid_filename($x) {
     return preg_match('/^[\w\-.]+$/', $x);
 }
 
+function filename_rules() {
+    return 'Names can contain only A-Z a-z 0-9 . - _';
+}
+
 ?>

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -239,22 +239,32 @@ function variant_action($user) {
     global $buda_root;
     $variant = get_str('variant');
     if (!$variant) $variant = 'cpu';
-    if (!is_valid_filename($variant)) die('bad arg');
+    if (!is_valid_filename($variant)) {
+        error_page(filename_rules());
+    }
     $app = get_str('app');
     if (!is_valid_filename($app)) die('bad arg');
     $dockerfile = get_str('dockerfile');
-    if (!is_valid_filename($dockerfile)) die('bad arg');
+    if (!is_valid_filename($dockerfile)) {
+        error_page("Invalid dockerfile name: ".filename_rules());
+    }
     $app_files = get_array('app_files');
     foreach ($app_files as $fname) {
-        if (!is_valid_filename($fname)) die('bad arg');
+        if (!is_valid_filename($fname)) {
+            error_page("Invalid app file name: ".filename_rules());
+        }
     }
     $input_file_names = explode(' ', get_str('input_file_names'));
     $output_file_names = explode(' ', get_str('output_file_names'));
     foreach ($input_file_names as $fname) {
-        if (!is_valid_filename($fname)) die('bad arg');
+        if (!is_valid_filename($fname)) {
+            error_page("Invalid input file name: ".filename_rules());
+        }
     }
     foreach ($output_file_names as $fname) {
-        if (!is_valid_filename($fname)) die('bad arg');
+        if (!is_valid_filename($fname)) {
+            error_page("Invalid output file name: ".filename_rules());
+        }
     }
 
     if (file_exists("$buda_root/$app/$variant")) {
@@ -374,7 +384,9 @@ function app_form() {
 function app_action() {
     global $buda_root;
     $name = get_str('name');
-    if (!is_valid_filename($name)) die("bad arg: $name");
+    if (!is_valid_filename($name)) {
+        error_page(filename_rules());
+    }
     $dir = "$buda_root/$name";
     if (file_exists($dir)) {
         error_page("App $name already exists.");

--- a/html/user/sandbox.php
+++ b/html/user/sandbox.php
@@ -84,11 +84,10 @@ if (0) {
     page_tail();
 }
 
-function list_files($user) {
+function list_files($user, $notice=null) {
     $dir = sandbox_dir($user);
     if (!is_dir($dir)) error_page("Can't open sandbox directory");
     page_head("File sandbox");
-    $notice = htmlspecialchars(get_str('notice', true));
     if ($notice) {
         echo "<p>$notice<hr>";
     }
@@ -191,7 +190,7 @@ function upload_file($user) {
 
         $notice .= "Uploaded file <strong>$name</strong><br/>";
     }
-    header(sprintf('Location: sandbox.php?notice=%s', urlencode($notice)));
+    list_files($user, $notice);
 }
 
 function add_file($user) {
@@ -212,7 +211,7 @@ function add_file($user) {
     write_info_file("$dir/.md5/$name", $md5, $size);
 
     $notice = "Added file <strong>$name</strong> ($size bytes)";
-    header(sprintf('Location: sandbox.php?notice=%s', urlencode($notice)));
+    list_files($user, $notice);
 }
 
 function get_file($user) {
@@ -228,7 +227,7 @@ function get_file($user) {
     }
     copy($url, $path);
     $notice = "Fetched file from <strong>$url</strong><br/>";
-    header(sprintf('Location: sandbox.php?notice=%s', urlencode($notice)));
+    list_files($user, $notice);
 }
 
 // delete a sandbox file.
@@ -242,7 +241,7 @@ function delete_file($user) {
     unlink("$dir/$name");
     unlink("$dir/.md5/$name");
     $notice = "<strong>$name</strong> was deleted from your sandbox<br/>";
-    header(sprintf('Location: sandbox.php?notice=%s', urlencode($notice)));
+    list_files($user, $notice);
 }
 
 function download_file($user) {


### PR DESCRIPTION
- user file sandbox: improve error messages if bad filename Note: we don't currently allow spaces in sandbox filenames. This restriction probably isn't necessary.

- support dark mode if browser settings request it