### PR TITLE
Fix snprintf() errors introduced in PR #4864

### DIFF
--- a/client/mac_address.cpp
+++ b/client/mac_address.cpp
@@ -135,7 +135,7 @@ GetMACAddress(io_iterator_t intfIterator, char* buffer)
                 UInt8 MACAddress[ kIOEthernetAddressSize ];
 
                 CFDataGetBytes(refData, CFRangeMake(0,CFDataGetLength(refData)), MACAddress);
-                snprintf(buffer, sizeof(buffer), "%02x:%02x:%02x:%02x:%02x:%02x",
+                sprintf(buffer, "%02x:%02x:%02x:%02x:%02x:%02x",
                         MACAddress[0], MACAddress[1], MACAddress[2], MACAddress[3], MACAddress[4], MACAddress[5]);
                 CFRelease(MACAddressAsCFData);
             }
@@ -163,7 +163,7 @@ int get_mac_address(char* address) {
     strcpy(address, "");
     PIP_ADAPTER_INFO pAdapterInfo = AdapterInfo; // Contains pointer to current adapter info
     while (pAdapterInfo) {
-        snprintf(address, sizeof(address), "%02x:%02x:%02x:%02x:%02x:%02x",
+        sprintf(address, "%02x:%02x:%02x:%02x:%02x:%02x",
             pAdapterInfo->Address[0], pAdapterInfo->Address[1], pAdapterInfo->Address[2],
             pAdapterInfo->Address[3], pAdapterInfo->Address[4], pAdapterInfo->Address[5]
         );

--- a/lib/unix_util.cpp
+++ b/lib/unix_util.cpp
@@ -93,7 +93,7 @@ int setenv(const char *name, const char *value, int overwrite) {
         errno=ENOMEM;
         return -1;
     }
-    snprintf(buf, sizeof(buf),"%s=%s",name,value);
+    sprintf(buf, "%s=%s",name,value);
     rv=putenv(buf);
     // Yes, there is a potential memory leak here.  Some versions of operating
     // systems copy the string into the environment, others make the


### PR DESCRIPTION
PR #4864 introduced 4 erroneous changes of the form
   sprintf(buf, sizeof(buf), ....)
where buf is a char*.
(Note: in this case sizeof(buf) is 8.
It is NOT the size of the memory area that buf points to).

One of these (in file_names.cpp) was fixed in a later PR. This PR fixes the other 3.
Hopefully we didn't miss any.