### PR TITLE
[cmake] cmake 4.0.0 is incompatible with the build scripts that target cmake < 3.5.

### DIFF
--- a/3rdParty/vcpkg_ports/triplets/ci/x64-linux.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/x64-linux.cmake
@@ -19,3 +19,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/x64-linux.cmake)
 
 set(VCPKG_BUILD_TYPE release)
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")

--- a/3rdParty/vcpkg_ports/triplets/ci/x64-mingw-static.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/x64-mingw-static.cmake
@@ -19,3 +19,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/x64-mingw-static.cmake)
 
 set(VCPKG_BUILD_TYPE release)
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")

--- a/3rdParty/vcpkg_ports/triplets/default/arm64-windows-static.cmake
+++ b/3rdParty/vcpkg_ports/triplets/default/arm64-windows-static.cmake
@@ -20,3 +20,4 @@ include(${VCPKG_ROOT}/triplets/community/arm64-windows-static.cmake)
 
 set(VCPKG_CXX_FLAGS /Qspectre)
 set(VCPKG_C_FLAGS /Qspectre)
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")

--- a/3rdParty/vcpkg_ports/triplets/default/x64-windows-static.cmake
+++ b/3rdParty/vcpkg_ports/triplets/default/x64-windows-static.cmake
@@ -20,3 +20,4 @@ include(${VCPKG_ROOT}/triplets/x64-windows-static.cmake)
 
 set(VCPKG_CXX_FLAGS /Qspectre)
 set(VCPKG_C_FLAGS /Qspectre)
+set(VCPKG_CMAKE_CONFIGURE_OPTIONS "-DCMAKE_POLICY_VERSION_MINIMUM=3.5")


### PR DESCRIPTION
This fixes the build in the recommended way while waiting for the vcpkg ports to be updated and fixed.
