### PR TITLE
Web: Sandbox and job submission fixes (mostly for BUDA)

### DIFF
--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -394,14 +394,14 @@ function form_select($label, $name, $items, $selected=null) {
 // same, for multiple select.
 // $selected, if non-null, is a list of selected values
 //
-function form_select_multiple($label, $name, $items, $selected=null) {
+function form_select_multiple($label, $name, $items, $selected=null, $size=0) {
     echo sprintf('
         <div class="form-group">
             <label align=right class="%s" for="%s">%s</label>
             <div class="%s">
-                <select multiple class="form-control" id="%s" name="%s[]">
+                <select multiple class="form-control" id="%s" name="%s[]" size=%d>
         ',
-        FORM_LEFT_CLASS, $name, $label, FORM_RIGHT_CLASS, $name, $name
+        FORM_LEFT_CLASS, $name, $label, FORM_RIGHT_CLASS, $name, $name, $size
     );
     foreach ($items as $i) {
         echo sprintf(

--- a/html/user/buda_submit.php
+++ b/html/user/buda_submit.php
@@ -123,7 +123,7 @@ function parse_batch_dir($batch_dir, $variant_desc) {
             }
             $job_files[] = $f2;
         }
-        if (sort($job_files) != $unshared_files) {
+        if (array_values($job_files) != array_values($unshared_files)) {
             error_page("$fname doesn't have all input files");
         }
 

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -37,7 +37,9 @@ function get_file() {
     if ($download) {
         do_download($path);
     } else {
-        readfile($path);
+        echo "<pre>\n";
+        echo htmlspecialchars(file_get_contents($path));
+        echo "</pre>\n";
     }
 }
 

--- a/html/user/sandbox.php
+++ b/html/user/sandbox.php
@@ -115,7 +115,7 @@ function list_files($user, $notice=null) {
         $sort_rev = get_str('sort_rev', true);
         column_sort($files, $sort_field, $sort_rev);
 
-        start_table();
+        start_table('table-striped');
         table_header(
             column_sort_header(
                 'name',


### PR DESCRIPTION
- BUDA: allow variants with no input files
- BUDA: make app files sticky to avoid repeated download (at somepoint we'll think about how to eventually delete them from client)
- BUDA: show text files correctly
- show Ctrl-click instructions for multi-select
- expand multi-file selection box to 12 lines
- output file display: show files correctly
- sandbox: striped table