### PR TITLE
web: fix 'powered by BOINC' behavior in footer

### DIFF
--- a/html/project.sample/project.inc
+++ b/html/project.sample/project.inc
@@ -126,16 +126,22 @@ function project_banner($title, $prefix, $is_main) {
 //$fixed_navbar = true;
 
 function project_footer($show_return, $show_date, $prefix) {
-    // If you include any links, prepend URL with $prefix
-    //
-    echo '<br>
-        <a class="brand boinc-logo" href="https://boinc.berkeley.edu/"><img class="img-responsive center-block" src="'.secure_url_base().'img/pb_boinc.gif" alt="Powered by BOINC"></a>
-        <div class="form-group"></div>
-        <p class="text-center"> &copy;'.gmdate("Y ").COPYRIGHT_HOLDER.'</p>
-    ';
+    echo sprintf(
+        '<center><a href="%s"><img src=%s/%s alt="%s"></a></center>',
+        'https://boinc.berkeley.edu',
+        secure_url_base(),
+        'img/pb_boinc.gif',
+        'Powered by BOINC'
+    );
+    echo sprintf('<p><center>&copy; %s %s</center>',
+        gmdate("Y "),
+        COPYRIGHT_HOLDER
+    );
     if ($show_date) {
-        $t = time_str(time());
-        echo "<center><small>".tra("Generated")." $t</small><center>\n";
+        echo sprintf('<center><small>%s %s</small><center>',
+            tra('Generated'),
+            time_str(time())
+        );
     }
 }
 


### PR DESCRIPTION
It was hyperlinking the entire row, not just the image. Not sure why.  Fixed it by removing CSS incantations.

To use this, projects will need to check out html/project.sample/project.inc,
then merge it with their own project.inc
(the only change is in project_footer())

Fixes #6294
