### PR TITLE
Mac screensaver: Add bridging utility SS_GFX_Bridge

### DIFF
--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1411,12 +1411,15 @@ static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
     string theScreensaverLoginUser;
     char screensaverLoginUser[256];
     char switcher_path[MAXPATHLEN];
+    char gfx_switcher_path[MAXPATHLEN];
     char *execName, *execPath;
     char current_dir[MAXPATHLEN];
     char *execDir;
     int newPID = 0;
     ACTIVE_TASK* atp = NULL;
     char cmd[256];
+    bool need_to_launch_gfx_ss_bridge =false;
+    static int gfx_ss_bridge_pid = 0;
 
     while (!grc.xp.get_tag()) {
         if (grc.xp.match_tag("/run_graphics_app")) break;
@@ -1496,6 +1499,36 @@ static void handle_run_graphics_app(GUI_RPC_CONN& grc) {
                             theScreensaverLoginUser, grc);
         grc.mfout.printf("<success/>\n");
         return;
+    }
+
+    // As of MacOS 14.0, the legacyScreenSaver sandbox prevents using
+    // bootstrap_look_up, so we launch a bridging utility to relay Mach
+    // communications between the graphics apps and the legacyScreenSaver.
+    if (gfx_ss_bridge_pid == 0) {
+        need_to_launch_gfx_ss_bridge = true;
+    } else if (waitpid(gfx_ss_bridge_pid, 0, WNOHANG)) {
+        gfx_ss_bridge_pid = 0;
+        need_to_launch_gfx_ss_bridge = true;
+    }
+    if (need_to_launch_gfx_ss_bridge) {
+        if (g_use_sandbox) {
+
+            snprintf(gfx_switcher_path, sizeof(gfx_switcher_path),
+                "/Library/Screen Savers/%s.saver/Contents/Resources/gfx_switcher",
+                saverName[iBrandID]
+            );
+        }
+        argv[0] = const_cast<char*>("gfx_switcher");
+        argv[1] = "-run_bridge";
+        argv[2] = gfx_switcher_path;
+        argc = 3;
+        if (!theScreensaverLoginUser.empty()) {
+            argv[argc++] = "--ScreensaverLoginUser";
+            safe_strcpy(screensaverLoginUser, theScreensaverLoginUser.c_str());
+            argv[argc++] = screensaverLoginUser;
+        }
+        argv[argc] = 0;
+        retval = run_program(current_dir, gfx_switcher_path, argc, argv, gfx_ss_bridge_pid);
     }
 
     if (slot == -1) {

--- a/clientscr/Mac_Saver_ModuleView.m
+++ b/clientscr/Mac_Saver_ModuleView.m
@@ -516,7 +516,8 @@ void launchedGfxApp(char * appPath, char * wuName, pid_t thePID, int slot) {
                     if (mySharedGraphicsController) {
                         [ mySharedGraphicsController cleanUpOpenGL ];   // Must be called from main thread
                         [ mySharedGraphicsController closeServerPort ]; // Must be called after cleanUpOpenGL
-//                        [ NSApp terminate:nil ];  // Comment out to let legacyScreensaver continue in background
+                        [ NSApp terminate:nil ];  // Comment out to let legacyScreensaver continue in background
+                        //TODO: Kill GFX_SS_Bridge if letting legacyScreensaver continue in background
                     }
                     return;
                 }
@@ -1172,7 +1173,7 @@ static bool okToDraw;
     mach_port_t servicePortNum = MACH_PORT_NULL;
     kern_return_t machErr;
     char *portNameV1 = "edu.berkeley.boincsaver";
-    char *portNameV2 = "edu.berkeley.boincsaver-v2";
+    char *portNameV3 = "edu.berkeley.boincsaver-v3";
 
     if ((!gMach_bootstrap_unavailable_to_screensavers) || (serverPort == MACH_PORT_NULL)) {
         // Try to check in with master.
@@ -1189,7 +1190,7 @@ static bool okToDraw;
                 // As of MacOS 14.0, the legacyScreenSaver sandbox prevents using
                 // bootstrap_look_up. I have filed bug report FB13300491 with
                 // Apple and hope they will change this in a future MacOS.
-                machErr = bootstrap_check_in(bootstrap_port, portNameV2, &servicePortNum);
+                machErr = bootstrap_check_in(bootstrap_port, portNameV3, &servicePortNum);
                 if (machErr != KERN_SUCCESS) {
                    [NSApp terminate:nil];
                 }

--- a/clientscr/gfx_ss_bridge.m
+++ b/clientscr/gfx_ss_bridge.m
@@ -1,0 +1,65 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2025 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  gfx_ss_bridge
+//
+//  gfx_ss_bridge.m
+//
+// As of MacOS 14.0, the legacyScreenSaver sandbox prevents using
+// bootstrap_look_up, so we use this bridging utility to relay Mach
+// communications between the graphics apps and the legacyScreenSaver.
+
+
+#define ShowGFXWindow false
+
+#import <Cocoa/Cocoa.h>
+#import "sharedGraphicsController.h"
+
+extern bool simulateSS;
+extern SharedGraphicsController *GFXIn_SharedGraphicsController;
+extern SharedGraphicsController *GFXOut_SharedGraphicsController;
+extern int IOSurfaceWidth;
+extern int IOSurfaceHeight;
+
+
+int main(int argc, const char * argv[]) {
+    simulateSS = false;
+
+#if ShowGFXWindow
+    NSRect contentRect = NSMakeRect(300, 300, 500, 500);
+    NSWindowStyleMask myWinStyle = NSWindowStyleMaskTitled
+ | NSWindowStyleMaskResizable | NSWindowStyleMaskFullSizeContentView;
+    NSWindow *win = [ [ NSWindow alloc ] initWithContentRect:contentRect styleMask:myWinStyle backing:NSBackingStoreBuffered defer:false ];
+#endif
+
+    if (!GFXOut_SharedGraphicsController) {
+        GFXOut_SharedGraphicsController = [SharedGraphicsController alloc];
+        [GFXOut_SharedGraphicsController init:NULL thePortName: "edu.berkeley.boincsaver-v3" direction:false];
+    }
+
+    if (!GFXIn_SharedGraphicsController) {
+        GFXIn_SharedGraphicsController = [SharedGraphicsController alloc];
+#if ShowGFXWindow
+        [GFXIn_SharedGraphicsController init:win thePortName: "edu.berkeley.boincsaver" direction:true];
+#else
+        [GFXIn_SharedGraphicsController init:NULL thePortName: "edu.berkeley.boincsaver" direction:true];
+#endif
+    }
+
+    return 0;
+}

--- a/clientscr/sharedGraphicsController.h
+++ b/clientscr/sharedGraphicsController.h
@@ -1,0 +1,88 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2025 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  gfx_ss_bridge
+//
+//  sharedGraphicsController.h
+
+#ifndef BOINC_GFX_SS_bridge_SHARED_GFX_CONTROLLER_H
+#define BOINC_GFX_SS_bridge_SHARED_GFX_CONTROLLER_H
+
+#define GL_DO_NOT_WARN_IF_MULTI_GL_VERSION_HEADERS_INCLUDED
+
+#import <Foundation/Foundation.h>
+#import <OpenGL/gl.h>
+#import <GLKit/GLKit.h>
+#include <servers/bootstrap.h>
+#import "MultiGPUMig.h"
+#import "MultiGPUMigServer.h"
+
+static NSTimer * myTimer = NULL;
+
+#define DPI_multiplier 4.0
+
+#define NUM_IOSURFACE_BUFFERS 2
+
+
+
+@interface saverOpenGLView : NSOpenGLView
+
+- (GLuint)setupIOSurfaceTexture:(IOSurfaceRef)ioSurfaceBuffer;
+
+@end
+
+
+@interface SharedGraphicsController : NSObject <NSMachPortDelegate>
+{
+    bool isFromGFXApp;
+    bool runningSharedGraphics;
+    char portNameToLookUp[128];
+
+	NSMachPort *serverPort;
+	NSMachPort *localPort;
+
+	uint32_t serverPortName;
+	uint32_t localPortName;
+
+	int32_t clientIndex;
+	uint32_t nextFrameIndex;
+    
+	NSMachPort *clientPort[16];
+	uint32_t clientPortNames[16];
+	uint32_t clientPortCount;
+
+    NSView *screenSaverView;
+    saverOpenGLView *openGLView;
+
+	IOSurfaceRef _ioSurfaceBuffers[NUM_IOSURFACE_BUFFERS];
+    mach_port_t _ioSurfaceMachPorts[NUM_IOSURFACE_BUFFERS];
+	GLuint _textureNames[NUM_IOSURFACE_BUFFERS];
+}
+
+@property (NS_NONATOMIC_IOSONLY, readonly) GLuint currentTextureName;
+- (void)init:(NSWindow*)win thePortName:(const char*)nameToLookUp direction:(bool)fromGFXApp;
+- (void)testConnection;
+- (kern_return_t)checkInClient:(mach_port_t)client_port index:(int32_t *)client_index;
+- (void)portDied:(NSNotification *)notification;
+- (void)sendIOSurfaceMachPortToClients: (uint32_t)index withMachPort:(mach_port_t) iosurface_port;
+- (void)closeServerPort;
+- (void)cleanUpOpenGL;
+
+@end
+
+#endif // BOINC_GFX_SS_bridge_SHARED_GFX_CONTROLLER_H

--- a/clientscr/sharedGraphicsController.m
+++ b/clientscr/sharedGraphicsController.m
@@ -1,0 +1,622 @@
+// This file is part of BOINC.
+// http://boinc.berkeley.edu
+// Copyright (C) 2025 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+//
+//  gfx_ss_bridge
+//
+//  aharedGraphicsController.m
+
+// On OS 10.13 or later, use MachO comunication and IOSurfaceBuffer to
+// display the graphics output of our child graphics apps in our window.
+// All code past this point is for that implementation.
+
+// Adapted from Apple Developer Tech Support Sample Code MutiGPUIOSurface:
+// <https://developer.apple.com/library/content/samplecode/MultiGPUIOSurface>
+
+#import "sharedGraphicsController.h"
+#include <servers/bootstrap.h>
+#include <notify.h>
+
+#define CREATE_LOG 0
+
+#if CREATE_LOG
+#ifdef __cplusplus
+extern "C" {
+#endif
+static void print_to_log_file(const char *format, ...);
+static void strip_cr(char *buf);
+#ifdef __cplusplus
+}
+#endif
+#else
+#define print_to_log_file(...)
+#endif
+
+bool simulateSS;
+static bool okToDraw;
+SharedGraphicsController *GFXIn_SharedGraphicsController = NULL;
+SharedGraphicsController *GFXOut_SharedGraphicsController = NULL;
+int IOSurfaceWidth;
+int IOSurfaceHeight;
+int notification_token = 0;
+mach_port_t notification_port;
+
+
+@implementation SharedGraphicsController
+
+- (void)init:win thePortName:(const char*)nameToLookUp direction:(bool)fromGFXApp{
+    isFromGFXApp = fromGFXApp;
+    strlcpy(portNameToLookUp, nameToLookUp, sizeof(portNameToLookUp));
+    clientPortCount = 0;
+    if (fromGFXApp) {
+        runningSharedGraphics = false;
+
+        if (win) {
+            screenSaverView = [win contentView];
+            [win makeKeyAndOrderFront:self];
+        } else {
+            screenSaverView = NULL;
+        }
+        [[NSNotificationCenter defaultCenter] removeObserver:self
+            name:NSPortDidBecomeInvalidNotification object:nil];
+
+        openGLView = nil;
+
+        if (myTimer == NULL) {
+            myTimer = [NSTimer scheduledTimerWithTimeInterval:(NSTimeInterval) 1./60. target:self selector:@selector(testConnection)
+                                        userInfo:nil repeats:YES];
+
+        [[NSNotificationCenter defaultCenter] addObserver:self
+            selector:@selector(portDied:) name:NSPortDidBecomeInvalidNotification object:nil];
+        }
+
+        [self testConnection];
+    } else {
+        mach_port_t servicePortNum = MACH_PORT_NULL;
+        kern_return_t machErr;
+
+        // NSMachBootstrapServer is deprecated in OS 10.13, so use bootstrap_look_up
+        //	serverPort = [(NSMachPort *)([[NSMachBootstrapServer sharedInstance] portForName:@"edu.berkeley.boincsaver"]) retain];
+        machErr = bootstrap_look_up(bootstrap_port, portNameToLookUp, &servicePortNum);
+        if (machErr != KERN_SUCCESS) {
+            fprintf(stderr, "Failed to connect to screensaver\n");
+            fflush(stderr);
+            print_to_log_file("terminated in testConnection");
+            exit(0);
+        }
+
+        int32_t dummy_index;
+        [self checkInClient:servicePortNum index:&dummy_index];
+
+        serverPort = (NSMachPort*)[NSMachPort portWithMachPort:servicePortNum];
+
+#if 1
+        // Register server port with the current runloop.
+        [serverPort setDelegate:self];  // CAF STD
+        notification_port = servicePortNum;
+        //int retval =
+            notify_register_mach_port([NSPortDidBecomeInvalidNotification UTF8String], &notification_port, NOTIFY_REUSE, & notification_token);
+        [[NSNotificationCenter defaultCenter] addObserver:self
+            selector:@selector(portDied:) name:NSPortDidBecomeInvalidNotification object:nil];
+#else
+            localPort = [[NSMachPort alloc] init];
+
+            // Retrieve raw mach port names.
+            serverPortName = [serverPort machPort];
+            localPortName  = [localPort machPort];
+
+            // Register our local port with the current runloop.
+            [localPort setDelegate:self];
+            [localPort scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+#endif
+    }
+
+    if (fromGFXApp || simulateSS) {
+        [[NSRunLoop currentRunLoop] run];
+    }
+}
+
+
+- (void) testConnection
+{
+    mach_port_t servicePortNum = MACH_PORT_NULL;
+    kern_return_t machErr;
+
+    if (runningSharedGraphics) {
+        return;
+    }
+
+    if (simulateSS) {
+        machErr = bootstrap_check_in(bootstrap_port, portNameToLookUp, &servicePortNum);
+    } else {
+        // Try to check in with master.
+        // NSMachBootstrapServer is deprecated in OS 10.13, so use bootstrap_look_up
+        //	serverPort = [(NSMachPort *)([[NSMachBootstrapServer sharedInstance] portForName:@"edu.berkeley.boincsaver"]) retain];
+        machErr = bootstrap_look_up(bootstrap_port, portNameToLookUp, &servicePortNum);
+    }
+
+    if (machErr == KERN_SUCCESS) {
+        serverPort = (NSMachPort*)[NSMachPort portWithMachPort:servicePortNum];
+    } else {
+        serverPort = MACH_PORT_NULL;
+    }
+
+    if (simulateSS) {
+        if ((serverPort != MACH_PORT_NULL) && (localPort == MACH_PORT_NULL)) {
+            // Retrieve raw mach port names.
+            serverPortName = [serverPort machPort];
+            // Register server port with the current runloop.
+            [serverPort setDelegate:self];
+            [serverPort scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+        }
+    } else {
+        if(serverPort != MACH_PORT_NULL) {
+            // Create our own local port.
+            localPort = [[NSMachPort alloc] init];
+
+            // Retrieve raw mach port names.
+            serverPortName = [serverPort machPort];
+            localPortName  = [localPort machPort];
+
+            // Register our local port with the current runloop.
+            [localPort setDelegate:self];
+            [localPort scheduleInRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+
+            // Check in with server.
+            int kr;
+            kr = _MGCCheckinClient(serverPortName, localPortName, &clientIndex);
+            if(kr != 0) {
+                print_to_log_file("terminated in testConnection");
+                exit(0);
+            }
+
+            runningSharedGraphics = true;
+        }
+    }
+}
+
+- (void)cleanUpOpenGL
+{
+    if (serverPort != MACH_PORT_NULL) {
+       [serverPort removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+    }
+
+    if ((serverPort == MACH_PORT_NULL) && (localPort == MACH_PORT_NULL)) {
+        if (openGLView) {
+            if (NSThread.isMainThread) {
+               [openGLView removeFromSuperview];   // Releases openGLView
+            } else {
+                    static saverOpenGLView *temp = 0;   // Static to allow asynchronous use
+                    temp = openGLView;
+                    // Both dispatch_sync and dispatch_async cause problems when
+                    //  called from CScreensaver::DataManagementProc thread
+                    dispatch_sync(dispatch_get_main_queue(), ^{
+                        [temp removeFromSuperview];   // Releases openGLView
+                });
+            }
+            openGLView = nil;
+        }
+
+        int i;
+        for(i = 0; i < NUM_IOSURFACE_BUFFERS; i++) {
+            if (_ioSurfaceBuffers[i]) {
+               CFRelease(_ioSurfaceBuffers[i]);
+                _ioSurfaceBuffers[i] = nil;
+            }
+
+            // if (glIsTexture(_textureNames[i])) {
+                // glDeleteTextures(1, _textureNames[i]);
+            // }
+            _textureNames[i] = 0;
+
+            if (_ioSurfaceMachPorts[i] != MACH_PORT_NULL) {
+                mach_port_deallocate(mach_task_self(), _ioSurfaceMachPorts[i]);
+                _ioSurfaceMachPorts[i] = MACH_PORT_NULL;
+            }
+        }
+
+        runningSharedGraphics = false;  // Do this last!!
+    }
+}
+
+
+- (void)portDied:(NSNotification *)notification
+{
+	NSPort *port = [notification object];
+    if(port == serverPort) {
+        if (isFromGFXApp) {
+            [ self closeServerPort ];
+            [ self cleanUpOpenGL ];
+        } else {
+            print_to_log_file("terminated in portDied");
+            exit(0);
+        }
+    } else if ((!isFromGFXApp) && (!simulateSS)) {
+        int i;
+		for(i = 0; i < clientPortCount+1; i++)
+		{
+			if([clientPort[i] isEqual:port])
+			{
+//				[clientPort[i] release];
+				clientPort[i] = nil;
+				clientPortNames[i] = 0;
+			}
+		}
+    }
+}
+
+- (void)closeServerPort
+{
+    if ([serverPort isValid]) {
+        [serverPort invalidate];
+//            [serverPort release];
+    }
+    serverPort = MACH_PORT_NULL;
+
+    if ((isFromGFXApp) && (!simulateSS)) {
+        if (localPort != MACH_PORT_NULL) {
+            [localPort removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSRunLoopCommonModes];
+
+            if ([localPort isValid]) {
+                [localPort invalidate];
+            }
+    //          [localPort release];
+            localPort = MACH_PORT_NULL;
+
+#if 1
+            int i;
+            for(i = 0; i < NUM_IOSURFACE_BUFFERS; i++) {
+                if (_ioSurfaceBuffers[i]) {
+                    CFRelease(_ioSurfaceBuffers[i]);
+                    _ioSurfaceBuffers[i] = nil;
+                }
+
+                // if (glIsTexture(_textureNames[i])) {
+                    // glDeleteTextures(1, _textureNames[i]);
+                // }
+                _textureNames[i] = 0;
+
+                if (_ioSurfaceMachPorts[i] != MACH_PORT_NULL) {
+                    mach_port_deallocate(mach_task_self(), _ioSurfaceMachPorts[i]);
+                    _ioSurfaceMachPorts[i] = MACH_PORT_NULL;
+                }
+            }
+#endif
+        }
+
+        if ((serverPort == nil) && (localPort == nil)) {
+            if (openGLView) {
+                [openGLView removeFromSuperview];   // Releases openGLView
+                openGLView = nil;
+            }
+        }
+    }
+}
+
+- (void)handleMachMessage:(void *)msg
+{
+	union __ReplyUnion___MGCMGSServer_subsystem reply;
+
+	mach_msg_header_t *reply_header = (mach_msg_header_t *)&reply;
+	kern_return_t kr;
+
+	if(MGSServer_server((mach_msg_header_t *)msg, reply_header) && reply_header->msgh_remote_port != MACH_PORT_NULL)
+	{
+		kr = mach_msg(reply_header, MACH_SEND_MSG, reply_header->msgh_size, 0, MACH_PORT_NULL,
+			     0, MACH_PORT_NULL);
+        if(kr != 0) {
+            print_to_log_file("terminated in MGSServer_server");
+			exit(0);
+        }
+	}
+}
+
+- (kern_return_t)displayFrame:(int32_t)frameIndex surfacemachport:(mach_port_t)iosurface_port
+{
+	nextFrameIndex = frameIndex;
+
+	if(!_ioSurfaceBuffers[frameIndex])
+	{
+		_ioSurfaceBuffers[frameIndex] = IOSurfaceLookupFromMachPort(iosurface_port);
+        _ioSurfaceMachPorts[frameIndex] = iosurface_port;
+	}
+
+    IOSurfaceWidth = (int)IOSurfaceGetWidth((IOSurfaceRef)_ioSurfaceBuffers[frameIndex]);
+    IOSurfaceHeight = (int)IOSurfaceGetHeight((IOSurfaceRef)_ioSurfaceBuffers[frameIndex]);
+
+    if ( screenSaverView &&(openGLView == nil)) {
+        NSRect theframe;
+        theframe.origin.x = theframe.origin.y = 0.0;
+        theframe.size.width = IOSurfaceWidth;
+        theframe.size.height = IOSurfaceHeight;
+        openGLView = [[saverOpenGLView alloc] initWithFrame:theframe];
+        [screenSaverView addSubview:openGLView];
+    }
+
+    if (openGLView) {
+        if(!_textureNames[frameIndex])
+        {
+            _textureNames[frameIndex] = [openGLView setupIOSurfaceTexture:_ioSurfaceBuffers[frameIndex]];
+        }
+
+        okToDraw = true;    // Tell drawRect that we have real data to display
+
+        [openGLView setNeedsDisplay:YES];
+        [openGLView display];
+    }
+
+    if (isFromGFXApp) {
+        // TODO: Should we keep frame index of GFXIn_SharedGraphicsController separate from GFXOut_SharedGraphicsController?
+        [ GFXOut_SharedGraphicsController sendIOSurfaceMachPortToClients:frameIndex withMachPort:iosurface_port];
+    }
+	return 0;
+}
+
+- (kern_return_t)checkInClient:(mach_port_t)client_port index:(int32_t *)client_index
+{	
+	clientPortCount++;			// clients always start at index 1
+	clientPortNames[clientPortCount] = client_port;
+	clientPort[clientPortCount] = [[NSMachPort alloc] initWithMachPort:client_port];
+	
+	*client_index = clientPortCount;
+	return 0;
+}
+
+kern_return_t _MGSCheckinClient(mach_port_t server_port, mach_port_t client_port,
+			       int32_t *client_index)
+{
+//    if (isFromGFXApp) {
+        // For the MachO client, this is a no-op.
+//        return 0;
+//    }
+
+    return [GFXOut_SharedGraphicsController checkInClient:client_port index:client_index];
+}
+
+kern_return_t _MGSDisplayFrame(mach_port_t server_port, int32_t frame_index, mach_port_t iosurface_port)
+{
+//    if (!isFromGFXApp) {
+    // For the MachO server, this is a no-op
+//    return 0;
+//    }
+
+    return [GFXIn_SharedGraphicsController displayFrame:frame_index surfacemachport:iosurface_port];
+}
+
+- (void)sendIOSurfaceMachPortToClients:(uint32_t)index withMachPort:(mach_port_t)iosurface_port
+{
+	int i;
+	for(i = 0; i < clientPortCount+1; i++)
+	{
+		if(clientPortNames[i])
+		{
+			_MGCDisplayFrame(clientPortNames[i], index, iosurface_port);
+		}
+	}
+}
+
+- (GLuint)currentTextureName
+{
+	return _textureNames[nextFrameIndex];
+}
+
+@end
+
+@implementation saverOpenGLView
+
+- (instancetype)initWithFrame:(NSRect)frame {
+    NSOpenGLPixelFormatAttribute	attribs []	=
+    {
+//		NSOpenGLPFAWindow,
+		NSOpenGLPFADoubleBuffer,
+		NSOpenGLPFAAccelerated,
+		NSOpenGLPFANoRecovery,
+		NSOpenGLPFAColorSize,		(NSOpenGLPixelFormatAttribute)32,
+		NSOpenGLPFAAlphaSize,		(NSOpenGLPixelFormatAttribute)8,
+		NSOpenGLPFADepthSize,		(NSOpenGLPixelFormatAttribute)24,
+		(NSOpenGLPixelFormatAttribute) 0
+	};
+
+    NSOpenGLPixelFormat *pix_fmt = [[NSOpenGLPixelFormat alloc] initWithAttributes:attribs];
+
+    if(!pix_fmt) {
+        print_to_log_file("terminated in saverOpenGLView initWithFrame");
+       exit(0);
+    }
+
+	self = [super initWithFrame:frame pixelFormat:pix_fmt];
+
+
+	[[self openGLContext] makeCurrentContext];
+
+    // drawRect is apparently called due to the above code, causing the
+    // screen to flash unless we prevent any actual drawing, so tell
+    // drawRect that we do not yet have real data to display
+    okToDraw = false;
+
+	return self;
+}
+
+- (void)prepareOpenGL
+{
+    [super prepareOpenGL];
+}
+
+- (void)update
+{
+    [super update];
+	// Override to do nothing.
+}
+
+// Create an IOSurface backed texture
+- (GLuint)setupIOSurfaceTexture:(IOSurfaceRef)ioSurfaceBuffer
+{
+	GLuint name;
+	CGLContextObj cgl_ctx = (CGLContextObj)[[self openGLContext] CGLContextObj];
+
+	glGenTextures(1, &name);
+
+	glBindTexture(GL_TEXTURE_RECTANGLE, name);
+    // At the moment, CGLTexImageIOSurface2D requires the GL_TEXTURE_RECTANGLE target
+	CGLTexImageIOSurface2D(cgl_ctx, GL_TEXTURE_RECTANGLE, GL_RGBA, (GLsizei)self.bounds.size.width, (GLsizei)self.bounds.size.height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+					ioSurfaceBuffer, 0);
+
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_RECTANGLE, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+	return name;
+}
+
+- (BOOL)isOpaque
+{
+	return YES;
+}
+
+// Render a quad with the the IOSurface backed texture
+- (void)renderTextureFromIOSurfaceWithWidth:(GLsizei)logoWidth height:(GLsizei)logoHeight
+{
+    GLfloat quad[] = {
+        //x, y            s, t
+        (GLfloat)logoWidth, 0.0f,    0.0f, 0.0f,
+        0.0f, (GLfloat)logoHeight,   0.0f, 0.0f,
+        0.0f,  0.0f,     1.0f, 0.0f,
+        0.0f,  0.0f,     0.0f, 1.0f
+    };
+
+    GLint		saveMatrixMode;
+
+    glGetIntegerv(GL_MATRIX_MODE, &saveMatrixMode);
+    glMatrixMode(GL_TEXTURE);
+    glPushMatrix();
+    glLoadMatrixf(quad);
+    glMatrixMode(saveMatrixMode);
+
+    glBindTexture(GL_TEXTURE_RECTANGLE, [GFXIn_SharedGraphicsController currentTextureName]);
+    glEnable(GL_TEXTURE_RECTANGLE);
+
+    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
+
+	//Draw textured quad
+	glBegin(GL_QUADS);
+		glTexCoord2f(0.0, 0.0);
+		glVertex3f(-1.0, -1.0, 0.0);
+		glTexCoord2f(1.0, 0.0);
+		glVertex3f(1.0, -1.0, 0.0);
+		glTexCoord2f(1.0, 1.0);
+		glVertex3f(1.0, 1.0, 0.0);
+		glTexCoord2f(0.0, 1.0);
+		glVertex3f(-1.0, 1.0, 0.0);
+	glEnd();
+
+		glDisable(GL_TEXTURE_RECTANGLE);
+
+		glGetIntegerv(GL_MATRIX_MODE, &saveMatrixMode);
+		glMatrixMode(GL_TEXTURE);
+		glPopMatrix();
+		glMatrixMode(saveMatrixMode);
+
+}
+
+// OpenGL / GLUT apps which call glutFullScreen() and are built using
+// Xcode 11 apparently use window dimensions based on the number of
+// backing store pixels. That is, they double the window dimensions
+// for Retina displays (which have 2X2 pixels per point.) But OpenGL
+// apps built under earlier versions of Xcode don't.
+//
+// OS 10.15 Catalina assumes OpenGL / GLUT apps work as built under
+// Xcode 11, so it displays older builds at half width and height,
+// unless we compensate in our code.
+//
+// To ensure that BOINC graphics apps built on all versions of Xcode work
+// properly on different versions of OS X, we set the IOSurface dimensions
+// in this module to double the screen dimensions when running under
+// OS 10.15 or later.
+//
+// See also MacGLUTFix(bool isScreenSaver) in api/macglutfix.m for more info.
+//
+// NOTE: Graphics apps must now be linked with the IOSurface framework.
+//
+- (void)drawRect:(NSRect)theRect
+{
+    glViewport(0, 0, (GLint)[[self window]frame].size.width*DPI_multiplier, (GLint)[[self window] frame].size.height*DPI_multiplier);
+
+    glClearColor(0.0, 0.0, 0.0, 0.0);
+
+    glClear(GL_COLOR_BUFFER_BIT|GL_DEPTH_BUFFER_BIT);
+
+    // drawRect is apparently called before we have real data to display,
+    // causing the screen to flash unless we prevent any actual drawing.
+    if (!okToDraw) {
+        [[self openGLContext] flushBuffer];
+        return;
+    }
+
+    // MachO client draws with current IO surface contents as texture
+    [self renderTextureFromIOSurfaceWithWidth:(GLsizei)self.bounds.size.width height:(GLsizei)self.bounds.size.height];
+
+    [[self openGLContext] flushBuffer];
+}
+
+@end
+
+#if CREATE_LOG
+
+#include <sys/stat.h>
+
+static void print_to_log_file(const char *format, ...) {
+    FILE *f;
+    va_list args;
+    char buf[256];
+    time_t t;
+
+    f = fopen("/Users/Shared/test_log_gfx_ss_bridge.txt", "a");
+    if (!f) return;
+
+//  freopen(buf, "a", stdout);
+//  freopen(buf, "a", stderr);
+
+    time(&t);
+    strlcpy(buf, asctime(localtime(&t)), sizeof(buf));
+    strip_cr(buf);
+
+    fputs(buf, f);
+    fputs("   ", f);
+
+    va_start(args, format);
+    vfprintf(f, format, args);
+    va_end(args);
+
+    fputs("\n", f);
+    fflush(f);
+    fclose(f);
+    chmod("/Users/Shared/test_log_gfx_ss_bridge.txt", 0666);
+}
+
+static void strip_cr(char *buf)
+{
+    char *theCR;
+
+    theCR = strrchr(buf, '\n');
+    if (theCR)
+        *theCR = '\0';
+    theCR = strrchr(buf, '\r');
+    if (theCR)
+        *theCR = '\0';
+}
+#endif	// CREATE_LOG

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				DD2521502E44A113002726E2 /* PBXTargetDependency */,
 				DD3719482E3B5AB000E75DF3 /* PBXTargetDependency */,
 				DDC04DA52E2908AB006AB01D /* PBXTargetDependency */,
 				DDA8694C2E1FCEE400642CD3 /* PBXTargetDependency */,
@@ -76,6 +77,13 @@
 		DD21B49D0D750FC600AFFEE5 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
 		DD22DF5E1A235F58007FB597 /* DlgExclusiveApps.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD22DF5C1A235F58007FB597 /* DlgExclusiveApps.cpp */; };
 		DD247AF90AEA308A0034104A /* SkinManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD247AF70AEA308A0034104A /* SkinManager.cpp */; };
+		DD2521472E44983E002726E2 /* gfx_ss_bridge.m in Sources */ = {isa = PBXBuildFile; fileRef = DD2521462E44983E002726E2 /* gfx_ss_bridge.m */; };
+		DD2521492E449875002726E2 /* sharedGraphicsController.m in Sources */ = {isa = PBXBuildFile; fileRef = DD2521482E449875002726E2 /* sharedGraphicsController.m */; };
+		DD25214B2E4499A0002726E2 /* MultiGPUMig.defs in Sources */ = {isa = PBXBuildFile; fileRef = DD64D8001F6BE5BA00FEEAAA /* MultiGPUMig.defs */; settings = {ATTRIBUTES = (Client, Server, ); }; };
+		DD25214C2E4499E9002726E2 /* IOSurface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD0BB7A11F62B105000151B2 /* IOSurface.framework */; };
+		DD25214D2E449A0B002726E2 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDFE854A0B60CFD0009B43D9 /* AppKit.framework */; };
+		DD25214E2E449A16002726E2 /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD89165E0F3B1BC200DE5B1C /* OpenGL.framework */; };
+		DD2521532E44A145002726E2 /* gfx_ss_bridge in Resources */ = {isa = PBXBuildFile; fileRef = DD2521452E449816002726E2 /* gfx_ss_bridge */; };
 		DD2580D42D63442600D8E343 /* MacFixUserGroups.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD2580D32D63442600D8E343 /* MacFixUserGroups.cpp */; };
 		DD25F72815914F8C007845B5 /* gpu_nvidia.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD25F72315914F8C007845B5 /* gpu_nvidia.cpp */; };
 		DD25F72915914F8C007845B5 /* gpu_amd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD25F72415914F8C007845B5 /* gpu_amd.cpp */; };
