### PR TITLE
library interfaces: remove dependency on config.h

### DIFF
--- a/client/client_msgs.h
+++ b/client/client_msgs.h
@@ -45,7 +45,7 @@ struct MESSAGE_DESC {
 struct MESSAGE_DESCS {
     std::deque<MESSAGE_DESC*> msgs;
     void insert(PROJ_AM *p, int priority, int now, char* msg);
-    void write(int seqno, class MIOFILE&, bool translatable);
+    void write(int seqno, MIOFILE&, bool translatable);
     int highest_seqno();
     void cleanup();
 };

--- a/client/hostinfo_linux.cpp
+++ b/client/hostinfo_linux.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include "str_replace.h"
+#include "str_util.h"
 #include "util.h"
 
 #include "hostinfo.h"

--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -28,6 +28,7 @@
 #include "miofile.h"
 #include "parse.h"
 #include "str_util.h"
+#include "str_replace.h"
 #include "url.h"
 #include "util.h"
 

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -29,8 +29,10 @@
 #ifndef BOINC_COMMON_DEFS_H
 #define BOINC_COMMON_DEFS_H
 
-#include "miofile.h"
-#include "parse.h"
+#include <string.h>
+
+class MIOFILE;
+class XML_PARSER;
 
 #define GUI_RPC_PORT 31416
     // for TCP connection

--- a/lib/common_defs.h
+++ b/lib/common_defs.h
@@ -31,8 +31,8 @@
 
 #include <string.h>
 
-class MIOFILE;
-class XML_PARSER;
+struct MIOFILE;
+struct XML_PARSER;
 
 #define GUI_RPC_PORT 31416
     // for TCP connection

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -80,11 +80,13 @@
 #include "boinc_stdio.h"
 #include "miofile.h"
 #include "error_numbers.h"
-#include "parse.h"
 #include "cal_boinc.h"
 #include "cl_boinc.h"
 #include "opencl_boinc.h"
 #include "common_defs.h"
+
+class MIOFILE;
+class XML_PARSER;
 
 #define MAX_COPROC_INSTANCES 64
 #define MAX_RSC 8

--- a/lib/coproc.h
+++ b/lib/coproc.h
@@ -85,8 +85,8 @@
 #include "opencl_boinc.h"
 #include "common_defs.h"
 
-class MIOFILE;
-class XML_PARSER;
+struct MIOFILE;
+struct XML_PARSER;
 
 #define MAX_COPROC_INSTANCES 64
 #define MAX_RSC 8

--- a/lib/miofile.h
+++ b/lib/miofile.h
@@ -40,7 +40,7 @@
 // Why is this here?  Because on Windows (9x, maybe all)
 // you can't do fdopen() on a socket.
 
-class MIOFILE {
+struct MIOFILE {
     MFILE* mf;
     char* wbuf;
     int len;

--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -20,8 +20,8 @@
 
 #include "cl_boinc.h"
 
-class MIOFILE;
-class XML_PARSER;
+struct MIOFILE;
+struct XML_PARSER;
 
 #define MAX_OPENCL_PLATFORMS 16
 #define MAX_OPENCL_CPU_PLATFORMS 4

--- a/lib/opencl_boinc.h
+++ b/lib/opencl_boinc.h
@@ -19,9 +19,9 @@
 #define BOINC_OPENCL_BOINC_H
 
 #include "cl_boinc.h"
-#include "common_defs.h"
-#include "miofile.h"
-#include "parse.h"
+
+class MIOFILE;
+class XML_PARSER;
 
 #define MAX_OPENCL_PLATFORMS 16
 #define MAX_OPENCL_CPU_PLATFORMS 4

--- a/lib/proxy_info.h
+++ b/lib/proxy_info.h
@@ -19,7 +19,7 @@
 #define BOINC_PROXY_INFO_H
 
 struct XML_PARSER;
-class MIOFILE;
+struct MIOFILE;
 
 // info on whether HTTP requests need to go through a proxy
 //

--- a/lib/str_util.h
+++ b/lib/str_util.h
@@ -22,8 +22,6 @@
 #include <vector>
 #include <string.h>
 
-#include "str_replace.h"
-
 #define safe_strcpy(x, y) strlcpy(x, y, sizeof(x))
 #define safe_strcat(x, y) strlcat(x, y, sizeof(x))
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -63,6 +63,7 @@ extern "C" {
 #include "miofile.h"
 #include "parse.h"
 #include "hostinfo.h"
+#include "str_replace.h"
 #include "util.h"
 
 using std::min;

--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -20,6 +20,7 @@
 #include "boinc_win.h"
 
 #include "diagnostics.h"
+#include "error_numbers.h"
 #include "util.h"
 #include "filesys.h"
 #include "str_replace.h"

--- a/tests/unit-tests/lib/test_parse.cpp
+++ b/tests/unit-tests/lib/test_parse.cpp
@@ -18,6 +18,8 @@
 #include "gtest/gtest.h"
 #include "common_defs.h"
 #include "url.h"
+#include "parse.h"
+
 #include <string>
 #include <ios>
 

--- a/tests/unit-tests/lib/test_str_util.cpp
+++ b/tests/unit-tests/lib/test_str_util.cpp
@@ -18,6 +18,8 @@
 #include "gtest/gtest.h"
 #include "common_defs.h"
 #include "str_util.h"
+#include "error_numbers.h"
+
 #include <string>
 #include <ios>
 


### PR DESCRIPTION
We need to be able to compile with libboinc and libboinc_api without needing config.h.

To do this: avoid having .h files include other .h files
(in particular, avoid chains of includes that lead to str_replace.h,
which is what needs config.h).

Fixes #6271
