### PR TITLE
client: avoid erroneous 'suspended - non-BOINC CPU' when running Docker apps

### DIFF
--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -882,7 +882,8 @@ void APP_VERSION::init() {
     graphics_exec_path[0] = 0;
     graphics_exec_file[0] = 0;
     max_working_set_size = 0;
-    is_vm_app = false;
+    is_vbox_app = false;
+    is_docker_app = false;
     is_wrapper = false;
     index = 0;
 #ifdef SIM
@@ -902,7 +903,10 @@ int APP_VERSION::parse(XML_PARSER& xp) {
                 dont_throttle = true;
             }
             if (strstr(plan_class, "vbox")) {
-                is_vm_app = true;
+                is_vbox_app = true;
+            }
+            if (strstr(plan_class, "docker")) {
+                is_docker_app = true;
             }
             return 0;
         }
@@ -914,9 +918,6 @@ int APP_VERSION::parse(XML_PARSER& xp) {
                     "couldn't parse file_ref: %s", boincerror(retval)
                 );
                 return retval;
-            }
-            if (strstr(file_ref.file_name, "vboxwrapper")) {
-                is_vm_app = true;
             }
             app_files.push_back(file_ref);
             continue;

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -372,8 +372,10 @@ struct APP_VERSION {
         // to use this much RAM,
         // so that we don't run a long sequence of jobs,
         // each of which turns out not to fit in available RAM
-    bool is_vm_app;
-        // currently this set if plan class includes "vbox" (kludge)
+    bool is_vbox_app;
+        // set if plan class includes "vbox"
+    bool is_docker_app;
+        // set if plan class includes "docker"
     bool is_wrapper;
         // the main program is a wrapper; run it above idle priority
 

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -173,7 +173,7 @@ void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
 //      we don't account Docker/podman CPU time here,
 //      since we don't know what the processes are.
 //      Instead we do it in the client (by looking at ACTIVE_TASKS)
-//      
+//
 //      processes named 'podman'
 //
 // This is subtracted from total CPU time to get

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -170,7 +170,10 @@ void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
 // - (if Vbox apps are running) the Vbox daemon
 // - Windows: WSL daemon ('vmmem')
 // - Linux/Mac:
-//      root processes (Docker containers run as root)
+//      we don't account Docker/podman CPU time here,
+//      since we don't know what the processes are.
+//      Instead we do it in the client (by looking at ACTIVE_TASKS)
+//      
 //      processes named 'podman'
 //
 // This is subtracted from total CPU time to get
@@ -193,9 +196,6 @@ double boinc_related_cpu_time(PROC_MAP& pm, bool vbox_app_running) {
                 // e.g. VBoxHeadless.exe and VBoxSVC.exe on Win
 #ifdef _WIN32
             || strstr(p.command, "vmmem")
-#else
-            || strstr(p.command, "podman")
-            // || p.userid == 0
 #endif
         ) {
             sum += (p.user_time + p.kernel_time);

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -164,8 +164,8 @@ void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
 #endif
 }
 
-// get CPU time of
-// - BOINC-related processes
+// get CPU time of things we don't want to count as non-BOINC-related
+// - BOINC apps
 // - low-priority processes
 // - (if Vbox apps are running) the Vbox daemon
 // - Windows: WSL daemon ('vmmem')
@@ -192,13 +192,13 @@ double boinc_related_cpu_time(PROC_MAP& pm, bool vbox_app_running) {
                 // count VBox processes as BOINC-related
                 // e.g. VBoxHeadless.exe and VBoxSVC.exe on Win
 #ifdef _WIN32
-            || strstr(p.command, 'vmmem')
+            || strstr(p.command, "vmmem")
 #else
-            || strstr(p.command, 'podman')
+            || strstr(p.command, "podman")
             // || p.userid == 0
 #endif
         ) {
-            sum += p.user_time;
+            sum += (p.user_time + p.kernel_time);
         }
     }
     return sum;

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -123,9 +123,11 @@ void find_children(PROC_MAP& pm) {
     }
 }
 
-// get resource usage of non-BOINC apps
+// get resource usage of non-BOINC apps running above background priority.
 // NOTE: this is flawed because it doesn't account for short-lived processes.
-// It's not used on Win, Mac, or Linux, which have better ways of getting total CPU usage.
+// It's not used on Win, Mac, or Linux,
+// which have ways of getting total CPU usage.
+// See client/app.cpp
 //
 void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
     procinfo.clear();
@@ -162,8 +164,17 @@ void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
 #endif
 }
 
-// get CPU time of BOINC-related processes, low-priority processes,
-// and (if we're using Vbox) the Vbox daemon.
+// get CPU time of
+// - BOINC-related processes
+// - low-priority processes
+// - (if Vbox apps are running) the Vbox daemon
+// - Windows: WSL daemon ('vmmem')
+// - Linux/Mac:
+//      root processes (Docker containers run as root)
+//      processes named 'podman'
+//
+// This is subtracted from total CPU time to get
+// the 'non-BOINC CPU time' used in computing preferences
 //
 double boinc_related_cpu_time(PROC_MAP& pm, bool vbox_app_running) {
     double sum = 0;
@@ -180,6 +191,12 @@ double boinc_related_cpu_time(PROC_MAP& pm, bool vbox_app_running) {
                 // if a VBox app is running,
                 // count VBox processes as BOINC-related
                 // e.g. VBoxHeadless.exe and VBoxSVC.exe on Win
+#ifdef _WIN32
+            || strstr(p.command, 'vmmem')
+#else
+            || strstr(p.command, 'podman')
+            // || p.userid == 0
+#endif
         ) {
             sum += p.user_time;
         }

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -111,7 +111,7 @@ struct PROC_STAT {
 
 // parse a /proc/<pid>/stat files (1 line)
 // see https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html
-// 
+//
 int PROC_STAT::parse(char* buf) {
     int n = sscanf(buf,
         "%d (%[^)]) %c %d %d %d %d %d "

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -109,6 +109,9 @@ struct PROC_STAT {
     int parse(char*);
 };
 
+// parse a /proc/<pid>/stat files (1 line)
+// see https://man7.org/linux/man-pages/man5/proc_pid_stat.5.html
+// 
 int PROC_STAT::parse(char* buf) {
     int n = sscanf(buf,
         "%d (%[^)]) %c %d %d %d %d %d "


### PR DESCRIPTION
Win: count 'vmmem' (WSL process) as BOINC
Others: get Docker app CPU time from the apps themselves

Fixes #6398 (not tested on linux/mac)
