### PR TITLE
docker_wrapper (Mac/Linux): show appropriate error message if Docker not present

### DIFF
--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -78,7 +78,9 @@ void HOST_INFO::clear_host_info() {
     wsl_distros.clear();
 #else
     safe_strcpy(docker_version, "");
+    docker_type = NONE;
     safe_strcpy(docker_compose_version, "");
+    docker_compose_type = NONE;
 #endif
 
     safe_strcpy(product_name, "");

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -764,7 +764,18 @@ int main(int argc, char** argv) {
         boinc_finish(1);
     }
 #else
-    docker_type = boinc_is_standalone()?PODMAN:aid.host_info.docker_type;
+    if (boinc_is_standalone()) {
+        docker_type = PODMAN;
+    } else {
+        if (!strlen(aid.host_info.docker_version)
+            || aid.host_info.docker_type == NONE
+        ) {
+            fprintf(stderr, "Docker type missing from app_init_data.xml\n");
+            fprintf(stderr, "Check project plan class configuration\n");
+            boinc_finish(1);
+        }
+        docker_type = aid.host_info.docker_type;
+    }
     docker_conn.init(docker_type, config.verbose>0);
 #endif
     fprintf(stderr, "Using %s\n", docker_type_str(docker_type));


### PR DESCRIPTION
If no Docker type is specified in app_init_data.xml, write a message to stderr and exit(1).
Before we were trying to run 'unknown' as the Docker CLI program.