@@ -635,6 +643,20 @@
 			remoteGlobalIDString = DD407A4907D2FB1200163EF5;
 			remoteInfo = libboinc;
 		};
+		DD25214F2E44A113002726E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD25213C2E449816002726E2;
+			remoteInfo = GFX_SS_Bridge;
+		};
+		DD2521512E44A133002726E2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DD25213C2E449816002726E2;
+			remoteInfo = GFX_SS_Bridge;
+		};
 		DD3719472E3B5AB000E75DF3 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 20286C28FDCF999611CA2CEA /* Project object */;
@@ -871,6 +893,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		DD2521412E449816002726E2 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		DD3719402E3B50BD00E75DF3 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -946,6 +977,10 @@
 		DD22DF5D1A235F58007FB597 /* DlgExclusiveApps.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DlgExclusiveApps.h; sourceTree = "<group>"; };
 		DD247AF70AEA308A0034104A /* SkinManager.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; name = SkinManager.cpp; path = ../clientgui/SkinManager.cpp; sourceTree = SOURCE_ROOT; };
 		DD247AF80AEA308A0034104A /* SkinManager.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = SkinManager.h; path = ../clientgui/SkinManager.h; sourceTree = SOURCE_ROOT; };
+		DD2521452E449816002726E2 /* gfx_ss_bridge */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = gfx_ss_bridge; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD2521462E44983E002726E2 /* gfx_ss_bridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = gfx_ss_bridge.m; path = ../clientscr/gfx_ss_bridge.m; sourceTree = "<group>"; };
+		DD2521482E449875002726E2 /* sharedGraphicsController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = sharedGraphicsController.m; path = ../clientscr/sharedGraphicsController.m; sourceTree = "<group>"; };
+		DD25214A2E449890002726E2 /* sharedGraphicsController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = sharedGraphicsController.h; path = ../clientscr/sharedGraphicsController.h; sourceTree = "<group>"; };
 		DD252F3009E3E014006454D7 /* boinc_glut.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; name = boinc_glut.h; path = ../api/boinc_glut.h; sourceTree = SOURCE_ROOT; };
 		DD2580D32D63442600D8E343 /* MacFixUserGroups.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = MacFixUserGroups.cpp; path = ../clientgui/mac/MacFixUserGroups.cpp; sourceTree = "<group>"; };
 		DD25F72315914F8C007845B5 /* gpu_nvidia.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = gpu_nvidia.cpp; sourceTree = "<group>"; };
@@ -1440,6 +1475,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DD2521402E449816002726E2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD25214C2E4499E9002726E2 /* IOSurface.framework in Frameworks */,
+				DD25214D2E449A0B002726E2 /* AppKit.framework in Frameworks */,
+				DD25214E2E449A16002726E2 /* OpenGL.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD35352F07E1E05C00C4718D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1650,6 +1695,7 @@
 				DDEED38629ADFD7000DC3E5D /* BOINC_Finish_Install.app */,
 				DD67F1952D5A24FD00A78699 /* Fix_BOINC_Users */,
 				DD3719442E3B50BD00E75DF3 /* Run_Podman */,
