### PR TITLE
Server: fix DB purge for batch-oriented apps

### DIFF
--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -407,17 +407,22 @@ struct HOST_DELETED {
     void clear();
 };
 
-// values for file_delete state
+// values for
+// WORKUNIT::file_delete_state
+// RESULT::file_delete_state
+// TRANSITIONER_ITEM::res_file_delete_state
 // see html/inc/common_defs.inc
+//
 #define FILE_DELETE_INIT        0
 #define FILE_DELETE_READY       1
-    // set to this value only when we believe all files are uploaded
+    // WU is assimilated and all results are OVER,
+    // so we don't need output files anymore
 #define FILE_DELETE_DONE        2
-    // means the files were successfully deleted
+    // files were successfully deleted
 #define FILE_DELETE_ERROR       3
-    // Any error was returned while attempting to delete the file
+    // error in file deletion
 
-// values for assimilate_state
+// values for WORKUNIT::assimilate_state
 #define ASSIMILATE_INIT         0
 #define ASSIMILATE_READY        1
 #define ASSIMILATE_DONE         2
@@ -436,7 +441,7 @@ struct HOST_DELETED {
 #define WU_ERROR_CANCELLED                      16
 #define WU_ERROR_NO_CANONICAL_RESULT            32
 
-// bit fields of transition_flags; used for assigned jobs
+// bit fields of WORKUNIT::transitioner_flags; used for assigned jobs
 //
 #define TRANSITION_NONE             1
     // don't transition; used for broadcast jobs

--- a/html/inc/buda.inc
+++ b/html/inc/buda.inc
@@ -24,6 +24,7 @@ function get_buda_variants($app_name) {
     foreach ($dirs as $dir) {
         if ($dir[0] == '.') continue;
         if (!is_dir("$app_dir/$dir")) continue;
+        if (!file_exists("$app_dir/$dir/variant.json")) continue;
         $x[] = $dir;
     }
     return $x;

--- a/html/inc/submit_db.inc
+++ b/html/inc/submit_db.inc
@@ -48,10 +48,9 @@ class BoincBatch {
         $db = BoincDb::get();
         return $db->update_aux('batch', $clause);
     }
-    static function delete_batch($id) {
+    function delete() {
         $db = BoincDb::get();
-        $id = intval($id);
-        return $db->delete_aux('batch', "id=$id");
+        return $db->delete($this, 'batch');
     }
     function get_cpu_time() {
         $db = BoincDb::get();

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -135,7 +135,7 @@ function delete_remote_submit_user($user) {
     BoincUserSubmitApp::delete_user($user->id);
 }
 
-// given its WUs, compute parameters of the batch:
+// compute parameters of the batch:
 //   credit_canonical: credit granted to canonical instances
 //   fraction_done: frac of jobs that are done (success or failed)
 //   state: whether complete (all jobs done)
@@ -146,10 +146,18 @@ function delete_remote_submit_user($user) {
 //   njobs_success: # of jobs with canonical instance
 //   njobs_in_prog: # of jobs not success or fail,
 //      and at least one result in progress
-//
 // return the batch object, with these values
 //
-// Also add the status field to WUs
+// You need to pass in a list of the batch's WUs.
+// These need to have the following fields:
+//
+// id
+// rsc_fpops_est
+// canonical_resultid
+// canonical_credit
+// error_mask
+//
+// add 'status' field (UNSENT, IN_PROGRESS, SUCCESS) to WUs
 //
 // TODO: update est_completion_time
 //
@@ -289,7 +297,9 @@ function abort_workunit($wu) {
         )
     );
     $wu->update(
-        sprintf('error_mask=error_mask|%d', WU_ERROR_CANCELLED)
+        sprintf('error_mask=error_mask|%d, file_delete_state=%d',
+            WU_ERROR_CANCELLED, FILE_DELETE_READY
+        )
     );
 }
 
@@ -304,6 +314,8 @@ function abort_batch($batch) {
     }
     if ($ids) {
         $ids = implode(',', $ids);
+        // cancel unsent instances
+        //
         BoincResult::update_aux(
             sprintf(
                 'server_state=%d, outcome=%d where server_state=%d and workunitid in (%s)',
@@ -313,8 +325,8 @@ function abort_batch($batch) {
             )
         );
         BoincWorkunit::update_aux(
-            sprintf('error_mask=error_mask|%d where id in(%s)',
-                WU_ERROR_CANCELLED, $ids
+            sprintf('error_mask=error_mask|%d, file_delete_state=%d where id in(%s)',
+                WU_ERROR_CANCELLED, FILE_DELETE_READY, $ids
             )
         );
     }
@@ -324,35 +336,44 @@ function abort_batch($batch) {
     return 0;
 }
 
-// mark WUs as assimilated; this lets them be purged
+// retire a batch:
+// - mark the batch as retired (don't delete it; might be useful later)
+// - delete output files (results/batchid/)
+// - mark unsent WUs as cancelled
+//
+// Don't delete the batch; it may have in-progress jobs that
+// we still need to file-delete and purge,
+// and the batch needs to be present for this.
+// Use ops/delete_batches.php to delete retired batches with no WUs
 //
 function retire_batch($batch) {
-    $wus = BoincWorkunit::enum_fields(
-        'id, result_template_file',
-        "batch=$batch->id"
-    );
-    $now = time();
-    $ids = [];
-    foreach ($wus as $wu) {
-        $ids[] = $wu->id;
-    }
-    if ($ids) {
-        $ids = implode(',', $ids);
-        BoincWorkunit::update_aux(
-            sprintf('assimilate_state=%d, transition_time=%d where id in(%s)',
-                ASSIMILATE_DONE, $now, $ids
-            )
-        );
-        foreach ($wus as $wu) {
-            // remove output template if it's a temporary
-            //
-            if (strstr($wu->result_template_file, "templates/tmp/")) {
-                @unlink($wu->result_template_file);
-            }
-        }
-    }
     $batch->update("state=".BATCH_STATE_RETIRED);
     system("rm -rf ../../results/$batch->id");
+
+    // get list of unsent WUs in this batch
+    //
+    $wus = BoincWorkunit::enum_fields(
+        'id, rsc_fpops_est, canonical_credit, canonical_resultid, error_mask',
+        "batch = $batch->id"
+    );
+    get_batch_params($batch, $wus);
+    $wu_ids = [];
+    foreach ($wus as $wu) {
+        if ($wu->state == WU_STATE_UNSENT) {
+            $wu_ids[] = $wu->id;
+        }
+    }
+
+    // cancel them
+    //
+    if ($wu_ids) {
+        $wu_ids = implode(',', $wu_ids);
+        BoincWorkunit::update_aux(
+            sprintf('error_mask=error_mask|%d, file_delete_state=%d where id in (%s)',
+                WU_ERROR_CANCELLED, FILE_DELETE_READY, $wu_ids
+            )
+        );
+    }
 }
 
 function expire_batch($batch) {

--- a/html/ops/delete_batches.php
+++ b/html/ops/delete_batches.php
@@ -1,3 +1,5 @@
+#! /usr/bin/env php
+
 <?php
 // This file is part of BOINC.
 // https://boinc.berkeley.edu

--- a/html/ops/delete_batches.php
+++ b/html/ops/delete_batches.php
@@ -1,0 +1,60 @@
+<?php
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2025 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// delete retired batches with no WUs
+
+require_once('../inc/boinc_db.inc');
+require_once('../inc/submit_db.inc');
+
+function main() {
+    $batches = BoincBatch::enum(sprintf('state=%d', BATCH_STATE_RETIRED));
+    foreach ($batches as $batch) {
+        $wus = BoincWorkunit::enum_fields(
+            'id',
+            "batch=$batch->id"
+        );
+        if (!$wus) {
+            echo "deleting batch $batch->id\n";
+            $batch->delete();
+        }
+    }
+}
+
+// clean up results/.
+// In theory should have to do this just once.
+//
+function cleanup_results() {
+    foreach (scandir('../../results') as $d) {
+        if ($d[0] == '.') continue;
+        if (!is_numeric($d)) continue;
+        $id = (int)$d;
+        if (!$id) continue;
+        $batch = BoincBatch::lookup_id($id);
+        if ($batch) {
+            if ($batch->state != BATCH_STATE_RETIRED) continue;
+        }
+        $dir = "../../results/$d";
+        echo "deleting $dir\n";
+        system("/bin/rm -rf $dir");
+    }
+}
+
+main();
+//cleanup_results();
+
+?>

--- a/html/ops/delete_spammers.php
+++ b/html/ops/delete_spammers.php
@@ -104,6 +104,8 @@
 //
 // --id_range N M
 //   delete users with ID N to M inclusive
+// --id N
+//   delete user N
 //
 // --teams
 //   delete teams (and their owners and members) where the team
@@ -192,7 +194,7 @@ function delete_forums() {
     // This is faster than enumerating all users
     //
     $prefs = BoincForumPrefs::enum("posts>0");
-    $n = 0;
+    $count = 0;
     foreach ($prefs as $p) {
         $user = BoincUser::lookup_id($p->userid);
         if (!$user) {
@@ -211,12 +213,13 @@ function delete_forums() {
         $h = BoincHost::count("userid=$p->userid");
         if ($h) continue;
 
-        $n = BoincPost::count("user=$user->id and (content like '%<a %' or content like '%[url%' or content like '%http://%' or content like '%https://%')");
+        // posts with at least 2 URLs
+        $n = BoincPost::count("user=$user->id and (content like '%http%http%')");
         if (!$n) continue;
         do_delete_user($user);
-        $n++;
+        $count++;
     }
-    echo "deleted $n users\n";
+    echo "delete_forums(): deleted $count users\n";
 }
 
 function delete_profiles() {
@@ -250,7 +253,7 @@ function delete_profiles() {
             $n++;
         }
     }
-    echo "deleted $n users\n";
+    echo "delete_profiles(): deleted $n users\n";
 }
 
 function delete_profiles_strict() {

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -628,7 +628,10 @@ function query_batches($r) {
     foreach ($batches as $batch) {
         if ($batch->state == BATCH_STATE_RETIRED) continue;
         if ($batch->state < BATCH_STATE_COMPLETE) {
-            $wus = BoincWorkunit::enum("batch = $batch->id");
+            $wus = BoincWorkunit::enum_fields(
+                'id, name, rsc_fpops_est, canonical_credit, canonical_resultid, error_mask',
+                "batch = $batch->id"
+            );
             $batch = get_batch_params($batch, $wus);
         }
         echo "    <batch>\n";
@@ -731,7 +734,10 @@ function query_batch($r) {
         xml_error(-1, "not owner of batch");
     }
 
-    $wus = BoincWorkunit::enum("batch = $batch->id", "order by id");
+    $wus = BoincWorkunit::enum_fields(
+        'id, name, rsc_fpops_est, canonical_credit, canonical_resultid, error_mask',
+        "batch = $batch->id", 'order by id'
+    );
     $batch = get_batch_params($batch, $wus);
     $get_cpu_time = (int)($r->get_cpu_time);
     $get_job_details = (int)($r->get_job_details);
@@ -742,13 +748,6 @@ function query_batch($r) {
         <name>$wu->name</name>
         <canonical_instance_id>$wu->canonical_resultid</canonical_instance_id>
 ";
-        // does anyone need this?
-        //
-        if (0) {
-            $n_outfiles = n_outfiles($wu);
-            echo "     <n_outfiles>$n_outfiles</n_outfiles>\n";
-        }
-
         if ($get_job_details) {
             show_job_details($wu);
         }

--- a/sched/Makefile.linux
+++ b/sched/Makefile.linux
@@ -7,7 +7,7 @@
 # 3) do the same in this dir
 
 #OPTS = -g -DBUDA_TEST
-OPTS = -g -DBUDA
+OPTS = -g
 
 FOO = -Wformat -Wformat=2 \
 -Wimplicit-fallthrough \

--- a/sched/buda.cpp
+++ b/sched/buda.cpp
@@ -143,10 +143,8 @@ void BUDA_APPS::read_json() {
     DirScanner ds(BUDA_APPS_DIR);
     string name;
     while (ds.scan(name)) {
-        log_messages.printf(MSG_NORMAL, "BUDA: checking %s\n", name.c_str());
         BUDA_APP ba(name);
         if (ba.read_json()) {
-            log_messages.printf(MSG_NORMAL, "BUDA: adding %s\n", name.c_str());
             apps.push_back(ba);
         }
     }

--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -15,13 +15,18 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// db_purge options
+// db_purge [options]
 // options are listed in usage() below
 //
-// purge workunit and result records that are no longer needed.
-// Specifically, purges WUs for which file_delete_state=DONE.
-// Purging a WU means writing it and all its results
-// to XML-format archive files, then deleting it and its results from the DB.
+// purge (delete) workunit and result records that are no longer needed.
+// if --retired_wus:
+//      purge WUs for which file_delete_state=FILE_DELETE_DONE
+//      and the WU is in a retired batch
+// otherwise
+//      purge WUs for which file_delete_state=FILE_DELETE_DONE.
+// Purging a WU means optionally writing it and its results
+// to XML archive files,
+// then deleting it and the results from the DB.
 //
 // The XML files have names of the form
 // wu_archive_TIME and result_archive_TIME
@@ -43,6 +48,8 @@
 #include <string.h>
 #include "zlib.h"
 
+using std::string;
+
 #include "boinc_db.h"
 #include "filesys.h"
 #include "parse.h"
@@ -61,22 +68,22 @@ void usage() {
     fprintf(stderr,
         "Purge workunit and result records that are no longer needed.\n\n"
         "Usage: db_purge [options]\n"
-        "    [-d N | --debug_level N]      Set verbosity level (1 to 4)\n"
-        "    [--min_age_days N]            Purge Wus w/ mod time at least N days ago\n"
-        "    [--max N]                     Purge at most N WUs\n"
-        "    [--zip]                       Compress output files by piping through zip\n"
-        "    [--gzip]                      Compress output files by piping through gzip\n"
-        "    [--zlib]                      Compress output files using zlib\n"
-        "    [--no_archive]                Don't write output files, just purge\n"
-        "    [--daily_dir]                 Write archives in a new directory each day\n"
-        "    [--max_wu_per_file N]         Write at most N WUs per output file\n"
-        "    [--sleep N]                   Sleep N sec after DB scan\n"
-        "    [--one_pass]                  Make one DB scan, then exit\n"
-        "    [--dont_delete]               Don't actually delete anything from the DB (for testing only)\n"
-        "    [--mod M R ]                  Handle only WUs with ID mod M == R\n"
-        "    [--batches]                   Delete retired batches from the batch table\n"
-        "    [--h | --help]                Show this help text\n"
-        "    [--v | --version]             Show version information\n"
+        "   -d N or --debug_level N     Set verbosity level (1 to 4)\n"
+        "   --retired_wus               purge WUs only from retired batches\n"
+        "   --min_age_days N            Purge Wus w/ mod time at least N days ago\n"
+        "   --max N                     Purge at most N WUs\n"
+        "   --zip                       Compress output files by piping through zip\n"
+        "   --gzip                      Compress output files by piping through gzip\n"
+        "   --zlib                      Compress output files using zlib\n"
+        "   --no_archive                Don't write output files, just purge\n"
+        "   --daily_dir                 Write archives in a new directory each day\n"
+        "   --max_wu_per_file N         Write at most N WUs per output file\n"
+        "   --sleep N                   Sleep N sec after DB scan\n"
+        "   --one_pass                  Make one DB scan, then exit\n"
+        "   --dont_delete               Don't actually delete anything from the DB (for testing)\n"
+        "   --mod M R                   Handle only WUs with ID mod M == R\n"
+        "   -h or --help                Show this help text\n"
+        "   -v or --version             Show version information\n"
     );
 }
 
@@ -228,13 +235,13 @@ double min_age_days = 0;
 bool no_archive = false;
 bool dont_delete = false;
 bool daily_dir = false;
-bool delete_batches = false;
-int purged_workunits = 0;
-    // used if limiting the total number of workunits to eliminate
+bool retired_wus = false;
 int max_number_workunits_to_purge = 0;
     // If nonzero, maximum number of workunits to purge.
     // Since all results associated with a purged workunit are also purged,
     // this also limits the number of purged results.
+int purged_workunits = 0;
+    // # of WUs purged so far
 const char *suffix[4] = {"", ".gz", ".zip", ".gz"};
     // subscripts MUST be in agreement with defines above
 int compression_type = COMPRESSION_NONE;
@@ -247,6 +254,8 @@ int id_modulus=0, id_remainder=0;
     // allow more than one to run - doesn't work if archiving is enabled
 char app_name[256];
 DB_APP app;
+string retired_batch_ids;
+    // if --retired_wus, a list of retired batch IDs as "id1,id2,..."
 
 bool time_to_quit() {
     if (max_number_workunits_to_purge) {
@@ -603,6 +612,35 @@ int purge_and_archive_results(DB_WORKUNIT& wu, int& number_results) {
     return 0;
 }
 
+// get list of IDs of retired batches
+//
+int get_retired_batch_ids(string &out) {
+    out.clear();
+    char query[256];
+    sprintf(query, "select id from batch where state=%d", BATCH_STATE_RETIRED);
+    int retval = boinc_db.do_query(query);
+    if (retval) return mysql_errno(boinc_db.mysql);
+
+    MYSQL_RES *rp;
+    rp = mysql_store_result(boinc_db.mysql);
+    if (!rp) return mysql_errno(boinc_db.mysql);
+    bool first = true;
+    while (1) {
+        MYSQL_ROW row = mysql_fetch_row(rp);
+        if (!row) {
+            mysql_free_result(rp);
+            break;
+        }
+        if (first) {
+            first = false;
+        } else {
+            out += ",";
+        }
+        out += row[0];
+    }
+    return 0;
+}
+
 // return true if did anything
 //
 bool do_pass() {
@@ -625,42 +663,41 @@ bool do_pass() {
 
     bool did_something = false;
     DB_WORKUNIT wu;
-    char buf[256], buf2[256];
-
-    if (delete_batches) {
-      if (dont_delete) {
-	log_messages.printf(MSG_DEBUG,
-			  "Didn't delete retired batches from database (-dont_delete)\n");
-      } else {
-        DB_BATCH batch;
-	sprintf(buf, "state=%d", BATCH_STATE_RETIRED);
-        batch.delete_from_db_multi(buf);
-      }
-    }
+    char buf[256];
+    string clause;
 
     sprintf(buf, "where file_delete_state=%d", FILE_DELETE_DONE);
+    clause = buf;
     if (min_age_days) {
         min_age_seconds = (int) (min_age_days*86400);
-        sprintf(buf2,
+        sprintf(buf,
             " and mod_time<current_timestamp() - interval %d second",
             min_age_seconds
         );
-        strcat(buf, buf2);
+        clause += buf;
     }
     if (id_modulus) {
-        sprintf(buf2, " and id %% %d = %d", id_modulus, id_remainder);
-        strcat(buf, buf2);
+        sprintf(buf, " and id %% %d = %d", id_modulus, id_remainder);
+        clause += buf;
     }
     if (strlen(app_name)) {
-        sprintf(buf2, " and appid=%lu", app.id);
-        strcat(buf, buf2);
+        sprintf(buf, " and appid=%lu", app.id);
+        clause += buf;
     }
-    sprintf(buf2, " limit %d", DB_QUERY_LIMIT);
-    strcat(buf, buf2);
+    if (retired_wus) {
+        clause += " and batch in (";
+        clause += retired_batch_ids;
+        clause += ")";
+    } else {
+        clause += " and batch=0";
+    }
+
+    sprintf(buf, " limit %d", DB_QUERY_LIMIT);
+    clause += buf;
 
     int n=0;
     while (1) {
-        retval = wu.enumerate(buf);
+        retval = wu.enumerate(clause.c_str());
         if (retval) {
             if (retval != ERR_DB_NOT_FOUND) {
                 log_messages.printf(MSG_DEBUG,
@@ -720,8 +757,8 @@ bool do_pass() {
             }
             if (config.enable_assignment) {
                 DB_ASSIGNMENT asg;
-                sprintf(buf2, "workunitid=%lu", wu.id);
-                asg.delete_from_db_multi(buf2);
+                sprintf(buf, "workunitid=%lu", wu.id);
+                asg.delete_from_db_multi(buf);
             }
             log_messages.printf(MSG_DEBUG,
                 "Purged workunit [%lu] from database\n", wu.id
@@ -824,10 +861,10 @@ int main(int argc, char** argv) {
             max_wu_per_file = atoi(argv[i]);
         } else if (is_arg(argv[i], "no_archive")) {
             no_archive = true;
-        } else if (is_arg(argv[i], "batches")) {
-            delete_batches=true;
+        } else if (is_arg(argv[i], "retired_wus")) {
+            retired_wus = true;
         } else if (is_arg(argv[i], "sleep")) {
-            if(!argv[++i]) {
+            if (!argv[++i]) {
                 log_messages.printf(MSG_CRITICAL, "%s requires an argument\n\n", argv[--i]);
                 usage();
                 exit(1);
@@ -841,10 +878,10 @@ int main(int argc, char** argv) {
                 usage();
                 exit(1);
             }
-        } else if (is_arg(argv[i], "--help") || is_arg(argv[i], "-help") || is_arg(argv[i], "-h")) {
+        } else if (is_arg(argv[i], "--help") || is_arg(argv[i], "-h")) {
             usage();
             return 0;
-        } else if (is_arg(argv[i], "--version") || is_arg(argv[i], "-version")) {
+        } else if (is_arg(argv[i], "--version") || is_arg(argv[i], "-v")) {
             printf("%s\n", SVN_VERSION);
             exit(0);
         } else if (is_arg(argv[i], "mod")) {
@@ -895,6 +932,7 @@ int main(int argc, char** argv) {
         );
         exit(2);
     }
+
     install_stop_signal_handler();
     boinc_mkdir(config.project_path("archives"));
 
@@ -918,6 +956,16 @@ int main(int argc, char** argv) {
         if (time_to_quit()) {
             break;
         }
+        if (retired_wus) {
+            retval = get_retired_batch_ids(retired_batch_ids);
+            if (retval) {
+                log_messages.printf(MSG_CRITICAL,
+                    "Can't get retired batch IDs"
+                );
+                exit(1);
+            }
+        }
+
         if (!do_pass() && !one_pass) {
             log_messages.printf(MSG_NORMAL, "Sleeping....\n");
             daemon_sleep(sleep_sec);

--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -812,7 +812,7 @@ int main(int argc, char** argv) {
     int retval;
     bool one_pass = false;
     int i;
-    int sleep_sec = 600;
+    int sleep_sec = 300;
     check_stop_daemons();
     char buf[256];
 
@@ -964,14 +964,26 @@ int main(int argc, char** argv) {
                 );
                 exit(1);
             }
+            if (retired_batch_ids.empty()) {
+                log_messages.printf(MSG_NORMAL,
+                    "no retired batches; sleeping %d\n",
+                    sleep_sec
+                );
+                daemon_sleep(sleep_sec);
+                continue;
+            }
         }
 
-        if (!do_pass() && !one_pass) {
-            log_messages.printf(MSG_NORMAL, "Sleeping....\n");
-            daemon_sleep(sleep_sec);
-        }
+        bool did_something = do_pass();
         if (one_pass) {
             break;
+        }
+        if (!did_something) {
+            log_messages.printf(MSG_NORMAL,
+                "No WUs to purge; sleeping %d\n",
+                sleep_sec
+            );
+            daemon_sleep(sleep_sec);
         }
     }
 

--- a/sched/file_deleter.cpp
+++ b/sched/file_deleter.cpp
@@ -72,13 +72,15 @@ using std::string;
 int id_modulus=0, id_remainder=0;
 DB_ID_TYPE appid=0;
 bool dont_retry_errors = false;
-bool dont_delete_batches = false;
 bool do_input_files = true;
 bool do_output_files = true;
-bool dry_run = false;
+bool no_db_update = false;
 int sleep_interval = DEFAULT_SLEEP_INTERVAL;
 char *xml_doc_like = NULL;
 char *download_dir = NULL;
+bool preserve_wu_files = false;
+bool preserve_result_files = false;
+
 
 void usage(char *name) {
     fprintf(stderr, "Deletes files that are no longer needed.\n\n"
@@ -89,27 +91,25 @@ void usage(char *name) {
         "3) repeat from 1)\n"
         "4) every 1 hour, enumerate everything in state FILE_DELETE_ERROR\n"
         "   and try to delete it.\n"
-        "Usage: %s [OPTION]...\n\n"
+        "Usage: %s [OPTIONS]\n\n"
         "Options:\n"
-        "  -d N | --debug_level N          set debug output level (1 to 4)\n"
-        "  --mod M R                       handle only WUs with ID mod M == R\n"
-        "  --appid ID                      handle only WUs of app with id ID\n"
-        "  --app NAME                      handle only WUs of app with name NAME\n"
-        "  --one_pass                      instead of sleeping in 2), exit\n"
-        "  --dont_retry_error              don't do 4)\n"
-        "  --preserve_result_files         update the DB, but don't delete output files.\n"
-        "                                  For debugging.\n"
-        "  --preserve_wu_files             update the DB, but don't delete input files.\n"
-        "                                  For debugging.\n"
-        "  --dont_delete_batches           don't delete anything with positive batch number\n"
-        "  --input_files_only              delete only input (download) files\n"
-        "  --dry_run                       Don't update DB\n"
-        "                                  For debugging.\n"
-        "  --output_files_only             delete only output (upload) files\n"
-        "  --xml_doc_like L                only process workunits where xml_doc LIKE 'L'\n"
-        "  --download_dir D                override download_dir from project config with D\n"
-        "  [ -h | --help ]                 shows this help text\n"
-        "  [ -v | --version ]              shows version information\n",
+        "  -d N | --debug_level N       set debug output level (1 to 4)\n"
+        "  --mod M R                    handle only WUs with ID mod M == R\n"
+        "  --appid ID                   handle only WUs of app with id ID\n"
+        "  --app NAME                   handle only WUs of app with name NAME\n"
+        "  --one_pass                   instead of sleeping in 2), exit\n"
+        "  --dont_retry_error           don't do step 4) above\n"
+        "  --preserve_result_files      update the DB, but don't delete output files.\n"
+        "                               For debugging.\n"
+        "  --preserve_wu_files          update the DB, but don't delete input files.\n"
+        "                               For debugging.\n"
+        "  --input_files_only           delete only input (download) files\n"
+        "  --no_db_update               don't update wu/result file_delete_state\n"
+        "  --output_files_only          delete only output (upload) files\n"
+        "  --xml_doc_like L             only process workunits where xml_doc LIKE 'L'\n"
+        "  --download_dir D             override download_dir from project config with D\n"
+        "  [ -h | --help ]              shows this help text\n"
+        "  [ -v | --version ]           shows version information\n",
         name
     );
 }
@@ -274,9 +274,9 @@ int result_delete_files(RESULT& result) {
                     );
                 } else if (retval) {
                     // the fact that no result files were found is a critical
-                    // error if this was a successful result, but is to be
-                    // expected if the result outcome was failure, since in
-                    // that case there may well be no output file produced.
+                    // error if this was a successful result,
+                    // but is to be expected if the result outcome was failure,
+                    // since in that case no output file may have been produced.
                     //
                     int msg_mode;
                     if (RESULT_OUTCOME_SUCCESS == result.outcome) {
@@ -314,11 +314,6 @@ int result_delete_files(RESULT& result) {
     return mthd_retval;
 }
 
-// set by corresponding command line arguments.
-//
-static bool preserve_wu_files=false;
-static bool preserve_result_files=false;
-
 // return true if we changed the file_delete_state of a WU or a result
 //
 bool do_pass(bool retry_error) {
@@ -334,9 +329,6 @@ bool do_pass(bool retry_error) {
     strcpy(clause, "");
     if (id_modulus) {
         sprintf(clause, " and id %% %d = %d ", id_modulus, id_remainder);
-    }
-    if (dont_delete_batches) {
-        strcat(clause, " and batch <= 0 ");
     }
     if (appid) {
         sprintf(buf, " and appid = %lu ", appid);
@@ -374,7 +366,7 @@ bool do_pass(bool retry_error) {
         }
         if (new_state != result.file_delete_state) {
             sprintf(buf, "file_delete_state=%d", new_state);
-            if (dry_run) {
+            if (no_db_update) {
                 retval = 0;
             } else {
                 retval = result.update_field(buf);
@@ -428,7 +420,7 @@ bool do_pass(bool retry_error) {
         }
         if (new_state != wu.file_delete_state) {
             sprintf(buf, "file_delete_state=%d", new_state);
-            if (dry_run) {
+            if (no_db_update) {
                 retval = 0;
             } else {
                 retval = wu.update_field(buf);
@@ -526,20 +518,8 @@ int main(int argc, char** argv) {
             xml_doc_like = argv[i];
         } else if (is_arg(argv[i], "dont_delete_antiques")) {
             log_messages.printf(MSG_CRITICAL, "'%s' has no effect, this file deleter does no antique files deletion\n", argv[i]);
-        } else if (is_arg(argv[i], "antiques_deletion_dry_run")) {
-            log_messages.printf(MSG_CRITICAL, "'%s' has no effect, this file deleter does no antique files deletion\n", argv[i]);
-        } else if (is_arg(argv[i], "delete_antiques_interval")) {
-            log_messages.printf(MSG_CRITICAL, "'%s' has no effect, this file deleter does no antique files deletion\n", argv[i]);
-        } else if (is_arg(argv[i], "delete_antiques_usleep")) {
-            log_messages.printf(MSG_CRITICAL, "'%s' has no effect, this file deleter does no antique files deletion\n", argv[i]);
-        } else if (is_arg(argv[i], "delete_antiques_limit")) {
-            log_messages.printf(MSG_CRITICAL, "'%s' has no effect, this file deleter does no antique files deletion\n", argv[i]);
-        } else if (is_arg(argv[i], "dont_delete_batches")) {
-            dont_delete_batches = true;
-        } else if (is_arg(argv[i], "dry_run")) {
-            dry_run = true;
-        } else if (is_arg(argv[i], "delete_antiques_now")) {
-            log_messages.printf(MSG_CRITICAL, "'%s' has no effect, this file deleter does no antique files deletion\n", argv[i]);
+        } else if (is_arg(argv[i], "no_db_update")) {
+            no_db_update = true;
         } else if (is_arg(argv[i], "input_files_only")) {
             do_output_files = false;
         } else if (is_arg(argv[i], "output_files_only")) {

--- a/sched/sched_main.cpp
+++ b/sched/sched_main.cpp
@@ -503,9 +503,7 @@ int main(int argc, char** argv) {
     }
     strip_whitespace(code_sign_key);
 
-#ifdef BUDA
     buda_init();
-#endif
 
     g_pid = getpid();
 #ifdef _USING_FCGI_

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -1438,8 +1438,9 @@ int HOST::parse(XML_PARSER& xp) {
         if (xp.parse_string("accelerators", stemp)) continue;
 
 #if 1
-        // deprecated items
+        // deprecated items from old client versions
         //
+        if (xp.parse_int("wsl_available", x)) continue;
         if (xp.parse_string("cpu_caps", stemp)) continue;
         if (xp.parse_string("cache_l1", stemp)) continue;
         if (xp.parse_string("cache_l2", stemp)) continue;

--- a/tools/sample_assimilate.py
+++ b/tools/sample_assimilate.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 
-# Sample script for the script-based assimilator (sched/script_assimilator.cpp)
+# Assimilator for batch-oriented apps
+# Use with the script-based assimilator (sched/script_assimilator.cpp)
 # Moves output files into a results/ hierarchy
 #
 # Use with a config.xml command of the form

--- a/version.h
+++ b/version.h
@@ -2,12 +2,11 @@
 // version.h is automatically updated by `configure` on *nix systems
 // Do not edit version.h directly
 //
-// To update versions run (in release_tools):
+// To update versions run:
 // - for the client/manager: set-client-version.py
 // - for the vboxwrapper: set-vboxwrapper-version.py
 // - for the worker: set-worker-version.py
 // - for the wrapper: set-wrapper-version.py
-// - for docker_wrapper: set-dockerwrapper-version.py
 
 #ifndef BOINC_VERSION_H
 #define BOINC_VERSION_H


### PR DESCRIPTION
The BOINC back-end architecture was originally designed
for stream-oriented apps, in which jobs are processed, assimilated,
file-deleted, and then purged from the DB.

Recently we've added support for batch-oriented apps,
for which we don't want to purge the WU and result records
until the batch has been retired.

Fix: add an option --retired_wus to db_purge.
If set, it purges only WUs and results in retired batches.
(If not set, it purges only WUs that are not in a batch;
so if your project has both stream- and batch-oriented apps,
run one of each).

Also: fix the logic for retire_batch().
It shouldn't set WUs to FILE_DELETE_DONE.
WUs may be in progress, and we still need to file-delete them.
Instead, mark unsent WUs as WU_ERROR_CANCELLED so we don't send them.

Also: add a script ops/delete_batches.php which deletes
retired batches with no WUs (i.e. they've all been purged).
This improves the efficiency of db_purge.
You don't need to do it very often - once a week is enough.

Also: aborting a batch sets its WU error masks to CANCELLED,
in which case the WUs won't go through file-deletion
and their input files will be orphaned.
Fix: when aborting a job, set the WU file delete state to READY.
Similar for unsent jobs when you retire a batch.
