### PR TITLE
web (job submission): 'only own computers' fixes

### DIFF
--- a/html/user/buda_submit.php
+++ b/html/user/buda_submit.php
@@ -213,7 +213,7 @@ function stage_input_files($batch_dir, $batch_desc, $batch_id) {
 // Use --stdin, where each job is described by a line
 //
 function create_jobs(
-    $app, $app_desc, $batch_desc, $batch_id, $batch_dir_name,
+    $user, $app, $app_desc, $batch_desc, $batch_id, $batch_dir_name,
     $wrapper_verbose, $cmdline, $max_fpops, $exp_fpops,
     $keywords
 ) {
@@ -251,6 +251,9 @@ function create_jobs(
     );
     if ($keywords) {
         $cmd .= " --keywords '$keywords'";
+    }
+    if ($user->seti_id) {
+        $cmd .= " --target_user $user->id ";
     }
     $cmd .= sprintf(' > %s 2<&1', "buda_batches/errfile");
 
@@ -328,7 +331,7 @@ function handle_submit($user) {
     $keywords = implode(' ', $keywords);
 
     create_jobs(
-        $app, $app_desc, $batch_desc, $batch->id, $batch_dir_name,
+        $user, $app, $app_desc, $batch_desc, $batch->id, $batch_dir_name,
         $wrapper_verbose, $cmdline, $max_fpops, $exp_fpops, $keywords
     );
 
@@ -349,7 +352,7 @@ function show_list() {
     echo 'Select app:<p><br>';
     foreach ($apps as $app) {
         $desc = get_buda_app_desc($app);
-        echo sprintf('<li><a href=buda_submit.php?action=form&app=%s>%s</a>',
+        echo sprintf('<p><a href=buda_submit.php?action=form&app=%s>%s</a>',
             $app, $desc->long_name
         );
     }

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -376,7 +376,7 @@ function show_submit_links($user) {
                         );
                     } else {
                         echo sprintf(
-                            '<li><a href=%s>%s</a><p>',
+                            '<a href=%s>%s</a><p>',
                             $app->form, $app->long_name
                         );
                     }
@@ -414,6 +414,13 @@ function handle_show_user_batches($user) {
 }
 
 function handle_update_only_own($user) {
+    if (!parse_bool(get_config(), 'enable_assignment')) {
+        error_page(
+            'Job assignment is not enabled in the project config file.
+            Please ask the project admins to enable it.'
+        );
+        return;
+    }
     $val = get_int('only_own');
     $user->update("seti_id=$val");
     header("Location: submit.php");
@@ -441,6 +448,7 @@ function handle_admin($user) {
         // user can administer all apps
         //
         page_head("Job submission: manage all apps");
+        echo '<ul>';
         echo "<li> <a href=submit.php?action=admin_all>View/manage all batches</a>
         ";
         $app_names = get_remote_app_names();
@@ -469,6 +477,7 @@ function handle_admin($user) {
         // see if user can administer specific apps
         //
         page_head("Job submission: manage apps");
+        echo '<ul>';
         $usas = BoincUserSubmitApp::enum("user_id=$user->id");
         foreach ($usas as $usa) {
             $app = BoincApp::lookup_id($usa->app_id);


### PR DESCRIPTION
- It's implemented by passing --target_user to create_work in the job submission script. This was being done for autodock, but not BUDA.

- It's enforced in the scheduler, but only if <enable_assignment/> is set in config.xml. If the user tries to set 'only my computers' and this is not enabled, show an error page.

Also: don't use <li> without enclosing </ul>;
it produces ugly flush-left layout.