### PR TITLE
web: job submission enhancements

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -411,6 +411,10 @@ class BoincWorkunit {
         $db = BoincDb::get();
         return $db->enum('workunit', 'BoincWorkunit', $where_clause);
     }
+    static function enum_fields($fields, $where_clause, $order_clause=null) {
+        $db = BoincDb::get();
+        return $db->enum_fields('workunit', 'BoincWorkunit', $fields, $where_clause, $order_clause);
+    }
     function update($clause) {
         $db = BoincDb::get();
         return $db->update($this, 'workunit', $clause);

--- a/html/user/buda_submit.php
+++ b/html/user/buda_submit.php
@@ -316,6 +316,26 @@ function handle_submit($user) {
     header("Location: submit.php?action=query_batch&batch_id=$batch->id");
 }
 
+function show_list() {
+    page_head('BUDA job submission');
+    $apps = get_buda_apps();
+    echo 'Select app and variant:<p><br>';
+    foreach ($apps as $app) {
+        $desc = get_buda_desc($app);
+        $vars = get_buda_variants($app);
+        echo "$desc->long_name
+            <ul>
+        ";
+        foreach ($vars as $var) {
+            echo sprintf('<li><a href=buda_submit.php?action=form&app=%s&variant=%s>%s</a>',
+                $app, $var, $var
+            );
+        }
+        echo "</ul>\n";
+    }
+    page_tail();
+}
+
 $user = get_logged_in_user();
 $buda_boinc_app = BoincApp::lookup("name='buda'");
 if (!$buda_boinc_app) error_page('no buda app');
@@ -325,8 +345,10 @@ if (!has_submit_access($user, $buda_boinc_app->id)) {
 $action = get_str('action', true);
 if ($action == 'submit') {
     handle_submit($user);
-} else {
+} else if ($action == 'form') {
     submit_form($user);
+} else {
+    show_list();
 }
 
 ?>

--- a/html/user/get_output2.php
+++ b/html/user/get_output2.php
@@ -18,14 +18,28 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // web API for fetching output files.
+// This is for apps that don't use an assimilator
+// that moves output files into project/results/...
+// I.e., the output files are in the upload hierarchy with physical names
+//
+// For assim_move apps, use get_output3.php instead of this.
+
 // This is an updated version of get_output.php;
 // I didn't want to change that on the (unlikely) chance
 // that someone is using it.
 
 // args:
-// cmd: batch, workunit, or result
-// auth: user authenticator
-// batch_id, wu_id, result_id: as needed
+// cmd: batch, workunit, result or file
+// auth: optional user authenticator (if not logged in)
+// result:
+//      result_id
+// workunit:
+//      wu_id
+// batch:
+//      batch_id
+// file:
+//      result_id
+//      file_num
 //
 // action (see https://github.com/BOINC/boinc/issues/5262):
 // result: if 1 output file, return it as resultname__logicalname
@@ -96,7 +110,7 @@ function do_result($result_id, $auth, $file_num=null) {
     $batch = BoincBatch::lookup_id($workunit->batch);
     if (!$batch) die("no batch for $result_id");
     check_auth($auth, $batch);
-    do_result_aux($result, $batch);
+    do_result_aux($result, $batch, $file_num);
 }
 
 function do_wu($wu_id, $auth) {

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -18,8 +18,18 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // get output files, individually or zipped groups
-// Assumes the layout used by sample_assimilator.cpp and sample_assimilate.py:
-// <project>/results/
+//
+// args:
+// action: get_file or get_batch
+// get_file:
+//      path: relative to project root dir
+//      download: if set, download file; else show it in browser
+// get_batch:
+//      batch_id
+//      downloads zip of batch's output files
+//      Assumes the layout used by sample_assimilator.cpp
+//      and sample_assimilate.py:
+//      <project>/results/
 //      <batchid>/   (0 if not in a batch)
 //
 

--- a/html/user/workunit.php
+++ b/html/user/workunit.php
@@ -46,9 +46,17 @@ function show_wu($wu) {
     page_head(tra("Workunit %1", $wu->id));
     $app = BoincApp::lookup_id($wu->appid);
 
+    $x = "<in>".$wu->xml_doc."</in>";
+    $xml_doc = simplexml_load_string($x);
+
     start_table();
     row2(tra("name"), $wu->name);
     row2(tra("application"), $app->user_friendly_name);
+    if ($wu->batch) {
+        row2('batch',
+            "<a href=submit.php?action=query_batch&batch_id=$wu->batch>$wu->batch</a>"
+        );
+    }
     row2(tra("created"), time_str($wu->create_time));
     if (isset($wu->keywords) && $wu->keywords) {
         row2(tra("keywords"), keyword_string($wu->keywords));
@@ -80,11 +88,13 @@ function show_wu($wu) {
         if ($wu->need_validate) {
             row2(tra("validation"), tra("Pending"));
         }
+        row2('Command line', $xml_doc->workunit->command_line);
         if (function_exists('project_workunit')) {
             project_workunit($wu);
         }
         end_table();
 
+        echo "<h2>Job instances</h2>\n";
         result_table_start(false, true, null);
         $results = BoincResult::enum("workunitid=$wu->id");
         foreach ($results as $result) {
@@ -93,6 +103,26 @@ function show_wu($wu) {
         echo "</table>\n";
     }
 
+    // show input files
+    //
+    echo "<h2>Input files</h2>\n";
+    start_table('table-striped');
+    table_header("Name<br><small>(click to view)</small>", "Size (bytes)");
+    foreach ($xml_doc->workunit->file_ref as $fr) {
+        $pname = (string)$fr->file_name;
+        $lname = (string)$fr->open_name;
+        foreach ($xml_doc->file_info as $fi) {
+            if ((string)$fi->name == $pname) {
+                table_row(
+                    "<a href=$fi->url>$lname</a>",
+                    $fi->nbytes
+                );
+                break;
+            }
+        }
+    }
+
+    end_table();
     page_tail();
 }
 


### PR DESCRIPTION
- anything that enumerates the WUs or results in a batch
    should fetch only the fields it needs.
    Otherwise PHP runs out of memory with big batches and large stderr output.
- Add missing piece for BUDA job submission
- get_output2.php and get_output3.php: add comments
   Scripts should document their GET arguments.
- workunit.php
     show WU command line
     show links to input files