### PR TITLE
client: notify user if there's a newer BOINC WSL distro

### DIFF
--- a/client/client_msgs.cpp
+++ b/client/client_msgs.cpp
@@ -161,8 +161,9 @@ void msg_printf(PROJ_AM *p, int priority, const char *fmt, ...) {
 
 void msg_printf_notice(
     PROJ_AM *p,
-    bool is_html,   // msg has HTML tags; don't XML-escape it
-    const char* link, const char *fmt, ...
+    bool is_html,       // msg has HTML tags; don't XML-escape it
+    const char* link,   // where 'more info' goes to
+    const char *fmt, ...
 ) {
     char buf[8192];  // output can be much longer than format
     va_list ap;

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -252,12 +252,12 @@ void CLIENT_STATE::show_host_info() {
         msg_printf(NULL, MSG_INFO, "WSL: no usable distros found");
     } else {
         msg_printf(NULL, MSG_INFO, "Usable WSL distros:");
-        for (auto &wsl: host_info.wsl_distros.distros) {
+        for (auto& wsl : host_info.wsl_distros.distros) {
             msg_printf(NULL, MSG_INFO,
                 "-   %s (WSL %d)%s",
                 wsl.distro_name.c_str(),
                 wsl.wsl_version,
-                wsl.is_default?" (default)":""
+                wsl.is_default ? " (default)" : ""
             );
             msg_printf(NULL, MSG_INFO,
                 "-      OS: %s (%s)",
@@ -278,6 +278,11 @@ void CLIENT_STATE::show_host_info() {
                 msg_printf(NULL, MSG_INFO, "-      Docker compose version %s (%s)",
                     wsl.docker_compose_version.c_str(),
                     docker_type_str(wsl.docker_compose_type)
+                );
+            }
+            if (wsl.boinc_buda_runner_version) {
+                msg_printf(NULL, MSG_INFO, "-      BOINC WSL distro version %d",
+                    wsl.boinc_buda_runner_version
                 );
             }
         }

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -727,7 +727,7 @@ int CLIENT_STATE::init() {
     //
     newer_version_startup_check();
 
-#ifdef _WIN32
+#if !defined(SIM) && defined(_WIN32)
     show_wsl_messages();
 #endif
 

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -569,7 +569,7 @@ extern THREAD_LOCK client_thread_mutex;
 extern THREAD throttle_thread;
 
 #ifdef _WIN32
-extern show_wsl_messages();
+extern void show_wsl_messages();
 #endif
 
 //////// TIME-RELATED CONSTANTS ////////////

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -249,7 +249,13 @@ struct CLIENT_STATE {
 
 // --------------- current_version.cpp:
     string newer_version;
+        // if nonempty, there was a newer client version than us.
+        // this is the newer version number.
     string client_version_check_url;
+        // where we last got version info from
+#ifdef _WIN32
+    int latest_boinc_buda_runner_version;
+#endif
 
 // --------------- client_state.cpp:
     CLIENT_STATE();
@@ -561,6 +567,10 @@ extern double calculate_exponential_backoff(
 //
 extern THREAD_LOCK client_thread_mutex;
 extern THREAD throttle_thread;
+
+#ifdef _WIN32
+extern show_wsl_messages();
+#endif
 
 //////// TIME-RELATED CONSTANTS ////////////
 

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -505,6 +505,11 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
         if (xp.parse_string("newer_version", newer_version)) {
             continue;
         }
+#ifdef _WIN32
+        if (xp.parse_int("latest_boinc_buda_runner_version", latest_boinc_buda_runn_version)) {
+            continue;
+        }
+#endif
         if (xp.parse_string("client_version_check_url", client_version_check_url)) {
             continue;
         }
@@ -807,9 +812,15 @@ int CLIENT_STATE::write_state(MIOFILE& f) {
     if (strlen(language)) {
         f.printf("<language>%s</language>\n", language);
     }
-    if (newer_version.size()) {
+    if (!newer_version.empty()) {
         f.printf("<newer_version>%s</newer_version>\n", newer_version.c_str());
     }
+#ifdef _WIN32
+    f.printf(
+        "<latest_boinc_buda_runner_version>%d</latest_boinc_buda_runner_version>\n",
+        latest_boinc_buda_runner_version
+    );
+#endif
     if (client_version_check_url.size()) {
         f.printf("<client_version_check_url>%s</client_version_check_url>\n", client_version_check_url.c_str());
     }

--- a/client/cs_statefile.cpp
+++ b/client/cs_statefile.cpp
@@ -506,7 +506,7 @@ int CLIENT_STATE::parse_state_file_aux(const char* fname) {
             continue;
         }
 #ifdef _WIN32
-        if (xp.parse_int("latest_boinc_buda_runner_version", latest_boinc_buda_runn_version)) {
+        if (xp.parse_int("latest_boinc_buda_runner_version", latest_boinc_buda_runner_version)) {
             continue;
         }
 #endif

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -182,10 +182,11 @@ static int get_current_macos_version() {
 #endif
 
 // Parse the output of download.php?xml=1.
-// If there is a newer version for our primary platform,
-// copy it to new_version and return true.
+// If there is a version for our primary platform
+// that's newer than what we're running,
+// copy the version string to new_version and return true.
 //
-static bool parse_version(FILE* f, char* new_version, int len) {
+static bool parse_version(XML_PARSER &xp, char* new_version, int len) {
     char buf2[256];
     bool same_platform = false, newer_version_exists = false;
 #ifdef __APPLE__
@@ -193,10 +194,6 @@ static bool parse_version(FILE* f, char* new_version, int len) {
     int val = 0;
     int macOS_version = get_current_macos_version();
 #endif
-
-    MIOFILE mf;
-    XML_PARSER xp(&mf);
-    mf.init_file(f);
 
     while (!xp.get_tag()) {
         if (xp.match_tag("/version")) {
@@ -261,8 +258,12 @@ static void show_newer_version_msg(const char* new_vers) {
 }
 
 void GET_CURRENT_VERSION_OP::handle_reply(int http_op_retval) {
-    char buf[256], new_version[256], newest_version[256];
+    char new_version[256], newest_version[256];
     int maj=0, min=0, rel=0;
+#ifdef _WIN32
+    int bbrv;
+#endif
+
     if (http_op_retval) {
         error_num = http_op_retval;
         return;
@@ -271,14 +272,21 @@ void GET_CURRENT_VERSION_OP::handle_reply(int http_op_retval) {
     newest_version[0] = '\0';
     FILE* f = boinc_fopen(GET_CURRENT_VERSION_FILENAME, "r");
     if (!f) return;
-    while (fgets(buf, 256, f)) {
-        if (match_tag(buf, "<version>")) {
-            if (parse_version(f, new_version, sizeof(new_version))) {
+    MIOFILE mf;
+    XML_PARSER xp(&mf);
+    mf.init_file(f);
+    while (!xp.get_get()) {
+        if (xp.match_tag("version")) {
+            if (parse_version(xp, new_version, sizeof(new_version))) {
                 if (is_version_newer(new_version, maj, min, rel)) {
                     strlcpy(newest_version, new_version, sizeof(newest_version));
                     sscanf(newest_version, "%d.%d.%d", &maj, &min, &rel);
                 }
             }
+#ifdef _WIN32
+        } else xp.parse_int("boinc_buda_runner_version", bbrv) {
+            gstate.latest_boinc_buda_runner_version = bbrv;
+#endif
         }
     }
     fclose(f);
@@ -287,7 +295,7 @@ void GET_CURRENT_VERSION_OP::handle_reply(int http_op_retval) {
         show_newer_version_msg(newest_version);
     }
 
-    // Cache neweer version number. Empty string if no newer version
+    // Cache newer version number. Empty string if no newer version
     gstate.newer_version = string(newest_version);
 }
 

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -295,7 +295,7 @@ void GET_CURRENT_VERSION_OP::handle_reply(int http_op_retval) {
         show_newer_version_msg(newest_version);
     }
 
-#ifdef _WIN32
+#if !defined(SIM) && defined(_WIN32)
     show_wsl_messages();
 #endif
 

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -275,7 +275,7 @@ void GET_CURRENT_VERSION_OP::handle_reply(int http_op_retval) {
     MIOFILE mf;
     XML_PARSER xp(&mf);
     mf.init_file(f);
-    while (!xp.get_get()) {
+    while (!xp.get_tag()) {
         if (xp.match_tag("version")) {
             if (parse_version(xp, new_version, sizeof(new_version))) {
                 if (is_version_newer(new_version, maj, min, rel)) {
@@ -284,7 +284,7 @@ void GET_CURRENT_VERSION_OP::handle_reply(int http_op_retval) {
                 }
             }
 #ifdef _WIN32
-        } else xp.parse_int("boinc_buda_runner_version", bbrv) {
+        } else if (xp.parse_int("boinc_buda_runner_version", bbrv)) {
             gstate.latest_boinc_buda_runner_version = bbrv;
 #endif
         }

--- a/client/current_version.h
+++ b/client/current_version.h
@@ -36,9 +36,15 @@ struct GET_CURRENT_VERSION_OP: public GUI_HTTP_OP {
 
 extern void newer_version_startup_check();
 
+// where to get latest-version list from,
+// where to download new version from, etc.
+// Normally points to BOINC server but can override
+// using a file nvc_config.xml
+//
 struct NVC_CONFIG {
     std::string client_download_url;
     std::string client_new_version_name;
+        // if empty, we're using BOINC server and name is 'BOINC'
     std::string client_version_check_url;
     std::string network_test_url;
 

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -345,7 +345,7 @@ int get_wsl_information(WSL_DISTROS &distros) {
         if (wd.distro_name == BOINC_WSL_DISTRO_NAME) {
             wd.boinc_buda_runner_version = 1;
             if (!rs.run_program_in_wsl(
-                wd.distro_name, "cat version.txt"
+                wd.distro_name, "cat /home/boinc/version.txt"
             )) {
                 string buf;
                 char buf2[256];

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -15,8 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-using std::vector;
-using std::string;
+// enumerate the WSL distros on this host.
+// For each one, see if it contains Podman or Docker, and get the version
 
 #include "boinc_win.h"
 #include "win_util.h"
@@ -25,6 +25,9 @@ using std::string;
 #include "client_msgs.h"
 #include "hostinfo.h"
 #include "util.h"
+
+using std::vector;
+using std::string;
 
 // timeout for commands run in WSL container
 // If something goes wrong we don't want client to hang
@@ -335,6 +338,25 @@ int get_wsl_information(WSL_DISTROS &distros) {
         if (std::find(dw.begin(), dw.end(), wd.distro_name) != dw.end()) {
             wd.disallowed = true;
         }
+
+        // if it's boinc-buda-runner, look for version file
+        //
+        if (wd.distro_name == BOINC_WSL_DISTRO_NAME) {
+            wd.boinc_buda_runner_version = 1;
+            if (!rs.run_program_in_wsl(
+                wd.distro_name, "cat version.txt"
+            )) {
+                string buf;
+                char buf2[256];
+                read_from_pipe(rs.out_read, rs.proc_handle, buf, CMD_TIMEOUT);
+                safe_strcpy(buf2, buf.c_str());
+                char *p = strstr(buf2, "version: ");
+                if (p) {
+                    wd.boinc_buda_runner_version = atoi(p+strlen("version: "));
+                }
+            }
+        }
+
         distros.distros.push_back(wd);
     }
 
@@ -405,4 +427,23 @@ static bool get_docker_compose_version_aux(
 static void get_docker_compose_version(WSL_CMD& rs, WSL_DISTRO &wd) {
     if (get_docker_compose_version_aux(rs, wd, PODMAN)) return;
     get_docker_compose_version_aux(rs, wd, DOCKER);
+}
+
+// called on startup (after scanning distros)
+// and after doing an RPC to get latest version info.
+//
+void show_wsl_messages() {
+    int bdv = host_info.wsl_distros.boinc_distro_version();
+    const char *url = "https://github.com/BOINC/boinc/wiki/Installing-Docker";
+    if (bdv == 0) {
+        msg_printf_notice(0, true, url,
+            "Some BOINC projects require Windows Subsystem for Linux (WSL).  <a href=%s>Learn how to enable WSL</a>",
+            url
+        );
+    } else if (bdv < gstate.latest_boinc_buda_runner_version)) {
+        msg_printf_notice(0, true, url,
+            "A new version of the BOINC WSL distro is available.  <a href=%s>Learn how to upgrade.</a>",
+            url
+        );
+    }
 }

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -22,6 +22,7 @@
 #include "win_util.h"
 
 #include "str_replace.h"
+#include "client_state.h"
 #include "client_msgs.h"
 #include "hostinfo.h"
 #include "util.h"
@@ -433,14 +434,14 @@ static void get_docker_compose_version(WSL_CMD& rs, WSL_DISTRO &wd) {
 // and after doing an RPC to get latest version info.
 //
 void show_wsl_messages() {
-    int bdv = host_info.wsl_distros.boinc_distro_version();
+    int bdv = gstate.host_info.wsl_distros.boinc_distro_version();
     const char *url = "https://github.com/BOINC/boinc/wiki/Installing-Docker";
     if (bdv == 0) {
         msg_printf_notice(0, true, url,
             "Some BOINC projects require Windows Subsystem for Linux (WSL).  <a href=%s>Learn how to enable WSL</a>",
             url
         );
-    } else if (bdv < gstate.latest_boinc_buda_runner_version)) {
+    } else if (bdv < gstate.latest_boinc_buda_runner_version) {
         msg_printf_notice(0, true, url,
             "A new version of the BOINC WSL distro is available.  <a href=%s>Learn how to upgrade.</a>",
             url

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -23,8 +23,6 @@
 #include "common_defs.h"
 #include "wslinfo.h"
 
-#define BOINC_DISTRO_NAME "boinc-buda-runner"
-
 void WSL_DISTRO::clear() {
     distro_name = "";
     os_name = "";
@@ -35,6 +33,7 @@ void WSL_DISTRO::clear() {
     wsl_version = 0;
     docker_version = "";
     docker_compose_version = "";
+    boinc_buda_runner_version = 0;
 }
 
 void WSL_DISTRO::write_xml(MIOFILE& f) {
@@ -186,9 +185,9 @@ WSL_DISTRO* WSL_DISTROS::find_docker() {
     // look for the BOINC distro first
     //
     for (WSL_DISTRO &wd: distros) {
-        if (wd.distro_name != BOINC_DISTRO_NAME) continue;
+        if (wd.distro_name != BOINC_WSL_DISTRO_NAME) continue;
         if (wd.docker_version.empty()) {
-            fprintf(stderr, "%s is missing Podman", BOINC_DISTRO_NAME);
+            fprintf(stderr, "%s is missing Podman", BOINC_WSL_DISTRO_NAME);
         } else {
             return &wd;
         }
@@ -201,6 +200,15 @@ WSL_DISTRO* WSL_DISTROS::find_docker() {
         }
     }
     return NULL;
+}
+
+int WSL_DISTROS::boinc_distro_version() {
+    for (WSL_DISTRO &wd: distros) {
+        if (wd.distro_name == BOINC_WSL_DISTRO_NAME) {
+            return wd.boinc_buda_runner_version;
+        }
+    }
+    return 0;
 }
 
 #endif  // _USING_FCGI_

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -27,6 +27,8 @@
 #include "parse.h"
 #include "common_defs.h"
 
+#define BOINC_WSL_DISTRO_NAME "boinc-buda-runner"
+
 // describes a WSL (Windows Subsystem for Linux) distro,
 // and its Docker features
 //
@@ -52,6 +54,8 @@ struct WSL_DISTRO {
     std::string docker_compose_version;
         // version of Docker Compose; empty if none
     DOCKER_TYPE docker_compose_type;
+    int boinc_buda_runner_version;
+        // if this distro is boinc_buda_runner, the version
 
     WSL_DISTRO(){
         clear();
@@ -77,6 +81,8 @@ struct WSL_DISTROS {
     );
     WSL_DISTRO *find_docker();
         // find a distro containing Docker
+    int boinc_distro_version();
+        // version number of BOINC distro, if present, else 0
 };
 
 #endif


### PR DESCRIPTION
Fixes #6407

- BOINC WSL distro has version number in /home/boinc/version.txt:
version: 1

- client version RPC includes current BOINC WSL distro version
- check at startup and after RPC; show notice with link to wiki page