+				DD2521452E449816002726E2 /* gfx_ss_bridge */,
 			);
 			name = Products;
 			sourceTree = SOURCE_ROOT;
@@ -1992,6 +2038,7 @@
 			isa = PBXGroup;
 			children = (
 				DD89163B0F3B182700DE5B1C /* boinc_ss_opengl.h */,
+				DD2521462E44983E002726E2 /* gfx_ss_bridge.m */,
 				DD89163C0F3B182700DE5B1C /* ss_app.cpp */,
 				DDB873960C85072500E0DE1F /* mac_saver_module.cpp */,
 				DDA290360CB5D80E00512BD8 /* Mac_Saver_Module.h */,
@@ -1999,6 +2046,8 @@
 				DDB873970C85072500E0DE1F /* Mac_Saver_ModuleView.h */,
 				DD7AEB490C87CE1300AC3B5C /* screensaver.cpp */,
 				DD7AEB680C87CE6500AC3B5C /* screensaver.h */,
+				DD25214A2E449890002726E2 /* sharedGraphicsController.h */,
+				DD2521482E449875002726E2 /* sharedGraphicsController.m */,
 				DDE7A3AF15C6739E002B3B96 /* ttfont.cpp */,
 				DDE7A3B015C6739E002B3B96 /* ttfont.h */,
 				DDFA60E30CB3396C0037B88C /* gfx_switcher.cpp */,
@@ -2328,6 +2377,26 @@
 			productReference = DD1AFEBA0A512D8700EE5B82 /* BOINC Installer.app */;
 			productType = "com.apple.product-type.application";
 		};
