### PR TITLE
web (job submission): make output file download more secure

### DIFF
--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -34,17 +34,35 @@
 //
 
 require_once("../inc/util.inc");
+require_once("../inc/submit_util.inc");
+
+// the path of an output file in the 'assim move' scheme.
+// This must agree with the corresponding assimilators:
+// tools/sample_assimilate.py
+// sched/sample_assimilator.cpp
+// and with tools/query_job
+//
+function outfile_path($wu, $index, $log_names) {
+    return sprintf('results/%d/%s__file_%s',
+        $wu->batch, $wu->name, $log_names[$index]
+    );
+}
 
 // show or download a single output file,
 // identified by result ID and file index
 //
 function get_file() {
-    $path = get_str('path');
-    if (strstr($path, '..')) error_page('bad path');
-    $path = "../../$path";
+    $result_id = get_int('result_id');
+    $index = get_int('index');
+    $result = BoincResult::lookup_id($result_id);
+    if (!$result) error_page('no result');
+    $wu = BoincWorkunit::lookup_id($result->workunitid);
+    if (!$wu) error_page('no workunit');
+    $log_names = get_outfile_log_names($result);
+    if ($index >= count($log_names)) error_page('bad index');
+    $path = sprintf('../../%s', outfile_path($wu, $index, $log_names));
 
-    $download = get_str('download', true);
-    if ($download) {
+    if (get_str('download', true)) {
         do_download($path);
     } else {
         echo "<pre>\n";

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -43,6 +43,8 @@ require_once("../inc/submit_util.inc");
 // and with tools/query_job
 //
 function outfile_path($wu, $index, $log_names) {
+    if (!is_valid_filename($wu->name)) error_page("bad WU name");
+    if (!is_valid_filename($log_names[$index])) error_page("bad logical name");
     return sprintf('results/%d/%s__file_%s',
         $wu->batch, $wu->name, $log_names[$index]
     );

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -809,7 +809,8 @@ function handle_query_job($user) {
         if ($is_assim_move) {
             if ($result->id == $wu->canonical_resultid) {
                 $log_names = get_outfile_log_names($result);
-                for ($i=0; $i<count($log_names); $i++) {
+                $nfiles = count($log_names);
+                for ($i=0; $i<$nfiles; $i++) {
                     $name = $log_names[$i];
                     // don't show 'view' link if it's a .zip
                     $y = "$name: ";
@@ -832,7 +833,8 @@ function handle_query_job($user) {
             if ($result->server_state == RESULT_SERVER_STATE_OVER) {
                 $phys_names = get_outfile_phys_names($result);
                 $log_names = get_outfile_log_names($result);
-                for ($i=0; $i<count($phys_names); $i++) {
+                $nfiles = count($log_names);
+                for ($i=0; $i<$nfiles; $i++) {
                     $path = dir_hier_path(
                         $phys_names[$i], $upload_dir, $fanout
                     );


### PR DESCRIPTION
In the scheme for downloading output files, we were passing a path in a URL.
We checked for '..' but there may be other vulnerabilities.
Instead, pass the result ID and file index, which are ints.
Don't pass paths in URLs.