### PR TITLE
docs: update INSTALL with server build info

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -16,3 +16,20 @@ you can build and install BOINC libraries using [vcpkg](https://github.com/Micro
     ./vcpkg install boinc
 
 The BOINC port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+To build the BOINC server components use the normal configure and make steps
+without `--disable-server`:
+
+    ./_autosetup
+    ./configure
+    make
+
+More detailed information about setting up a server can be found on the
+BOINC wiki (<https://boinc.berkeley.edu/trac/wiki/ServerIntro>).
+
+If you prefer downloading the dependencies yourself instead of using vcpkg,
+have a look at the helper scripts in the `3rdParty` directory.  They fetch and
+build the required libraries on Linux and macOS:
+
+    ./3rdParty/buildLinuxDependencies.sh
+    ./3rdParty/buildMacDependencies.sh


### PR DESCRIPTION
Updated the INSTALL guide with instructions for configuring and building the server, and added pointers to scripts in the 3rdParty directory for downloading dependencies