### PR TITLE
Fix compiler warning and avoid magic number in function call

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1251,7 +1251,7 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
         // normally the version is on the first line,
         // but it's on the 2nd line if using podman-docker
         //
-        while (fgets(buf, 256, f)) {
+        while (fgets(buf, sizeof(buf), f)) {
             string version;
             if (get_docker_version_string(type, buf, version)) {
                 safe_strcpy(docker_version, version.c_str());
@@ -1273,7 +1273,7 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
         bool found = false;
         f = popen(cmd.c_str(), "r");
         if (f) {
-            while (fgets(buf, 256, f)) {
+            while (fgets(buf, sizeof(buf), f)) {
                 if (strstr(buf, "Hello")) {
                     found = true;
                     break;
@@ -1324,12 +1324,14 @@ bool HOST_INFO::get_docker_compose_version_aux(DOCKER_TYPE type){
     FILE* f = popen(cmd.c_str(), "r");
     if (f) {
         char buf[256];
-        fgets(buf, 256, f);
-        string version;
-        if (get_docker_compose_version_string(type, buf, version)) {
-            safe_strcpy(docker_compose_version, version.c_str());
-            docker_compose_type = type;
-            ret = true;
+        while (fgets(buf, sizeof(buf), f)) {
+            string version;
+            if (get_docker_compose_version_string(type, buf, version)) {
+                safe_strcpy(docker_compose_version, version.c_str());
+                docker_compose_type = type;
+                ret = true;
+                break;
+            }
         }
         pclose(f);
     }


### PR DESCRIPTION
Replace fix size with `sizeof(buf)` in `fgets()` calls.

Avoid compiler warning:
```
hostinfo_unix.cpp: In member function ‘bool HOST_INFO::get_docker_compose_version_aux(DOCKER_TYPE)’:
hostinfo_unix.cpp:1327:14: warning: ignoring return value of ‘char* fgets(char*, int, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
 1327 |         fgets(buf, 256, f);
      |         ~~~~~^~~~~~~~~~~~~
```