### PR TITLE
MacOS 26 Screensaver fixes

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -248,7 +248,7 @@ int use_sandbox, int isManager, char* path_to_error, int len
         fscanf(f, "BrandId=%ld\n", &brandId);
         fclose(f);
     }
-    
+
     snprintf(full_path, sizeof(full_path),"/%s/Contents/Resources/boinc", appPath[brandId]);
         retval = stat(full_path, &sbuf);
         if (retval)

--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -242,7 +242,15 @@ int use_sandbox, int isManager, char* path_to_error, int len
         // Require absolute owner and group boinc_master:boinc_master
         // Get the full path to BOINC Client inside this application's bundle
         //
-        retval = stat("/Applications/BOINCManager.app/Contents/Resources/boinc", &sbuf);
+    long brandId = 0;
+    FILE *f = fopen("/Library/Application Support/BOINC Data/Branding", "r");
+    if (f) {
+        fscanf(f, "BrandId=%ld\n", &brandId);
+        fclose(f);
+    }
+    
+    snprintf(full_path, sizeof(full_path),"/%s/Contents/Resources/boinc", appPath[brandId]);
+        retval = stat(full_path, &sbuf);
         if (retval)
             return -1016;          // Should never happen
 

--- a/client/switcher.cpp
+++ b/client/switcher.cpp
@@ -278,7 +278,7 @@ static void print_to_log_file(const char *format, ...) {
     char buf[256];
     time_t t;
 
-    f = fopen("/Users/Shared/test_log_gfx_switcher.txt", "a");
+    f = fopen("/Users/Shared/test_log_switcher.txt", "a");
     if (!f) return;
 
 //  freopen(buf, "a", stdout);
@@ -298,7 +298,7 @@ static void print_to_log_file(const char *format, ...) {
     fputs("\n", f);
     fflush(f);
     fclose(f);
-    chmod("/Users/Shared/test_log_gfx_switcher.txt", 0666);
+    chmod("/Users/Shared/test_log_switcher.txt", 0666);
 }
 
 static void strip_cr(char *buf)

--- a/clientgui/mac/templates/Finish_Install-Info.plist
+++ b/clientgui/mac/templates/Finish_Install-Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -8,6 +8,8 @@
 	<string>BOINC_Finish_Install</string>
 	<key>CFBundleIdentifier</key>
 	<string>edu.berkeley.boinc.finish-install</string>
+	<key>CFBundleIconFile</key>
+	<string>MacInstaller.icns</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/clientgui/mac/templates/PostInstall-Info.plist
+++ b/clientgui/mac/templates/PostInstall-Info.plist
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
 	<string>PostInstall</string>
+	<key>CFBundleIconFile</key>
+	<string>MacInstaller.icns</string>
 	<key>CFBundleIdentifier</key>
 	<string>edu.berkeley.boinc.PostInstall</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/clientgui/mac/templates/ScreenSaver-Info.plist
+++ b/clientgui/mac/templates/ScreenSaver-Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -10,8 +10,6 @@
 	<string>edu.berkeley.boincsaver</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>BOINCSaver</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleSignature</key>

--- a/clientscr/Mac_Saver_Module.h
+++ b/clientscr/Mac_Saver_Module.h
@@ -90,6 +90,7 @@ class CScreensaver
 {
 public:
     CScreensaver();
+    ~CScreensaver();
 
     int             Create();
     int             Run();
@@ -137,7 +138,6 @@ protected:
     int             launch_screensaver(RESULT* rp, int& graphics_application);
     int             launch_default_screensaver(char *dir_path, int& graphics_application);
     void            HandleRPCError(void);
-    int             KillScreenSaver(void);
     void            GetDefaultDisplayPeriods(struct ss_periods &periods);
     pthread_t       m_hDataManagementThread;
 
@@ -155,7 +155,6 @@ protected:
     bool            m_bResetCoreState;
     bool            m_bQuitDataManagementProc;
     bool            m_bDataManagementProcStopped;
-    bool            m_bV5_GFX_app_is_running;
 
 
     //

--- a/clientscr/Mac_Saver_ModuleView.h
+++ b/clientscr/Mac_Saver_ModuleView.h
@@ -44,6 +44,7 @@
 
 - (bool) setUpToUseCGWindowList;
 - (void) doPeriodicTasks;
+- (void) advancePosition:(NSTimer*)timer;
 
 @end
 
@@ -53,6 +54,7 @@
 - (void)init:(NSView*)saverView;
 - (void)testConnection;
 - (void)portDied:(NSNotification *)notification;
+- (void)closeServerPort;
 - (void)cleanUpOpenGL;
 
 @end

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -150,13 +150,13 @@ NSRect myViewBounds;
 static SharedGraphicsController *mySharedGraphicsController;
 static bool runningSharedGraphics;
 static bool useCGWindowList;
-static pid_t childPid;  // pid of the currently running grapics app, not actually our chkld
+static pid_t childPid;  // pid of the currently running graphics app, not actually our chkld
 static int gfxAppWindowNum;
 static NSView *imageView;
 static char gfxAppPath[MAXPATHLEN];
 static char gfxWuName[MAXPATHLEN];
 static int taskSlot;
-static NSRunningApplication *childApp;  // currently running grapics app, not actually our chkld
+static NSRunningApplication *childApp;  // currently running graphics app, not actually our child
 static double gfxAppStartTime;
 static bool UseSharedOffscreenBuffer(void);
 static double lastGetSSMsgTime;

--- a/clientscr/gfx_cleanup.mm
+++ b/clientscr/gfx_cleanup.mm
@@ -73,8 +73,8 @@ time_t elapsedTime = 0;
 #endif
 
 void killGfxApp(pid_t thePID) {
-#if 0
     print_to_log_file("in gfx_cleanup: killGfxApp()");
+#if 0
     kill(thePID, SIGKILL);
 #else
     char buf[256];
@@ -118,7 +118,7 @@ void killGfxApp(pid_t thePID) {
         retval = rpc->run_graphics_app("test", p, userName);
         if (retval || (p==0)) break;
     }
- print_to_log_file("in gfx_cleanup: killGfxApp(%d): rpc->run_graphics_app(test) returned pid %d, retval %d when i = %d", thePID, p, retval, i);
+    print_to_log_file("in gfx_cleanup: killGfxApp(%d): rpc->run_graphics_app(test) returned pid %d, retval %d when i = %d", thePID, p, retval, i);
 
     // Graphics apps called by screensaver or Manager (via Show
     // Graphics button) now write files in their slot directory as
@@ -144,14 +144,16 @@ void * MonitorParent(void* param) {
     print_to_log_file("in gfx_cleanup: Starting MonitorParent");
     while (true) {
         boinc_sleep(0.25);  // Test every 1/4 second
+        print_to_log_file("in gfx_cleanup: MonitorParent: getppd=%d, parentpid=%d", getppid(), parentPid);
         if (getppid() != parentPid) {
             if (GFX_PidFromScreensaver) {
+                print_to_log_file("in gfx_cleanup: MonitorParent: calling killGfxApp");
                 killGfxApp(GFX_PidFromScreensaver);
             }
             if (quit_MonitorParentThread) {
                 return 0;
             }
-            print_to_log_file("in gfx_cleanup: parent died, exiting (child) after handling %d",GFX_PidFromScreensaver);
+            print_to_log_file("in gfx_cleanup: MonitorParent: parent died, exiting (child) after handling %d",GFX_PidFromScreensaver);
 #if USE_TIMER
             endTime = time(NULL);
             elapsedTime = endTime - startTime;
@@ -189,10 +191,12 @@ NSWindow* myWindow;
         }
         if (ferror(stdin) && (errno != EINTR)) {
             fprintf(stderr, "in gfx_cleanup: fgets got error %d %s", errno, strerror(errno));
+            print_to_log_file("in gfx_cleanup: fgets got error %d %s", errno, strerror(errno));
             break;
         }
 
         if (!strcmp(buf, "Quit\n")) {
+            print_to_log_file("in gfx_cleanup: parent sent Quit to child");
             break;
         }
         GFX_PidFromScreensaver = atoi(buf);
@@ -200,6 +204,7 @@ NSWindow* myWindow;
     }
 
     if (GFX_PidFromScreensaver) {
+        print_to_log_file("in gfx_cleanup: calling killGfxApp");
         killGfxApp(GFX_PidFromScreensaver);
     }
 

--- a/clientscr/gfx_switcher.cpp
+++ b/clientscr/gfx_switcher.cpp
@@ -164,6 +164,10 @@ int main(int argc, char** argv) {
     getcwd( current_dir, sizeof(current_dir));
     print_to_log_file("current directory = %s", current_dir);
     print_to_log_file("user_name is %s, euid=%d, uid=%d, egid=%d, gid=%d", user_name, geteuid(), getuid(), getegid(), getgid());
+    print_to_log_file("gfx_switcher pid = %d", getpid()) ;
+    pid_t ScreenSaverEngine_Pid = 0;
+    ScreenSaverEngine_Pid = getPidIfRunning("com.apple.ScreenSaver.Engine.legacyScreenSaver");
+    print_to_log_file("main: ScreenSaverEngine_legacyScreenSaver_Pid=%d", ScreenSaverEngine_Pid);
 
     for (int i=0; i<argc; i++) {
          print_to_log_file("gfx_switcher arg %d: %s", i, argv[i]);
@@ -342,10 +346,11 @@ void * MonitorScreenSaverEngine(void* param) {
 #elif defined(__arm64__)
             ScreenSaverEngine_Pid = getPidIfRunning("com.apple.ScreenSaver.Engine.legacyScreenSaver.arm64");
 #endif
+        }
+
 #if VERBOSE           // For debugging only
         print_to_log_file("MonitorScreenSaverEngine: ScreenSaverEngine_legacyScreenSaver_Pid=%d", ScreenSaverEngine_Pid);
 #endif
-        }
 
     if (ScreenSaverEngine_Pid == 0) {
         kill(graphics_Pid, SIGKILL);

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -60,7 +60,7 @@ extern "C" {
 
 // Flags for testing & debugging
 #define CREATE_LOG 0
-#define USE_SPECIAL_LOG_FILE 1
+#define USE_SPECIAL_LOG_FILE 0
 #define FOR_TESTING_ONLY 0  // Set to 1 to simulate dualGPU MacBook Pro on other Macs
 // Set to 1 to simulate 30 seconds on AC, 30 on battery, 30 AC, 30 battery, etc.
 #define SIMULATE_AC_BATTERY_SWITCHING 0
@@ -131,6 +131,7 @@ const char *  CCNotRunningMsg = "BOINC is not running.";
 
 //const char *  BOINCExitedSaverMode = "BOINC is no longer in screensaver mode.";
 
+static bool created = false;    // CAF
 
 // If there are multiple displays, this may get called
 // multiple times (once for each display), so we need to guard
@@ -144,9 +145,20 @@ void initBOINCSaver() {
         "stdoutscr", "stderrscr"
         );
 
+    // When gfx_cleanup exits, it will send a SIGCHLD to legacysceensaver
+    // which is normally set to also exit when it receives that signal
+    struct sigaction temp;
+    sigaction(SIGCHLD, NULL, &temp);
+    temp.sa_handler = SIG_IGN;
+    sigaction(SIGCHLD, &temp, NULL);
+
+for (int i=1; i<32; ++i)
+boinc_set_signal_handler(i, boinc_catch_signal);
+
     if (gspScreensaver == NULL) {
         gspScreensaver = new CScreensaver();
-    }
+        created = false;    // CAF
+   }
 }
 
 
@@ -156,7 +168,10 @@ int startBOINCSaver() {
     IsDualGPUMacbook = true;
 #endif
     if (gspScreensaver) {
-        return gspScreensaver->Create();
+        if (!created) {     // CAF
+            created = true; // CAF
+            return gspScreensaver->Create();
+        }                   // CAF
     }
     return TEXTLOGOFREQUENCY;
 }
@@ -203,6 +218,8 @@ void closeBOINCSaver() {
         delete gspScreensaver;
         gspScreensaver = NULL;
     }
+for (int i=1; i<32; ++i)
+boinc_set_signal_handler(i, boinc_catch_signal);
 }
 
 
@@ -369,8 +386,12 @@ CScreensaver::CScreensaver() {
 }
 
 
+CScreensaver::~CScreensaver() {
+}
+
+
 int CScreensaver::Create() {
-        // Ugly workaround for a problem with the System Preferences app
+    // Ugly workaround for a problem with the System Preferences app
     // For an unknown reason, when this screensaver is run using the
     // Test button in the System Prefs Screensaver control panel, the
     // control panel calls our stopAnimation function as soon as the
@@ -567,7 +588,7 @@ int CScreensaver::getSSMessage(char **theMessage, int* coveredFreq) {
             // Wait 1 second to allow ScreenSaver engine to close us down
             if (++gQuitCounter > (m_MessageText[0] ? TEXTLOGOFREQUENCY : NOTEXTLOGOFREQUENCY)) {
                 closeBOINCSaver();
-                KillScreenSaver(); // Stop the ScreenSaver Engine
+                exit(0);    // Stop the ScreenSaver Engine
             }
             break;
 #endif
@@ -688,6 +709,7 @@ void CScreensaver::ShutdownSaver() {
             rpc->quit();    // Kill core client if we launched it
         }
 #endif
+        rpc->close();
         delete rpc;
         rpc = NULL;
     }
@@ -700,18 +722,14 @@ void CScreensaver::ShutdownSaver() {
     m_bQuitDataManagementProc = false;
     saverState = SaverState_Idle;
     retryCount = 0;
+    ScreenSaverStartTime = 0;
+    ScreenIsBlanked = false;
+
     if (m_gfx_Cleanup_IPC) {
         fprintf(m_gfx_Cleanup_IPC, "Quit\n");
         fflush(m_gfx_Cleanup_IPC);
         pclose(m_gfx_Cleanup_IPC);
-    }
-
-    // Under MacOS 14.0 Sonoma, screensavers continue to run and "draw" invisibly
-    // after they are dismissed by user activity, to allow them to be used as
-    // wallpaper. Since we don't want the BOINC screensaver to be used as wallpaper,
-    // this would waste system resources.
-    if (gIsSonoma) {
-        KillScreenSaver();
+        m_gfx_Cleanup_IPC = NULL;
     }
 }
 
@@ -794,7 +812,6 @@ bool CScreensaver::DestroyDataManagementThread() {
         }
         boinc_sleep(0.1);
     }
-
     m_hDataManagementThread = NULL; // Don't delay more if this routine is called again.
 
     if (m_hGraphicsApplication) {
@@ -906,18 +923,6 @@ pid_t CScreensaver::getClientPID() {
 
     close(fd);
     return fl.l_pid;
-}
-
-
-// Send a Quit AppleEvent to the process which called this module
-// (i.e., tell the ScreenSaver engine to quit)
-int CScreensaver::KillScreenSaver() {
-    pid_t                       thisPID;
-    int                         retval;
-
-    thisPID = getpid();
-    retval = kill(thisPID, SIGABRT);   // SIGINT
-    return retval;
 }
 
 

--- a/clientscr/mac_saver_module.cpp
+++ b/clientscr/mac_saver_module.cpp
@@ -152,7 +152,7 @@ void initBOINCSaver() {
     temp.sa_handler = SIG_IGN;
     sigaction(SIGCHLD, &temp, NULL);
 
-for (int i=1; i<32; ++i)
+for (int i=1; i<NSIG; ++i)
 boinc_set_signal_handler(i, boinc_catch_signal);
 
     if (gspScreensaver == NULL) {

--- a/clientscr/screensaver.cpp
+++ b/clientscr/screensaver.cpp
@@ -565,9 +565,10 @@ DataMgmtProcType CScreensaver::DataManagementProc() {
     m_bDefault_gfx_running = false;
     m_bShow_default_ss_first = false;
     graphics_app_result_ptr = NULL;
-    graphicsAppStartTime = 0;
 
 #ifdef __APPLE__
+    graphicsAppStartTime = 0;
+
     for (int i = 0; i < m_vIncompatibleGfxApps.size(); i++) {
         if (m_vIncompatibleGfxApps[i]) {
             free(m_vIncompatibleGfxApps[i]);
@@ -640,11 +641,13 @@ BOINCTRACE(_T("CScreensaver::DataManagementProc - Thread told to stop\n"));
                     m_hGraphicsApplication = 0;
                 }
 
+#ifdef __APPLE__
                 ss_shmem->gfx_pid = 0;
                 ss_shmem->gfx_slot = -1;
                 ss_shmem->major_version = 0;
                 ss_shmem->minor_version = 0;
                 ss_shmem->release = 0;
+#endif
 
                BOINCTRACE(_T("CScreensaver::DataManagementProc - Stopping...\n"));
                 m_bDataManagementProcStopped = true; // Tell main thread that we exited

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -13,9 +13,9 @@
 			buildPhases = (
 			);
 			dependencies = (
-				DDC04DA72E2908BC006AB01D /* PBXTargetDependency */,
-				DDC04D9F2E28C473006AB01D /* PBXTargetDependency */,
-				DDC04D9D2E28C44B006AB01D /* PBXTargetDependency */,
+				DDC04DA52E2908AB006AB01D /* PBXTargetDependency */,
+				DDA8694C2E1FCEE400642CD3 /* PBXTargetDependency */,
+				DDA8694A2E1FCE6A00642CD3 /* PBXTargetDependency */,
 				DD67F1A32D5A2C3700A78699 /* PBXTargetDependency */,
 				DDF9EC11144EB36E005D6144 /* PBXTargetDependency */,
 				DDF9EC17144EB36E005D6144 /* PBXTargetDependency */,
@@ -57,6 +57,7 @@
 		DD08648D19E0BE6D00994039 /* ProjectWelcomePage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD08648B19E0BE6D00994039 /* ProjectWelcomePage.cpp */; };
 		DD0925B51FB05490000902DF /* project_list.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD0925B31FB05490000902DF /* project_list.cpp */; };
 		DD0A06F50869A2D2007CD86E /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		DD0AF61C2E21359200C46A81 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
 		DD0C5A8B0816711400CEC5D7 /* boinc.jpg in Resources */ = {isa = PBXBuildFile; fileRef = DD0C5A8A0816711400CEC5D7 /* boinc.jpg */; };
 		DD0D32DD1E0ABEEE00A0FBAB /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DD11E5B617D1A89700947975 /* MacAccessiblity.mm in Sources */ = {isa = PBXBuildFile; fileRef = DD1907FA17D1A2F100596F03 /* MacAccessiblity.mm */; };
@@ -219,6 +220,7 @@
 		DD5F656523606AED009ED2A2 /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
 		DD5F656623607472009ED2A2 /* gfx_cleanup in Resources */ = {isa = PBXBuildFile; fileRef = DD5F654123605B41009ED2A2 /* gfx_cleanup */; };
 		DD5FE1B517828887003339DF /* translate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF9350F176B0D0C00A2793C /* translate.cpp */; };
+		DD612B522E2EA38500C634C8 /* PostInstall.app in Resources */ = {isa = PBXBuildFile; fileRef = DD1277B3081F3D67007B5DE1 /* PostInstall.app */; };
 		DD64A7782703379F005FE681 /* MacBitmapComboBox.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD64A774270329AA005FE681 /* MacBitmapComboBox.cpp */; };
 		DD64D8011F6BE5BA00FEEAAA /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
 		DD6617880A3FFD8C00FFEBEB /* check_security.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD6617870A3FFD8C00FFEBEB /* check_security.cpp */; };
@@ -462,6 +464,7 @@
 		DDD0CEAE1E1E36AE003BD920 /* mac_util.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDBAA9B41DF1902B004C48FD /* mac_util.mm */; };
 		DDD0CEAF1E1E36E4003BD920 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DDD3371310622D0800867C7D /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20286C33FDCF999611CA2CEA /* Carbon.framework */; };
+		DDD43F942E2D5BC60032DCDD /* MacInstaller.icns in Resources */ = {isa = PBXBuildFile; fileRef = DD531BC50C193D3800742E50 /* MacInstaller.icns */; };
 		DDD50AFA18C49D2300EC244E /* BOINCGUIApp.mm in Sources */ = {isa = PBXBuildFile; fileRef = DDCA2EBD18C49139007D5F6C /* BOINCGUIApp.mm */; };
 		DDD52DCA0C03CAE6009B5FC0 /* ViewProjects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD52DC40C03CAE6009B5FC0 /* ViewProjects.cpp */; };
 		DDD52DCC0C03CAE6009B5FC0 /* ViewTransfers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD52DC60C03CAE6009B5FC0 /* ViewTransfers.cpp */; };
@@ -552,7 +555,6 @@
 		DDEED39829ADFDC400DC3E5D /* finish_install.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD3EAAAE216A268500BC673C /* finish_install.cpp */; };
 		DDEED39929ADFDEC00DC3E5D /* mac_branding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD93854320F609C7008EDE5A /* mac_branding.cpp */; };
 		DDEED39B29ADFDFA00DC3E5D /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20286C33FDCF999611CA2CEA /* Carbon.framework */; };
