### PR TITLE
 Various BUDA-related bugs and enhancements

### DIFF
--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -797,7 +797,11 @@ void RESOURCE_USAGE::clear() {
     missing_coproc_name[0] = 0;
 }
 
-void RESOURCE_USAGE::check_gpu(char* plan_class) {
+// see if we have the GPU libraries (OpenCL/CUDA/CAL)
+// required by the plan class.
+// If not, set missing_coproc
+//
+void RESOURCE_USAGE::check_gpu_libs(char* plan_class) {
     int rt = rsc_type;
     if (!rt) return;
     if (strstr(plan_class, "opencl")) {
@@ -824,6 +828,41 @@ void RESOURCE_USAGE::check_gpu(char* plan_class) {
             missing_coproc = true;
             safe_strcpy(missing_coproc_name, coprocs.coprocs[rt].type);
         }
+    }
+}
+
+void RESOURCE_USAGE::write(MIOFILE& out) {
+    out.printf(
+        "    <avg_ncpus>%f</avg_ncpus>\n"
+        "    <flops>%f</flops>\n",
+        avg_ncpus,
+        flops
+    );
+    if (rsc_type) {
+        out.printf(
+            "    <coproc>\n"
+            "        <type>%s</type>\n"
+            "        <count>%f</count>\n"
+            "    </coproc>\n",
+            rsc_name(rsc_type),
+            coproc_usage
+        );
+    }
+    if (missing_coproc && strlen(missing_coproc_name)) {
+        out.printf(
+            "    <coproc>\n"
+            "        <type>%s</type>\n"
+            "        <count>%f</count>\n"
+            "    </coproc>\n",
+            missing_coproc_name,
+            coproc_usage
+        );
+    }
+    if (gpu_ram) {
+        out.printf(
+            "    <gpu_ram>%f</gpu_ram>\n",
+            gpu_ram
+        );
     }
 }
 
@@ -858,7 +897,7 @@ int APP_VERSION::parse(XML_PARSER& xp) {
     init();
     while (!xp.get_tag()) {
         if (xp.match_tag("/app_version")) {
-            resource_usage.check_gpu(plan_class);
+            resource_usage.check_gpu_libs(plan_class);
             if (resource_usage.rsc_type || is_wrapper) {
                 dont_throttle = true;
             }
@@ -944,14 +983,10 @@ int APP_VERSION::write(MIOFILE& out, bool write_file_info) {
         "<app_version>\n"
         "    <app_name>%s</app_name>\n"
         "    <version_num>%d</version_num>\n"
-        "    <platform>%s</platform>\n"
-        "    <avg_ncpus>%f</avg_ncpus>\n"
-        "    <flops>%f</flops>\n",
+        "    <platform>%s</platform>\n",
         app_name,
         version_num,
-        platform,
-        resource_usage.avg_ncpus,
-        resource_usage.flops
+        platform
     );
     if (strlen(plan_class)) {
         out.printf("    <plan_class>%s</plan_class>\n", plan_class);
@@ -971,32 +1006,7 @@ int APP_VERSION::write(MIOFILE& out, bool write_file_info) {
             if (retval) return retval;
         }
     }
-    if (resource_usage.rsc_type) {
-        out.printf(
-            "    <coproc>\n"
-            "        <type>%s</type>\n"
-            "        <count>%f</count>\n"
-            "    </coproc>\n",
-            rsc_name(resource_usage.rsc_type),
-            resource_usage.coproc_usage
-        );
-    }
-    if (resource_usage.missing_coproc && strlen(resource_usage.missing_coproc_name)) {
-        out.printf(
-            "    <coproc>\n"
-            "        <type>%s</type>\n"
-            "        <count>%f</count>\n"
-            "    </coproc>\n",
-            resource_usage.missing_coproc_name,
-            resource_usage.coproc_usage
-        );
-    }
-    if (resource_usage.gpu_ram) {
-        out.printf(
-            "    <gpu_ram>%f</gpu_ram>\n",
-            resource_usage.gpu_ram
-        );
-    }
+    resource_usage.write(out);
     if (dont_throttle) {
         out.printf(
             "    <dont_throttle/>\n"
@@ -1172,7 +1182,7 @@ int WORKUNIT::parse(XML_PARSER& xp) {
                 || resource_usage.rsc_type!=0
                 || resource_usage.missing_coproc;
             if (has_resource_usage) {
-                resource_usage.check_gpu(plan_class);
+                resource_usage.check_gpu_libs(plan_class);
             }
             return 0;
         }
@@ -1203,6 +1213,7 @@ int WORKUNIT::parse(XML_PARSER& xp) {
             continue;
         }
         if (xp.parse_str("plan_class", plan_class, sizeof(plan_class))) continue;
+        if (xp.parse_str("sub_appname", sub_appname, sizeof(sub_appname))) continue;
         if (xp.parse_double("avg_ncpus", resource_usage.avg_ncpus)) continue;
         if (xp.parse_double("flops", dtemp)) {
             if (dtemp <= 0) {
@@ -1286,6 +1297,13 @@ int WORKUNIT::write(MIOFILE& out, bool gui) {
     for (i=0; i<input_files.size(); i++) {
         input_files[i].write(out);
     }
+    if (strlen(sub_appname)) {
+        out.printf(
+            "    <sub_appname>%s</sub_appname>\n",
+            sub_appname
+        );
+    }
+    resource_usage.write(out);
 
     if (!job_keyword_ids.empty()) {
         if (gui) {

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -330,7 +330,8 @@ struct RESOURCE_USAGE {
     char missing_coproc_name[256];
 
     void clear();
-    void check_gpu(char* plan_class);
+    void check_gpu_libs(char* plan_class);
+    void write(MIOFILE&);
 };
 
 // if you add anything, initialize it in init()
@@ -407,10 +408,14 @@ struct WORKUNIT {
     int version_num;
         // Deprecated, but need to keep around to let people revert
         // to versions before multi-platform support
-    bool has_resource_usage;
+
+    // the following for BUDA jobs
+    char sub_appname[256];
     char plan_class[256];
-        // for BUDA jobs, the BUDA variant
+        // the BUDA variant
+    bool has_resource_usage;
     RESOURCE_USAGE resource_usage;
+
     std::string command_line;
     std::vector<FILE_REF> input_files;
     PROJECT* project;
@@ -423,10 +428,11 @@ struct WORKUNIT {
     JOB_KEYWORD_IDS job_keyword_ids;
 
     WORKUNIT(){
-        safe_strcpy(name, "");
-        safe_strcpy(app_name, "");
+        name[0] = 0;
+        app_name[0] = 0;
         version_num = 0;
         has_resource_usage = false;
+        sub_appname[0] = 0;
         plan_class[0] = 0;
         resource_usage.clear();
         command_line.clear();

--- a/clientgui/ViewWork.cpp
+++ b/clientgui/ViewWork.cpp
@@ -1253,6 +1253,12 @@ void CViewWork::GetDocApplicationName(wxInt32 item, wxString& strBuffer) const {
         if (!state_result) return;
         WORKUNIT* wup = state_result->wup;
         if (!wup) return;
+
+        if (strlen(wup->sub_appname)) {
+            strBuffer = HtmlEntityDecode(wxString(wup->sub_appname, wxConvUTF8));
+            return;
+        }
+
         APP* app = wup->app;
         if (!app) return;
         APP_VERSION* avp = state_result->avp;

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -233,6 +233,7 @@ struct APP_VERSION {
 struct WORKUNIT {
     char name[256];
     char app_name[256];
+    char sub_appname[256];
     int version_num;    // backwards compat
     double rsc_fpops_est;
     double rsc_fpops_bound;

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -606,6 +606,7 @@ int WORKUNIT::parse(XML_PARSER& xp) {
         if (xp.match_tag("/workunit")) return 0;
         if (xp.parse_str("name", name, sizeof(name))) continue;
         if (xp.parse_str("app_name", app_name, sizeof(app_name))) continue;
+        if (xp.parse_str("sub_appname", sub_appname, sizeof(sub_appname))) continue;
         if (xp.parse_int("version_num", version_num)) continue;
         if (xp.parse_double("rsc_fpops_est", rsc_fpops_est)) continue;
         if (xp.parse_double("rsc_fpops_bound", rsc_fpops_bound)) continue;
@@ -620,8 +621,9 @@ int WORKUNIT::parse(XML_PARSER& xp) {
 }
 
 void WORKUNIT::clear() {
-    safe_strcpy(name, "");
-    safe_strcpy(app_name, "");
+    name[0] = 0;
+    app_name[0] = 0;
+    sub_appname[0] = 0;
     version_num = 0;
     rsc_fpops_est = 0;
     rsc_fpops_bound = 0;

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -375,8 +375,13 @@ int create_container() {
     if (retval) return retval;
 
     // on MacOS/podman, you need the full path, not .
+    // Win: use . since full path has :
     //
+#ifdef __APPLE__
     getcwd(cwd, sizeof(cwd));
+#else
+    strcpy(cwd, ".");
+#endif
     snprintf(slot_cmd, sizeof(slot_cmd), " -v %s:%s", cwd, config.workdir.c_str());
     if (config.project_dir_mount.empty()) {
         project_cmd[0] = 0;

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -15,7 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// functions called from backend programs (scheduler, transitioner etc.)
+// functions called from create_work
+// and backend programs (scheduler, transitioner etc.)
 // to create result records and other utilities
 
 #include "config.h"

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -15,6 +15,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// functions called from backend programs (scheduler, transitioner etc.)
+// to create result records and other utilities
+
 #include "config.h"
 #include "boinc_stdio.h"
 #include <cstdlib>
@@ -27,7 +30,6 @@
 #include <cmath>
 #include <sys/types.h>
 #include <sys/stat.h>
-
 
 #include "boinc_db.h"
 #include "common_defs.h"

--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -481,10 +481,23 @@ int main(int argc, char** argv) {
                 jd2.create();
             }
         } else {
+            // stdin mode, unassigned.
+            // for max efficiency, do them all in one big SQL query
+            //
             string values;
             DB_WORKUNIT wu;
             int _argc;
             char* _argv[100], value_buf[MAX_QUERY_LEN];
+
+            char sub_appname_buf[256];
+            sub_appname_buf[0] = 0;
+            if (strlen(jd.sub_appname)) {
+                snprintf(sub_appname_buf, sizeof(sub_appname_buf),
+                    "   <sub_appname>%s</sub_appname>",
+                    jd.sub_appname
+                );
+            }
+
             for (int j=0; ; j++) {
                 char* p = fgets(buf, sizeof(buf), stdin);
                 if (p == NULL) break;
@@ -520,7 +533,7 @@ int main(int argc, char** argv) {
                     jd2.infiles,
                     config,
                     jd2.command_line,
-                    NULL,
+                    sub_appname_buf,
                     value_buf
                 );
                 if (retval) {


### PR DESCRIPTION
- client: include resource_usage in  WORKUNIT::write()
- docker_wrapper: on Mac need to use full paths for mounts.
    But on Win, full path includes :, which breaks the -v command!
    So use . for current dir
- client: add sub_appname to WORKUNIT.
    This is the BUDA app long name.
- create_work: add --sub_appname arg; adds it to the <workunit>
- buda_submit.php: pass --sub_appname to create_work
- Manager: if job has sub_appname, show it
- create_work: handle sub_appname correctly
