### PR TITLE
client: remove spurious error messages about WU FLOPS

### DIFF
--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -1303,7 +1303,9 @@ int WORKUNIT::write(MIOFILE& out, bool gui) {
             sub_appname
         );
     }
-    resource_usage.write(out);
+    if (resource_usage.present()) {
+        resource_usage.write(out);
+    }
 
     if (!job_keyword_ids.empty()) {
         if (gui) {

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -332,6 +332,9 @@ struct RESOURCE_USAGE {
     void clear();
     void check_gpu_libs(char* plan_class);
     void write(MIOFILE&);
+    bool present() {
+        return avg_ncpus>0 || coproc_usage>0;
+    }
 };
 
 // if you add anything, initialize it in init()


### PR DESCRIPTION
Don't write resource usage to <workunit> if it's not there; otherwise the client will print spurious error messages

Fixes #6342