-		DDEED3A029AE114D00DC3E5D /* BOINC_Finish_Install.app in Resources */ = {isa = PBXBuildFile; fileRef = DDEED38629ADFD7000DC3E5D /* BOINC_Finish_Install.app */; };
 		DDEED3A129AE116E00DC3E5D /* BOINC_Finish_Install.app in Resources */ = {isa = PBXBuildFile; fileRef = DDEED38629ADFD7000DC3E5D /* BOINC_Finish_Install.app */; };
 		DDF07768236C4D410046EE44 /* proxy_info.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BEF07C5B1770043025C /* proxy_info.cpp */; };
 		DDF07769236C4D6A0046EE44 /* hostinfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BB607C5AEEE0043025C /* hostinfo.cpp */; };
@@ -562,6 +564,8 @@
 		DDF0776E236C4E650046EE44 /* app_ipc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AA8B6B1B046C364400A80164 /* app_ipc.cpp */; };
 		DDF0776F236C4E8A0046EE44 /* prefs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD344BE407C5B1670043025C /* prefs.cpp */; };
 		DDF0C980291D2C3E00E72E0C /* shmem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AAA31C97042157A800A80164 /* shmem.cpp */; };
+		DDF2720E2E16A40300960554 /* translate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDF9350F176B0D0C00A2793C /* translate.cpp */; };
+		DDF2720F2E16AE6E00960554 /* filesys.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F5EAD475031AEFF8018E201A /* filesys.cpp */; };
 		DDF5E23318B8673E005DEA6E /* uninstall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD4688590C1661970089F500 /* uninstall.cpp */; };
 		DDF5E23418B86803005DEA6E /* AddRemoveUser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDD33709106224E800867C7D /* AddRemoveUser.cpp */; };
 		DDF5F85A10DD05DB006A50CD /* notice.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DDE1372D10DC5E8D00161D6B /* notice.cpp */; };
@@ -734,6 +738,20 @@
 			remoteGlobalIDString = DD7748970A356C880025D05E;
 			remoteInfo = SetUpSecurity;
 		};
+		DDA869492E1FCE6A00642CD3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DDEED38529ADFD7000DC3E5D;
+			remoteInfo = boinc_finish_install;
+		};
+		DDA8694B2E1FCEE400642CD3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B13E2D0E265564D100D5C977;
+			remoteInfo = detect_rosetta_cpu;
+		};
 		DDB874660C850DB600E0DE1F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
@@ -762,21 +780,7 @@
 			remoteGlobalIDString = DD35353007E1E05C00C4718D;
 			remoteInfo = api_libboinc;
 		};
