### PR TITLE
Mac podman fixes2

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -383,24 +383,29 @@ int use_sandbox, int isManager, char* path_to_error, int len
             return retval;
     }
 
-    snprintf(full_path, sizeof(full_path), "%s/%s", dir_path, PODMAN_DIR);
+    // "BOINC Podman" Directory is in "/Library/Application/Support/"
+    // directory, alongside "BOINC Data" directory
+    snprintf(full_path, sizeof(full_path), "%s/../%s", dir_path, PODMAN_DIR);
     retval = stat(full_path, &sbuf);
     if (! retval) {                 // Client can create podman directory if it does not yet exist.
        if (use_sandbox) {
             if (sbuf.st_gid != boinc_project_gid)
                 return -1071;
 
-            if ((sbuf.st_mode & 0777) != 0770)
+            if ((sbuf.st_mode & 0777) != 0777)
                 return -1072;
         }
 
         if (sbuf.st_uid != boinc_master_uid)
             return -1073;
 
-        // Step through slot directories
+#if 0   // We allow podman to write directories and files with different ownerships.
+        // This is safe because Pdoman runs everything in containers
+        // Step through subdirectories
         retval = CheckNestedDirectories(full_path, 1, use_sandbox, isManager, false, path_to_error, len);
         if (retval)
             return retval;
+#endif
     }
 
     snprintf(full_path, sizeof(full_path),

--- a/client/file_names.h
+++ b/client/file_names.h
@@ -89,7 +89,11 @@ extern void send_log_after(const char* filename, double t, MIOFILE& mf);
 #define LOOKUP_WEBSITE_FILENAME     "lookup_website.html"
 #define MASTER_BASE                 "master_"
 #define NOTICES_DIR                 "notices"
+#ifdef __APPLE__
+#define PODMAN_DIR                  "BOINC podman"
+#else
 #define PODMAN_DIR                  "podman"
+#endif
 #define PROJECTS_DIR                "projects"
 #define REMOTEHOST_FILE_NAME        "remote_hosts.cfg"
 #define SCHED_OP_REPLY_BASE         "sched_reply_"

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -531,51 +531,68 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
     // Does podman directory exist?
     strlcpy(fullpath, BOINCDataDirPath, MAXPATHLEN);
     strlcat(fullpath, "/", MAXPATHLEN);
+#ifdef __APPLE__
+    // "BOINC Podman" Directory is in "/Library/Application/Support/"
+    // directory, alongside "BOINC Data" directory
+    strlcat(fullpath, "../", MAXPATHLEN);
+#endif
     strlcat(fullpath, PODMAN_DIR, MAXPATHLEN);
-
     result = stat(fullpath, &sbuf);
     isDirectory = S_ISDIR(sbuf.st_mode);
     if ((result == noErr) && (isDirectory)) {
+#if 0
         // Set owner and group of podman directory and it's contents
         sprintf(buf1, "%s:%s", boinc_master_user_name, boinc_project_group_name);
-        // chown -R boinc_master:boinc_project "/Library/Application Support/BOINC Data/podman"
+        // chown -R boinc_master:boinc_project "/Library/Application Support/BOINC podman"
         err = DoSudoPosixSpawn(chownPath, "-Rh", buf1, fullpath, NULL, NULL, NULL);
         if (err)
             return err;
 
-#if 0       // Redundant if the same as podman directory's contents
+#else   // Redundant if the same as podman directory's contents
+        // We allow podman to write directories and files with different ownerships.
+        // This is safe because Pdoman runs everything in containers
         // Set owner and group of podman directory itself
         sprintf(buf1, "%s:%s", boinc_master_user_name, boinc_project_group_name);
-        // chown boinc_master:boinc_project "/Library/Application Support/BOINC Data/podman"
+        // chown boinc_master:boinc_project "/Library/Application Support/BOINC podman"
         err = DoSudoPosixSpawn(chownPath, buf1, fullpath, NULL, NULL, NULL, NULL);
         if (err)
             return err;
 #endif
 
         // Set permissions of podman directories' contents
-        // Contents of podman directories must be world-readable so BOINC Client can read
-        // files written by projects which have user boinc_project and group boinc_project
-        // chmod -R u+rw,g+rw,o+r-w "/Library/Application Support/BOINC Data/podman"
+        // We allow podman to write directories and files with different ownerships.
+        // This is safe because Pdoman runs everything in containers
+        // But it may not be safe to make all files world-writable because some are lock files.
+        //
+        // chmod -R u+rw,g+rw,o+r-w "/Library/Application Support/BOINC podman"
         // 0664 = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH
-        // set read and write permission for user and group, no access for others (leaves execute bits unchanged)
-        //TODO: Should we allow others to read / write for files and traverse subdirectories?
+        // set read, write and execute permission for user and group, and others
+#if 0
         err = DoSudoPosixSpawn(chmodPath, "-R", "u+rw,g+rw,o+r-w", fullpath, NULL, NULL, NULL);
+//#else
+        err = DoSudoPosixSpawn(chmodPath, "-R", "u+rw,g+rw,o+rw", fullpath, NULL, NULL, NULL);
+#endif
         if (err)
             return err;
 
         // Set permissions for podman directory itself (not its contents)
-        // chmod u=rwx,g=rwx,o= "/Library/Application Support/BOINC Data/podman"
+        // chmod u=rwx,g=rwx,o= "/Library/Application Support/BOINC podman"
         // 0770 = S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IXGRP
         // Set read, write and execute permission for user & group, no access for others
         //TODO: Should we allow others to read / write / traverse podman directory?
-        err = DoSudoPosixSpawn(chmodPath, "u=rwx,g=rwx,o=", fullpath, NULL, NULL, NULL, NULL);
+        err = DoSudoPosixSpawn(chmodPath, "u=rwx,g=rwx,o=rwx", fullpath, NULL, NULL, NULL, NULL);
         if (err)
             return err;
 
-        // Set execute permissions for slot subdirectories
+        //TODO: should we modify permissions of files in BOINC podman directory?
+#if 0
+        // Because some of the contents of the podman directory are lock files with
+        // very limited permissions, this may not be safe to do.
+        // Set execute permissions for podan subdirectories
         err = UpdateNestedDirectories(fullpath);    // Sets execute for user, group and others
         if (err)
             return err;
+#endif
     }       // podman directory
 
     // Does locale directory exist?

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -351,7 +351,7 @@ const char* docker_cli_prog(DOCKER_TYPE type) {
     switch (type) {
     case DOCKER: return "docker";
 #ifdef __APPLE__
-        case PODMAN: return "/opt/podman/bin/podman";
+        case PODMAN: return "/opt/podman/bin/podman --config \"/Library/Application Support/BOINC podman/config\" ";
 #else
     case PODMAN: return "podman";
 #endif
@@ -376,14 +376,13 @@ const char* docker_type_str(DOCKER_TYPE type) {
 //
 #ifdef __APPLE__
 const char* docker_cmd_prefix(DOCKER_TYPE type) {
-    static char buf[256];
+    static char buf[1024];
     if (type == PODMAN) {
-        const char* dir = "/Library/Application Support/BOINC Data/podman";
+       const char* dir = "/Library/Application Support/BOINC podman";
         // must end w/ space
         snprintf(buf, sizeof(buf),
-            "env XDG_CONFIG_HOME=\"%s\" XDG_DATA_HOME=\"%s\" ",
-            dir, dir
-        );
+                 "env XDG_CONFIG_HOME=\"%s\" XDG_DATA_HOME=\"%s\" HOME=\"%s\" ", dir, dir, dir
+                 );
         return buf;
     }
     return "";

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -241,6 +241,22 @@ int main(int argc, char *argv[])
             return DeleteReceipt();
     }
 
+f = popen("env >> /tmp/env.txt", "w");  // Temporary for debugging
+pclose(f);
+
+f = popen("a=`/usr/libexec/path_helper`;b=${a%\\\"*}\\\";env ${b} which podman", "r");
+s[0] = '\0';
+if (f) {
+    fgets(s, sizeof(s), f);
+    pclose(f);
+    char * p=strstr(s, "\n");
+    if (p) *p='\0';
+    printf("popen returned podman path = \"%s\"\n", s);
+    f = fopen("/Library/Application Support/BOINC Data/PodmanPathFromPostinstall.txt", "w");
+    fprintf(f, "%s", s);
+    fclose(f);
+}
+
     if (Initialize() != noErr) {
         REPORT_ERROR(true);
         return 0;

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -63,6 +63,7 @@
 ## Updated 5/17/23 to add comments about notarize_BOINC.sh script
 ## Updated 2/12/25 to add support for Fix_BOINC_Users utility
 ## Updated 7/22/25 to add MacOS 26 support, no Finish_Install embedded in Postinstall.
+## Updaed 7/29/25 to add "BOINC podman" directory
 ##
 ## NOTE: This script requires Mac OS 10.7 or later, and uses XCode developer
 ##   tools.  So you must have installed XCode Developer Tools on the Mac
@@ -261,6 +262,7 @@ mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data
 mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/locale
 mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher
 mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/skins
+mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ podman
 
 # We must create virtualbox directory so installer will set up its
 # ownership and permissions correctly, because vboxwrapper won't

--- a/mac_installer/release_brand.sh
+++ b/mac_installer/release_brand.sh
@@ -266,6 +266,7 @@ mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data
 mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/locale
 mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/switcher
 mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ Data/skins
+mkdir -p ../BOINC_Installer/Pkg_Root/Library/Application\ Support/BOINC\ podman
 
 # We must create virtualbox directory so installer will set up its
 # ownership and permissions correctly, because vboxwrapper won't

--- a/samples/docker_wrapper/docker_wrapper.xcodeproj/xcshareddata/xcschemes/docker_wrapper.xcscheme
+++ b/samples/docker_wrapper/docker_wrapper.xcodeproj/xcshareddata/xcschemes/docker_wrapper.xcscheme
@@ -23,14 +23,14 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Development"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
@@ -52,7 +52,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Deployment"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"


### PR DESCRIPTION
Continue getting Podman working properly on Macintosh.

* Adds the missing prefix (to set needed environment variables) to `podman machine init` and `podman machine start` calls.
* Adds _HOME_ environment variable to prefix used in `podman` calls
* Moved _podman_ directory out of _BOINC Data_ directory and renames it to _BOINC podman_.
* Adjusted code to deal with the fact that Podman always writes some files as the logged-in user not boinc_master or boinc_project

I spent a great deal of time trying to get Podman to write all its files as user _boinc_master_ / _boinc_project_, experimenting with every combination of environment variables and optional arguments in the podman documentation, but was unable to do so. It always wrote at least some of its files owned by the logged in user who was running BOINC.

The `system()` and `popen()` APIs create a shell and run the passed command under that shell, but that shell always runs as the logged-in user even if the `system()` or `popen()` call was called from a process running as _boinc_master_ / _boinc_project_. One can run a command as the calling user by using `fork()` and `execvp()` via the `run_program()` function. But Podman fails with permission errors trying to write and / or read some of its necessary files even when Podman itself runs as _boinc_master_  or  _boinc_project_. 

So I decided it is best to run Podman as the logged-in user. This is the only way I was able to get `podman machine init` and `podman machine start` to succeed. I believe that it is safe (from a security standpoint) to run BOINC podman tasks as the logged-in user because podman runs them in a container.

But because BOINC otherwise uses account-based sandboxing on the mac for security, it was problematic to have the podman directory used by BOINC inside the _/Library/Application Support/BOINC Data_ directory, so I moved it out of that directory and renamed it thus: _/Library/Application Support/BOINC podman_. I changed the name to _BOINC podman_ to make it clear that this is a directory belonging to BOINC. (This means that the client no longer has permission to create the podman directory, but the BOINC installer for MacOS can because it has root privileges, so I added the code there.

It is worth noting that Podman apparently has an issue with computers that are set up with multiple users who can each login separately. If a Podman VM is created by one user, then if a different user logs in and attempts to use that same VM it will fail because Podman doesn't have permission to access the files it created under the first user.  But I haven't tested this, so I'm not certain of it. It wouldn't surprise me if even trying to create a second, separate VM under a different user via `podman machine init` and `podman machine start` might fail because Podman keeps some of its files in shared directories like _/tmp_ and _/var_ (which I have found no way to change), but will fail because they were created with a  different owner. This is probably true  on all platforms, not just MacOS.

All this implies that, in a system where multiple users have separate logins, and each can run BOINC, podman jobs will fail if started under one user and resumed by another. This is different from non-podman tasks which work correctly when handed off from one user to another (at least on macOS) because of running as _boinc_project_ rather than as the logged-in user.