### PR TITLE
RPC-based job submission: make it work with PHP 8

### DIFF
--- a/html/inc/submit.inc
+++ b/html/inc/submit.inc
@@ -127,10 +127,10 @@ function req_to_xml($req, $op) {
 //
 function validate_request($req) {
     if (!is_object($req)) return "req is not an object";
-    if (!array_key_exists('project', $req)) return "missing req->project";
-    if (!array_key_exists('authenticator', $req)) return "missing req->authenticator";
-    if (!array_key_exists('app_name', $req)) return "missing req->app_name";
-    if (!array_key_exists('jobs', $req)) return "missing req->jobs";
+    if (!property_exists($req, 'project')) return "missing req->project";
+    if (!property_exists($req, 'authenticator')) return "missing req->authenticator";
+    if (!property_exists($req, 'app_name')) return "missing req->app_name";
+    if (!property_exists($req, 'jobs')) return "missing req->jobs";
     if (!is_array($req->jobs)) return "req->jobs is not an array";
     foreach ($req->jobs as $job) {
         // other checks


### PR DESCRIPTION
use property_exists() instead of array_key_exists() for objects

Fixes #6316