-		DDC04D9C2E28C44B006AB01D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = DDEED38529ADFD7000DC3E5D;
-			remoteInfo = boinc_finish_install;
-		};
-		DDC04D9E2E28C473006AB01D /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = B13E2D0E265564D100D5C977;
-			remoteInfo = detect_rosetta_cpu;
-		};
-		DDC04DA62E2908BC006AB01D /* PBXContainerItemProxy */ = {
+		DDC04DA42E2908AB006AB01D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
 			proxyType = 1;
@@ -1084,6 +1088,7 @@
 		DD7BF7D80B8E7A9800A009F7 /* str_util.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = str_util.h; path = ../lib/str_util.h; sourceTree = SOURCE_ROOT; };
 		DD7BF7E70B8E7BBE00A009F7 /* work_fetch.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = work_fetch.cpp; sourceTree = "<group>"; };
 		DD7C5E7508110AE3002FCE1E /* ScreenSaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScreenSaver.framework; path = /System/Library/Frameworks/ScreenSaver.framework; sourceTree = "<absolute>"; };
+		DD7FD7DD2E1F9ECC00390B0E /* Set_Screensaver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = Set_Screensaver.cpp; path = /Volumes/Dev/BOINC_GIT/boinc_trunk_fixes_for_macos26/mac_installer/Set_Screensaver.cpp; sourceTree = "<absolute>"; };
 		DD80C83D0CBAEB4F00F1121D /* sandbox.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = sandbox.cpp; sourceTree = "<group>"; };
 		DD80C83E0CBAEB4F00F1121D /* sandbox.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = sandbox.h; path = ../client/sandbox.h; sourceTree = SOURCE_ROOT; };
 		DD818294245ED4010076E5D0 /* boinc_ss_helper.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = boinc_ss_helper.sh; path = ../clientscr/boinc_ss_helper.sh; sourceTree = "<group>"; };
@@ -1685,6 +1690,7 @@
 				DD3EAAAE216A268500BC673C /* finish_install.cpp */,
 				DD1277C0081F3E73007B5DE1 /* PostInstall.cpp */,
 				DDF9350F176B0D0C00A2793C /* translate.cpp */,
+				DD7FD7DD2E1F9ECC00390B0E /* Set_Screensaver.cpp */,
 				DDF93510176B0D0C00A2793C /* translate.h */,
 				DD4688590C1661970089F500 /* uninstall.cpp */,
 				DDF1F47A09822C3400482C89 /* preinstall */,
@@ -2250,7 +2256,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD9E2371091CBDAE0048316E /* Build configuration list for PBXNativeTarget "PostInstall" */;
 			buildPhases = (
-				DD361D4E29E599E1000CC8D1 /* ShellScript */,
+				DD361D4E29E599E1000CC8D1 /* Run Script */,
 				DD1277AF081F3D67007B5DE1 /* Resources */,
 				DD1277B0081F3D67007B5DE1 /* Sources */,
 				DD1277B1081F3D67007B5DE1 /* Frameworks */,
@@ -2384,7 +2390,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD67F1992D5A24FD00A78699 /* Build configuration list for PBXNativeTarget "Fix_BOINC_Users" */;
 			buildPhases = (
-				DDC04DA12E28C8CC006AB01D /* ShellScript */,
+				DD0AF61B2E21250C00C46A81 /* ShellScript */,
 				DD67F1912D5A24FD00A78699 /* Sources */,
 				DD67F1922D5A24FD00A78699 /* Frameworks */,
 				DD67F1932D5A24FD00A78699 /* CopyFiles */,
@@ -2480,7 +2486,7 @@
 				DD96AFF50811075000A06F22 /* Resources */,
 				DD96AFF60811075000A06F22 /* Sources */,
 				DD96AFF70811075000A06F22 /* Frameworks */,
-				DD5FD5990A0233D60093C19F /* ShellScript */,
+				DDC04DA02E28C6AF006AB01D /* ShellScript */,
 				DD818296245EDA220076E5D0 /* ShellScript */,
 				DDF9B764245C12AA00587EBE /* ShellScript */,
 			);
@@ -2730,7 +2736,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD00F554176C081500850424 /* MacInstaller.icns in Resources */,
-				DDEED3A029AE114D00DC3E5D /* BOINC_Finish_Install.app in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2738,6 +2743,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD612B522E2EA38500C634C8 /* PostInstall.app in Resources */,
 				DD531BC60C193D3800742E50 /* MacInstaller.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2783,12 +2789,31 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DDD43F942E2D5BC60032DCDD /* MacInstaller.icns in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		DD0AF61B2E21250C00C46A81 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "source \"${PROJECT_DIR}/checkDependentLibraryVersions.sh\"\nexit $?\n";
+		};
 		DD1AFEB10A512D8700EE5B82 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -2870,7 +2895,7 @@
 			shellPath = /bin/sh;
 			shellScript = "source \"${PROJECT_DIR}/checkDependentLibraryVersions.sh\"\nexit $?\n";
 		};
-		DD361D4E29E599E1000CC8D1 /* ShellScript */ = {
+		DD361D4E29E599E1000CC8D1 /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -2880,6 +2905,7 @@
 			);
 			inputPaths = (
 			);
+			name = "Run Script";
 			outputFileListPaths = (
 			);
 			outputPaths = (
@@ -3163,22 +3189,6 @@
 			shellPath = /bin/sh;
 			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"CONFIGURATION = ${CONFIGURATION}\"\n# echo \"PRODUCT_NAME = ${PRODUCT_NAME}\"\nmkdir -p \"${SRCROOT}/build/${CONFIGURATION}\"\nif [ \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" -nt \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\" ]; then\n    cp -fp \"${BUILT_PRODUCTS_DIR}/lib${PRODUCT_NAME}.a\" \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    if [ \"$CONFIGURATION\" = \"Deployment\" ]; then\n        strip -S \"${SRCROOT}/build/${CONFIGURATION}/lib${PRODUCT_NAME}.a\"\n    fi\nfi\n";
 		};
-		DD5FD5990A0233D60093C19F /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/English.lproj/ScreenSaver-InfoPlist.strings",
-			);
-			outputPaths = (
-				"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj/InfoPlist.strings",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/ScreenSaver-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj/InfoPlist.strings\"\n";
-		};
 		DD5FD59B0A0234400093C19F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -3305,7 +3315,7 @@
 		DD77897E2A459453005B0A0E /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
+			buildActionMask = 8;
 			files = (
 			);
 			inputFileListPaths = (
@@ -3316,7 +3326,7 @@
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "source \"${PROJECT_DIR}/checkDependentLibraryVersions.sh\"\nexit $?\n";
 		};
@@ -3374,12 +3384,13 @@
 				"$(SRCROOT)/English.lproj/Uninstaller-InfoPlist.strings",
 				"$(SRCROOT)/BoincCmd-Info.plist",
 				"$(SRCROOT)/Finish_install-Info.plist",
+				"$(SRCROOT)/Set_Screensaver-Info.plist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n # Unfortunately, this does not work because other targets that\n # have SetVersion as a dependency only wait for SetVersion to\n # be built, not for its scripts to finish.\n# Run SetVersion in background so we can wait for it to finish running\n##\"${BUILT_PRODUCTS_DIR}/SetVersion\"\nwait\n\n";
+			shellScript = "## This is now handled by byuld pre-action scripts s in the\n## schemes for those targets which have inf.plist files.\n## Those pre-action scri[ts call mac_build/Update_Info_Plists.sh\n##\n# echo \"BuiltProductsDir = ${BUILT_PRODUCTS_DIR}\"\n# echo \"CONFIGURATIONTEMPDIR = ${CONFIGURATION_TEMP_DIR}\"\n# echo \"SRC ROOT = ${SRCROOT}\"\n# echo \"architecture = ${ARCHS}\"\n# echo \"native architecture = ${ARCHS}\"\n codesign -f -o runtime -s - \"${BUILT_PRODUCTS_DIR}/SetVersion\"\n # Unfortunately, this does not work because other targets that\n # have SetVersion as a dependency only wait for SetVersion to\n # be built, not for its scripts to finish.\n# Run SetVersion in background so we can wait for it to finish running\n##\"${BUILT_PRODUCTS_DIR}/SetVersion\"\n##wait\n\n";
 		};
-		DDC04DA12E28C8CC006AB01D /* ShellScript */ = {
+		DDC04DA02E28C6AF006AB01D /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -3388,14 +3399,16 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"${SRCROOT}/English.lproj/ScreenSaver-InfoPlist.strings",
 			);
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj/InfoPlist.strings",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "source \"${PROJECT_DIR}/checkDependentLibraryVersions.sh\"\nexit $?\n";
+			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj\"\ncp -fpv \"${SRCROOT}/English.lproj/ScreenSaver-InfoPlist.strings\" \"${BUILT_PRODUCTS_DIR}/BOINCSaver.saver/Contents/Resources/English.lproj/InfoPlist.strings\"\n";
 		};
 		DDC8FB2B1F6D398700BE55B8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -4105,8 +4118,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DDEED39929ADFDEC00DC3E5D /* mac_branding.cpp in Sources */,
+				DDF2720F2E16AE6E00960554 /* filesys.cpp in Sources */,
 				DDEED39829ADFDC400DC3E5D /* finish_install.cpp in Sources */,
+				DDEED39929ADFDEC00DC3E5D /* mac_branding.cpp in Sources */,
+				DDF2720E2E16A40300960554 /* translate.cpp in Sources */,
+				DD0AF61C2E21359200C46A81 /* mac_util.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4253,6 +4269,16 @@
 			target = DD7748970A356C880025D05E /* SetUpSecurity */;
 			targetProxy = DDA12AD00A369DEC00FBDD12 /* PBXContainerItemProxy */;
 		};
+		DDA8694A2E1FCE6A00642CD3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DDEED38529ADFD7000DC3E5D /* boinc_finish_install */;
+			targetProxy = DDA869492E1FCE6A00642CD3 /* PBXContainerItemProxy */;
+		};
+		DDA8694C2E1FCEE400642CD3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B13E2D0E265564D100D5C977 /* detect_rosetta_cpu */;
+			targetProxy = DDA8694B2E1FCEE400642CD3 /* PBXContainerItemProxy */;
+		};
 		DDB874670C850DB600E0DE1F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDB873E90C850BC800E0DE1F /* gfx2libboinc */;
@@ -4273,20 +4299,10 @@
 			target = DD35353007E1E05C00C4718D /* api_libboinc */;
 			targetProxy = DDBD681407FA830E0082C20D /* PBXContainerItemProxy */;
 		};
-		DDC04D9D2E28C44B006AB01D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = DDEED38529ADFD7000DC3E5D /* boinc_finish_install */;
-			targetProxy = DDC04D9C2E28C44B006AB01D /* PBXContainerItemProxy */;
-		};
-		DDC04D9F2E28C473006AB01D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = B13E2D0E265564D100D5C977 /* detect_rosetta_cpu */;
-			targetProxy = DDC04D9E2E28C473006AB01D /* PBXContainerItemProxy */;
-		};
-		DDC04DA72E2908BC006AB01D /* PBXTargetDependency */ = {
+		DDC04DA52E2908AB006AB01D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DDAEC9E007FA583B00A7BC36 /* SetVersion */;
-			targetProxy = DDC04DA62E2908BC006AB01D /* PBXContainerItemProxy */;
+			targetProxy = DDC04DA42E2908AB006AB01D /* PBXContainerItemProxy */;
 		};
 		DDD095510A3EE09900C95BA4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -4384,6 +4400,7 @@
 		DD1AFEB90A512D8700EE5B82 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = "Installer-Info.plist";
 				OTHER_CFLAGS = (
 					"-D_THREAD_SAFE",
@@ -5217,6 +5234,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Finish_Install-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "edu.berkeley.boinc.finish-install";

--- a/mac_build/boinc.xcodeproj/xcshareddata/xcschemes/boinc_finish_install.xcscheme
+++ b/mac_build/boinc.xcodeproj/xcshareddata/xcschemes/boinc_finish_install.xcscheme
@@ -11,6 +11,15 @@
             <ActionContent
                title = "Run Script"
                scriptText = "source &quot;$WORKSPACE_PATH/../../Update_Info_Plists.sh&quot;&#10;exit $?&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "DDEED38529ADFD7000DC3E5D"
+                     BuildableName = "BOINC_Finish_Install.app"
+                     BlueprintName = "boinc_finish_install"
+                     ReferencedContainer = "container:boinc.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
             </ActionContent>
          </ExecutionAction>
       </PreActions>

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -66,6 +66,10 @@
 
 #define USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS false
 
+// MPORTANT: The defnition of COPY_FINISH_INSTALL_TO_USER_DIRECTORY
+// must match the one in Finish_install.cpp
+#define COPY_FINISH_INSTALL_TO_USER_DIRECTORY false
+
 #include <Carbon/Carbon.h>
 #include <grp.h>
 
@@ -111,7 +115,6 @@ Boolean myFilterProc(DialogRef theDialog, EventRecord *theEvent, DialogItemIndex
 int DeleteReceipt(void);
 Boolean IsRestartNeeded();
 void CheckUserAndGroupConflicts();
-Boolean SetLoginItemOSAScript(long brandID, Boolean deleteLogInItem, char *userName);
 Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLogInItem, passwd *pw);
 OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen);
 OSErr SetScreenSaverSelection(char *moduleName, char *modulePath, int type);
