### PR TITLE
Workflow: Set RELEASE_ARCH for arm64 build non-release

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -166,6 +166,7 @@ jobs:
         if: success() && matrix.type == 'apps-arm64'
         run: |
           export CI=yes
+          export RELEASE_ARCH=arm64
           ./linux/arm64/build_libraries_arm64.sh
           ./linux/arm64/build_openssl_arm64.sh
           ./linux/arm64/build_curl_arm64.sh


### PR DESCRIPTION
Fixes #6219 

**Description of the Change**
Sets arm64 as the `RELEASE_ARCH` under the workflow step "Build apps for arm64" in `linux.yml`.

**Alternate Designs**
This is a band-aid fix, imo, but reworking the workflow to explicitly set the arch for every build might be more extensible, as right now it's assumed it's x86_64 unless told otherwise, and we're only 'telling it otherwise' when it's arm64. Not risc-v, for example.

**Release Notes**
N/A - Developer-facing only
