### PR TITLE
client: make resource usages take effect after reread app_config.xml

### DIFF
--- a/client/app_config.cpp
+++ b/client/app_config.cpp
@@ -95,6 +95,11 @@ int APP_CONFIGS::config_app_versions(PROJECT* p, bool show_warnings) {
             );
         }
     }
+
+    // copy new app version resource usage to results
+    //
+    gstate.init_result_resource_usage();
+
     if (showed_notice) return ERR_XML_PARSE;
     return 0;
 }

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -707,14 +707,7 @@ int CLIENT_STATE::init() {
     // must go after check_app_config() and parse_state_file()
     // and after the above app version stuff
     //
-    for (RESULT* rp: results) {
-        rp->init_resource_usage();
-        if (rp->resource_usage.missing_coproc) {
-            msg_printf(rp->project, MSG_INFO,
-                "Missing coprocessor for task %s", rp->name
-            );
-        }
-    }
+    init_result_resource_usage();
 
     // this needs to go after parse_state_file() because
     // GPU exclusions refer to projects
@@ -2459,6 +2452,24 @@ bool CLIENT_STATE::abort_sequence_done() {
         if (p->sched_rpc_pending == RPC_REASON_USER_REQ) return false;
     }
     return true;
+}
+
+// for each result, copy resource usage either from
+// - workunit if present there (e.g. BUDA jobs)
+// - app version otherwise
+//
+// call this on startup and after reread app_config.xml
+// (which can change app version resource usage)
+//
+void CLIENT_STATE::init_result_resource_usage() {
+    for (RESULT* rp: results) {
+        rp->init_resource_usage();
+        if (rp->resource_usage.missing_coproc) {
+            msg_printf(rp->project, MSG_INFO,
+                "Missing coprocessor for task %s", rp->name
+            );
+        }
+    }
 }
 
 #endif

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -2454,6 +2454,8 @@ bool CLIENT_STATE::abort_sequence_done() {
     return true;
 }
 
+#endif  // !SIM
+
 // for each result, copy resource usage either from
 // - workunit if present there (e.g. BUDA jobs)
 // - app version otherwise
@@ -2471,5 +2473,3 @@ void CLIENT_STATE::init_result_resource_usage() {
         }
     }
 }
-
-#endif

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -296,6 +296,7 @@ struct CLIENT_STATE {
     void clear_absolute_times();
     void set_now();
     void log_show_projects();
+    void init_result_resource_usage();
 
 // --------------- cpu_sched.cpp:
     double total_resource_share();


### PR DESCRIPTION
Resource usage is now stored in RESULT,
and is copied either from the workunit (for BUDA-type jobs) or from the app version (for other jobs).

This is done at startup; we also need to do it after rereading app_config.xml since the app version resource usage may have changed.

Fixes #6334