@@ -135,7 +138,6 @@ int check_rosetta2_installed();
 int optionally_install_rosetta2();
 #endif  // __arm64__
 pid_t FindProcessPID(char* name, pid_t thePID, Boolean currentUserOnly);
-static void SleepSeconds(double seconds);
 static OSErr QuitAppleEventHandler(const AppleEvent *appleEvt, AppleEvent* reply, UInt32 refcon);
 int callPosixSpawn(const char *cmd);
 void print_to_log(const char *format, ...);
@@ -908,179 +910,6 @@ void CheckUserAndGroupConflicts()
 #endif  // SANDBOX
 }
 
-enum {
-	kSystemEventsCreator = 'sevs'
-};
-
-CFStringRef kSystemEventsBundleID = CFSTR("com.apple.systemevents");
-char *systemEventsAppName = "System Events";
-
-
-Boolean SetLoginItemOSAScript(long brandID, Boolean deleteLogInItem, char *userName)
-{
-    int                     i, j;
-    char                    cmd[2048];
-    char                    systemEventsPath[1024];
-    pid_t                   systemEventsPID;
-    OSErr                   err, err2;
-#if USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS
-    // NOTE: It may not be necessary to kill and relaunch the
-    // System Events application for each logged in user under High Sierra
-    Boolean                 isHighSierraOrLater = (compareOSVersionTo(10, 13) >= 0);
-#endif
-
-    fprintf(stdout, "Adjusting login items for user %s\n", userName);
-    fflush(stdout);
-
-    // We must launch the System Events application for the target user
-    err = noErr;
-    systemEventsPath[0] = '\0';
-
-    err = GetPathToAppFromID(kSystemEventsCreator, kSystemEventsBundleID, systemEventsPath, sizeof(systemEventsPath));
-    REPORT_ERROR(err);
-
-#if CREATE_LOG
-    if (err == noErr) {
-        print_to_log("SystemEvents is at %s\n", systemEventsPath);
-    } else {
-        print_to_log("GetPathToAppFromID(kSystemEventsCreator, kSystemEventsBundleID) returned error %d ", (int) err);
-    }
-#endif
-
-    if (err == noErr) {
-        // Find SystemEvents process.  If found, quit it in case
-        // it is running under a different user.
-        fprintf(stdout, "Telling System Events to quit (at start of SetLoginItemOSAScript)\n");
-        fflush(stdout);
-        systemEventsPID = FindProcessPID(systemEventsAppName, 0, false);
-        if (systemEventsPID != 0) {
-            err = kill(systemEventsPID, SIGKILL);
-        }
-        if (err != noErr) {
-            REPORT_ERROR(true);
-            fprintf(stdout, "(systemEventsPID, SIGKILL) returned error %d \n", (int) err);
-            fflush(stdout);
-        }
-        // Wait for the process to be gone
-        for (i=0; i<50; ++i) {      // 5 seconds max delay
-            SleepSeconds(0.1);      // 1/10 second
-            systemEventsPID = FindProcessPID(systemEventsAppName, 0, false);
-            if (systemEventsPID == 0) break;
-        }
-        if (i >= 50) {
-            REPORT_ERROR(true);
-            fprintf(stdout, "Failed to make System Events quit\n");
-            fflush(stdout);
-            err = noErr;
-            goto cleanupSystemEvents;
-        }
-        sleep(4);
-    }
-
-    if (systemEventsPath[0] != '\0') {
-        fprintf(stdout, "Launching SystemEvents for user %s\n", userName);
-        fflush(stdout);
-
-        for (j=0; j<5; ++j) {
-            sprintf(cmd, "sudo -u \"%s\" open \"%s\"", userName, systemEventsPath);
-            err = callPosixSpawn(cmd);
-            if (err) {
-                REPORT_ERROR(true);
-                fprintf(stdout, "[2] Command: %s returned error %d (try %d of 5)\n", cmd, (int) err, j);
-                fflush(stdout);
-            }
-            // Wait for the process to start
-            for (i=0; i<50; ++i) {      // 5 seconds max delay
-                SleepSeconds(0.1);      // 1/10 second
-                systemEventsPID = FindProcessPID(systemEventsAppName, 0, false);
-                if (systemEventsPID != 0) break;
-            }
-            if (i < 50) break;  // Exit j loop on success
-        }
-        if (j >= 5) {
-            fprintf(stdout, "Failed to launch System Events for user %s\n", userName);
-            REPORT_ERROR(true);
-            fflush(stdout);
-            err = noErr;
-            goto cleanupSystemEvents;
-        }
-    }
-    sleep(2);
-
-    for (i=0; i<NUMBRANDS; i++) {
-        fprintf(stdout, "Deleting any login items containing %s for user %s\n", appName[i], userName);
-        fflush(stdout);
-#if USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS
-        if (isHighSierraOrLater) {
-            sprintf(cmd, "su -l \"%s\" -c 'osascript -e \"tell application \\\"System Events\\\" to delete login item \\\"%s\\\"\"'", userName, appName[i]);
-        } else
-#endif
-        {
-            sprintf(cmd, "sudo -u \"%s\" osascript -e 'tell application \"System Events\" to delete login item \"%s\"'", userName, appName[i]);
-        }
-        err = callPosixSpawn(cmd);
-        if (err) {
-            REPORT_ERROR(true);
-            fprintf(stdout, "[2] Command: %s\n", cmd);
-            fprintf(stdout, "[2] Delete login item containing %s returned error %d\n", appName[i], err);
-            fflush(stdout);
-        }
-    }
-
-    if (deleteLogInItem) {
-        err = noErr;
-        goto cleanupSystemEvents;
-    }
-
-    fprintf(stdout, "Making new login item %s for user %s\n", appName[brandID], userName);
-    fflush(stdout);
-#if USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS
-    if (isHighSierraOrLater) {
-        sprintf(cmd, "su -l \"%s\" -c 'osascript -e \"tell application \\\"System Events\\\" to make new login item at end with properties {path:\\\"%s\\\", hidden:true, name:\\\"%s\\\"}\"'", userName, appPath[brandID], appName[brandID]);
-    } else
-#endif
-    {
-        sprintf(cmd, "sudo -u \"%s\" osascript -e 'tell application \"System Events\" to make new login item at end with properties {path:\"%s\", hidden:true, name:\"%s\"}'", userName, appPath[brandID], appName[brandID]);
-    }
-    err = callPosixSpawn(cmd);
-    if (err) {
-        REPORT_ERROR(true);
-        fprintf(stdout, "[2] Command: %s\n", cmd);
-        printf("[2] Make login item for %s returned error %d\n", appPath[brandID], err);
-    }
-    fflush(stdout);
-
-cleanupSystemEvents:
-    // Clean up in case this was our last user
-    fprintf(stdout, "Telling System Events to quit (at end of SetLoginItemOSAScript)\n");
-    fflush(stdout);
-    systemEventsPID = FindProcessPID(systemEventsAppName, 0, false);
-    err2 = noErr;
-    if (systemEventsPID != 0) {
-        err2 = kill(systemEventsPID, SIGKILL);
-    }
-    if (err2 != noErr) {
-        REPORT_ERROR(true);
-        fprintf(stdout, "kill(systemEventsPID, SIGKILL) returned error %d \n", (int) err2);
-        fflush(stdout);
-    }
-    // Wait for the process to be gone
-    for (i=0; i<50; ++i) {      // 5 seconds max delay
-        SleepSeconds(0.1);      // 1/10 second
-        systemEventsPID = FindProcessPID(systemEventsAppName, 0, false);
-        if (systemEventsPID == 0) break;
-    }
-    if (i >= 50) {
-        REPORT_ERROR(true);
-        fprintf(stdout, "Failed to make System Events quit\n");
-        fflush(stdout);
-    }
-
-    sleep(4);
-
-    return (err == noErr);
-}
-
 
 // Under OS 10.13 High Sierra, telling System Events to modify Login Items for
 // users who are not currently logged in no longer works, even when System Events
@@ -1106,6 +935,9 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
     // Create a LaunchAgent to finish installation for the specified user, replacing any LaunchAgent
     // created previously (such as by Uninstaller or by installing a differently branded BOINC.)
 