+		DD25213C2E449816002726E2 /* gfx_ss_bridge */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD2521422E449816002726E2 /* Build configuration list for PBXNativeTarget "gfx_ss_bridge" */;
+			buildPhases = (
+				DD25213D2E449816002726E2 /* ShellScript */,
+				DD25213E2E449816002726E2 /* Sources */,
+				DD2521402E449816002726E2 /* Frameworks */,
+				DD2521412E449816002726E2 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = gfx_ss_bridge;
+			packageProductDependencies = (
+			);
+			productName = Fix_BOINC_Users;
+			productReference = DD2521452E449816002726E2 /* gfx_ss_bridge */;
+			productType = "com.apple.product-type.tool";
+		};
 		DD35353007E1E05C00C4718D /* api_libboinc */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DD9E2359091CBDAE0048316E /* Build configuration list for PBXNativeTarget "api_libboinc" */;
@@ -2550,6 +2619,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				DD2521522E44A133002726E2 /* PBXTargetDependency */,
 				DDFA60DD0CB338940037B88C /* PBXTargetDependency */,
 				DD5F654F2360648D009ED2A2 /* PBXTargetDependency */,
 			);
@@ -2785,6 +2855,7 @@
 				B13E2D0E265564D100D5C977 /* detect_rosetta_cpu */,
 				DD67F1942D5A24FD00A78699 /* Fix_BOINC_Users */,
 				DD37193A2E3B50BD00E75DF3 /* Run_Podman */,
