### PR TITLE
web: web-based job submission changes

### DIFF
--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -194,17 +194,7 @@ function sample_navbar(
                 $x[] = ["File sandbox", "sandbox.php"];
                 $x[] = ["Submit jobs", $url_prefix."submit.php"];
                 $x[] = ["Job status", $url_prefix."submit.php?action=status"];
-                $is_admin = $user_submit->manage_all;
-                if (!$is_admin) {
-                    $usas = BoincUserSubmitApp::enum("user_id=$user->id");
-                    foreach ($usas as $usa) {
-                        if ($usa->manage) {
-                            $is_admin = true;
-                            break;
-                        }
-                    }
-                }
-                if ($is_admin) {
+                if ($user_submit->manage_all) {
                     $x[] = ["Administer", $url_prefix."submit.php?action=admin"];
                 }
                 navbar_menu(tra("Job submission"), $x);
@@ -387,7 +377,8 @@ function form_input_textarea($label, $name, $value='', $nrows=4) {
     );
 }
 
-// $items is either a string of <option> elements, or an array
+// $items is either a string of <option> elements,
+// or an array of [value, name] pairs
 //
 function form_select($label, $name, $items, $selected=null) {
     echo sprintf('
@@ -542,7 +533,7 @@ function form_checkbox($label, $name, $checked=false) {
     );
 }
 
-// 'select2' is replacement for select boxed:
+// 'select2' is replacement for multiple select with a nicer UI:
 // https://github.com/select2/select2
 //
 // To use it you must use this version of page_head():
@@ -562,7 +553,7 @@ function page_head_select2($title) {
 }
 
 // show a multi-select using select2.
-// $items is a list of [val, label] pairs;
+// $items is a list of [value, name] pairs;
 // $selected is the list of selected values.
 // $extra is e.g. id=foo
 //

--- a/html/inc/buda.inc
+++ b/html/inc/buda.inc
@@ -1,0 +1,35 @@
+<?php
+
+$buda_root = "../../buda_apps";
+
+function get_buda_apps() {
+    global $buda_root;
+    $apps = [];
+    $x = scandir($buda_root);
+    foreach ($x as $app) {
+        if ($app[0] == '.') continue;
+        if (!is_dir("$buda_root/$app")) continue;
+        $apps[] = $app;
+    }
+    return $apps;
+}
+
+function get_buda_variants($app_name) {
+    global $buda_root;
+    $x = [];
+    $pcs = scandir("$buda_root/$app_name");
+    foreach ($pcs as $pc) {
+        if ($pc[0] == '.') continue;
+        if ($pc == 'desc.json') continue;
+        $x[] = $pc;
+    }
+    return $x;
+}
+
+function get_buda_desc($app) {
+    global $buda_root;
+    $path = "$buda_root/$app/desc.json";
+    return json_decode(file_get_contents($path));
+}
+
+?>

--- a/html/inc/keywords.inc
+++ b/html/inc/keywords.inc
@@ -303,4 +303,54 @@ keyword('KW_AMERICAS', KW_CATEGORY_LOC, 0, 0,
         keyword('KW_UND', KW_CATEGORY_LOC, 2, KW_US,
             'University of North Dakota'
         );
+
+// return a list of [value, name] pairs for the given category
+//
+function keyword_select_options($category) {
+    global $job_keywords;
+    $opts = [];
+    kw_children();
+    foreach ($job_keywords as $id=>$k) {
+        if ($k->category != $category) continue;
+        if ($k->parent) continue;
+        $opts = array_merge($opts, kw_options($id));
+    }
+    return $opts;
+}
+
+function kw_children() {
+    global $job_keywords;
+    foreach ($job_keywords as $id=>$k) {
+        $job_keywords[$id]->children = array();
+        $job_keywords[$id]->expand = 0;
+    }
+    foreach ($job_keywords as $id=>$k) {
+        if (!$k->parent) continue;
+        $job_keywords[$k->parent]->children[] = $id;
+    }
+}
+
+function kw_options($id, $indent='') {
+    global $job_keywords;
+    $kw = $job_keywords[$id];
+    $opts = [[$id, "$indent$kw->name"]];
+    $indent .= '&nbsp;&nbsp;&nbsp;&nbsp;';
+    foreach ($kw->children as $k) {
+        $opts = array_merge($opts, kw_options($k, $indent));
+    }
+    return $opts;
+}
+
+function kw_id_to_name($id) {
+    global $job_keywords;
+    $kw = $job_keywords[$id];
+    return $kw->name;
+}
+
+function kw_array_to_str($kws) {
+    $x = array_map('strval', $kws);
+    $x = array_map('kw_id_to_name', $x);
+    return implode('<br>', $x);
+}
+
 ?>

--- a/html/user/show_apps.php
+++ b/html/user/show_apps.php
@@ -1,0 +1,53 @@
+<?php
+
+require_once('../inc/util.inc');
+require_once('../inc/buda.inc');
+require_once('../inc/keywords.inc');
+require_once('../project/remote_apps.inc');
+
+function show_buda_apps() {
+    $apps = get_buda_apps();
+    foreach ($apps as $app) {
+        $desc = get_buda_desc($app);
+        table_row(
+            $desc->long_name,
+            $desc->description,
+            empty($desc->url)?'':"<a href=$desc->url>View</a>",
+            kw_array_to_str($desc->sci_kw)
+        );
+    }
+}
+
+function main() {
+    global $remote_apps;
+    page_head("Apps");
+    echo sprintf('%s distributes jobs for the following applications:<p>', PROJECT);
+    start_table('table-striped');
+    table_header(
+        'Name',
+        'Description',
+        'Web page',
+        'Science keywords'
+    );
+    foreach ($remote_apps as $category => $apps) {
+        if (strstr($category, 'Docker')) {
+            show_buda_apps();
+        } else {
+            foreach ($apps as $app) {
+                table_row(
+                    $app->long_name,
+                    $app->description,
+                    "<a href=$app->url>View</a>",
+                    kw_array_to_str($app->sci_kw)
+                );
+            }
+            echo '</ul>';
+        }
+    }
+    end_table();
+    page_tail();
+}
+
+main();
+
+?>


### PR DESCRIPTION
General goal: provide volunteers with more information about apps, in particular BUDA science apps.

Terminology: 'remote apps' are those for which jobs are submitted via web RPCs, or web forms, or both.
We use user-level permissions for these apps.

- If a project has remote apps, it must create a PHP file html/project/remote_apps.inc
that creates a data structure $remote_apps describing these apps. In the case of non-BUDA apps, these include
long name, description text, URL, and science keywords. (This replaces $web_apps, which was in project.inc)

- BUDA apps now have a JSON description file containing
    - short and long names
    - description
    - science keywords
    - URL of a page describing the app
    - user ID of creator
    - create time

- Added web interface for creating/editing the above

- A new page 'show_apps.php' shows remote apps and BUDA apps, including the above details.

TODO in a later PR: get info for job submitters,
including location keywords and what apps they can submit to