### PR TITLE
[manager] remove unneeded freeze/thaw when updating notification windows, instead to the refresh.

### DIFF
--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -356,11 +356,10 @@ bool CNoticeListCtrl::UpdateUI() {
             ((int)GetItemCount() != noticeCount))
         ) {
             pDoc->notices.complete = false;
-            Freeze();
             SetItemCount(noticeCount);
             m_bDisplayFetchingNotices = false;
             m_bDisplayEmptyNotice = false;
-            Thaw();
+            Refresh();
         }
 
         bAlreadyRunning = false;


### PR DESCRIPTION
This fixes #6490.
