### PR TITLE
Make `strftime()` format string compatible with old libraries

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -285,7 +285,7 @@ char* boinc_msg_prefix(char* sbuf, int len) {
         strlcpy(sbuf, "localtime() failed", len);
         return sbuf;
     }
-    if (strftime(buf, sizeof(buf)-1, "%F %H:%M:%S", tmp) == 0) {
+    if (strftime(buf, sizeof(buf)-1, "%Y-%m-%d %H:%M:%S", tmp) == 0) {
         strlcpy(sbuf, "strftime() failed", len);
         return sbuf;
     }


### PR DESCRIPTION
Fixes #6363