### PR TITLE
Add a config option <no_disk_usage/> that skips disk usage in sched requests

### DIFF
--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -190,16 +190,18 @@ int CLIENT_STATE::make_scheduler_request(PROJECT* p) {
 
     // get and write disk usage
     //
-    get_disk_usages();
-    get_disk_shares();
-    fprintf(f,
-        "    <disk_usage>\n"
-        "        <d_boinc_used_total>%f</d_boinc_used_total>\n"
-        "        <d_boinc_used_project>%f</d_boinc_used_project>\n"
-        "        <d_project_share>%f</d_project_share>\n"
-        "    </disk_usage>\n",
-        total_disk_usage, p->disk_usage, p->disk_share
-    );
+    if (!cc_config.no_disk_usage) {
+        get_disk_usages();
+        get_disk_shares();
+        fprintf(f,
+            "    <disk_usage>\n"
+            "        <d_boinc_used_total>%f</d_boinc_used_total>\n"
+            "        <d_boinc_used_project>%f</d_boinc_used_project>\n"
+            "        <d_project_share>%f</d_project_share>\n"
+            "    </disk_usage>\n",
+            total_disk_usage, p->disk_usage, p->disk_share
+        );
+    }
 
     if (coprocs.n_rsc > 1) {
         work_fetch.copy_requests();

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -243,6 +243,7 @@ void CC_CONFIG::defaults() {
     max_tasks_reported = 0;
     ncpus = -1;
     no_alt_platform = false;
+    no_disk_usage = false;
     no_gpus = false;
     no_info_fetch = false;
     no_opencl = false;
@@ -416,6 +417,7 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
         if (xp.parse_int("max_tasks_reported", max_tasks_reported)) continue;
         if (xp.parse_int("ncpus", ncpus)) continue;
         if (xp.parse_bool("no_alt_platform", no_alt_platform)) continue;
+        if (xp.parse_bool("no_disk_usage", no_disk_usage)) continue;
         if (xp.parse_bool("no_gpus", no_gpus)) continue;
         if (xp.parse_bool("no_info_fetch", no_info_fetch)) continue;
         if (xp.parse_bool("no_opencl", no_opencl)) continue;
@@ -661,6 +663,7 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         "        <max_tasks_reported>%d</max_tasks_reported>\n"
         "        <ncpus>%d</ncpus>\n"
         "        <no_alt_platform>%d</no_alt_platform>\n"
+        "        <no_disk_usage>%d</no_disk_usage>\n"
         "        <no_gpus>%d</no_gpus>\n"
         "        <no_info_fetch>%d</no_info_fetch>\n"
         "        <no_opencl>%d</no_opencl>\n"
@@ -678,6 +681,7 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         max_tasks_reported,
         ncpus,
         no_alt_platform,
+        no_disk_usage,
         no_gpus,
         no_info_fetch,
         no_opencl,

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -15,11 +15,14 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// flags determining what is written to standard out.
-// (errors go to stderr)
+// client configuration: cc_config.xml
 //
-// NOTE: all writes to stdout should have an if (log_flags.*) {} around them.
-//
+// This includes
+// 1) log flags: what messages are written
+//      These are editable via the GUI
+// 2) other config options
+//      These are mostly for debugging,
+//      or things that are too obscure to add them to the GUI
 
 #ifndef BOINC_CC_CONFIG_H
 #define BOINC_CC_CONFIG_H
@@ -193,6 +196,7 @@ struct CC_CONFIG {
     int max_tasks_reported;
     int ncpus;
     bool no_alt_platform;
+    bool no_disk_usage;     // don't include disk usage in sched req
     bool no_gpus;
     bool no_info_fetch;
     bool no_opencl;


### PR DESCRIPTION
This is an experiment to see if calculating disk usage is causing client performance problems.

Related to #6332 