### PR TITLE
fix compile warnings in lib/

### DIFF
--- a/client/Makefile.linux
+++ b/client/Makefile.linux
@@ -6,8 +6,19 @@
 #    make -f Makefile.linux clean all
 # 3) do the same in this dir
 
+OPTS = -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
+-Wno-deprecated-copy \
+-Werror=format-security \
+-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
+-D_GLIBCXX_ASSERTIONS \
+-fstack-protector -fstack-protector-strong \
+-Wl,-z,nodlopen -Wl,-z,noexecstack \
+-Wl,-z,relro -Wl,-z,now \
+-Wl,--as-needed -Wl,--no-copy-dt-needed-entries
+
 //CC = g++ -O4 -Wall -I ../ -I ../lib/
-CC = g++ -g -Wall -I ../ -I ../lib/
+//CC = g++ -g -Wall -I ../ -I ../lib/
+CC = g++ -g $(OPTS) -I ../ -I ../lib/
 
 PROGS = boinc boinccmd
 

--- a/lib/Makefile.linux
+++ b/lib/Makefile.linux
@@ -1,7 +1,18 @@
 # make libraries for Linux client and boinccmd
 
+OPTS = -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
+-Wno-deprecated-copy \
+-Werror=format-security \
+-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
+-D_GLIBCXX_ASSERTIONS \
+-fstack-clash-protection -fstack-protector-strong \
+-Wl,-z,nodlopen -Wl,-z,noexecstack \
+-Wl,-z,relro -Wl,-z,now \
+-Wl,--as-needed -Wl,--no-copy-dt-needed-entries
+
 //CC = g++ -O4 -Wall -I ../
-CC = g++ -g -Wall -I ../
+//CC = g++ -g -Wall -I ../
+CC = g++ -g $(OPTS) -I ../
 
 all: boinc.a boinc_cmd.a
 

--- a/lib/boinc_stdio.h
+++ b/lib/boinc_stdio.h
@@ -148,7 +148,7 @@ namespace boinc {
 #endif
     }
 