+				DD25213C2E449816002726E2 /* gfx_ss_bridge */,
 			);
 		};
 /* End PBXProject section */
@@ -2832,6 +2903,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DD2521532E44A145002726E2 /* gfx_ss_bridge in Resources */,
 				DDFA60E20CB3391C0037B88C /* gfx_switcher in Resources */,
 				DD5F656623607472009ED2A2 /* gfx_cleanup in Resources */,
 				DD818295245ED4110076E5D0 /* boinc_ss_helper.sh in Resources */,
@@ -2901,6 +2973,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "chown -R ${USER}:${GROUP} \"${BUILT_PRODUCTS_DIR}/boinc\"\nchmod u+s,g+s \"${BUILT_PRODUCTS_DIR}/boinc\"\n";
+		};
+		DD25213D2E449816002726E2 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "source \"${PROJECT_DIR}/checkDependentLibraryVersions.sh\"\nexit $?\n";
 		};
 		DD32CC900C27CFB90016F571 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -3626,6 +3716,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DD25213E2E449816002726E2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DD25214B2E4499A0002726E2 /* MultiGPUMig.defs in Sources */,
+				DD2521472E44983E002726E2 /* gfx_ss_bridge.m in Sources */,
+				DD2521492E449875002726E2 /* sharedGraphicsController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD35352E07E1E05C00C4718D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -4279,6 +4379,16 @@
 			target = DD407A4907D2FB1200163EF5 /* libboinc */;
 			targetProxy = DD1E45C92567FACC005B4EE7 /* PBXContainerItemProxy */;
 		};
