### PR TITLE
Various improvements to web-based job submission and app management

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -362,9 +362,11 @@ class BoincResult {
         $db = BoincDb::get();
         return $db->enum('result', 'BoincResult', $where_clause);
     }
-	static function enum_fields($fields, $where_clause, $order_clause) {
+	static function enum_fields($fields, $where_clause, $order_clause=null) {
         $db = BoincDb::get();
-		return $db->enum_fields('result', 'BoincResult', $fields, $where_clause, $order_clause);
+		return $db->enum_fields(
+            'result', 'BoincResult', $fields, $where_clause, $order_clause
+        );
 	}
     function update($clause) {
         $db = BoincDb::get();

--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -195,7 +195,27 @@ function sample_navbar(
                 $x[] = ["Submit jobs", $url_prefix."submit.php"];
                 $x[] = ["Job status", $url_prefix."submit.php?action=status"];
                 if ($user_submit->manage_all) {
-                    $x[] = ["Administer", $url_prefix."submit.php?action=admin"];
+                    $x[] = ["Manage apps", $url_prefix."submit.php?action=admin"];
+                    $x[] = ["Manage permissions", $url_prefix."manage_project.php"];
+                } else {
+                    // if user has manage permissions for apps, show links
+                    $usas = BoincUserSubmitApp::enum("user_id=$user->id");
+                    foreach ($usas as $usa) {
+                        if ($usa->manage) {
+                            $app = BoincApp::lookup_id($usa->app_id);
+                            if ($app->name == 'buda') {
+                                $x[] = [
+                                    'Manage BUDA apps',
+                                    'buda.php'
+                                ];
+                            } else {
+                                $x[] = [
+                                    "Manage $app->name",
+                                    "manage_project.php"
+                                ];
+                            }
+                        }
+                    }
                 }
                 navbar_menu(tra("Job submission"), $x);
             }

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -172,14 +172,13 @@ function get_batch_params($batch, $wus) {
         'workunitid',
         sprintf('batch=%d and server_state=%d',
             $batch->id, RESULT_SERVER_STATE_IN_PROGRESS
-        ),
-        null
+        )
     );
     $wus_in_prog = [];
     foreach ($res_in_prog as $res) {
         $wus_in_prog[$res->workunitid] = true;
     }
-    unset($res_in_progress);
+    unset($res_in_progress);    // does this do anything?
 
     $fp_total = 0;
     $fp_done = 0;

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -82,9 +82,9 @@ function has_submit_access($user, $app_id) {
     return true;
 }
 
-// can user administer given app (or all apps if zero)?
+// can user manage given app (or all apps if zero)?
 //
-function has_admin_access($user, $app_id) {
+function has_manage_access($user, $app_id) {
     $us = BoincUserSubmit::lookup_userid($user->id);
     if (!$us) return false;
     if ($us->manage_all) return true;
@@ -168,15 +168,18 @@ function get_batch_params($batch, $wus) {
     }
 
     // make list of WU IDs with an in-progress result
-    $res_in_prog = BoincResult::enum(
+    $res_in_prog = BoincResult::enum_fields(
+        'workunitid',
         sprintf('batch=%d and server_state=%d',
             $batch->id, RESULT_SERVER_STATE_IN_PROGRESS
-        )
+        ),
+        null
     );
     $wus_in_prog = [];
     foreach ($res_in_prog as $res) {
         $wus_in_prog[$res->workunitid] = true;
     }
+    unset($res_in_progress);
 
     $fp_total = 0;
     $fp_done = 0;

--- a/html/user/manage_app.php
+++ b/html/user/manage_app.php
@@ -16,20 +16,22 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// app-specific management interface
+// app management interface
+//      - deprecate app versions
+//      - 
 
 require_once("../inc/submit_util.inc");
 require_once("../inc/util.inc");
 
 function app_version_form($app) {
-    page_head("Manage app versions");
+    page_head("Manage versions of $app->name");
     echo "
         <form action=manage_app.php>
         <input type=hidden name=action value=app_version_action>
         <input type=hidden name=app_id value=$app->id>
     ";
     $avs = BoincAppVersion::enum("appid=$app->id");
-    start_table();
+    start_table('table-striped');
     table_header("platform", "plan class", "version#", "deprecated");
     foreach ($avs as $av) {
         $platform = BoincPlatform::lookup_id($av->platformid);
@@ -48,7 +50,7 @@ function app_version_form($app) {
         <td><br></td>
         <td><br></td>
         <td><br></td>
-        <td><input class=\"btn btn-default\" type=submit value=Update></td>
+        <td><input class=\"btn\" type=submit value=Update></td>
         </tr>
     ";
     end_table();
@@ -69,58 +71,6 @@ function app_version_action($app) {
                 $av->update("deprecated=0");
             }
         }
-    }
-    page_head("Update successful");
-    echo "
-        <a href=submit.php>Return to job submission page</a>
-    ";
-    page_tail();
-}
-
-function permissions_form($app) {
-    page_head("Manage user permissions for $app->name");
-    echo "
-        <form action=manage_app.php>
-        <input type=hidden name=action value=permissions_action>
-        <input type=hidden name=app_id value=$app->id>
-    ";
-    $busas = BoincUserSubmitApp::enum("app_id=$app->id");
-    start_table();
-    table_header("User", "Allowed to submit jobs to $app->name");
-    foreach ($busas as $busa) {
-        $user = BoincUser::lookup_id($busa->user_id);
-        echo "
-            <tr>
-            <td>$user->name (ID: $user->id)</td>
-            <td><input type=checkbox name=user_$user->id checked></td>
-            </tr>
-        ";
-    }
-    echo "
-        <tr>
-        <td>Add new user</td>
-        <td>User ID: <input name=new_user_id></td>
-        </tr>
-        <tr>
-        <td><br></td>
-        <td><input class=\"btn btn-default\" type=submit value=OK></td>
-        </tr>
-    ";
-    end_table();
-    echo "<form>\n";
-    page_tail();
-}
-
-function permissions_action($app) {
-    $busas = BoincUserSubmitApp::enum("app_id=$app->id");
-    foreach ($busas as $busa) {
-        if (!get_str("user_$busa->user_id", true)) {
-            BoincUserSubmitApp::delete_user($busa->user_id);
-        }
-    }
-    $userid = get_int("new_user_id", true);
-    if ($userid) {
-        BoincUserSubmitApp::insert("(user_id, app_id) values ($userid, $app->id)");
     }
     page_head("Update successful");
     echo "
@@ -199,10 +149,6 @@ case "app_version_form":
     app_version_form($app); break;
 case "app_version_action":
     app_version_action($app); break;
-case "permissions_form":
-    permissions_form($app); break;
-case "permissions_action":
-    permissions_action($app); break;
 case "batches_form":
     batches_form($app); break;
 case "batches_action":

--- a/html/user/manage_app.php
+++ b/html/user/manage_app.php
@@ -18,7 +18,6 @@
 
 // app management interface
 //      - deprecate app versions
-//      - 
 
 require_once("../inc/submit_util.inc");
 require_once("../inc/util.inc");
@@ -79,59 +78,6 @@ function app_version_action($app) {
     page_tail();
 }
 
-function batches_form($app) {
-    page_head("Manage jobs for $app->name");
-    echo "
-        <form action=manage_app.php>
-        <input type=hidden name=action value=batches_action>
-        <input type=hidden name=app_id value=$app->id>
-    ";
-    start_table();
-    table_header("Batch ID", "Submitter", "Submitted", "State", "# jobs", "Abort?");
-    $batches = BoincBatch::enum("app_id=$app->id");
-    foreach ($batches as $batch) {
-        $user = BoincUser::lookup_id($batch->user_id);
-        echo "<tr>
-            <td>$batch->id</td>
-            <td>$user->name</td>
-            <td>".time_str($batch->create_time)."</td>
-            <td>".batch_state_string($batch->state)."
-            <td>$batch->njobs</td>
-            <td><input type=checkbox name=abort_$batch->id></td>
-            </tr>
-        ";
-    }
-    echo "<tr>
-        <td colspan=5>Abort all jobs for $app->name?</td>
-        <td><input type=checkbox name=abort_all></td>
-        </tr>
-    ";
-    echo "<tr>
-        <td><br></td>
-        <td><br></td>
-        <td><br></td>
-        <td><input class=\"btn btn-default\" type=submit value=OK></td>
-        </tr>
-    ";
-    end_table();
-    page_tail();
-}
-
-function batches_action($app) {
-    $batches = BoincBatch::enum("app_id=$app->id");
-    $abort_all = (get_str("abort_all", true));
-    foreach ($batches as $batch) {
-        if ($abort_all || get_str("abort_$batch->id", true)) {
-            abort_batch($batch);
-        }
-    }
-    page_head("Update successful");
-    echo "
-        <a href=submit.php>Return to job submission page</a>
-    ";
-    page_tail();
-}
-
 $user = get_logged_in_user();
 $app_id = get_int("app_id");
 $app = BoincApp::lookup_id($app_id);
@@ -149,10 +95,6 @@ case "app_version_form":
     app_version_form($app); break;
 case "app_version_action":
     app_version_action($app); break;
-case "batches_form":
-    batches_form($app); break;
-case "batches_action":
-    batches_action($app); break;
 default:
     error_page("unknown action");
 }

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -344,7 +344,7 @@ function handle_admin($user) {
         // user can administer all apps
         //
         page_head("Job submission: manage all apps");
-        echo "<li> <a href=submit.php?action=admin_all>View all batches</a>
+        echo "<li> <a href=submit.php?action=admin_all>View/manage all batches</a>
         ";
         $app_names = get_remote_app_names();
         foreach ($app_names as $app_name) {
@@ -353,8 +353,7 @@ function handle_admin($user) {
             echo "
                 <li>$app->user_friendly_name<br>
                 <ul>
-                <li><a href=submit.php?action=admin_app&app_id=$app->id>View batches</a>
-                <li> <a href=manage_app.php?app_id=$app->id&amp;action=batches_form>Manage batches</a>
+                <li><a href=submit.php?action=admin_app&app_id=$app->id>View/manage batches</a>
             ";
             if ($app_name == 'buda') {
                 echo "

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -49,7 +49,7 @@ display_errors();
 define("PAGE_SIZE", 20);
 
 function return_link() {
-    echo "<p><a href=submit.php>Return to job submission page</a>\n";
+    echo "<p><a href=submit.php?action=status>Return to job status page</a>\n";
 }
 
 // get params of in-progress batches; they might not be in progress anymore.
@@ -90,6 +90,8 @@ function show_all_link($batches, $state, $limit, $user, $app) {
     }
 }
 
+// show in-progress batches.
+//
 function show_in_progress($batches, $limit, $user, $app) {
     echo "<h3>Batches in progress</h3>\n";
     $first = true;
@@ -101,32 +103,37 @@ function show_in_progress($batches, $limit, $user, $app) {
         if ($first) {
             $first = false;
             if ($limit) {
-                show_all_link($batches, BATCH_STATE_IN_PROGRESS, $limit, $user, $app);
+                show_all_link(
+                    $batches, BATCH_STATE_IN_PROGRESS, $limit, $user, $app
+                );
             }
-            form_start('');     // for alignment
+            form_start('submit.php');
+            form_input_hidden('action', 'abort_selected');
             start_table('table-striped');
-            table_header(
+            $x = [
                 "Name",
                 "ID",
                 "User",
                 "App",
                 "# jobs",
                 "Progress",
-                "Submitted"
+                "Submitted",
                 //"Logical end time<br><small>Determines priority</small>"
-            );
+            ];
+            row_heading_array($x);
         }
         $pct_done = (int)($batch->fraction_done*100);
-        table_row(
+        $x = [
             "<a href=submit.php?action=query_batch&batch_id=$batch->id>$batch->name</a>",
             "<a href=submit.php?action=query_batch&batch_id=$batch->id>$batch->id</a>",
             $batch->user_name,
             $batch->app_name,
             $batch->njobs,
             "$pct_done%",
-            local_time_str($batch->create_time)
+            local_time_str($batch->create_time),
             //local_time_str($batch->logical_end_time)
-        );
+        ];
+        row_array($x);
     }
     if ($first) {
         echo "<p>None.\n";
@@ -212,8 +219,14 @@ function show_aborted($batches, $limit, $user, $app) {
 // and doing lookup just once.
 //
 function fill_in_app_and_user_names(&$batches) {
+    $apps = [];
     foreach ($batches as $batch) {
-        $app = BoincApp::lookup_id($batch->app_id);
+        if (array_key_exists($batch->app_id, $apps)) {
+            $app = $apps[$batch->app_id];
+        } else {
+            $app = BoincApp::lookup_id($batch->app_id);
+            $apps[$batch->app_id] = $app;
+        }
         if ($app) {
             $batch->app_name = $app->name;
             if ($batch->description) {
@@ -291,6 +304,9 @@ function handle_main($user) {
     page_tail();
 }
 
+// show batches of logged in user.
+// They have manage access to these batches.
+//
 function handle_show_status($user) {
     page_head("Job status");
     $batches = BoincBatch::enum("user_id = $user->id order by id desc");
@@ -324,15 +340,11 @@ function get_remote_app_names() {
 function handle_admin($user) {
     $user_submit = BoincUserSubmit::lookup_userid($user->id);
     if (!$user_submit) error_page('no access');
-    page_head("Administer job submission");
     if ($user_submit->manage_all) {
         // user can administer all apps
         //
-        echo "<li>All applications<br>
-            <ul>
-            <li> <a href=submit.php?action=admin_all>View all batches</a>
-            <li> <a href=manage_project.php>Manage user permissions</a>
-            </ul>
+        page_head("Job submission: manage all apps");
+        echo "<li> <a href=submit.php?action=admin_all>View all batches</a>
         ";
         $app_names = get_remote_app_names();
         foreach ($app_names as $app_name) {
@@ -342,15 +354,25 @@ function handle_admin($user) {
                 <li>$app->user_friendly_name<br>
                 <ul>
                 <li><a href=submit.php?action=admin_app&app_id=$app->id>View batches</a>
-                <li> <a href=manage_app.php?app_id=$app->id&amp;action=app_version_form>Manage app versions</a>
-                <li> <a href=manage_app.php?app_id=$app->id&amp;action=permissions_form>Manage user permissions</a>
                 <li> <a href=manage_app.php?app_id=$app->id&amp;action=batches_form>Manage batches</a>
+            ";
+            if ($app_name == 'buda') {
+                echo "
+                    <li> <a href=buda.php>Manage BUDA apps and variants</a>
+                ";
+            } else {
+                echo "
+                    <li> <a href=manage_app.php?app_id=$app->id&amp;action=app_version_form>Manage app versions</a>
+                ";
+            }
+            echo "
                 </ul>
             ";
         }
     } else {
         // see if user can administer specific apps
         //
+        page_head("Job submission: manage apps");
         $usas = BoincUserSubmitApp::enum("user_id=$user->id");
         foreach ($usas as $usa) {
             $app = BoincApp::lookup_id($usa->app_id);
@@ -372,11 +394,11 @@ function handle_admin_app($user) {
     $app_id = get_int("app_id");
     $app = BoincApp::lookup_id($app_id);
     if (!$app) error_page("no such app");
-    if (!has_admin_access($user, $app_id)) {
+    if (!has_manage_access($user, $app_id)) {
         error_page('no access');
     }
 
-    page_head("Administer batches for $app->user_friendly_name");
+    page_head("Manage batches for $app->user_friendly_name");
     $batches = BoincBatch::enum("app_id = $app_id order by id desc");
     show_batches($batches, PAGE_SIZE, null, $app);
     page_tail();
@@ -394,7 +416,12 @@ function handle_admin_all($user) {
 function handle_batch_stats($user) {
     $batch_id = get_int('batch_id');
     $batch = BoincBatch::lookup_id($batch_id);
-    $results = BoincResult::enum("batch = $batch->id");
+    $results = BoincResult::enum_fields(
+        'peak_working_set_size, peak_swap_size, peak_disk_usage',
+        sprintf('batch = %d and outcome=%d',
+            $batch->id, RESULT_OUTCOME_SUCCESS
+        )
+    );
     page_head("Statistics for batch $batch_id");
     $n = 0;
     $wss_sum = 0;
@@ -404,9 +431,6 @@ function handle_batch_stats($user) {
     $swap_max = 0;
     $disk_max = 0;
     foreach ($results as $r) {
-        if ($r->outcome != RESULT_OUTCOME_SUCCESS) {
-            continue;
-        }
         // pre-7.3.16 clients don't report usage info
         //
         if ($r->peak_working_set_size == 0) {
@@ -484,7 +508,9 @@ function progress_bar($batch, $wus, $width) {
     return $x;
 }
 
-// show the details of an existing batch
+// show the details of an existing batch.
+// $user has access to abort/retire the batch
+// and to get its output files
 //
 function handle_query_batch($user) {
     $batch_id = get_int('batch_id');
@@ -828,7 +854,7 @@ function handle_show_all($user) {
     } else {
         // admin looking at batches
         //
-        if (!has_admin_access($user, $appid)) {
+        if (!has_manage_access($user, $appid)) {
             error_page('no access');
         }
         if ($appid) {

--- a/html/user/submit_example.php
+++ b/html/user/submit_example.php
@@ -30,6 +30,8 @@
 //   When you adapt this to your own purposes,
 //   you can strip out this stuff if the web site doesn't use BOINC
 
+// THIS IS PRETTY MUCH USELESS
+
 require_once("../inc/submit.inc");
 require_once("../inc/common_defs.inc");
 require_once("../inc/submit_db.inc");


### PR DESCRIPTION
- Clarify access-control semantics
    if you have submit access to BUDA, you can submit jobs to any app/variant
    if you have manage access to BUDA, you can edit/create/delete
        apps and variants
    if you have manage access to an app,
        you can view/abort/retire batches for that app
        (even if they belong to someone else)
- Divide BUDA functions accordingly;
    management functions are under the 'Manage apps' navbar item,
    submission functions are under 'Submit jobs'
    Don't mix the two.
    Note: users without manage permissions can see app/variant details
        but they don't get the edit/add/remove controls
- Change the default 'Job submission' menu to show
    'Manage apps' if use has any manage access
    'Manage permissions' if user has manage_all access
        (grant/revoke permissions to other users)
- When showing lists of batches, don't enumerate their full results;
    just get result.workunitid.
    This prevents PHP running out of memory.
- Similar when showing usage statistics for a batch
- BUDA: add max turnaround time to variants
- Permission management form:
    you can multi-select apps to give manage permission for