+    // deleteLogInItem will be true only if we are deleting BOINCManagr
+    // access for only this user, but installing for others.
+
     // Create LaunchAgents directory for this user if it does not yet exist
     snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents", pw->pw_name);
     if (stat(s, &sbuf) != 0) {
@@ -1124,7 +956,15 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
     fprintf(f, "\t<string>edu.berkeley.fix_login_items</string>\n");
     fprintf(f, "\t<key>ProgramArguments</key>\n");
     fprintf(f, "\t<array>\n");
+#if COPY_FINISH_INSTALL_TO_USER_DIRECTORY
     fprintf(f, "\t\t<string>/Users/%s/Library/Application Support/BOINC/%s_Finish_Install.app/Contents/MacOS/%s_Finish_Install</string>\n", pw->pw_name, brandName[brandID], brandName[brandID]);
+#else
+    // For a reason I do't understand, setting the screensaver under MacOS 26
+    // works if we use the BOINC_Finish_Install in the BOINC Data directory
+    // but not one at /Users/%s/Library/Application Support/BOINC/ so we no
+    // longer put one in the usr's directory tree.
+    fprintf(f, "\t\t<string>/Library/Application Support/BOINC Data/%s_Finish_Install.app/Contents/MacOS/%s_Finish_Install</string>\n", brandName[brandID], brandName[brandID]);
+#endif
     if (deleteLogInItem) {
         fprintf(f, "\t\t<string>-d</string>\n");
         fprintf(f, "\t\t<string>%d</string>\n", (int)oldBrandID);
@@ -1598,8 +1438,6 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
 #endif
     int                 i;
     int                 userIndex;
-    char                path[MAXPATHLEN];
-    Boolean             hadLoginItemLaunchAgent = false;
 
 //    char                nameOfSkin[256];
 //    FindSkinName(nameOfSkin, sizeof(nameOfSkin));
@@ -1709,6 +1547,8 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
     //automatically. I have filed bug report FB13270885 about this.
     // The response to my bug report is that it will be fixed in a
     // future rlease of MacOS.
+    // As of MacOS 26, we again can set the screensaver using Applescripts,
+    // but only for the current user, so we do it from BOINC_Finish_Install.
     // See also the comment at top of SetScreenSaverSelection().
     if (compareOSVersionTo(14, 0) < 0) {
         if (! saverAlreadySetForAll) {
@@ -1733,7 +1573,6 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
     fflush(stdout);
 
     for (userIndex=0; userIndex<(int)human_user_names.size(); ++userIndex) {
-        hadLoginItemLaunchAgent = false;
         strlcpy(human_user_name, human_user_names[userIndex].c_str(), sizeof(human_user_name));
 
         printf("[2] Checking user %s\n", human_user_name);
@@ -1837,10 +1676,12 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
             useOSASript = IsUserLoggedIn(pw->pw_name);
         }
 #endif
-       if (useOSASript) {
+        if (useOSASript) {
             snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents/edu.berkeley.boinc.plist", pw->pw_name);
             boinc_delete_file(s);
 
+            // We no longer put a copy of %s_Finish_Install in the user's folder,
+            // but a previous BOINC installation might have put one there.
             for (i=0; i< NUMBRANDS; i++) {
                 snprintf(s, sizeof(s), "rm -fR \"/Users/%s/Library/Application Support/BOINC/%s_Finish_Install.app\"", pw->pw_name, brandName[i]);
                 err = callPosixSpawn(s);
@@ -1850,6 +1691,7 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                     fflush(stdout);
                 }
 
+                // The uninstaller still does put a copy of %s_Finish_Uninstall in the user's folder,
                 snprintf(s, sizeof(s), "rm -fR \"/Users/%s/Library/Application Support/BOINC/%s_Finish_Uninstall.app\"", pw->pw_name, brandName[i]);
                 err = callPosixSpawn(s);
                 REPORT_ERROR(err);
@@ -1860,14 +1702,11 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
             }
 
             if (compareOSVersionTo(10, 13) >= 0) {
-                snprintf(s, sizeof(s), "/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist", pw->pw_name);
-                if (boinc_file_exists(s)) hadLoginItemLaunchAgent = true;
-                deleteLoginItem =  true;    // Use LaunchAgent to autostart BOINC Manager
                 // The -i argument tells BOINC_Finish_Install not to "Launchctl load" our
                 // LaunchAgent, because doing that launches the Manager immediately (before
                 // we can finish setting things up) and the Manager starts incorrectly,
                 // especially causing problems if starting in SimpleView.
-               snprintf(s, sizeof(s), "open \"/Library/Application Support/BOINC Data/%s_Finish_Install.app\" --args -i", brandName[brandID]);
+                snprintf(s, sizeof(s), "su -l \"%s\" -c '\"/Library/Application Support/BOINC Data/%s_Finish_Install.app/Contents/MacOS/%s_Finish_Install\" -i %d'", loginName, brandName[brandID], brandName[brandID], (int)brandID);
                 err = callPosixSpawn(s);
                 REPORT_ERROR(err);
                 if (err) {
@@ -1875,17 +1714,7 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                     fflush(stdout);
                 }
             }
-            // SetLoginItemOSAScript uses "System Events" which can trigger an aert which
-            // the user may find alraming. If we previously set a login item launch agent,
-            // we removed the old style login item at that time, so we avoid that alert.
-            if (!hadLoginItemLaunchAgent) {
-                printf("[2] calling SetLoginItemOSAScript for user %s, euid = %d, deleteLoginItem = %d\n",
-                    pw->pw_name, geteuid(), deleteLoginItem);
-                fflush(stdout);
-                SetLoginItemOSAScript(brandID, deleteLoginItem, pw->pw_name);
-            }
         } else {
-
             printf("[2] calling FixLaunchServicesDataBase for Finish_Install for user %s\n", pw->pw_name);
             fflush(stdout);
             FixLaunchServicesDataBase(pw->pw_uid, NULL, "edu.berkeley.boinc.finish-install");
@@ -1904,6 +1733,8 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
             for (i=0; i< NUMBRANDS; i++) {
                 // If we previously ran the installer for any brand but did not log in to
                 // this user, remove the user's unused BOINC_Manager_Finish_Install file.
+                // We no longer put a copy of %s_Finish_Install in the user's folder,
+                // but a previous BOINC installation might have put one there.
                 snprintf(s, sizeof(s), "rm -fR \"/Users/%s/Library/Application Support/BOINC/%s_Finish_Install.app\"", pw->pw_name, brandName[i]);
                 err = callPosixSpawn(s);
                 REPORT_ERROR(err);
@@ -1914,6 +1745,7 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
 
                 // If we previously ran the installer for any brand but did not log in to
                 // this user, remove the user's unused BOINC_Manager_Finish_Uninstall file.
+                // The uninstaller still does put a copy of %s_Finish_Uninstall in the user's folder,
                 snprintf(s, sizeof(s), "rm -fR \"/Users/%s/Library/Application Support/BOINC/%s_Finish_Uninstall.app\"", pw->pw_name, brandName[i]);
                 err = callPosixSpawn(s);
                 REPORT_ERROR(err);
@@ -1923,9 +1755,9 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                 }
             }
 
-            getPathToThisApp(path, sizeof(path));
-            snprintf(s, sizeof(s), "cp -fR \"%s/Contents/Resources/%s_Finish_Install.app\" \"/Users/%s/Library/Application Support/BOINC/\"",
-                        path, brandName[brandID], pw->pw_name);
+#if COPY_FINISH_INSTALL_TO_USER_DIRECTORY
+            snprintf(s, sizeof(s), "cp -fR \"/Library/Application Support/BOINC Data/%s_Finish_Install.app\" \"/Users/%s/Library/Application Support/BOINC/\"",
+                        brandName[brandID], pw->pw_name);
             err = callPosixSpawn(s);
             REPORT_ERROR(err);
             if (err) {
@@ -1949,6 +1781,7 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                 printf("*** user %s: lsregister call returned error %d for %s_Finish_Install.app\n", pw->pw_name, err, brandName[brandID]);
                 fflush(stdout);
             }
+#endif
 
             printf("[2] calling SetLoginItemLaunchAgent for user %s, euid = %d, deleteLoginItem = %d\n",
                 pw->pw_name, geteuid(), deleteLoginItem);
@@ -1971,14 +1804,16 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
             }
             SetSkinInSelectionAndShutdownBySystemFlagInUserPrefs(pw->pw_name, skinName[brandID]);
 
-            if (setSaverForAllUsers) {
-                seteuid(pw->pw_uid);    // Temporarily set effective uid to this user
-                sprintf(s, "/Library/Screen Savers/%s.saver", saverName[brandID]);
-                err = SetScreenSaverSelection(saverName[brandID], s, 0);
-                seteuid(saved_uid);     // Set effective uid back to privileged user
-                // This seems to work also:
-                // sprintf(s, "su -l \"%s\" -c 'defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName \"%s\" path \"/Library/Screen Savers/%s.saver\" type 0'", pw->pw_name, saverName[brandID], s);
-                // callPosixSpawn(s);
+            if (compareOSVersionTo(14, 0) < 0) {
+                if (setSaverForAllUsers) {
+                    seteuid(pw->pw_uid);    // Temporarily set effective uid to this user
+                    sprintf(s, "/Library/Screen Savers/%s.saver", saverName[brandID]);
+                    err = SetScreenSaverSelection(saverName[brandID], s, 0);
+                    seteuid(saved_uid);     // Set effective uid back to privileged user
+                    // This seems to work also:
+                    // sprintf(s, "su -l \"%s\" -c 'defaults -currentHost write com.apple.screensaver moduleDict -dict moduleName \"%s\" path \"/Library/Screen Savers/%s.saver\" type 0'", pw->pw_name, saverName[brandID], s);
+                    // callPosixSpawn(s);
+                }
             }
 
             if (compareOSVersionTo(10, 15) >= 0) {
@@ -2055,9 +1890,11 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
 
 // As of MacOS 14.0 Sonoma, this code no longer will detect the current screensaver,
 // and will need to be rewritten. See the comment at top of SetScreenSaverSelection().
-// It is unclear whether this will be fixed in a uture rlease of MacOS.
-// This Applescript stoll works:
+// It is unclear whether this will be fixed in a future rlease of MacOS.
+// These Applescripts work again as of MacOS 26, but only for the current user, and
+// they will trigger an alert asking for permission:
 //    tell application "System Events" to set mysaver to name of current screen saver
+//    tell application "System Events" to set current screen saver to screen saver "BOINC Screen Saver"'
 OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen) {
     char                buf[1024];
     FILE                *f;
@@ -2100,7 +1937,10 @@ OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen
 // As of MacOS 14.0 Sonoma, we can't set the screensaver automatically.
 // I have filed bug report FB13270885 about this. After this is fixed,
 // probably need to put an AppleScript to do this in the launch agent
-// we add for each user. See also:
+// we add for each user.
+// As of MacOS 26, we again can set the screensaver using Applescripts,
+// but only for the current user, so we do it from BOINC_Finish_Install.
+// See also:
 // https://forum.iscreensaver.com/t/understanding-the-macos-sonoma-screensaver-plist/718
 OSErr SetScreenSaverSelection(char *moduleName, char *modulePath, int type) {
     OSErr err = noErr;
@@ -2445,24 +2285,6 @@ pid_t FindProcessPID(char* name, pid_t thePID, Boolean currentUserOnly)
     }
     pclose(f);
     return 0;
-}
-
-
-// Uses usleep to sleep for full duration even if a signal is received
-static void SleepSeconds(double seconds) {
-    double end_time = dtime() + seconds - 0.01;
-    // sleep() and usleep() can be interrupted by SIGALRM,
-    // so we may need multiple calls
-    //
-    while (1) {
-        if (seconds >= 1) {
-            sleep((unsigned int) seconds);
-        } else {
-            usleep((int)fmod(seconds*1000000, 1000000));
-        }
-        seconds = end_time - dtime();
-        if (seconds <= 0) break;
-    }
 }
 
 

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -66,7 +66,7 @@
 
 #define USE_OSASCRIPT_FOR_ALL_LOGGED_IN_USERS false
 
-// MPORTANT: The defnition of COPY_FINISH_INSTALL_TO_USER_DIRECTORY
+// IMPORTANT: The definition of COPY_FINISH_INSTALL_TO_USER_DIRECTORY
 // must match the one in Finish_install.cpp
 #define COPY_FINISH_INSTALL_TO_USER_DIRECTORY false
 

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -96,7 +96,7 @@ int main(int argc, const char * argv[]) {
     }
 
     pw = getpwuid(getuid());
-    
+
     for (i=1; i<argc; i++) {
         if (strcmp(argv[i], "-d") == 0) {
             isUninstall = true;
@@ -431,15 +431,15 @@ static void GetAndLoadPreferredLanguages() {
     int i, j, k;
     char * language;
     char *uscore;
-    
+
     // Create an array of all our supported languages
     supportedLanguages = CFArrayCreateMutable(kCFAllocatorDefault, 100, &kCFTypeArrayCallBacks);
-    
+
     aLanguage = CFStringCreateWithCString(NULL, "en", kCFStringEncodingMacRoman);
     CFArrayAppendValue(supportedLanguages, aLanguage);
     CFRelease(aLanguage);
     aLanguage = NULL;
-    
+
     dirp = opendir(Catalogs_Dir);
     if (!dirp) {
         goto cleanup;
@@ -448,10 +448,10 @@ static void GetAndLoadPreferredLanguages() {
         dp = readdir(dirp);
         if (dp == NULL)
             break;                  // End of list
-        
+
         if (dp->d_name[0] == '.')
             continue;               // Ignore names beginning with '.'
-        
+
         strlcpy(searchPath, Catalogs_Dir, sizeof(searchPath));
         strlcat(searchPath, dp->d_name, sizeof(searchPath));
         strlcat(searchPath, "/", sizeof(searchPath));
@@ -463,7 +463,7 @@ static void GetAndLoadPreferredLanguages() {
         CFArrayAppendValue(supportedLanguages, aLanguage);
         CFRelease(aLanguage);
         aLanguage = NULL;
-        
+
         // If it has a region code ("it_IT") also try without region code ("it")
         // TODO: Find a more general solution
         strlcpy(shortLanguage, dp->d_name, sizeof(shortLanguage));
@@ -476,12 +476,12 @@ static void GetAndLoadPreferredLanguages() {
             aLanguage = NULL;
         }
     }
-    
+
     closedir(dirp);
-    
+
     for (i=0; i<MAX_LANGUAGES_TO_TRY; ++i) {
         preferredLanguages = CFBundleCopyLocalizationsForPreferences(supportedLanguages, NULL );
-        
+
 #if 0   // For testing
         int c = CFArrayGetCount(preferredLanguages);
         for (k=0; k<c; ++k) {
@@ -489,7 +489,7 @@ static void GetAndLoadPreferredLanguages() {
             printf("Preferred language %u is %s\n", k, CFStringGetCStringPtr(s, kCFStringEncodingMacRoman));
         }
 #endif
-        
+
         for (j=0; j<CFArrayGetCount(preferredLanguages); ++j) {
             aLanguage = (CFStringRef)CFArrayGetValueAtIndex(preferredLanguages, j);
             language = (char *)CFStringGetCStringPtr(aLanguage, kCFStringEncodingMacRoman);
@@ -513,7 +513,7 @@ static void GetAndLoadPreferredLanguages() {
                     CFArrayRemoveValueAtIndex(supportedLanguages, k);
                 }
             }
-            
+
             // Since the original strings are English, no
             // further translation is needed for language en.
             if (language) {
@@ -524,12 +524,12 @@ static void GetAndLoadPreferredLanguages() {
                 }
             }
         }
-        
+
         CFRelease(preferredLanguages);
         preferredLanguages = NULL;
         
     }
-    
+
     if (!BOINCTranslationAddCatalog(Catalogs_Dir, "en", Catalog_Name)) {
         printf("could not load catalog for langage en\n");
     }

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -403,7 +403,7 @@ void MaybeSetScreenSaver(int brandId){
         //
         // Use -n flag to open a new instance of the System Settings even if one is
         // already running. We can then use the returned PID to quit only that instance.
-        callPosixSpawn("open -gj \"x-apple.systempreferences:com.apple.Wallpaper-Settings.extension\""));
+        callPosixSpawn("open -gj \"x-apple.systempreferences:com.apple.Wallpaper-Settings.extension\"");
 
         sleep(1); // This delay seems to be needed, probably to give Wallpaper pane time to open
 

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -16,10 +16,10 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 //
-//  main.cpp
+//  Finish_install.cpp
 //  boinc_Finish_Install
 
-// Usage: boinc_Finish_Install [-d] [brandID]
+// Usage: boinc_Finish_Install [-d | -m] | -i brandID | -a brandID]
 //
 // * Deletes Login Items of all possible branded and unbranded BOINC Managers for current user.
 // * If first argument is -d then also kills the application specified by the second argument.
@@ -51,15 +51,30 @@
 #include <unistd.h>
 #include <pwd.h>    // getpwname, getpwuid, getuid
 #include <spawn.h>
+#include <dirent.h>
 
 #include "mac_branding.h"
+#include "translate.h"
+#include "mac_util.h"
+
+#define MAX_LANGUAGES_TO_TRY 5
+
+// MPORTANT: The defnition of COPY_FINISH_INSTALL_TO_USER_DIRECTORY
+// must match the one in PostInstall.cpp
+#define COPY_FINISH_INSTALL_TO_USER_DIRECTORY false
+
+
+static char * Catalog_Name = (char *)"BOINC-Setup";
+static char * Catalogs_Dir = "/Library/Application Support/BOINC Data/locale/";
 
 static int callPosixSpawn(const char *cmd);
 static Boolean MakeLaunchManagerLaunchAgent(long brandID, passwd *pw);
 static void FixLaunchServicesDataBase(int brandId, bool isUninstall);
 static Boolean IsUserActive(const char *userName);
+void MaybeSetScreenSaver(int brandId);
 static char * PersistentFGets(char *buf, size_t buflen, FILE *f);
-static int compareOSVersionTo(int toMajor, int toMinor);
+static Boolean ShowMessage(Boolean askYesNo, const char *format, ...);
+static void GetAndLoadPreferredLanguages();
 static void print_to_log_file(const char *format, ...);
 
 int main(int argc, const char * argv[]) {
@@ -71,8 +86,8 @@ int main(int argc, const char * argv[]) {
     bool                    isUninstall = false;
     int                     iBrandId = 0;
     bool                    calledFromInstaller = false;
+    bool                    createdByUninstaller = false;
     bool                    calledFromManager = false;
-    struct stat             buf;
 
     // Wait until we are the active login (in case of fast user switching)
     userName = getenv("USER");
@@ -81,32 +96,20 @@ int main(int argc, const char * argv[]) {
     }
 
     pw = getpwuid(getuid());
-
-    // Using "System Events" which can trigger an alert which the user may find alraming.
-    // If we previously set a login item launch agent,  we removed the old style login
-    // item at that time, so we can avoid that alert.
-    snprintf(cmd, sizeof(cmd), "/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist", pw->pw_name);
-    if (!stat(cmd, &buf)) {
-        for (i=0; i<NUMBRANDS; i++) {
-            snprintf(cmd, sizeof(cmd), "osascript -e 'tell application \"System Events\" to delete login item \"%s\"'", appName[i]);
-            err = callPosixSpawn(cmd);
-            if (err) {
-                print_to_log_file("Command: %s\n", cmd);
-                print_to_log_file("Delete login item containing %s returned error %d\n", appName[i], err);
-            }
-        }
-    }
-
+    
     for (i=1; i<argc; i++) {
-        print_to_log_file("argv[%d] = '%s'", i, argv[i]);
         if (strcmp(argv[i], "-d") == 0) {
             isUninstall = true;
         } else if (strcmp(argv[i], "-a") == 0) {
-            iBrandId = atoi(argv[i]);
+            iBrandId = atoi(argv[++i]);
         } else if (strcmp(argv[i], "-i") == 0) {
+            iBrandId = atoi(argv[++i]);
             calledFromInstaller = true;
         } else if (strcmp(argv[i], "-m") == 0) {
             calledFromManager = true;
+        } else if (strcmp(argv[i], "-u") == 0) {
+            isUninstall = true;
+            createdByUninstaller = true;
         }
     }   // end for (i=i; i<argc; i+=2)
 
@@ -118,55 +121,38 @@ int main(int argc, const char * argv[]) {
         snprintf(cmd, sizeof(cmd), "killall -u %d -9 \"%s\"", getuid(), appName[iBrandId]);
         err = callPosixSpawn(cmd);
         if (err) {
-            print_to_log_file("Command: %s\n", cmd);
-            print_to_log_file("killall %s returned error %d\n", appName[iBrandId], err);
         }
 
         if (compareOSVersionTo(10, 13) >= 0) {
             snprintf(cmd, sizeof(cmd), "launchctl unload \"/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist\"", pw->pw_name);
             err = callPosixSpawn(cmd);
             if (err) {
-                print_to_log_file("Command: %s\n", cmd);
-                print_to_log_file("returned error %d\n", err);
             }
             sprintf(cmd, "rm -f \"/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist\"", pw->pw_name);
             callPosixSpawn (cmd);
             if (err) {
-                print_to_log_file("Command: %s\n", cmd);
-                print_to_log_file("returned error %d\n", err);
-            }
+             }
         }
 
     } else {
-        if (compareOSVersionTo(10, 13) >= 0) {
-            bool success = MakeLaunchManagerLaunchAgent(iBrandId, pw);
-            if (!success) {
-                print_to_log_file("Command: %s\n", cmd);
-                print_to_log_file("MakeLaunchManagerLaunchAgent for %s failed\n", appName[iBrandId]);
-            }
-        } else {
-            snprintf(cmd, sizeof(cmd), "osascript -e 'tell application \"System Events\" to make new login item at end with properties {path:\"%s\", hidden:true, name:\"%s\"}'", appPath[iBrandId], appName[iBrandId]);
-            err = callPosixSpawn(cmd);
-            if (err) {
-                print_to_log_file("Command: %s\n", cmd);
-                print_to_log_file("Make new login item for %s returned error %d\n", appName[iBrandId], err);
-            }
+        bool success = MakeLaunchManagerLaunchAgent(iBrandId, pw);
+        if (!success) {
+        }
+        if (compareOSVersionTo(26, 0) >= 0) {
+            GetAndLoadPreferredLanguages();
+            MaybeSetScreenSaver(iBrandId);
         }
 
         if (compareOSVersionTo(10, 13) >= 0) {
             snprintf(cmd, sizeof(cmd), "launchctl unload \"/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist\"", pw->pw_name);
             err = callPosixSpawn(cmd);
             if (err) {
-                print_to_log_file("Command: %s\n", cmd);
-                print_to_log_file("returned error %d\n", err);
             }
 
             if (! (calledFromInstaller || calledFromManager)) {
                 snprintf(cmd, sizeof(cmd), "launchctl load \"/Users/%s/Library/LaunchAgents/edu.berkeley.launchboincmanager.plist\"", pw->pw_name);
                 err = callPosixSpawn(cmd);
                 if (err) {
-                    print_to_log_file("Command: %s\n", cmd);
-                    print_to_log_file("returned error %d\n", err);
                 }
             }
 
@@ -174,8 +160,6 @@ int main(int argc, const char * argv[]) {
             snprintf(cmd, sizeof(cmd), "open -jg \"%s\"", appPath[iBrandId]);
             err = callPosixSpawn(cmd);
             if (err) {
-                print_to_log_file("Command: %s\n", cmd);
-                print_to_log_file("\"open -jg \"%s\" returned error %d\n", appPath[iBrandId], err);
             }
         }
     }
@@ -198,8 +182,19 @@ int main(int argc, const char * argv[]) {
             // Delete per-user BOINC Manager and screensaver files, including this executable
             fprintf(f, "rm -fR \"/Users/%s/Library/Application Support/BOINC\"\n", pw->pw_name);
         } else {
-            // Delete only this executable
-            fprintf(f, "rm -fR \"/Users/%s/Library/Application Support/BOINC/%s_Finish_Install.app\"", pw->pw_name, brandName[iBrandId]);
+#if ! COPY_FINISH_INSTALL_TO_USER_DIRECTORY
+            // The installer no longer put a copy of %s_Finish_Install in the user's folder;
+            // all users now call the one in the BOINC Data folder
+            // But the uninstaller stil puts a copy of %s_Finish_Uninstall in the user's
+            // folder (in case the user might have already deleted the BOINC Data directory.)
+            // So we don't want to delete ourselves unless we were created by the uninstaller.
+            // The uninstaller set up the launchagent to pass us a "u" to tell us self-delete.
+            if (createdByUninstaller)
+#endif
+            {
+                // Delete only this executable
+                fprintf(f, "rm -fR \"/Users/%s/Library/Application Support/BOINC/%s_Finish_Install.app\"", pw->pw_name, brandName[iBrandId]);
+            }
         }
         fclose(f);
         sprintf(cmd, "sh \"%s\"", scriptName);
@@ -362,41 +357,247 @@ static Boolean IsUserActive(const char *userName){
 }
 
 
-// Test OS version number on all versions of OS X without using deprecated Gestalt
-// compareOSVersionTo(x, y) returns:
-// -1 if the OS version we are running on is less than x.y
-//  0 if the OS version we are running on is equal to x.y
-// +1 if the OS version we are running on is lgreater than x.y
-static int compareOSVersionTo(int toMajor, int toMinor) {
-    static SInt32 major = -1;
-    static SInt32 minor = -1;
+// It would be nice to check whether our screen saver is already set for
+// this user so we can ask wethr to set it only if necessary, but that
+// triggrs a scary warning asking for permission to let System Events
+// administer the Mac, so we don't. (If the user answers yes to setting
+// the screensaver, then the code which sets the screensaver will show
+// that warning, but this seems less scary than having it pop up for no
+// apparent reason.)
+void MaybeSetScreenSaver(int brandId){
+    char                buf[MAXPATHLEN];
+    char                mySaverName[1024];
 
-    if (major < 0) {
-        char vers[100], *p1 = NULL;
-        FILE *f;
-        vers[0] = '\0';
-        f = popen("sw_vers -productVersion", "r");
-        if (f) {
-            fscanf(f, "%s", vers);
-            pclose(f);
-        }
-        if (vers[0] == '\0') {
-            print_to_log_file("popen(\"sw_vers -productVersion\" failed\n");
-            return 0;
-        }
-        // Extract the major system version number
-        major = atoi(vers);
-        // Extract the minor system version number
-        p1 = strchr(vers, '.');
-        minor = atoi(p1+1);
+    if ((ShowMessage(true,
+        (char *)_("Do you want to set %s as your screensaver?"),
+                    brandName[brandId], brandName[brandId])) == false) {
+        return;
     }
 
-    if (major < toMajor) return -1;
-    if (major > toMajor) return 1;
-    // if (major == toMajor) compare minor version numbers
-    if (minor < toMinor) return -1;
-    if (minor > toMinor) return 1;
-    return 0;
+    CFBundleRef myBundle = NULL;
+    mySaverName[0] = '\0';
+    snprintf(buf, sizeof(buf), "/Library/Screen Savers/%s.saver", saverName[brandId]);
+    CFStringRef cfpath = CFStringCreateWithCString(NULL, buf, kCFStringEncodingUTF8);
+    if (cfpath) {
+        CFURLRef bundleURL = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, cfpath, kCFURLPOSIXPathStyle, true);
+        if (bundleURL) {
+            myBundle = CFBundleCreate(kCFAllocatorDefault, bundleURL);
+            CFRelease(bundleURL);
+        }
+        CFRelease(cfpath);
+    }
+
+    if (myBundle) {
+        CFStringRef bundleNameCF = (CFStringRef)CFBundleGetValueForInfoDictionaryKey(myBundle, CFSTR("CFBundleName"));
+        if (bundleNameCF) {
+            strncpy(mySaverName, CFStringGetCStringPtr(bundleNameCF, kCFStringEncodingUTF8), sizeof(mySaverName));
+        }
+        if(mySaverName[0] == '\0') {
+            strncpy(mySaverName, saverName[brandId], sizeof(mySaverName));
+        }
+
+        // The AppleEvent call doesn't work unless we have opened the Sysem Preferences
+        // Wallpaper pane, even though that's not necessary if we do the osascript from
+        // Terminal.app or run the Applescript from the Script Editor or  from an
+        // Applescript application created by the Script Editor.
+        //
+        // Use -n flag to open a new instance of the System Settings even if one is
+        // already running. We can then use the returned PID to quit only that instance.
+        sprintf(buf, "open -gj \"x-apple.systempreferences:com.apple.Wallpaper-Settings.extension\"");
+        callPosixSpawn(buf);
+
+        sleep(1); // This delay seems to be needed, probably to give Wallpaper pane time to open
+
+        sprintf(buf, "osascript -e 'tell application \"System Events\" to set current screen saver to screen saver \"%s\"'", mySaverName);
+        callPosixSpawn(buf);
+
+        // TODO: find a way to kill only the new hidden instance of System Settigs that we opened
+        callPosixSpawn("killall \"System Settings\"");
+
+        CFRelease(myBundle);
+    }
+}
+
+
+static void GetAndLoadPreferredLanguages() {
+    DIR *dirp;
+    struct dirent *dp;
+    char searchPath[MAXPATHLEN];
+    struct stat sbuf;
+    CFMutableArrayRef supportedLanguages;
+    CFStringRef aLanguage;
+    char shortLanguage[32];
+    CFArrayRef preferredLanguages;
+    int i, j, k;
+    char * language;
+    char *uscore;
+    
+    // Create an array of all our supported languages
+    supportedLanguages = CFArrayCreateMutable(kCFAllocatorDefault, 100, &kCFTypeArrayCallBacks);
+    
+    aLanguage = CFStringCreateWithCString(NULL, "en", kCFStringEncodingMacRoman);
+    CFArrayAppendValue(supportedLanguages, aLanguage);
+    CFRelease(aLanguage);
+    aLanguage = NULL;
+    
+    dirp = opendir(Catalogs_Dir);
+    if (!dirp) {
+        goto cleanup;
+    }
+    while (true) {
+        dp = readdir(dirp);
+        if (dp == NULL)
+            break;                  // End of list
+        
+        if (dp->d_name[0] == '.')
+            continue;               // Ignore names beginning with '.'
+        
+        strlcpy(searchPath, Catalogs_Dir, sizeof(searchPath));
+        strlcat(searchPath, dp->d_name, sizeof(searchPath));
+        strlcat(searchPath, "/", sizeof(searchPath));
+        strlcat(searchPath, Catalog_Name, sizeof(searchPath));
+        strlcat(searchPath, ".mo", sizeof(searchPath));
+        if (stat(searchPath, &sbuf) != 0) continue;
+        //        printf("Adding %s to supportedLanguages array\n", dp->d_name);
+        aLanguage = CFStringCreateWithCString(NULL, dp->d_name, kCFStringEncodingMacRoman);
+        CFArrayAppendValue(supportedLanguages, aLanguage);
+        CFRelease(aLanguage);
+        aLanguage = NULL;
+        
+        // If it has a region code ("it_IT") also try without region code ("it")
+        // TODO: Find a more general solution
+        strlcpy(shortLanguage, dp->d_name, sizeof(shortLanguage));
+        uscore = strchr(shortLanguage, '_');
+        if (uscore) {
+            *uscore = '\0';
+            aLanguage = CFStringCreateWithCString(NULL, shortLanguage, kCFStringEncodingMacRoman);
+            CFArrayAppendValue(supportedLanguages, aLanguage);
+            CFRelease(aLanguage);
+            aLanguage = NULL;
+        }
+    }
+    
+    closedir(dirp);
+    
+    for (i=0; i<MAX_LANGUAGES_TO_TRY; ++i) {
+        preferredLanguages = CFBundleCopyLocalizationsForPreferences(supportedLanguages, NULL );
+        
+#if 0   // For testing
+        int c = CFArrayGetCount(preferredLanguages);
+        for (k=0; k<c; ++k) {
+            CFStringRef s = (CFStringRef)CFArrayGetValueAtIndex(preferredLanguages, k);
+            printf("Preferred language %u is %s\n", k, CFStringGetCStringPtr(s, kCFStringEncodingMacRoman));
+        }
+#endif
+        
+        for (j=0; j<CFArrayGetCount(preferredLanguages); ++j) {
+            aLanguage = (CFStringRef)CFArrayGetValueAtIndex(preferredLanguages, j);
+            language = (char *)CFStringGetCStringPtr(aLanguage, kCFStringEncodingMacRoman);
+            if (language == NULL) {
+                if (CFStringGetCString(aLanguage, shortLanguage, sizeof(shortLanguage), kCFStringEncodingMacRoman)) {
+                    language = shortLanguage;
+                }
+            }
+            if (language) {
+#if CREATE_LOG
+                print_to_log_file("Adding language: %s\n", language);
+#endif
+                if (!BOINCTranslationAddCatalog(Catalogs_Dir, language, Catalog_Name)) {
+                    printf("could not load catalog for langage %s\n", language);
+                }
+            }
+            // Remove all copies of this language from our list of supported languages
+            // so we can get the next preferred language in order of priority
+            for (k=CFArrayGetCount(supportedLanguages)-1; k>=0; --k) {
+                if (CFStringCompare(aLanguage, (CFStringRef)CFArrayGetValueAtIndex(supportedLanguages, k), 0) == kCFCompareEqualTo) {
+                    CFArrayRemoveValueAtIndex(supportedLanguages, k);
+                }
+            }
+            
+            // Since the original strings are English, no
+            // further translation is needed for language en.
+            if (language) {
+                if (!strcmp(language, "en")) {
+                    CFRelease(preferredLanguages);
+                    preferredLanguages = NULL;
+                    goto cleanup;
+                }
+            }
+        }
+        
+        CFRelease(preferredLanguages);
+        preferredLanguages = NULL;
+        
+    }
+    
+    if (!BOINCTranslationAddCatalog(Catalogs_Dir, "en", Catalog_Name)) {
+        printf("could not load catalog for langage en\n");
+    }
+
+cleanup:
+    CFArrayRemoveAllValues(supportedLanguages);
+    CFRelease(supportedLanguages);
+    supportedLanguages = NULL;
+#if CREATE_LOG
+    print_to_log_file("Exiting GetAndLoadPreferredLanguages");
+#endif
+}
+
+
+static Boolean ShowMessage(Boolean askYesNo, const char *format, ...) {
+  // CAUTION: vsprintf will produce undesirable results if the string
+  // contains a % character that is not a format specification!
+  // But CFString is OK!
+
+    va_list                 args;
+    char                    s[1024];
+    CFOptionFlags           responseFlags;
+    CFURLRef                myIconURLRef = NULL;
+    CFBundleRef             myBundleRef;
+
+    myBundleRef = CFBundleGetMainBundle();
+    if (myBundleRef) {
+        myIconURLRef = CFBundleCopyResourceURL(myBundleRef, CFSTR("MacInstaller.icns"), NULL, NULL);
+    }
+
+#if 1
+    va_start(args, format);
+    vsprintf(s, format, args);
+    va_end(args);
+#else
+    strcpy(s, format);
+#endif
+
+    // If defaultButton is nil or an empty string, a default localized
+    // button title ("OK" in English) is used.
+
+#if 0
+    enum {
+   kCFUserNotificationDefaultResponse = 0,
+   kCFUserNotificationAlternateResponse = 1,
+   kCFUserNotificationOtherResponse = 2,
+   kCFUserNotificationCancelResponse = 3
+};
+#endif
+
+    CFStringRef myString = CFStringCreateWithCString(NULL, s, kCFStringEncodingUTF8);
+    CFStringRef yes = CFStringCreateWithCString(NULL, (char*)_((char*)"Yes"), kCFStringEncodingUTF8);
+    CFStringRef no = CFStringCreateWithCString(NULL, (char*)_((char*)"No"), kCFStringEncodingUTF8);
+
+//    BringAppToFront();
+    SInt32 retval = CFUserNotificationDisplayAlert(0.0, kCFUserNotificationPlainAlertLevel,
+                myIconURLRef, NULL, NULL, CFSTR(" "), myString,
+                askYesNo ? yes : NULL, askYesNo ? no : NULL, NULL,
+                &responseFlags);
+
+
+    if (myIconURLRef) CFRelease(myIconURLRef);
+    if (myString) CFRelease(myString);
+    if (yes) CFRelease(yes);
+    if (no) CFRelease(no);
+
+    if (retval) return false;
+    return (responseFlags == kCFUserNotificationDefaultResponse);
 }
 
 

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -101,9 +101,13 @@ int main(int argc, const char * argv[]) {
         if (strcmp(argv[i], "-d") == 0) {
             isUninstall = true;
         } else if (strcmp(argv[i], "-a") == 0) {
-            iBrandId = atoi(argv[++i]);
+            if (i + 1 < argc) {
+                iBrandId = atoi(argv[++i]);
+            }
         } else if (strcmp(argv[i], "-i") == 0) {
-            iBrandId = atoi(argv[++i]);
+            if (i + 1 < argc) {
+                iBrandId = atoi(argv[++i]);
+            }
             calledFromInstaller = true;
         } else if (strcmp(argv[i], "-m") == 0) {
             calledFromManager = true;

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -59,7 +59,7 @@
 
 #define MAX_LANGUAGES_TO_TRY 5
 
-// MPORTANT: The defnition of COPY_FINISH_INSTALL_TO_USER_DIRECTORY
+// IMPORTANT: The definition of COPY_FINISH_INSTALL_TO_USER_DIRECTORY
 // must match the one in PostInstall.cpp
 #define COPY_FINISH_INSTALL_TO_USER_DIRECTORY false
 
@@ -403,12 +403,11 @@ void MaybeSetScreenSaver(int brandId){
         //
         // Use -n flag to open a new instance of the System Settings even if one is
         // already running. We can then use the returned PID to quit only that instance.
-        sprintf(buf, "open -gj \"x-apple.systempreferences:com.apple.Wallpaper-Settings.extension\"");
-        callPosixSpawn(buf);
+        callPosixSpawn("open -gj \"x-apple.systempreferences:com.apple.Wallpaper-Settings.extension\""));
 
         sleep(1); // This delay seems to be needed, probably to give Wallpaper pane time to open
 
-        sprintf(buf, "osascript -e 'tell application \"System Events\" to set current screen saver to screen saver \"%s\"'", mySaverName);
+        snprintf(buf, sizeof(buf), "osascript -e 'tell application \"System Events\" to set current screen saver to screen saver \"%s\"'", mySaverName);
         callPosixSpawn(buf);
 
         // TODO: find a way to kill only the new hidden instance of System Settigs that we opened
@@ -527,7 +526,6 @@ static void GetAndLoadPreferredLanguages() {
 
         CFRelease(preferredLanguages);
         preferredLanguages = NULL;
-        
     }
 
     if (!BOINCTranslationAddCatalog(Catalogs_Dir, "en", Catalog_Name)) {

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -449,7 +449,7 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
     # Code Sign the PostInstall app embedded in the BOINC installer app if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources/PostInstall.app"
 
-    # Code Sign BOINC_Finish_BOINC_Finish_Uninstall app embedded in BOINC uninstaller app if we have a signing identity
+    # Code Sign BOINC_Finish_Uninstall app embedded in BOINC uninstaller app if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app"
 
     # Code Sign the BOINC uninstaller app if we have a signing identity

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -62,6 +62,7 @@
 ## Updated 4/30/23 code sign AddRemoveUser; eliminate old code signing workaround
 ## Updated 5/17/23 to add comments about notarize_BOINC.sh script
 ## Updated 2/12/25 to add support for Fix_BOINC_Users utility
+## Updated 7/22/25 to add MacOS 26 support, no Finish_Install embedded in Postinstall.
 ##
 ## NOTE: This script requires Mac OS 10.7 or later, and uses XCode developer
 ##   tools.  So you must have installed XCode Developer Tools on the Mac
@@ -351,21 +352,32 @@ echo "BrandId=0" > "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOS
 # Change BOINC_Finish_Install.app embedded in uninstaller to BOINC_Finish_Uninstall.app
 sudo mv "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Install.app" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app"
 
-# Change executable name of BOINC_Finish_Uninstall.app to match app name
+# Change executable name of BOINC_Finish_Uninstall.app embedded in uninstaller to match app name
 sudo mv "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/MacOS/BOINC_Finish_Install" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/MacOS/BOINC_Finish_Uninstall"
 
-# Fix version number in Info.plist file of BOINC_Finish_Uninstall.app
+# Fix version number in Info.plist file of BOINC_Finish_Uninstall.app embedded
+# in uninstaller
 sudo plutil -replace CFBundleVersion -string `plutil -extract CFBundleVersion raw "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Info.plist"` "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Info.plist"
 
 sudo plutil -remove CFBundleShortVersionString "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Info.plist"
 
-# Fix bundle name in Info.plist file of BOINC_Finish_Uninstall.app
+# Fix bundle name in Info.plist file of BOINC_Finish_Uninstall.app embedded in uninstaller
 sudo plutil -replace CFBundleName -string "BOINC_Finish_Uninstall" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Info.plist"
 
 sudo plutil -replace CFBundleExecutable -string "BOINC_Finish_Uninstall" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Info.plist"
 
+# If you re-enable this you must also change it in uninstall.cpp
 # Change Bundle ID of BOINC_Finish_Uninstall.app
 ###sudo plutil -replace CFBundleIdentifier -string edu.berkeley.boinc.finish-uninstall "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Info.plist"
+
+# Replace icon reference in Info.plist file of BOINC_Finish_Uninstall.app embedded
+# in uninstaller
+sudo plutil -replace CFBundleIconFile -string "MacUninstaller.icns" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Info.plist"
+
+# Replace icon in Info.plist file of BOINC_Finish_Uninstall.app embedded in uninstaller
+sudo rm -dfR "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Resources/MacInstaller.icns"
+
+sudo cp -fpRL "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/MacUninstaller.icns" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app/Contents/Resources"
 
 sudo chown -R root:admin ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall\ BOINC.app
 sudo chmod -R u+r-w,g+r-w,o+r-w ../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall\ BOINC.app
@@ -379,15 +391,10 @@ cp -fpRL "${BUILDPATH}/BOINC Installer.app" ../BOINC_Installer/New_Release_$1_$2
 
 cp -fpR "${BUILDPATH}/PostInstall.app" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources"
 
+# Copy BOINC_Finish_Install.app into BOINC Data folder
+cp -fpR "${BUILDPATH}/BOINC_Finish_Install.app" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/"
+
 echo "BrandId=0" > "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources/PostInstall.app/Contents/Resources/Branding"
-
-# Fix version number in Info.plist file of BOINC_Finish_Install.app
-sudo plutil -replace CFBundleVersion -string `plutil -extract CFBundleVersion raw "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Info.plist"` "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources/PostInstall.app/Contents/Resources/BOINC_Finish_Install.app/Contents/Info.plist"
-
-sudo plutil -remove CFBundleShortVersionString "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources/PostInstall.app/Contents/Resources/BOINC_Finish_Install.app/Contents/Info.plist"
-
-# Copy BOINC_Finish_Install.app into BOINC Data folder for possible use by AddRemoveUser
-sudo cp -fpRL "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources/PostInstall.app/Contents/Resources/BOINC_Finish_Install.app" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/"
 
 ## If you wish to code sign the client, manager, installer and uninstaller,
 ## create a file ~/BOINCCodeSignIdentities.txt whose first line is the
@@ -439,13 +446,10 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
     # Code Sign the BOINC Manager if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Applications/BOINCManager.app"
 
-    # Code Sign BOINC_Finish_Install app embedded in the PostInstall app if we have a signing identity
-    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources/PostInstall.app/Contents/Resources/BOINC_Finish_Install.app"
-
     # Code Sign the PostInstall app embedded in the BOINC installer app if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/BOINC Installer.app/Contents/Resources/PostInstall.app"
 
-    # Code Sign BOINC_Finish_Install app embedded in BOINC uninstaller app if we have a signing identity
+    # Code Sign BOINC_Finish_BOINC_Finish_Uninstall app embedded in BOINC uninstaller app if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_$1_$2_$3/boinc_$1.$2.$3_macOSX_$arch/extras/Uninstall BOINC.app/Contents/Resources/BOINC_Finish_Uninstall.app"
 
     # Code Sign the BOINC uninstaller app if we have a signing identity

--- a/mac_installer/release_brand.sh
+++ b/mac_installer/release_brand.sh
@@ -438,7 +438,7 @@ sudo plutil -replace CFBundleExecutable -string "${LONGBRANDNAME}_Finish_Uninsta
 # Replace icon reference in Info.plist file of ${LONGBRANDNAME}_Finish_Uninstall.app
 sudo plutil -replace CFBundleIconFile -string "${UNINSTALLERICON}.icns" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Info.plist"
 
-# Replace icon in in ${LONGBRANDNAME}_Finish_Uninstall.app
+# Replace icon in ${LONGBRANDNAME}_Finish_Uninstall.app
 sudo rm -dfR "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Resources/MacInstaller.icns"
 
 sudo cp -fpRL "./clientgui/res/${UNINSTALLERICON}.icns" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Resources/"

--- a/mac_installer/release_brand.sh
+++ b/mac_installer/release_brand.sh
@@ -191,7 +191,7 @@ if [ $Products_Have_arm64 = "yes" ]; then
     fi
 fi
 
-for Executable in "boinc" "boinccmd" "switcher" "setprojectgrp" "boincscr" "Fix_BOINC_Users" "BOINCSaver.saver/Contents/MacOS/BOINCSaver" "Uninstall BOINC.app/Contents/MacOS/Uninstall BOINC" "BOINC Installer.app/Contents/MacOS/BOINC Installer" "PostInstall.app/Contents/MacOS/PostInstall" "BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install"
+for Executable in "boinc" "boinccmd" "switcher" "setprojectgrp" "boincscr" "Fix_BOINC_Users" "BOINCSaver.saver/Contents/MacOS/BOINCSaver" "Uninstall BOINC.app/Contents/MacOS/Uninstall BOINC" "BOINC Installer.app/Contents/MacOS/BOINC Installer" "PostInstall.app/Contents/MacOS/PostInstall" "BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install" "AddRemoveUser"
 do
     Have_x86_64="no"
     Have_arm64="no"
@@ -390,23 +390,27 @@ rm -rf "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNA
 mv "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/MacOS/BOINC Installer" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/MacOS/${INSTALLERAPPNAME}"
 sed -i "" s/"BOINC Installer"/"${INSTALLERAPPNAME}"/g "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/English.lproj/InfoPlist.strings"
 
-cp -fpR "${BUILDPATH}/PostInstall.app" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources"
+# Copy BOINC_Finish_Install.app into BOINC Data folder
+cp -fpR "${BUILDPATH}/BOINC_Finish_Install.app" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/"
 
-# Rename BOINC_Finish_Install.app embedded in PostInstall.app
-sudo mv "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/BOINC_Finish_Install.app" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app"
+# Rename BOINC_Finish_Install.app
+sudo mv "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/BOINC_Finish_Install.app" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/${LONGBRANDNAME}_Finish_Install.app"
 
 # Change executable name of BOINC_Finish_Install.app to match app name
-sudo mv "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app/Contents/MacOS/${LONGBRANDNAME}_Finish_Install"
+sudo mv "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/${LONGBRANDNAME}_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/${LONGBRANDNAME}_Finish_Install.app/Contents/MacOS/${LONGBRANDNAME}_Finish_Install"
 
-# Fix version number in Info.plist file of BOINC_Finish_Install.app
-sudo plutil -replace CFBundleVersion -string `plutil -extract CFBundleVersion raw "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Info.plist"` "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app/Contents/Info.plist"
+sudo plutil -replace CFBundleExecutable -string "${LONGBRANDNAME}_Finish_Install" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/${LONGBRANDNAME}_Finish_Install.app/Contents/Info.plist"
 
-sudo plutil -remove CFBundleShortVersionString "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app/Contents/Info.plist"
+# Replace icon reference in Info.plist file of ${LONGBRANDNAME}_Finish_Install.app
+sudo plutil -replace CFBundleIconFile -string "${INSTALLERICON}.icns" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/${LONGBRANDNAME}_Finish_Install.app/Contents/Info.plist"
 
-sudo plutil -replace CFBundleExecutable -string "${LONGBRANDNAME}_Finish_Install" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app/Contents/Info.plist"
+# Replace icon in ${LONGBRANDNAME}_Finish_Install.app
+sudo rm -dfR "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/${LONGBRANDNAME}_Finish_Install.app/Contents/Resources/MacInstaller.icns"
 
-# Copy BOINC_Finish_Install.app into BOINC Data folder for possible use by AddRemoveUser
-sudo cp -fpRL "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/"
+sudo cp -fpRL "./clientgui/res/${INSTALLERICON}.icns" "../BOINC_Installer/Pkg_Root/Library/Application Support/BOINC Data/${LONGBRANDNAME}_Finish_Install.app/Contents/Resources/"
+
+
+cp -fpR "${BUILDPATH}/PostInstall.app" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources"
 
 # Change BOINC_Finish_Install.app embedded in uninstaller to BOINC_Finish_Uninstall.app
 sudo mv "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/BOINC_Finish_Install.app" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app"
@@ -427,8 +431,21 @@ sudo plutil -replace CFBundleExecutable -string "${LONGBRANDNAME}_Finish_Uninsta
 # Change Bundle ID of BOINC_Finish_Uninstall.app
 ###sudo plutil -replace CFBundleIdentifier -string edu.berkeley.boinc.finish-uninstall "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Info.plist"
 
+# Replace icon in ${LONGBRANDNAME}_Finish_Uninstall.app
+# Replace MacInstaller.icns with ${UNINSTALLERICON}.icns, but renamed MacInstaller.icns
+###cp -fpRL ./clientgui/res/${UNINSTALLERICON}.icns "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Resources/MacInstaller.icns"
+
+# Replace icon reference in Info.plist file of ${LONGBRANDNAME}_Finish_Uninstall.app
+sudo plutil -replace CFBundleIconFile -string "${UNINSTALLERICON}.icns" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Info.plist"
+
+# Replace icon in in ${LONGBRANDNAME}_Finish_Uninstall.app
+sudo rm -dfR "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Resources/MacInstaller.icns"
+
+sudo cp -fpRL "./clientgui/res/${UNINSTALLERICON}.icns" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/extras/${UNINSTALLERAPPNAME}.app/Contents/Resources/${LONGBRANDNAME}_Finish_Uninstall.app/Contents/Resources/"
+
 echo ${BRANDING_INFO} > "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/Branding"
 
+# Replace MacInstaller.icns with ${INSTALLERICON}.icns, but renamed MacInstaller.icns
 cp -fpRL ./clientgui/res/${INSTALLERICON}.icns "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/MacInstaller.icns"
 
 
@@ -478,9 +495,6 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
 
     # Code Sign the BOINC Manager if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Applications/${MANAGERAPPNAME}.app"
-
-    # Code Sign BOINC_Finish_Install app embedded in the PostInstall app if we have a signing identity
-    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app/Contents/Resources/${LONGBRANDNAME}_Finish_Install.app"
 
     # Code Sign the PostInstall app embedded in the BOINC installer app if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/New_Release_${SHORTBRANDNAME}_$1_$2_$3/${SHORTBRANDNAME}_$1.$2.$3_macOSX_$arch/${INSTALLERAPPNAME}.app/Contents/Resources/PostInstall.app"


### PR DESCRIPTION
This PR updates 2 aspects of BOINC screensaver logic for MacOS 25:
 - The BOINC screensaver coordinator runs properly under the legacy screensaver engine
 -  MacOS 14 and MacOS 15 broke the ability select a screensaver programmatically, so the BOINC installer cold no longer offer the option to set BOINC as your screensaver. MacOS 26 restores that capability, but using a different API. Changes in this PR implement that capability, again offering the user the option to set BOINC as their screensaver.

This code is backward compatible with earlier versions of MacOS, so it can be merged into all new releases of BOINC.