### PR TITLE
client: Hook in reading of last_active_time from event_detect in hostinfo_unix

### DIFF
--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -465,6 +465,17 @@ string timediff_format(double diff) {
 
 }
 
+int64_t ParseStringtoInt64(const std::string& str)
+{
+    try {
+        return static_cast<int64_t>(std::stoll(str));
+    } catch (const std::invalid_argument& e){
+        throw;
+    } catch (const std::out_of_range& e){
+        throw;
+    }
+}
+
 void mysql_timestamp(double dt, char* p) {
     struct tm* tmp;
     time_t t = (time_t)dt;

--- a/lib/str_util.h
+++ b/lib/str_util.h
@@ -20,6 +20,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <string.h>
 
 #include "str_replace.h"
@@ -42,6 +43,8 @@ extern char* time_to_string(double);
 extern char* precision_time_to_string(double);
 extern void secs_to_hmsf(double, char*);
 extern std::string timediff_format(double);
+int64_t ParseStringtoInt64(const std::string& str);
+
 
 inline bool empty(char* p) {
     return p[0] == 0;


### PR DESCRIPTION
hostinfo_unix.cpp, str_util.h, str_util.cpp

Fixes #1187, #2199, #2256, #3405, #5226

**Description of the Change**
This is a PR to introduce transitional code to make use of the new idle_detect service that I have been developing as a self contained idle detector. Please see https://github.com/jamescowens/idle_detect and in particular https://github.com/jamescowens/idle_detect/discussions/4.

What is meant by transitional is that user_idle_time() in hostinfo_unix.cpp first checks ReadLastActiveTimeDat() and if it is successfully read (which means that event_detect is present and running), uses the output to calculate idle time. If the file is not there, it falls back to the original code. Eventually this existing fallback code will be removed and/or simplified.

Note that the idle_detect/event_detect solution solves for 99% of the idle detection issues in Linux, including both X and Wayland KDE and Gnome sessions (including idle inhibit when watching a movie), and non KDE non Gnome sessions (X and Wayland) but without idle inhibit functionality. Additional monitor functions can be easily added to idle_detect to address Window manager specific APIs for idle inhibit.

**Alternate Designs**
The thread in #5226 in addition to the above discussion explains why this is the best approach to solve this problem.

**Release Notes**
<!--Introduces the use of the event_detect/idle_detect service for BOINC client idle detection on Linux -->

