### PR TITLE
scheduler: if 'only run my jobs on my computers' set, run only your jobs

### DIFF
--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -396,7 +396,7 @@ function show_submit_links($user) {
         'Jobs you submit can run', 'only_own',
         [
             [0, 'on any computer'],
-            [1, 'only on your computers']
+            [1, 'only on your computers (and no other jobs will run there)']
         ],
         $user->seti_id
     );

--- a/sched/sched_send.cpp
+++ b/sched/sched_send.cpp
@@ -1717,6 +1717,13 @@ void send_work() {
         }
     }
 
+    // if user is job submitter and has 'only run jobs on my computers' set,
+    // send them only their own jobs
+    //
+    if (g_reply->user.seti_id) {
+        goto done;
+    }
+
     if (config.enable_assignment_multi) {
         if (send_broadcast_jobs()) {
             if (config.debug_assignment) {


### PR DESCRIPTION
If you're using your computer to test your jobs,
you probably don't want other stuff running there.