+		DD2521502E44A113002726E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD25213C2E449816002726E2 /* gfx_ss_bridge */;
+			targetProxy = DD25214F2E44A113002726E2 /* PBXContainerItemProxy */;
+		};
+		DD2521522E44A133002726E2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DD25213C2E449816002726E2 /* gfx_ss_bridge */;
+			targetProxy = DD2521512E44A133002726E2 /* PBXContainerItemProxy */;
+		};
 		DD3719482E3B5AB000E75DF3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DD37193A2E3B50BD00E75DF3 /* Run_Podman */;
@@ -4511,6 +4621,24 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = edu.berkeley.boinc.Installer;
 				PRODUCT_NAME = "BOINC Installer";
+			};
+			name = Deployment;
+		};
+		DD2521432E449816002726E2 /* Development */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Development;
+		};
+		DD2521442E449816002726E2 /* Deployment */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Deployment;
 		};
@@ -5440,6 +5568,15 @@
 			buildConfigurations = (
 				DD1AFEB60A512D8700EE5B82 /* Development */,
 				DD1AFEB90A512D8700EE5B82 /* Deployment */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Development;
+		};
+		DD2521422E449816002726E2 /* Build configuration list for PBXNativeTarget "gfx_ss_bridge" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DD2521432E449816002726E2 /* Development */,
+				DD2521442E449816002726E2 /* Deployment */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Development;

