### PR TITLE
Remove libatomic reference in linux aarch64 build

### DIFF
--- a/linux/arm64/build_curl_arm64.sh
+++ b/linux/arm64/build_curl_arm64.sh
@@ -26,7 +26,7 @@ export CXX=aarch64-linux-gnu-g++
 export LD=aarch64-linux-gnu-ld
 export CFLAGS="--sysroot=$TCSYSROOT -I$TCINCLUDES/include -march=armv8-a -O3"
 export CXXFLAGS="--sysroot=$TCSYSROOT -I$TCINCLUDES/include -march=armv8-a -O3 -std=c++11"
-export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -march=armv8-a -latomic -static-libstdc++"
+export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -march=armv8-a -static-libstdc++"
 
 MAKE_FLAGS=""
 

--- a/linux/arm64/build_example_arm64.sh
+++ b/linux/arm64/build_example_arm64.sh
@@ -27,7 +27,7 @@ export CXX=aarch64-linux-gnu-g++
 export LD=aarch64-linux-gnu-ld
 export CFLAGS="--sysroot=$TCSYSROOT -I$TCINCLUDES/include -march=armv8-a -O3 -I$BOINC -I$BOINC_LIB_DIR -I$BOINC_API_DIR -I$BOINC_ZIP_DIR"
 export CXXFLAGS="--sysroot=$TCSYSROOT -I$TCINCLUDES/include -march=armv8-a -O3 -I$BOINC -I$BOINC_LIB_DIR -I$BOINC_API_DIR -I$BOINC_ZIP_DIR -std=c++11"
-export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -march=armv8-a -latomic -static-libstdc++"
+export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -march=armv8-a -static-libstdc++"
 
 CONFIG_FLAGS="--with-ssl=$TCINCLUDES --with-libcurl=$TCINCLUDES"
 CONFIG_LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib"

--- a/linux/arm64/build_openssl_arm64.sh
+++ b/linux/arm64/build_openssl_arm64.sh
@@ -26,7 +26,7 @@ export CXX=aarch64-linux-gnu-g++
 export LD=aarch64-linux-gnu-ld
 export CFLAGS="--sysroot=$TCSYSROOT -march=armv8-a -O3"
 export CXXFLAGS="--sysroot=$TCSYSROOT -march=armv8-a -O3 -std=c++11"
-export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -march=armv8-a -latomic -static-libstdc++"
+export LDFLAGS="-L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -march=armv8-a -static-libstdc++"
 
 MAKE_FLAGS=""
 


### PR DESCRIPTION
Fixes #6226

**Description of the Change**
Removed libatomic from the aarch64 build of BOINC.
It's still left alone in the android builds, but if it's not needed there either we could also remove it there.

**Alternate Designs**
No real alternates are possible besides leaving libatomic referenced. 

**Release Notes**
Libatomic is no longer a requirement for running BOINC apps using aarch64 hardware on linux.
This would've mostly impacted people running builds of BOINC software that was built using the workflows in github. I'm not aware of how the publicly facing builds are handled, if it's any different to begin with, or if anyone ever noticed because it's possible a lot of distros come with libatomic pre-installed.
