### PR TITLE
web (job submission): big fixes and enhancements

### DIFF
--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -535,7 +535,8 @@ function form_checkbox($label, $name, $checked=false) {
         FORM_LEFT_CLASS, $label, FORM_RIGHT_CLASS
     );
     echo sprintf('
-        <input type="checkbox" name="%s" %s>
+              <input type="checkbox" name="%s" %s>
+           </div>
         </div>
         ', $name, $checked?"checked":""
     );

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -21,6 +21,15 @@
 
 require_once("../inc/submit_db.inc");
 
+// The status of a workunit.
+// Not stored in the DB;
+// it's computed by get_batch_params() and added to the workunit object
+//
+define('WU_UNSENT', 0);
+define('WU_IN_PROGRESS', 1);
+define('WU_SUCCESS', 2);
+define('WU_ERROR', 3);
+
 // write status and error messages to log
 //
 function log_write($x) {
@@ -126,7 +135,7 @@ function delete_remote_submit_user($user) {
     BoincUserSubmitApp::delete_user($user->id);
 }
 
-// given its WUs, compute parameters of a batch:
+// given its WUs, compute parameters of the batch:
 //   credit_canonical: credit granted to canonical instances
 //   fraction_done: frac of jobs that are done (success or failed)
 //   state: whether complete (all jobs done)
@@ -140,10 +149,7 @@ function delete_remote_submit_user($user) {
 //
 // return the batch object, with these values
 //
-// NOTE: this involves reading the batch's WUs and results,
-// which could be inefficient for huge batches.
-// It could instead be done by server components
-// (transitioner, validator etc.) as jobs complete or time out
+// Also add the status field to WUs
 //
 // TODO: update est_completion_time
 //
@@ -185,12 +191,17 @@ function get_batch_params($batch, $wus) {
             $fp_done += $wu->rsc_fpops_est;
             $njobs_success++;
             $batch->credit_canonical += $wu->canonical_credit;
+            $wu->status = WU_SUCCESS;
         } else if ($wu->error_mask) {
             $batch->nerror_jobs++;
+            $wu->status = WU_ERROR;
         } else {
             $completed = false;
             if (array_key_exists($wu->id, $wus_in_prog)) {
                 $njobs_in_prog++;
+                $wu->status = WU_IN_PROGRESS;
+            } else {
+                $wu->status = WU_UNSENT;
             }
         }
     }

--- a/html/user/buda_submit.php
+++ b/html/user/buda_submit.php
@@ -41,7 +41,7 @@ function submit_form($user) {
         containing command-line arguments.
         <a href=https://github.com/BOINC/boinc/wiki/BUDA-job-submission>Details</a></small>.
     ";
-    page_head("Submit jobs to $app ($variant)");
+    page_head("BUDA: Submit jobs to $app ($variant)");
     form_start('buda_submit.php');
     form_input_hidden('action', 'submit');
     form_input_hidden('app', $app);

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -240,10 +240,18 @@ function handle_main($user) {
             panel($area,
                 function() use ($apps) {
                     foreach ($apps as $app) {
-                        echo sprintf(
-                            '<a href=%s><img width=100 src=%s></a>&nbsp;',
-                            $app[1], $app[2]
-                        );
+                        // show app logo if available
+                        if ($app[2]) {
+                            echo sprintf(
+                                '<a href=%s><img width=100 src=%s></a>&nbsp;',
+                                $app[1], $app[2]
+                            );
+                        } else {
+                            echo sprintf(
+                                '<li><a href=%s>%s</a><p>',
+                                $app[1], $app[0]
+                            );
+                        }
                     }
                 }
             );
@@ -430,14 +438,14 @@ function progress_bar($batch, $wus, $width) {
         $x .= "<td width=$w_prog bgcolor=lightgreen></td>";
     }
     if ($w_unsent) {
-        $x .= "<td width=$w_unsent bgcolor=lightgray></td>";
+        $x .= "<td width=$w_unsent bgcolor=gray></td>";
     }
     $x .= "</tr></table>
         <strong>
-        <font color=red>$nerror fail</font> &middot;
-        <font color=green>$nsuccess success</font> &middot;
+        <font color=red>$nerror failed</font> &middot;
+        <font color=green>$nsuccess completed</font> &middot;
         <font color=lightgreen>$nin_prog in progress</font> &middot;
-        <font color=lightgray>$nunsent unsent</font>
+        <font color=gray>$nunsent unsent</font>
         </strong>
     ";
     return $x;
@@ -527,30 +535,26 @@ function handle_query_batch($user) {
         "Name <br><small>click for details</small>",
         "status"
     ];
-    if (!$is_assim_move) {
-        $x[] = "Download Results";
-    }
     row_heading_array($x);
     foreach($wus as $wu) {
-        $resultid = $wu->canonical_resultid;
-        if ($resultid) {
+        switch($wu->status) {
+        case WU_SUCCESS:
+            $resultid = $wu->canonical_resultid;
             $y = '<font color="green">completed</font>';
-            $text = "<a href=get_output2.php?cmd=workunit&wu_id=$wu->id>Download output files</a>";
-        } else {
-            $text = "---";
-            if ($batch->state == BATCH_STATE_COMPLETE) {
-                $y = '<font color="red">failed</font>';
-            }   else {
-                $y = "in progress";
-            }
+            break;
+        case WU_ERROR:
+            $y = '<font color="red">failed</font>';
+            break;
+        case WU_IN_PROGRESS:
+            $y = '<font color="lightgreen">in progress</font>';
+            break;
+        case WU_UNSENT:
+            $y = '<font color="gray">unsent</font>';
         }
         $x = [
             "<a href=submit.php?action=query_job&wuid=$wu->id>$wu->name</a>",
             $y,
         ];
-        if (!$is_assim_move) {
-            $x[] = $text;
-        }
         row_array($x);
     }
     end_table();

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -537,6 +537,7 @@ function handle_query_batch($user) {
     ];
     row_heading_array($x);
     foreach($wus as $wu) {
+        $y = '';
         switch($wu->status) {
         case WU_SUCCESS:
             $resultid = $wu->canonical_resultid;
@@ -550,6 +551,7 @@ function handle_query_batch($user) {
             break;
         case WU_UNSENT:
             $y = '<font color="gray">unsent</font>';
+            break;
         }
         $x = [
             "<a href=submit.php?action=query_job&wuid=$wu->id>$wu->name</a>",


### PR DESCRIPTION
- BUDA: add "min success instances" and "max total instances" to BUDA varian
ts.
    e.g. min_success=1 and max_total=3 means send instances
    until 1 succeeds, but don't send more than 3
    Note: I made these a property of the variant because that's
    where the input template is.
    This is much simpler than making it a batch property, for example.
- BUDA: in displaying a variant, show
    - Docker file
    - app files
    - auto-generated files
    - input/output filenames
    - replication params
    In other words, all the info you'd need to make a new variant.
- job submission page: if app doesn't have a logo, show its name
- in batch status page, show job status correctly,
    and with colors that match progress bar
- In BUDA variant page
- fix bug in form checkboxes