--- a/mac_installer/release_boinc.sh
+++ b/mac_installer/release_boinc.sh
@@ -65,6 +65,7 @@
 ## Updated 7/22/25 to add MacOS 26 support, no Finish_Install embedded in Postinstall.
 ## Updated 7/29/25 to add "BOINC podman" directory
 ## Updated 7/31/25 to add "Run_Podman" utility
+## Updated 8/7/25 to add "gfx_ss_bridge" utility
 ##
 ## NOTE: This script requires Mac OS 10.7 or later, and uses XCode developer
 ##   tools.  So you must have installed XCode Developer Tools on the Mac
@@ -183,7 +184,7 @@ if [ $Products_Have_arm64 = "yes" ]; then
     fi
 fi
 
-for Executable in "boinc" "boinccmd" "switcher" "setprojectgrp" "boincscr" "Fix_BOINC_Users" "Run_Podman" "BOINCSaver.saver/Contents/MacOS/BOINCSaver" "Uninstall BOINC.app/Contents/MacOS/Uninstall BOINC" "BOINC Installer.app/Contents/MacOS/BOINC Installer" "PostInstall.app/Contents/MacOS/PostInstall" "BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install" "AddRemoveUser"
+for Executable in "boinc" "boinccmd" "switcher" "setprojectgrp" "boincscr" "Fix_BOINC_Users" "Run_Podman" "BOINCSaver.saver/Contents/MacOS/BOINCSaver" "BOINCSaver.saver/Contents/Resources/gfx_switcher" "BOINCSaver.saver/Contents/Resources/gfx_cleanup" "BOINCSaver.saver/Contents/Resources/gfx_ss_bridge" "Uninstall BOINC.app/Contents/MacOS/Uninstall BOINC" "BOINC Installer.app/Contents/MacOS/BOINC Installer" "PostInstall.app/Contents/MacOS/PostInstall" "BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install" "AddRemoveUser"
 do
     Have_x86_64="no"
     Have_arm64="no"
