### PR TITLE
Delete the created container, keep image

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1287,10 +1287,11 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
     // if we're running as an unprivileged user, Docker/podman may not work.
     // Check by running the Hello World image.
     //
-    // Since we do this every time on startup, don't delete the image.
+    // Since we do this every time on startup: delete the created container 
+    // but don't delete the image.
     //
     snprintf(cmd, sizeof(cmd),
-        "%s run hello-world 2>/dev/null",
+        "%s run --rm hello-world 2>/dev/null",
         docker_cli_prog(type)
     );
     found = false;


### PR DESCRIPTION
Fixes #

**Description of the Change**
BOINC version 8.2.4: in `/var/lib/boinc/.local/share/containers/storage/overlay-containers/containers.json` there is a growing list of containers created by the startup check of the usability of Docker/Podman. Using the --rm option will clean up the created container in stead of keeping it forever.

**Alternate Designs**
A general check for cleaning up unused Podman/Docker containers and images could be handy, for example when a new BOINC-version is installed. This PR is only for preventing the build up of unneeded hello-world containers.

**Release Notes**
Linux: clean up hello-world containers