-    inline int ftell(FILE *f) {
+    inline long ftell(FILE *f) {
 #ifdef _USING_FCGI_
         return FCGI_ftell(f);
 #else

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -189,7 +189,7 @@ void COPROCS::summary_string(char* buf, int len) {
         snprintf(buf2, sizeof(buf2),
             "[INTEL|%s|%d|%dMB|%s|%d]",
             intel_gpu.name, intel_gpu.count,
-            (int)(intel_gpu.opencl_prop.global_mem_size/MEGA),
+            (int)((double)intel_gpu.opencl_prop.global_mem_size/MEGA),
             intel_gpu.version,
             intel_gpu.opencl_prop.opencl_device_version_int
         );
@@ -199,7 +199,7 @@ void COPROCS::summary_string(char* buf, int len) {
         snprintf(buf2, sizeof(buf2),
             "[apple_gpu|%s|%d|%dMB|%d|%d]",
             apple_gpu.model, apple_gpu.count,
-            (int)(apple_gpu.opencl_prop.global_mem_size/MEGA),
+            (int)((double)apple_gpu.opencl_prop.global_mem_size/MEGA),
             apple_gpu.metal_support,
             apple_gpu.opencl_prop.opencl_device_version_int
         );
@@ -219,7 +219,7 @@ void COPROCS::summary_string(char* buf, int len) {
             "[opencl_gpu|%s|%d|%dMB|%d]",
             cp.type,
             cp.count,
-            (int)(cp.opencl_prop.global_mem_size/MEGA),
+            (int)((double)cp.opencl_prop.global_mem_size/MEGA),
             cp.opencl_prop.opencl_device_version_int
         );
         strlcat(buf, buf2, len);
@@ -964,7 +964,7 @@ int COPROC_INTEL::parse(XML_PARSER& xp) {
 				set_peak_flops();
             }
             if (!available_ram) {
-                available_ram = opencl_prop.global_mem_size;
+                available_ram = (double)opencl_prop.global_mem_size;
             }
             return 0;
         }
@@ -1072,7 +1072,7 @@ int COPROC_APPLE::parse(XML_PARSER& xp) {
 				set_peak_flops();
             }
             if (!available_ram) {
-                available_ram = opencl_prop.global_mem_size;
+                available_ram = (double)opencl_prop.global_mem_size;
             }
             return 0;
         }

--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -98,7 +98,7 @@ int print_raw_data(FILE* f, DATA_BLOCK& x) {
 int scan_raw_data(FILE *f, DATA_BLOCK& x) {
     int i=0,j;
     while(EOF!=(j=fgetc(f))) {
-        x.data[i]=j;
+        x.data[i]=(unsigned char)j;
         i++;
     }
     x.len = i;
@@ -132,7 +132,7 @@ int scan_hex_data(FILE* f, DATA_BLOCK& x) {
         int j;
         n = fscanf(f, "%2x", &j);
         if (n <= 0) break;
-        x.data[x.len] = j;
+        x.data[x.len] = (unsigned char)j;
         x.len++;
     }
 #endif
@@ -159,7 +159,7 @@ static int sscan_hex_data(const char* p, DATA_BLOCK& x) {
             );
             return ERR_BAD_HEX_FORMAT;
         }
-        x.data[x.len++] = m;
+        x.data[x.len++] = (unsigned char)m;
         nleft--;
         p += 2;
     }
@@ -173,7 +173,7 @@ int print_key_hex(FILE* f, KEY* key, int size) {
     DATA_BLOCK x;
 
     fprintf(f, "%d\n", key->bits);
-    len = size - sizeof(key->bits);
+    len = size - (int)sizeof(key->bits);
     x.data = key->data;
     x.len = len;
     return print_hex_data(f, x);
@@ -207,14 +207,14 @@ int scan_key_hex(FILE* f, KEY* key, int size) {
 #else
     int fs = fscanf(f, "%d", &num_bits);
     if (fs != 1) return ERR_NULL;
-    key->bits = num_bits;
-    len = size - sizeof(key->bits);
+    key->bits = (unsigned short)num_bits;
+    len = size - (int)sizeof(key->bits);
     for (i=0; i<len; i++) {
         // coverity[check_return]
         if (fscanf(f, "%2x", &n) != 1) {
             return ERR_NULL;
         }
-        key->data[i] = n;
+        key->data[i] = (unsigned char)n;
     }
     fs = fscanf(f, ".");
     if (fs == EOF) return ERR_NULL;
@@ -230,7 +230,7 @@ int sscan_key_hex(const char* buf, KEY* key, int size) {
 
     //fprintf(stderr, "buf = %s\n", buf);
     n = sscanf(buf, "%d", &num_bits);
-    key->bits = num_bits; //key->bits is a short
+    key->bits = (unsigned short)num_bits; //key->bits is a short
     //fprintf(stderr, "key->bits = %d\n", key->bits);
 
     if (n != 1) return ERR_XML_PARSE;
@@ -238,7 +238,7 @@ int sscan_key_hex(const char* buf, KEY* key, int size) {
     if (!buf) return ERR_XML_PARSE;
     buf += 1;
     db.data = key->data;
-    db.len = size - sizeof(key->bits); //huh???
+    db.len = (unsigned)(size - sizeof(key->bits));
     retval = sscan_hex_data(buf, db);
     return retval;
 }
@@ -479,7 +479,7 @@ void openssl_to_keys(
 #endif
 
     memset(&priv, 0, sizeof(priv));
-    priv.bits = nbits;
+    priv.bits = (unsigned short)nbits;
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
     if (n)
         bn_to_bin(n, priv.modulus, sizeof(priv.modulus));
@@ -583,7 +583,7 @@ int openssl_to_private(RSA *from, R_RSA_PRIVATE_KEY *to) {
     RSA_get0_factors(from, &p, &q);
     RSA_get0_crt_params(from, &dmp1, &dmq1, &iqmp);
 
-    to->bits = BN_num_bits(n);
+    to->bits = (unsigned short)BN_num_bits(n);
     if (!_bn2bin(n,to->modulus,MAX_RSA_MODULUS_LEN))
         return(0);
     if (!_bn2bin(e,to->publicExponent,MAX_RSA_MODULUS_LEN))

--- a/lib/crypt_prog.cpp
+++ b/lib/crypt_prog.cpp
@@ -338,7 +338,7 @@ int test_crypt(const std::string& private_keyfile,
     strcpy((char*)buf2, test_string.c_str());
     DATA_BLOCK in, out;
     in.data = buf2;
-    in.len = test_string.size();
+    in.len = (unsigned)test_string.size();
     out.data = buf;
     retval = encrypt_private(private_key, in, out);
     if (retval) {

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -798,17 +798,17 @@ void boinc_catch_signal(int signal) {
     ssize_t retval = write(fileno(stderr),"Stack trace (",strlen("Stack trace ("));
     char mbuf[10];
     char *p=mbuf+9;
-    int i=size;
+    int i=(int)size;
     *(p--)=0;
     while (i) {
-      *(p--)=i%10+'0';
+      *(p--)=(char)(i%10+'0');
       i/=10;
     }
     retval = write(fileno(stderr),p+1,strlen(p+1));
     retval = write(fileno(stderr)," frames):",strlen(" frames):"));
     mbuf[0]=10;
     retval = write(fileno(stderr),mbuf,1);
-    backtrace_symbols_fd(array, size, fileno(stderr));
+    backtrace_symbols_fd(array, (int)size, fileno(stderr));
     if (retval) {}
 #endif
 

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -795,7 +795,7 @@ void boinc_catch_signal(int signal) {
     size = backtrace (array, 64);
 //  Anything that calls malloc here (i.e *printf()) will probably fail
 //  so we'll do it the hard way.
-    int retval = write(fileno(stderr),"Stack trace (",strlen("Stack trace ("));
+    ssize_t retval = write(fileno(stderr),"Stack trace (",strlen("Stack trace ("));
     char mbuf[10];
     char *p=mbuf+9;
     int i=size;

--- a/lib/filesys.cpp
+++ b/lib/filesys.cpp
@@ -688,7 +688,7 @@ int boinc_copy(const char* orig, const char* newf) {
     // under sandbox security, so we copy the file directly.
     //
     FILE *src, *dst;
-    int m, n;
+    size_t m, n;
     int retval = 0;
     unsigned char buf[65536];
     src = boinc_fopen(orig, "r");
@@ -700,7 +700,7 @@ int boinc_copy(const char* orig, const char* newf) {
     }
     while (1) {
         n = boinc::fread(buf, 1, sizeof(buf), src);
-        if (n <= 0) {
+        if (n == 0) {
             // could be either EOF or an error.
             // Check for error case.
             //
@@ -1111,11 +1111,11 @@ int read_file_malloc(const char* path, char*& buf, size_t max_len, bool tail) {
     if (!f) return ERR_FOPEN;
 
 #ifndef _USING_FCGI_
-    if (max_len && size > max_len) {
+    if (max_len && size > (double)max_len) {
         if (tail) {
             fseek(f, (long)size-(long)max_len, SEEK_SET);
         }
-        size = max_len;
+        size = (double)max_len;
     }
 #endif
     size_t isize = (size_t)size;

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -104,19 +104,19 @@ int RPC_CLIENT::get_ip_addr(const char* host, int port) {
         sin->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     }
     if (port) {
-        port = htons(port);
+        port = (int)htons(port);
     } else {
-        port = htons(GUI_RPC_PORT);
+        port = (int)htons(GUI_RPC_PORT);
     }
 #ifdef _WIN32
     addr.sin_port = port;
 #else
     if (addr.ss_family == AF_INET) {
         sockaddr_in* sin = (sockaddr_in*)&addr;
-        sin->sin_port = port;
+        sin->sin_port = (in_port_t)port;
     } else {
         sockaddr_in6* sin = (sockaddr_in6*)&addr;
-        sin->sin6_port = port;
+        sin->sin6_port = (in_port_t)port;
     }
 #endif
     return 0;
@@ -309,7 +309,7 @@ int RPC_CLIENT::send_request(const char* p) {
     buf = "<boinc_gui_rpc_request>\n";
     buf += p;
     buf += "</boinc_gui_rpc_request>\n\003";
-    int n = send(sock, buf.c_str(), (int)buf.size(), 0);
+    ssize_t n = send(sock, buf.c_str(), (int)buf.size(), 0);
     if (n < 0) {
         //printf("send: %d\n", n);
         //perror("send");
@@ -323,7 +323,7 @@ int RPC_CLIENT::send_request(const char* p) {
 int RPC_CLIENT::get_reply(char*& mbuf) {
     char buf[8193];
     MFILE mf;
-    int n;
+    ssize_t n;
 
     mf.puts("");    // make sure buffer is non-NULL
     while (1) {

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -104,7 +104,7 @@ int RPC_CLIENT::get_ip_addr(const char* host, int port) {
         sin->sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     }
     if (port) {
-        port = (int)htons(port);
+        port = (int)htons((uint16_t)port);
     } else {
         port = (int)htons(GUI_RPC_PORT);
     }
@@ -323,11 +323,11 @@ int RPC_CLIENT::send_request(const char* p) {
 int RPC_CLIENT::get_reply(char*& mbuf) {
     char buf[8193];
     MFILE mf;
-    ssize_t n;
+    int n;
 
     mf.puts("");    // make sure buffer is non-NULL
     while (1) {
-        n = recv(sock, buf, 8192, 0);
+        n = (int) recv(sock, buf, 8192, 0);
         if (n <= 0) return ERR_READ;
         buf[n]=0;
         mf.puts(buf);

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -298,7 +298,7 @@ void HOST_INFO::print() {
         }
         if (ci.have_opencl) {
             ci.opencl_prop.peak_flops = ci.peak_flops;
-            ci.opencl_prop.opencl_available_ram = ci.opencl_prop.global_mem_size;
+            ci.opencl_prop.opencl_available_ram = (double)ci.opencl_prop.global_mem_size;
             ci.opencl_prop.is_used = COPROC_USED;
             ci.opencl_prop.description(buf, sizeof(buf), "Intel GPU");
             printf("    %s\n", buf);
@@ -312,7 +312,7 @@ void HOST_INFO::print() {
         }
         if (cap.have_opencl) {
             cap.opencl_prop.peak_flops = cap.peak_flops;
-            cap.opencl_prop.opencl_available_ram = cap.opencl_prop.global_mem_size;
+            cap.opencl_prop.opencl_available_ram = (double)cap.opencl_prop.global_mem_size;
             cap.opencl_prop.is_used = COPROC_USED;
             cap.opencl_prop.description(buf, sizeof(buf), "Apple GPU");
             printf("    %s\n", buf);

--- a/lib/mem_usage.cpp
+++ b/lib/mem_usage.cpp
@@ -104,7 +104,7 @@ int mem_usage(double& vm_usage, double& resident_set) {
         int i;
         unsigned long tmp;
 
-        i = fread(buf, sizeof(char), 255, f);
+        i = (int)fread(buf, sizeof(char), 255, f);
         buf[i] = '\0'; // terminate string
         p = &buf[0];
 

--- a/lib/msg_queue.cpp
+++ b/lib/msg_queue.cpp
@@ -40,7 +40,7 @@ int create_message_queue(key_t key) {
 }
 
 int receive_message(key_t key, void *msg, size_t msg_size, bool wait) {
-    int mq_id, retval;
+    int mq_id;
 
     mq_id = msgget(key, 0666);
     if (mq_id < 0) {
@@ -48,7 +48,7 @@ int receive_message(key_t key, void *msg, size_t msg_size, bool wait) {
         return -1;
     }
 
-    retval = msgrcv(mq_id, msg, msg_size, 0, (wait?0:IPC_NOWAIT));
+    ssize_t retval = msgrcv(mq_id, msg, msg_size, 0, (wait?0:IPC_NOWAIT));
     if (retval < 0) {
         boinc::perror("receive_message: msgrcv");
         return -1;

--- a/lib/opencl_boinc.cpp
+++ b/lib/opencl_boinc.cpp
@@ -115,7 +115,7 @@ int OPENCL_DEVICE_PROP::parse(XML_PARSER& xp, const char* end_tag) {
         if (xp.parse_str("name", name, sizeof(name))) continue;
         if (xp.parse_str("vendor", vendor, sizeof(vendor))) continue;
         if (xp.parse_ulonglong("vendor_id", ull)) {
-            vendor_id = ull;
+            vendor_id = (unsigned)ull;
             continue;
         }
         if (xp.parse_int("available", n)) {
@@ -251,7 +251,7 @@ int OPENCL_DEVICE_PROP::get_opencl_driver_revision() {
         rev=0;
       }
     }
-    opencl_driver_revision=floor(rev*100+0.5);
+    opencl_driver_revision = (int)floor(rev*100+0.5);
     return 0;
 }
 
@@ -265,7 +265,7 @@ void OPENCL_DEVICE_PROP::description(char* buf, int buflen, const char* type) {
     snprintf(s2, sizeof(s2),
         "%.64s (driver version %.64s, device version %.64s, %.2fGB, %.2fGB available, %.0f GFLOPS peak)",
         name, opencl_driver_version,
-        s1, global_mem_size/GIGA,
+        s1, (double)global_mem_size/GIGA,
         opencl_available_ram/GIGA, peak_flops/1.e9
     );
 

--- a/lib/parse.cpp
+++ b/lib/parse.cpp
@@ -230,7 +230,7 @@ int copy_element_contents(FILE* in, const char* end_tag, string& str) {
     while (1) {
         c = boinc::fgetc(in);
         if (c == EOF) break;
-        str += c;
+        str += (char)c;
         n++;
         if (n < end_tag_len) {
             continue;
@@ -353,7 +353,7 @@ void non_ascii_escape(const char* in, char* out, int len) {
             strcpy(p, buf);
             p += strlen(buf);
         } else {
-            *p++ = x;
+            *p++ = (char)x;
         }
         if (p > out + len - 8) break;
     }
@@ -400,10 +400,10 @@ void xml_escape(const char* in, char* out, int len) {
                 p += 6;
                 in += 2;  // +1 from for loop
             } else {
-                *p++ = x;
+                *p++ = (char)x;
             }
         } else {
-            *p++ = x;
+            *p++ = (char)x;
         }
         if (p > out + len - 8) break;
     }
@@ -473,7 +473,7 @@ void xml_unescape(char* buf) {
                 int ascii = atoi(in);
 
                 if (goodescape && ascii < 256) {
-                    *out++ = ascii;
+                    *out++ = (char)ascii;
                     in = p + 1;
                 } else {
                     *out++ = '&';
@@ -533,7 +533,7 @@ int XML_PARSER::scan_comment() {
     while (1) {
         int c = f->_getc();
         if (!c || c == EOF) return XML_PARSE_EOF;
-        *p++ = c;
+        *p++ = (char)c;
         *p = 0;
         if (strstr(buf, "-->")) {
             return XML_PARSE_COMMENT;
@@ -552,7 +552,7 @@ int XML_PARSER::scan_cdata(char* buf, int len) {
         int c = f->_getc();
         if (!c || c == EOF) return XML_PARSE_EOF;
         if (len) {
-            *p++ = c;
+            *p++ = (char)c;
             len--;
         }
         if (c == '>') {
@@ -677,7 +677,7 @@ bool XML_PARSER::parse_int(const char* start_tag, int& i) {
         }
     }
     errno = 0;
-    int val = strtol(buf, &end, 0);
+    long val = strtol(buf, &end, 0);
     if (errno) return false;
     if (end != buf+strlen(buf)) return false;
 
@@ -685,7 +685,7 @@ bool XML_PARSER::parse_int(const char* start_tag, int& i) {
     if (eof) return false;
     if (!is_tag) return false;
     if (strcmp(tag, end_tag)) return false;
-    i = val;
+    i = (int)val;
     return true;
 }
 

--- a/lib/parse.h
+++ b/lib/parse.h
@@ -299,9 +299,9 @@ inline bool parse_int(const char* buf, const char* tag, int& x) {
     const char* p = strstr(buf, tag);
     if (!p) return false;
     errno = 0;
-    int y = strtol(p+strlen(tag), 0, 0);        // this parses 0xabcd correctly
+    long y = strtol(p+strlen(tag), 0, 0);        // this parses 0xabcd correctly
     if (errno) return false;
-    x = y;
+    x = (int)y;
     return true;
 }
 

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -240,16 +240,16 @@ int procinfo_setup(PROC_MAP& pm) {
         p.clear();
         p.id = ps.pid;
         p.parentid = ps.ppid;
-        p.swap_size = ps.vsize;
+        p.swap_size = (double)ps.vsize;
         // rss = pages, need bytes
         // assumes page size = 4k
-        p.working_set_size = ps.rss * (float)getpagesize();
+        p.working_set_size = ps.rss * getpagesize();
         // page faults: I/O + non I/O
         p.page_fault_count = ps.majflt + ps.minflt;
         // times are in jiffies, need seconds
         // assumes 100 jiffies per second
-        p.user_time = ps.utime / 100.;
-        p.kernel_time = ps.stime / 100.;
+        p.user_time = (double)ps.utime / 100.;
+        p.kernel_time = (double)ps.stime / 100.;
         strlcpy(p.command, ps.comm, sizeof(p.command));
         p.is_boinc_app = (p.id == pid || strcasestr(p.command, "boinc"));
         p.is_low_priority = (ps.priority == 39);
@@ -278,7 +278,7 @@ double total_cpu_time() {
             return 0;
         }
         long hz = sysconf(_SC_CLK_TCK);
-        scale = 1./hz;
+        scale = 1./(double)hz;
     } else {
         fflush(f);
         rewind(f);

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -183,8 +183,8 @@ int ndays_to_string (double x, int smallest_timescale, char *buf) {
 // convert seconds into a string "0h00m00s00"
 //
 void secs_to_hmsf(double secs, char* buf) {
-    int s = secs;
-    int f = (secs - s) * 100.0;
+    int s = (int)secs;
+    int f = (int)((secs - s) * 100.0);
     int h = s / 3600;
     s -= h * 3600;
     int m = s / 60;

--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -108,19 +108,19 @@ void parse_url(const char* url, PARSED_URL& purl) {
 // to be passed in a URL
 
 static char x2c(char *what) {
-    char digit;
+    int digit;
     if (what[0] >= 'A') {
-        digit = (what[0] & 0xdf) - 'A' + (char)10;
+        digit = (what[0] & 0xdf) - 'A' + 10;
     } else {
         digit = what[0] - '0';
     }
     digit *= 16;
     if (what[1] >= 'A') {
-        digit += (what[1] & 0xdf) - 'A' + (char)10;
+        digit += (what[1] & 0xdf) - 'A' + 10;
     } else {
         digit += what[1] - '0';
     }
-    return digit;
+    return (char)digit;
 }
 
 // size not really needed since unescaping can only shrink

--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -90,7 +90,7 @@ void parse_url(const char* url, PARSED_URL& purl) {
     //
     p = strchr(buf,':');
     if (p) {
-        purl.port = atol(p+1);
+        purl.port = (int)atol(p+1);
         *p = 0;
     } else {
         // CMC note:  if they didn't pass in a port #,
@@ -109,9 +109,9 @@ void parse_url(const char* url, PARSED_URL& purl) {
 
 static char x2c(char *what) {
     char digit;
-    digit = (what[0] >= 'A' ? ((what[0] & 0xdf) - 'A')+10 : (what[0] - '0'));
+    digit = (char)(what[0] >= 'A' ? ((what[0] & 0xdf) - 'A')+10 : (what[0] - '0'));
     digit *= 16;
-    digit += (what[1] >= 'A' ? ((what[1] & 0xdf) - 'A')+10 : (what[1] - '0'));
+    digit += (char)(what[1] >= 'A' ? ((what[1] & 0xdf) - 'A')+10 : (what[1] - '0'));
     return digit;
 }
 
@@ -142,8 +142,8 @@ static void c2x(unsigned char num, char* buf) {
     char d2 = num % 16;
     int abase1 = (d1 < 10) ? 48 : 55;
     int abase2 = (d2 < 10) ? 48 : 55;
-    buf[0] = d1 + abase1;
-    buf[1] = d2 + abase2;
+    buf[0] = d1 + (char)abase1;
+    buf[1] = d2 + (char)abase2;
     buf[2] = 0;
 }
 
@@ -231,7 +231,7 @@ void canonicalize_master_url(char* url, int len) {
     for (size_t i=0; i<n-1; i++) {
         // stop converting to lower-case, if we've reached the boundary of the domain name
         if (buf[i] == '/') break;
-        buf[i] = tolower(static_cast<unsigned char>(buf[i]));
+        buf[i] = (char)tolower(static_cast<unsigned char>(buf[i]));
     }
     snprintf(url, len, "http%s://%s", (bSSL ? "s" : ""), buf);
     url[len-1] = 0;

--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -109,9 +109,17 @@ void parse_url(const char* url, PARSED_URL& purl) {
 
 static char x2c(char *what) {
     char digit;
-    digit = (char)(what[0] >= 'A' ? ((what[0] & 0xdf) - 'A')+10 : (what[0] - '0'));
+    if (what[0] >= 'A') {
+        digit = (what[0] & 0xdf) - 'A' + (char)10;
+    } else {
+        digit = what[0] - '0';
+    }
     digit *= 16;
-    digit += (char)(what[1] >= 'A' ? ((what[1] & 0xdf) - 'A')+10 : (what[1] - '0'));
+    if (what[1] >= 'A') {
+        digit += (what[1] & 0xdf) - 'A' + (char)10;
+    } else {
+        digit += what[1] - '0';
+    }
     return digit;
 }
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -751,7 +751,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
 #ifdef _WIN32
     string output;
 
-    sprintf(buf, "%s %s; echo EOM\n", cli_prog, cmd);
+    snprintf(buf, sizeof(buf), "%s %s; echo EOM\n", cli_prog, cmd);
     write_to_pipe(ctl_wc.in_write, buf);
     retval = read_from_pipe(
         ctl_wc.out_read, ctl_wc.proc_handle, output, CMD_TIMEOUT, "EOM"
@@ -762,7 +762,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     }
     out = split(output, '\n');
 #else
-    sprintf(buf, "%s %s\n", cli_prog, cmd);
+    snprintf(buf, sizeof(buf), "%s %s\n", cli_prog, cmd);
     retval = run_command(buf, out);
     if (retval) {
         if (verbose) {
@@ -847,7 +847,7 @@ string docker_container_name(
     safe_strcpy(result_buf, result_name);
     downcase_string(result_buf);
 
-    sprintf(buf, "boinc__%s__%s", url_buf, result_buf);
+    snprintf(buf, sizeof(buf), "boinc__%s__%s", url_buf, result_buf);
     return string(buf);
 }
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -96,7 +96,7 @@ double dtime() {
 #else
     struct timeval tv;
     gettimeofday(&tv, 0);
-    return tv.tv_sec + (tv.tv_usec/1.e6);
+    return (double)tv.tv_sec + ((double)tv.tv_usec/1.e6);
 #endif
 #endif
 }
@@ -830,7 +830,7 @@ string docker_image_name(
     safe_strcpy(wu_buf, wu_name);
     downcase_string(wu_buf);
 
-    sprintf(buf, "boinc__%s__%s", url_buf, wu_buf);
+    snprintf(buf, sizeof(buf), "boinc__%s__%s", url_buf, wu_buf);
     return string(buf);
 }
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -820,10 +820,8 @@ int DOCKER_CONN::parse_container_name(string line, string &name) {
 // - unique per WU (hence projurl__wuname)
 // - lowercase (required by Docker)
 //
-string docker_image_name(
-    const char* proj_url_esc, const char* wu_name
-) {
-    char buf[1024], url_buf[1024], wu_buf[1024];
+string docker_image_name(const char* proj_url_esc, const char* wu_name) {
+    char buf[2048], url_buf[512], wu_buf[512];
 
     safe_strcpy(url_buf, proj_url_esc);
     downcase_string(url_buf);
@@ -840,7 +838,7 @@ string docker_image_name(
 string docker_container_name(
     const char* proj_url_esc, const char* result_name
 ){
-    char buf[1024], url_buf[1024], result_buf[1024];
+    char buf[2048], url_buf[512], result_buf[512];
 
     safe_strcpy(url_buf, proj_url_esc);
     downcase_string(url_buf);


### PR DESCRIPTION
In lib/, fix warnings with Linux g++ version 11.4.0, using the compiler options listed here:
https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html

(except for the RSA deprecation warnings, which appear even with -Wno-deprecated)

Note: it's pretty much all type casting.
In many cases this could also be eliminated by using the right types in the first place,
e.g. size_t instead of int in various places.