### PR TITLE
client: run benchmarks on startup if new install or upgrade

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -422,14 +422,16 @@ bool CLIENT_STATE::is_new_client() {
         || (core_client_version.minor != old_minor_version)
         || (core_client_version.release != old_release)
     ) {
-        msg_printf_notice(0, true, 0,
-            "The BOINC client version has changed from %d.%d.%d to %d.%d.%d.<br>To see what's new, view the <a href=%s>Client release notes</a>.",
-            old_major_version, old_minor_version, old_release,
-            core_client_version.major,
-            core_client_version.minor,
-            core_client_version.release,
-            "https://github.com/BOINC/boinc/wiki/Client-release-notes"
-        );
+        if (old_major_version) {
+            msg_printf_notice(0, true, 0,
+                "The BOINC client version has changed from %d.%d.%d to %d.%d.%d.<br>To see what's new, view the <a href=%s>Client release notes</a>.",
+                old_major_version, old_minor_version, old_release,
+                core_client_version.major,
+                core_client_version.minor,
+                core_client_version.release,
+                "https://github.com/BOINC/boinc/wiki/Client-release-notes"
+            );
+        }
         new_client = true;
     }
     if (statefile_platform_name.size() && strcmp(get_primary_platform(), statefile_platform_name.c_str())) {
@@ -778,6 +780,9 @@ int CLIENT_STATE::init() {
         } else {
             net_status.need_to_contact_reference_site = true;
         }
+    }
+    if (host_info.p_fpops == 0) {
+        run_cpu_benchmarks = true;
     }
 
     check_if_need_benchmarks();

--- a/client/cs_benchmark.cpp
+++ b/client/cs_benchmark.cpp
@@ -326,11 +326,6 @@ void CLIENT_STATE::check_if_need_benchmarks() {
 //
 bool CLIENT_STATE::can_run_cpu_benchmarks() {
     if (tasks_suspended) return false;
-
-    // if no projects attached yet, don't run
-    //
-    if (projects.size()==0) return false;
-
     return true;
 }
 

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -106,12 +106,6 @@ int CLIENT_STATE::parse_state_file() {
         fname = STATE_FILE_PREV;
     } else {
         msg_printf(0, MSG_INFO, "Creating new client state file");
-
-        // avoid warning messages about version
-        //
-        old_major_version = BOINC_MAJOR_VERSION;
-        old_minor_version = BOINC_MINOR_VERSION;
-        old_release = BOINC_RELEASE;
         return ERR_FOPEN;
     }
     return parse_state_file_aux(fname);

--- a/lib/Makefile.linux
+++ b/lib/Makefile.linux
@@ -5,7 +5,8 @@ OPTS = -O2 -Wall -Wformat -Wformat=2 -Wconversion -Wimplicit-fallthrough \
 -Werror=format-security \
 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 \
 -D_GLIBCXX_ASSERTIONS \
--fstack-clash-protection -fstack-protector-strong \
+# -fstack-clash-protection \
+-fstack-protector-strong \
 -Wl,-z,nodlopen -Wl,-z,noexecstack \
 -Wl,-z,relro -Wl,-z,now \
 -Wl,--as-needed -Wl,--no-copy-dt-needed-entries


### PR DESCRIPTION
Previous: we ran benchmarks only after attaching to a project.
