### PR TITLE
Replace egrep

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ AC_SUBST(REV)
 AC_SUBST(RDATE)
 
 dnl Are we compiling for windows
-if echo $host_os | egrep '^mingw|^winnt' > /dev/null ; then
+if echo $host_os | grep -E '^mingw|^winnt' > /dev/null ; then
   isWIN32=yes
 else
   isWIN32=no
@@ -1123,7 +1123,7 @@ fi
 AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep '^linux' > /dev/null])
 AM_CONDITIONAL(OS_FREEBSD, [echo $host_os | grep '^freebsd' > /dev/null])
 dnl In case anyone wants to try building the windows code using mingw!
-AM_CONDITIONAL(OS_WIN32, [echo $host_os | egrep '^mingw|^winnt' > /dev/null])
+AM_CONDITIONAL(OS_WIN32, [echo $host_os | grep -E '^mingw|^winnt' > /dev/null])
 AM_CONDITIONAL(OS_WIN32_MINGW, [echo $host_os | grep '^mingw' > /dev/null])
 dnl or OS2
 AM_CONDITIONAL(OS_OS2, [echo $host_os | grep '^os2' > /dev/null])

--- a/m4/ax_check_glut.m4
+++ b/m4/ax_check_glut.m4
@@ -21,7 +21,7 @@ else
   #
   # If were running under windows assume we need GDI32 and WinMM
   #
-  if echo $host_os | egrep '^mingw|^winnt' > /dev/null ; then
+  if echo $host_os | grep -E '^mingw|^winnt' > /dev/null ; then
     GLUT_LIBS="${GLUT_LIBS} -lgdi32 -lwinmm"
   fi
 

--- a/m4/boinc_gtk.m4
+++ b/m4/boinc_gtk.m4
@@ -8,7 +8,7 @@ AC_DEFUN([BOINC_CHECK_GTK],[
     AC_MSG_RESULT(yes)
     AC_PATH_PROG(PKGCONFIG,[$mypkgconfig pkg-config])
     AC_MSG_CHECKING([if gtk uses pkg-config])
-    gtk_module="`$PKGCONFIG --list-all | egrep '^gtk\+?-' | head -1 | awk '{print $[]1}'`"
+    gtk_module="`$PKGCONFIG --list-all | grep -E '^gtk\+?-' | head -1 | awk '{print $[]1}'`"
     if test "x${gtk_module}" != x; then
       GTK_CONFIG="$PKGCONFIG ${gtk_module}"
       AC_MSG_RESULT([yes])

--- a/samples/nvcuda/common.mk
+++ b/samples/nvcuda/common.mk
@@ -16,7 +16,7 @@ OSLOWER = $(shell uname -s 2>/dev/null | tr [:upper:] [:lower:])
 # 'linux' is output for Linux system, 'darwin' for OS X
 DARWIN = $(strip $(findstring DARWIN, $(OSUPPER)))
 ifneq ($(DARWIN),)
-   SNOWLEOPARD = $(strip $(findstring 10.6, $(shell egrep "<string>10\.6" /System/Library/CoreServices/SystemVersion.plist)))
+   SNOWLEOPARD = $(strip $(findstring 10.6, $(shell grep -E "<string>10\.6" /System/Library/CoreServices/SystemVersion.plist)))
 endif
 
 # detect 32-bit or 64-bit platform
@@ -441,8 +441,8 @@ makedirectories:
 
 
 tidy :
-	$(VERBOSE)find . | egrep "#" | xargs rm -f
-	$(VERBOSE)find . | egrep "\~" | xargs rm -f
+	$(VERBOSE)find . | grep -E "#" | xargs rm -f
+	$(VERBOSE)find . | grep -E "\~" | xargs rm -f
 
 clean : tidy
 	$(VERBOSE)rm -f $(OBJS)

--- a/samples/nvcuda/common_mac.mk
+++ b/samples/nvcuda/common_mac.mk
@@ -16,7 +16,7 @@ OSLOWER = $(shell uname -s 2>/dev/null | tr [:upper:] [:lower:])
 # 'linux' is output for Linux system, 'darwin' for OS X
 DARWIN = $(strip $(findstring DARWIN, $(OSUPPER)))
 ifneq ($(DARWIN),)
-   SNOWLEOPARD = $(strip $(findstring 10.6, $(shell egrep "<string>10\.6" /System/Library/CoreServices/SystemVersion.plist)))
+   SNOWLEOPARD = $(strip $(findstring 10.6, $(shell grep -E "<string>10\.6" /System/Library/CoreServices/SystemVersion.plist)))
 endif
 
 # detect 32-bit or 64-bit platform

--- a/tools/check_project
+++ b/tools/check_project
@@ -66,7 +66,7 @@ def determineapacheuser(user):
       print("WARNING: Script could not determine which user runs apache Web server. Aborting")
       print("         You should specify the apache user with the -a/--apache_user flag")
       print("         Try running the following command with apache Web server running:")
-      print("           ps -ef | egrep '(httpd|apache2|apache)' | grep -v `whoami` | grep -v root")
+      print("           ps -ef | grep -E '(httpd|apache2|apache)' | grep -v `whoami` | grep -v root")
       sys.exit(1)
    else:
       check_user(user)

--- a/tools/update_versions
+++ b/tools/update_versions
@@ -209,7 +209,7 @@ function get_api_version($a, $v, $p, $fds) {
     foreach ($fds as $fd) {
         if ($fd->main_program) {
             $path = "apps/$a/$v/$p/$fd->physical_name";
-            $handle = popen("strings $path | egrep --max-count=1 'API_VERSION_[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'", "r");
+            $handle = popen("strings $path | grep -E --max-count=1 'API_VERSION_[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$'", "r");
             $x = fread($handle, 8192);
             pclose($handle);
             $x = strstr($x, "API_VERSION_");

--- a/tools/update_versions_v6
+++ b/tools/update_versions_v6
@@ -39,7 +39,7 @@ def xlistdir(dir):
 
 def get_api_version(exec_file):
     tmpfile = '.uvtemp'
-    cmd = "strings %s | egrep '^API_VERSION_[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' > %s"%(exec_file, tmpfile)
+    cmd = "strings %s | grep -E '^API_VERSION_[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' > %s"%(exec_file, tmpfile)
     os.system(cmd)
     f = open(tmpfile, 'r')
     if (f):


### PR DESCRIPTION
The build process prints a couple of warnings like this:
`egrep: warning: egrep is obsolescent; using grep -E`

Since `egrep` is deprecated for many years it should be replaced by `grep -E`.