### PR TITLE
scheduler: for 'docker' plan class on Mac, require 8.2.6 or later client

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -601,6 +601,14 @@ bool PLAN_CLASS_SPEC::check(
                 add_no_work_message("Docker not present");
                 return false;
             }
+            if (strstr(sreq.host.os_name, "Darwin")) {
+                if (sreq.core_client_version < 80206) {
+                    add_no_work_message(
+                        "Docker jobs need 8.2.6+ client"
+                    );
+                    return false;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The 8.2.5 client detects Docker but doesn't have Run_Podman, so if we send it Docker jobs they'll fail.