### PR TITLE
client and docker_wrapper (Mac/podman): set env vars to use accessable dir

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -374,6 +374,26 @@ int use_sandbox, int isManager, char* path_to_error, int len
             return retval;
     }
 
+    snprintf(full_path, sizeof(full_path), "%s/%s", dir_path, PODMAN_DIR);
+    retval = stat(full_path, &sbuf);
+    if (! retval) {                 // Client can create podman directory if it does not yet exist.
+       if (use_sandbox) {
+            if (sbuf.st_gid != boinc_project_gid)
+                return -1071;
+
+            if ((sbuf.st_mode & 0777) != 0770)
+                return -1072;
+        }
+
+        if (sbuf.st_uid != boinc_master_uid)
+            return -1073;
+
+        // Step through slot directories
+        retval = CheckNestedDirectories(full_path, 1, use_sandbox, isManager, false, path_to_error, len);
+        if (retval)
+            return retval;
+    }
+
     snprintf(full_path, sizeof(full_path),
         "%s/%s", dir_path, GUI_RPC_PASSWD_FILE
     );
@@ -595,6 +615,7 @@ static int CheckNestedDirectories(
         if (!S_ISLNK(sbuf.st_mode)) {   // The system ignores ownership & permissions of symbolic links
             if (depth > 1)  {
                 // files and subdirectories created by projects may have owner boinc_master or boinc_project
+                // TODO: Is this is true of subdirectories created by Podman tasks?
                 if ( (sbuf.st_uid != boinc_master_uid) && (sbuf.st_uid != boinc_project_uid) ) {
                     if (!isSlotDir) {
                             retval = -1202;

--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -15,7 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// check_security.C
+// Functions to check ownership and permissions of files and dirs
+// in the BOINC data directory on Mac OS
 
 //#define DEBUG_CHECK_SECURITY
 

--- a/client/file_names.h
+++ b/client/file_names.h
@@ -89,6 +89,7 @@ extern void send_log_after(const char* filename, double t, MIOFILE& mf);
 #define LOOKUP_WEBSITE_FILENAME     "lookup_website.html"
 #define MASTER_BASE                 "master_"
 #define NOTICES_DIR                 "notices"
+#define PODMAN_DIR                  "podman"
 #define PROJECTS_DIR                "projects"
 #define REMOTEHOST_FILE_NAME        "remote_hosts.cfg"
 #define SCHED_OP_REPLY_BASE         "sched_reply_"

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1266,12 +1266,12 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
     if (type == PODMAN) {
         snprintf(cmd, sizeof(cmd),
             "%s podman machine init 2>/dev/null",
-            docker_cmd_prefix()
+            docker_cmd_prefix(type)
         );
         system(cmd);
         snprintf(cmd, sizeof(cmd),
             "%s podman machine start 2>/dev/null",
-            docker_cmd_prefix()
+            docker_cmd_prefix(type)
         );
         system(cmd);
     }

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1289,7 +1289,8 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
 }
 
 bool HOST_INFO::get_docker_version(){
-#ifdef __linux__
+    bool check_podman = true;
+    #ifdef __linux__
     // podman doesn't work on Linux with remote FS
     bool remote;
     int retval = is_filesystem_remote(".", remote);
@@ -1318,8 +1319,10 @@ bool HOST_INFO::get_docker_version(){
     }
 #endif
 
-    if (get_docker_version_aux(PODMAN)) {
-        return true;
+    if (check_podman) {
+        if (get_docker_version_aux(PODMAN)) {
+            return true;
+        }
     }
 
     if (get_docker_version_aux(DOCKER)) {

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1304,6 +1304,15 @@ bool HOST_INFO::get_docker_version(){
         msg_printf(NULL, MSG_INFO, "Data dir is remote: not checking podman");
     }
 #endif
+
+#ifdef __APPLE__
+    // on Mac, Podman requires an accessable dir 'podman'
+    //
+    if (!is_dir("podman")) {
+        check_podman = false;
+    }
+#endif
+
     if (check_podman) {
         if (get_docker_version_aux(PODMAN)) {
             return true;

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2024 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -363,6 +363,20 @@ const char* docker_type_str(DOCKER_TYPE type) {
     default: break;
     }
     return "unknown";
+}
+
+const char* set_docker_cmd_prefix(DOCKER_TYPE type) {
+#ifdef __APPLE__
+    if (type == PODMAN) {
+        char buf[1024];
+        const char* dir = "/Library/Application Support/BOINC Data/podman";
+        sprintf(buf,
+            "env XDG_CONFIG_HOME=\"%s\" XDG_DATA_HOME=\"%s\" ",
+            dir, dir
+        );
+    }
+#endif
+    return "";
 }
 
 // parse a string like

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -365,19 +365,28 @@ const char* docker_type_str(DOCKER_TYPE type) {
     return "unknown";
 }
 
-const char* set_docker_cmd_prefix(DOCKER_TYPE type) {
+// on Mac+podman we need to set env variables
+// to use a directory accessable to boinc_master and boinc_projects
+//
 #ifdef __APPLE__
+const char* docker_cmd_prefix(DOCKER_TYPE type) {
+    static char buf[256];
     if (type == PODMAN) {
-        char buf[1024];
         const char* dir = "/Library/Application Support/BOINC Data/podman";
-        sprintf(buf,
+        // must end w/ space
+        snprintf(buf, sizeof(buf),
             "env XDG_CONFIG_HOME=\"%s\" XDG_DATA_HOME=\"%s\" ",
             dir, dir
         );
+        return buf;
     }
-#endif
     return "";
 }
+#else
+const char* docker_cmd_prefix(DOCKER_TYPE) {
+    return "";
+}
+#endif
 
 // parse a string like
 // Docker version 24.0.7, build 24.0.7-0ubuntu2~22.04.1

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -53,7 +53,7 @@ const char file_redhatrelease[] = "/etc/redhat-release";
 
 extern const char* docker_cli_prog(DOCKER_TYPE type);
 extern const char* docker_type_str(DOCKER_TYPE type);
-extern const char* set_docker_cmd_prefix(DOCKER_TYPE type);
+extern const char* docker_cmd_prefix(DOCKER_TYPE type);
 
 // if you add fields, update clear_host_info()
 

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -53,6 +53,7 @@ const char file_redhatrelease[] = "/etc/redhat-release";
 
 extern const char* docker_cli_prog(DOCKER_TYPE type);
 extern const char* docker_type_str(DOCKER_TYPE type);
+extern const char* set_docker_cmd_prefix(DOCKER_TYPE type);
 
 // if you add fields, update clear_host_info()
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -775,7 +775,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     // Adds environment string or empty string as appropriate
     sprintf(buf, "%s%s %s\n", set_docker_cmd_prefix(type), cli_prog, cmd);
 #else
-    sprintf(buf, set_docker_cmd_prefix(type)"%s %s\n", cli_prog, cmd);
+    sprintf(buf, "%s %s\n", cli_prog, cmd);
 #endif  // __APPLE__
 
     retval = run_command(buf, out);

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// Copyright (C) 2025 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -772,17 +772,10 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     // to use a directory accessable to boinc_master and boinc_projects
 
 #ifdef __APPLE__
-    if (type == PODMAN) {
-        const char* dir = "/Library/Application Support/BOINC Data/podman";
-        sprintf(buf,
-            "env XDG_CONFIG_HOME=\"%s\" XDG_DATA_HOME=\"%s\" %s %s\n",
-            dir, dir, cli_prog, cmd
-        );
-    } else {
-        sprintf(buf, "%s %s\n", cli_prog, cmd);
-    }
+    // Adds environment string or empty string as appropriate
+    sprintf(buf, "%s%s %s\n", set_docker_cmd_prefix(type), cli_prog, cmd);
 #else
-    sprintf(buf, "%s %s\n", cli_prog, cmd);
+    sprintf(buf, set_docker_cmd_prefix(type)"%s %s\n", cli_prog, cmd);
 #endif  // __APPLE__
 
     retval = run_command(buf, out);

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -775,7 +775,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     if (type == PODMAN) {
         const char* dir = "/Library/Application Support/BOINC Data/podman";
         sprintf(buf,
-            "env XDG_CONFIG_HOME=\"%s\" XDG_DATA_HOME =\"%s\" %s %s\n",
+            "env XDG_CONFIG_HOME=\"%s\" XDG_DATA_HOME=\"%s\" %s %s\n",
             dir, dir, cli_prog, cmd
         );
     } else {

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -767,17 +767,10 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     }
     out = split(output, '\n');
 #else
-
-    // on Mac/podman we need to set env variables
-    // to use a directory accessable to boinc_master and boinc_projects
-
-#ifdef __APPLE__
-    // Adds environment string or empty string as appropriate
-    sprintf(buf, "%s%s %s\n", set_docker_cmd_prefix(type), cli_prog, cmd);
-#else
-    sprintf(buf, "%s %s\n", cli_prog, cmd);
-#endif  // __APPLE__
-
+    snprintf(buf, sizeof(buf),
+        "%s%s %s",
+        docker_cmd_prefix(type), cli_prog, cmd
+    );
     retval = run_command(buf, out);
     if (retval) {
         if (verbose) {

--- a/mac_build/Finish_Install-Info.plist
+++ b/mac_build/Finish_Install-Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleVersion</key>
-	<string>8.1.0</string>
+	<string>8.3.0</string>
 	<key>CFBundleShortVersionString</key>
-	<string>8.1.0</string>
+	<string>8.3.0</string>
 </dict>
 </plist>

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -70,6 +70,7 @@
 # Updated 4/6/23 revised setprojectgrp ownership to match PR #5061
 # Updated 2/11/25 to add Fix_BOINC_Users
 # Updated 2/23/25 to fix PrimaryGroupID for users boinc_master, boinc_project
+# Updated 5/9/25 to add podman directory
 #
 # WARNING: do not use this script with versions of BOINC older
 # than 7.20.4
@@ -254,6 +255,12 @@ if [ -d slots ] ; then
     set_perm_recursive slots boinc_master boinc_project u+rw,g+rw,o+r-w
     set_perm slots boinc_master boinc_project 0770
     update_nested_dirs slots
+fi
+
+if [ -d podman ] ; then
+    set_perm_recursive podman boinc_master boinc_project u+rw,g+rw,o+r-w
+    set_perm podman boinc_master boinc_project 0770
+    update_nested_dirs podman
 fi
 
 # AppStats application must run setuid root (used in BOINC 5.7 through 5.8.14 only)


### PR DESCRIPTION
Podman on Mac was failing because it tried to store data in .config/ in the user's home dir.
Podman runs as boinc_master (in the client)
and boinc_projects (in the wrapper)
and neither account has access to this dir.

To fix this, we'll have the installer create an accessable dir 'podman' in the BOINC data dir.
This change prepends an 'env' directive to Podman commands on Mac, telling it to use this dir.

Fixes #6302
