### PR TITLE
web: minor fixes

### DIFF
--- a/html/inc/cache.inc
+++ b/html/inc/cache.inc
@@ -142,7 +142,7 @@ function cache_need_to_regenerate($path, $max_age){
 function get_cached_data($max_age, $params=""){
     global $no_cache;
 
-    if ($no_cache) return;
+    if ($no_cache) return false;
 
     $path = get_path($params);
     if ($max_age) {

--- a/html/project.sample/cache_parameters.inc
+++ b/html/project.sample/cache_parameters.inc
@@ -1,21 +1,33 @@
 <?php
 
-// Define the lifetime of public php pages.
-// define to zero to turn of caching for these pages.
+// Some web pages need lots of DB access to generate.
+// To reduce DB server load, these pages
+// (actually, the data used to create them) can be cached.
+// Each type of page has a 'time to live' (TTL) parameter.
+// If the age of a cached page exceeds the TTL,
+// the page is regenerated.
+//
+// TTL = 0 means don't cache that type of page
+
 define('TEAM_PAGE_TTL', 3600);
 define('USER_PAGE_TTL', 3600);
-define('USER_HOST_TTL', 3600);
 define('USER_PROFILE_TTL', 3600);
-define('TOP_PAGES_TTL', 43200);
+define('TOP_PAGES_TTL', 0);
+    // host/user/team leader boards
+    // caching these causes inconsistent results
 define('INDEX_PAGE_TTL', 3600);
 define('STATUS_PAGE_TTL', 3600);
 define('REMOTE_PROJECTS_TTL', 86400);
 
-// max allowed cache usage
+// max allowed cache usage, bytes
 //
-define('MAX_CACHE_USAGE', 104857600);
+define('MAX_CACHE_USAGE', 1e9);
 
-// Number of page views between cache size checks
+// the cache can grow without bound,
+// so every so often we need to check its size and
+// delete old entries.
+// We do this randomly, on average every N page views
+
 define('CACHE_SIZE_CHECK_FREQ', 1000);
 
 ?>

--- a/html/user/create_team.php
+++ b/html/user/create_team.php
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// web RPC for creating teams
+
 // Disabled.  being used by spammers,
 // and I can't think of a legit use for this.
 
@@ -42,7 +44,7 @@ if (!$user) {
     xml_error(ERR_DB_NOT_FOUND);
 }
 
-if (@constant('TEAM_CREATE_NEED_CREDIT')) {
+if (defined('TEAM_CREATE_NEED_CREDIT') && TEAM_CREATE_NEED_CREDIT) {
     if ($user->total_credit == 0) {
         xml_error(-1, "no credit");
     }

--- a/html/user/team_create_action.php
+++ b/html/user/team_create_action.php
@@ -31,7 +31,7 @@ check_get_args(array());
 
 $user = get_logged_in_user();
 
-if (@constant('TEAM_CREATE_NEED_CREDIT')) {
+if (defined('TEAM_CREATE_NEED_CREDIT') && TEAM_CREATE_NEED_CREDIT) {
     if ($user->total_credit == 0) {
         error_page("You must complete a task to create a team");
     }

--- a/html/user/team_create_form.php
+++ b/html/user/team_create_form.php
@@ -27,7 +27,7 @@ check_get_args(array());
 
 $user = get_logged_in_user();
 
-if (@constant('TEAM_CREATE_NEED_CREDIT')) {
+if (defined('TEAM_CREATE_NEED_CREDIT') && TEAM_CREATE_NEED_CREDIT) {
     if ($user->total_credit == 0) {
         error_page("You must complete a task to create a team");
     }


### PR DESCRIPTION
- don't use @constant('x') to see if a constant exists. With PHP 8+, this generates an exception (not a warning) if the constant doesn't exist. Use defined('x') instead.
- In the default cache params, disable caching for leader boards. Caching leader boards can produce inconsistent results (i.e. the same user or team appears multiple times)
