### PR TITLE
Fix shebang in sched/testasm.py

### DIFF
--- a/sched/testasm.py
+++ b/sched/testasm.py
@@ -1,4 +1,4 @@
-!/usr/bin/env python
+#!/usr/bin/env python3
 
 import boinc_path_config
 from Boinc.assimilator import *


### PR DESCRIPTION
Summary

correct the shebang in sched/testasm.py so the script can execute directly with Python 3