### PR TITLE
Fix spacing after commas in Windows source files

### DIFF
--- a/api/graphics2_win.cpp
+++ b/api/graphics2_win.cpp
@@ -111,7 +111,7 @@ void SetupPixelFormat(HDC dc) {
 }
 
 static void make_window(const char* title) {
-    RECT WindowRect = {0,0,0,0};
+    RECT WindowRect = {0, 0, 0, 0};
     int width, height;
     DWORD dwExStyle;
     DWORD dwStyle;
@@ -163,7 +163,7 @@ static void make_window(const char* title) {
 
     window = CreateWindowEx(dwExStyle, BOINC_WINDOW_CLASS_NAME, window_title,
         dwStyle|WS_CLIPSIBLINGS|WS_CLIPCHILDREN, WindowRect.left, WindowRect.top,
-        WindowRect.right-WindowRect.left,WindowRect.bottom-WindowRect.top,
+        WindowRect.right-WindowRect.left, WindowRect.bottom-WindowRect.top,
         NULL, NULL, instance, NULL
     );
 
@@ -436,7 +436,7 @@ void boinc_graphics_loop(int argc, char** argv, const char* title) {
     //
     reg_win_class();
 
-    wglMakeCurrent(NULL,NULL);
+    wglMakeCurrent(NULL, NULL);
     make_window(title);
 
     // Create a timer thread to do rendering
@@ -466,7 +466,7 @@ extern int main(int, char**);
 //
 void boinc_set_windows_icon(const char* icon16, const char* icon48) {
     LONGLONG ic;
-    HWND hWnd = FindWindow("BOINC_app",NULL);
+    HWND hWnd = FindWindow("BOINC_app", NULL);
 
     if ((ic = (LONGLONG)LoadIcon(instance, icon48)) != 0) {
 #ifdef _WIN64

--- a/api/windows_opengl.cpp
+++ b/api/windows_opengl.cpp
@@ -54,14 +54,14 @@ HANDLE graphics_threadh;
 
 void KillWindow() {
     window_ready=false;
-    wglMakeCurrent(NULL,NULL);  // release GL rendering context
+    wglMakeCurrent(NULL, NULL);  // release GL rendering context
     if (hRC) {
         wglDeleteContext(hRC);
         hRC=NULL;
     }
 
     if (hWnd && hDC) {
-        ReleaseDC(hWnd,hDC);
+        ReleaseDC(hWnd, hDC);
     }
     hDC = NULL;
 
@@ -115,7 +115,7 @@ void SetupPixelFormat(HDC hDC) {
 }
 
 static void make_new_window() {
-    RECT WindowRect = {0,0,0,0};
+    RECT WindowRect = {0, 0, 0, 0};
     int width, height;
     DWORD dwExStyle;
     DWORD dwStyle;
@@ -145,7 +145,7 @@ static void make_new_window() {
     get_window_title(aid, window_title, 256);
     hWnd = CreateWindowEx(dwExStyle, BOINC_WINDOW_CLASS_NAME, window_title,
         dwStyle|WS_CLIPSIBLINGS|WS_CLIPCHILDREN, WindowRect.left, WindowRect.top,
-        WindowRect.right-WindowRect.left,WindowRect.bottom-WindowRect.top,
+        WindowRect.right-WindowRect.left, WindowRect.bottom-WindowRect.top,
         NULL, NULL, hInstance, NULL
     );
 
@@ -413,7 +413,7 @@ LRESULT CALLBACK WndProc(
     }
 
     // Pass All Unhandled Messages To DefWindowProc
-    return DefWindowProc(hWnd,uMsg,wParam,lParam);
+    return DefWindowProc(hWnd, uMsg, wParam, lParam);
 }
 
 BOOL reg_win_class() {
@@ -434,7 +434,7 @@ BOOL reg_win_class() {
 
     // Attempt To Register The Window Class
     if (!RegisterClass(&wc)) {
-        MessageBox(NULL,"Failed To Register The Window Class.","ERROR",MB_OK|MB_ICONEXCLAMATION);
+        MessageBox(NULL, "Failed To Register The Window Class.", "ERROR", MB_OK|MB_ICONEXCLAMATION);
         return FALSE;                                            // Return FALSE
     }
 
@@ -442,8 +442,8 @@ BOOL reg_win_class() {
 }
 
 BOOL unreg_win_class() {
-    if (!UnregisterClass(BOINC_WINDOW_CLASS_NAME,hInstance)) {
-        MessageBox(NULL,"Could Not Unregister Class.","SHUTDOWN ERROR",MB_OK | MB_ICONINFORMATION);
+    if (!UnregisterClass(BOINC_WINDOW_CLASS_NAME, hInstance)) {
+        MessageBox(NULL, "Could Not Unregister Class.", "SHUTDOWN ERROR", MB_OK | MB_ICONINFORMATION);
         hInstance=NULL;                                    // Set hInstance To NULL
     }
 
@@ -527,7 +527,7 @@ void win_graphics_event_loop() {
         set_mode(MODE_HIDE_GRAPHICS);
     }
     while (1) {
-        if (GetMessage(&msg,NULL,0,0)) {
+        if (GetMessage(&msg, NULL, 0, 0)) {
             TranslateMessage(&msg);
             DispatchMessage(&msg);
         } else {

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -291,7 +291,7 @@ static void __cpuid(unsigned int cpuinfo[4], unsigned int type)  {
   #elif defined(_M_AMD64)
       // damn Microsoft for not having inline assembler in 64-bit code
       // so this is in an NASM compiled library
-      asm_cpuid(cpuinfo,type);
+      asm_cpuid(cpuinfo, type);
   #endif
 #endif
 }
@@ -1043,7 +1043,7 @@ int get_cpuid(unsigned int info_type, unsigned int& a, unsigned int& b, unsigned
 
 
     int retval = 1;
-    int CPUInfo[4] = {0,0,0,0};
+    int CPUInfo[4] = {0, 0, 0, 0};
 #ifdef _MSC_VER
     __try {
 #endif
@@ -1240,7 +1240,7 @@ bool is_avx_supported() {
     //
     // Note that XGETBV is only available on 686 or later CPUs, so
     // the instruction needs to be conditionally run.
-    unsigned int a,b,c,d;
+    unsigned int a, b, c, d;
     get_cpuid(1, a, b, c, d);
 
     bool osUsesXSAVE_XRSTORE = c & (1 << 27) || false;

--- a/samples/gfx_html/browserctrl_win.cpp
+++ b/samples/gfx_html/browserctrl_win.cpp
@@ -106,7 +106,7 @@ HWND CHTMLBrowserHost::Create(
         return NULL;
 
     // Allocate the thunk structure here, where we can fail gracefully.
-    BOOL result = m_thunk.Init(NULL,NULL);
+    BOOL result = m_thunk.Init(NULL, NULL);
     if (result == FALSE)
     {
         SetLastError(ERROR_OUTOFMEMORY);


### PR DESCRIPTION
Standardized the CPUInfo initializer in hostinfo_win.cpp to use spaced commas for readability

Added spaces after commas in assembly helper call for clarity

Ensured variables declared together are spaced correctly

Updated several Win32 API calls in windows_opengl.cpp to follow comma-spacing conventions

Applied the same formatting fixes in graphics2_win.cpp and sample HTML graphics code to keep style consistent