### PR TITLE
Change size of email and user name wxTextCtrl to default

### DIFF
--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -159,7 +159,7 @@ void CAccountInfoPage::CreateControls()
     itemFlexGridSizer64->Add(m_pAccountEmailAddressStaticCtrl, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     m_pAccountEmailAddressCtrl = new wxTextCtrl;
-    m_pAccountEmailAddressCtrl->Create( itemWizardPage56, ID_ACCOUNTEMAILADDRESSCTRL, wxEmptyString, wxDefaultPosition, wxSize(200, 22), 0 );
+    m_pAccountEmailAddressCtrl->Create( itemWizardPage56, ID_ACCOUNTEMAILADDRESSCTRL, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     itemFlexGridSizer64->Add(m_pAccountEmailAddressCtrl, 0, wxEXPAND|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     m_pAccountUsernameStaticCtrl = new wxStaticText;
@@ -167,7 +167,7 @@ void CAccountInfoPage::CreateControls()
     itemFlexGridSizer64->Add(m_pAccountUsernameStaticCtrl, 0, wxALIGN_RIGHT|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     m_pAccountUsernameCtrl = new wxTextCtrl;
-    m_pAccountUsernameCtrl->Create( itemWizardPage56, ID_ACCOUNTUSERNAMECTRL, wxEmptyString, wxDefaultPosition, wxSize(200, 22), 0 );
+    m_pAccountUsernameCtrl->Create( itemWizardPage56, ID_ACCOUNTUSERNAMECTRL, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     itemFlexGridSizer64->Add(m_pAccountUsernameCtrl, 0, wxEXPAND|wxALIGN_CENTER_VERTICAL|wxALL, 5);
 
     m_pAccountPasswordStaticCtrl = new wxStaticText;


### PR DESCRIPTION
Having a fixed size makes characters not completely visibile in some builds.

Fixes #5785

**Description of the Change**
Changed the size of the wxTextCtrl from a fixed value to wxDefaultSize

**Alternate Designs**
N/A

**Release Notes**
[Manager] Fixed bug where some characters were not completely visible when entering email or username in add project wizard.
