### PR TITLE
Mac: Fix path to Podman app under Mac OS 26

### DIFF
--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -348,7 +348,11 @@ int HOST_INFO::write_cpu_benchmarks(FILE* out) {
 const char* docker_cli_prog(DOCKER_TYPE type) {
     switch (type) {
     case DOCKER: return "docker";
+#ifdef __APPLE__
+        case PODMAN: return "/opt/podman/bin/podman";
+#else
     case PODMAN: return "podman";
+#endif
     default: break;
     }
     return "unknown";


### PR DESCRIPTION
Fixes Podman detection and execution under Mac OS 26 Beta.

Under Mac OS 26, BOINC client does not inherit all default paths from user;s environment, so client must specify full path to the podman app: _/opt/podman/bin/podman_.

I will be creating one or more additional PRs for the BOINC screensaver and possibly other issues under Mac OS 26, but this PR is now ready to merge.
