### PR TITLE
Wrapper: Replace malloc implementation with vectors, fix off-by-one e…

### DIFF
--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -167,7 +167,7 @@ struct TASK {
     int parse(XML_PARSER&);
     void substitute_macros();
     bool poll(int& status);
-    int run(int argc, vector<string> argv);
+    int run(int argc, vector<string>& argv);
     void kill();
     void stop();
     void resume();

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -596,7 +596,7 @@ int parse_job_file() {
     return ERR_XML_PARSE;
 }
 
-int start_daemons(int argc, vector<string> argv) {
+int start_daemons(int argc, vector<string>& argv) {
     for (TASK& task: daemons) {
         int retval = task.run(argc, argv);
         if (retval) return retval;
@@ -675,7 +675,7 @@ void backslash_to_slash(char* p) {
     }
 }
 
-int TASK::run(int argct, vector<string> argvt) {
+int TASK::run(int argct, vector<string>& argvt) {
     string stdout_path, stdin_path, stderr_path;
     char app_path[1024], buf[256];
 

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -1199,8 +1199,8 @@ int main(int argc, char** argv) {
     bool is_sporadic = false;
     bool passthrough_child = false;
     int child_arg_count = 0;
-    vector<string> child_args = {};
-    vector<string> wrapper_args = {};
+    vector<string> child_args;
+    vector<string> wrapper_args;
     // Log banner
     //
     fprintf(stderr, "%s wrapper (%d.%d.%d): starting\n",

--- a/samples/wrapper/wrapper.cpp
+++ b/samples/wrapper/wrapper.cpp
@@ -1232,7 +1232,7 @@ int main(int argc, char** argv) {
         } else if (!strcmp(argv[j], "--passthrough_child")) {
             passthrough_child = true;
             child_arg_count = (argc - (j+1));
-            
+
             for (int k = j+1; k < argc; k++) {
 
                 child_args.push_back(argv[k]);


### PR DESCRIPTION
Fixes #6214

**Description of the Change**
Mostly just replaced malloc'd c-style string arrays with vectors.
Also fixed off-by-one error I introduced which left `--passthrough_child` in `child_args`

**Alternate Designs**
Decided it was best to replace all instances of `char**` in reference to `argv` elsewhere in the program rather than build a `vector<string>` from a `char**` every time a `vector<string>` was needed.

I also avoided iterating twice to fill `wrapper_args` after already having iterated over argv.

A different, and maybe slightly smarter implementation might be to avoid looping a 2nd time for `child_args` and just avoid writing to `child_args` until we've seen `--passthrough-args` one time.

**Release Notes**
N/A

This is how #6216 should've been implemented to begin with.