@@ -443,6 +444,9 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
 
     # Code Sign the gfx_cleanup utility embedded in BOINC screensaver if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver/Contents/Resources/gfx_cleanup"
+
+    # Code Sign the gfx_ss_bridge utility embedded in BOINC screensaver if we have a signing identity
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver/Contents/Resources/gfx_ss_bridge"
 
     # Code Sign the BOINC screensaver code for OS 10.8 and later if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/BOINCSaver.saver"

--- a/mac_installer/release_brand.sh
+++ b/mac_installer/release_brand.sh
@@ -191,7 +191,7 @@ if [ $Products_Have_arm64 = "yes" ]; then
     fi
 fi
 
-for Executable in "boinc" "boinccmd" "switcher" "setprojectgrp" "boincscr" "Fix_BOINC_Users" "Run_Podman" "BOINCSaver.saver/Contents/MacOS/BOINCSaver" "Uninstall BOINC.app/Contents/MacOS/Uninstall BOINC" "BOINC Installer.app/Contents/MacOS/BOINC Installer" "PostInstall.app/Contents/MacOS/PostInstall" "BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install" "AddRemoveUser"
+for Executable in "boinc" "boinccmd" "switcher" "setprojectgrp" "boincscr" "Fix_BOINC_Users" "Run_Podman" "BOINCSaver.saver/Contents/MacOS/BOINCSaver" "BOINCSaver.saver/Contents/Resources/gfx_switcher" "BOINCSaver.saver/Contents/Resources/gfx_cleanup" "BOINCSaver.saver/Contents/Resources/gfx_ss_bridge" "Uninstall BOINC.app/Contents/MacOS/Uninstall BOINC" "BOINC Installer.app/Contents/MacOS/BOINC Installer" "PostInstall.app/Contents/MacOS/PostInstall" "BOINC_Finish_Install.app/Contents/MacOS/BOINC_Finish_Install" "AddRemoveUser"
 do
     Have_x86_64="no"
     Have_arm64="no"
@@ -491,6 +491,9 @@ if [ -e "${HOME}/BOINCCodeSignIdentities.txt" ]; then
 
     # Code Sign the gfx_cleanup utility embedded in BOINC screensaver if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/${SSAVERAPPNAME}.saver/Contents/Resources/gfx_cleanup"
+
+    # Code Sign the gfx_ss_bridge utility embedded in BOINC screensaver if we have a signing identity
+    sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/${SSAVERAPPNAME}.saver/Contents/Resources/gfx_ss_bridge"
 
     # Code Sign the BOINC screensaver code for OS 10.8 and later if we have a signing identity
     sudo codesign -f -o runtime -s "${APPSIGNINGIDENTITY}" "../BOINC_Installer/Pkg_Root/Library/Screen Savers/${SSAVERAPPNAME}.saver/"


### PR DESCRIPTION
Mac screensaver: implement a graphics bridging utility to display project graphics which have not been updated with most recent BOINC graphics libraries.

Background:
_BOINCSaver.saver_ is a Mac plugin for the screensaver engine (called _legacyScreenSaver_ in more recent versions of MacOS).

The original concept of the BOINC screensaver (still used under MS Windows) was that the BOINC screensaver launches project graphics applications fullscreen so that they cover and appear over the screensaver's window.

As of MacOS 10.13 (in September 2017) application windows can no longer appear on top of the screensaver's window. In PR #2149 I implemented changes to instead use Mach RPC communication and IOSurfaceBuffer to display the graphics output of the screensaver's child graphics apps in the screensaver's window, using code adapted from Apple Developer Tech Support Sample Code [MutiGPUIOSurface](https://developer.apple.com/library/content/samplecode/MultiGPUIOSurface). This required changes to both project graphics apps and _BOINCSaver.saver_. I implemented all the needed updates to the project graphics apps in the BOINC graphics libraries, so that projects could just relink their existing code with the new libraries. Eventually, most or all projects did that.

There were numerous other changes by Apple both before and after that time, but I was able to work around them entirely on the bOINC client side (client and _BOINCSaver.saver_.) until the introduction of MacOS 14 in September 2023.

The code I implemented in PR #2149 used the project graphics app as the Mach server (creating a mach port via the `bootstrap_check_in()` API and using _BOINCSaver.saver_ as the Mach client using the `bootstrap_look_up()` API to find and connect to the graphics app's Mach server.

But as of MacOS 14.0, the _legacyScreenSaver_ sandbox prevents using `bootstrap_look_up`. On 25 October 2023 I filed bug report FB13300491 with Apple asking this be reversed and filed a second bug report FB14177805 on 3 July 2024. Despite my several updates to those bug reports and pursuing other channels with Apple, both still remain marked "open" with no action taken.

In PR #5611, I again modified both _BOINCSaver.saver_ and the BOINC graphics libraries to first try  the old method (`bootstrap_check_in()` in the graphics app and `bootstrap_look_up()` in the screensaver.) If that fails, it tries the reverse approach: `bootstrap_check_in()` in the screensaver and `bootstrap_look_up()` in the graphics app. (This maintains backward compatibility.)

Once again, I implemented all the needed updates to the project graphics apps in the BOINC graphics libraries, so that projects could just relink their existing code with the new libraries. Unfortunately, many (if not all) projects have not yet done so.

Recognizing that many BOINC projects have very limited resources in personnel and funding, and that deploying an updated graphics application s not trivial, I eventually came up with the workaround in this PR.

This PR adds a new bridging utility SS_GFX_Bridge, which uses an instance of `bootstrap_look_up()` to connect to _BOINCSaver.saver_ and another instance of `bootstrap_look_up()` to connect to the project graphics app. It is launched by the client rather than by the screensaver, so it is not restricted from using `bootstrap_look_up()`. It then passes the IOSurfaceBuffers from the project graphics to the screensaver, while maintaining full GPU acceleration.
