### PR TITLE
docker wrapper (Mac): escape space in arg to 'stats' command

### DIFF
--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -647,10 +647,17 @@ int get_stats(RSC_USAGE &ru) {
     int retval;
     size_t n;
 
+#ifdef __APPLE__
+    snprintf(cmd, sizeof(cmd),
+        "stats --no-stream  --format \"{{.CPUPerc}}\\ {{.MemUsage}}\" %s",
+        container_name
+    );
+#else
     snprintf(cmd, sizeof(cmd),
         "stats --no-stream  --format \"{{.CPUPerc}} {{.MemUsage}}\" %s",
         container_name
     );
+#endif
     retval = docker_conn.command(cmd, out);
     if (retval) return -1;
     if (out.empty()) return -1;


### PR DESCRIPTION
The Mac version of Podman doesn't parse quoted args correctly :-( I already fixed this a couple of other places;
hopefully this one is the last