### PR TITLE
submit RPC bug fixes

### DIFF
--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -310,6 +310,9 @@ function submit_jobs(
     $errfile = sprintf('/tmp/create_work_%d.err', getmypid());
     $cmd .= sprintf(' >%s 2>&1', $errfile);
 
+    //echo "command: $cmd\n";
+    //echo "stdin: $x\n";
+
     $h = popen($cmd, "w");
     if ($h === false) {
         xml_error(-1, "can't run create_work");
@@ -392,7 +395,9 @@ function xml_get_jobs($r) {
         $job->input_template = null;
         if ($j->input_template) {
             $job->input_template = $j->input_template;
-            $job->input_template_xml = $j->input_template->asXML();
+            $x = $j->input_template->asXML();
+            $x = str_replace('<file_info/>', '<file_info></file_info>', $x);
+            $job->input_template_xml = $x;
         }
         $job->output_template = null;
         if ($j->output_template) {
@@ -1075,6 +1080,13 @@ estimate_batch($r);
 exit;
 }
 
+xml_header();
+if (0) {
+    $req = file_get_contents("req");
+} else {
+    $req = $_POST['request'];
+}
+
 // optionally write request message (XML) to log file
 //
 $request_log = parse_config(get_config(), "<remote_submit_request_log>");
@@ -1082,17 +1094,11 @@ if ($request_log) {
     $log_dir = parse_config(get_config(), "<log_dir>");
     $request_log = $log_dir . "/" . $request_log;
     if ($file = fopen($request_log, "a")) {
-        fwrite($file, "\n<submit_rpc_handler date=\"" . date(DATE_ATOM) . "\">\n" . $_POST['request'] . "\n</submit_rpc_handler>\n");
+        fwrite($file, "\n<submit_rpc_handler date=\"" . date(DATE_ATOM) . "\">\n" . $req . "\n</submit_rpc_handler>\n");
         fclose($file);
     }
 }
 
-xml_header();
-if (0) {
-    $req = file_get_contents("submit_req.xml");
-} else {
-    $req = $_POST['request'];
-}
 $r = simplexml_load_string($req);
 if (!$r) {
     log_write("----- RPC request: can't parse request message: $req");

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -354,7 +354,10 @@ int create_work2(
         return ERR_INVALID_PARAM;
     }
     if (wu.target_nresults > wu.max_success_results) {
-        boinc::fprintf(stderr, "target_nresults > max_success_results; can't create job\n");
+        boinc::fprintf(stderr,
+            "target_nresults %d > max_success_results %d; can't create job\n",
+            wu.target_nresults, wu.max_success_results
+        );
         return ERR_INVALID_PARAM;
     }
     if (wu.transitioner_flags) {

--- a/tools/process_input_template.cpp
+++ b/tools/process_input_template.cpp
@@ -511,6 +511,16 @@ static int process_workunit(
             out += "\n";
         }
     }
+
+    // fill in possibly missing parameters
+    //
+    if (wu.target_nresults > wu.max_success_results) {
+        wu.max_success_results = wu.target_nresults;
+    }
+    if (wu.target_nresults > wu.max_total_results) {
+        wu.max_total_results = wu.target_nresults;
+    }
+
     if (n_file_refs != (int)infiles.size()) {
         boinc::fprintf(stderr, "#file refs != #file infos\n");
         return ERR_XML_PARSE;

--- a/version.h
+++ b/version.h
@@ -29,7 +29,7 @@
 // worker version number
 #define WORKER_RELEASE 5
 
-// docker_wrapper version number
+// dockerwrapper version number
 #define DOCKERWRAPPER_RELEASE 6
 
 // client version number as string


### PR DESCRIPTION
- the RPC handler writes the input template using simplexml's asXML(). This writes empty elements as e.g. <file_info/>. process_input_template() expects <file_info></file_info>. Convert to this in the RPC handler.
- process_input_template(): if wu.max_success_results is not specified, set it to wu.target_nresults; otherwise create_work2() returns an error. Same with wu.max_total_results