### PR TITLE
client (Android): fix battery check logic

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -159,7 +159,9 @@ CLIENT_STATE::CLIENT_STATE()
     benchmarks_running = false;
     client_disk_usage = 0.0;
     total_disk_usage = 0.0;
+#ifdef ANDROID
     device_status_time = 0;
+#endif
 
     rec_interval_start = 0;
     total_cpu_time_this_rec_interval = 0.0;
@@ -183,7 +185,6 @@ CLIENT_STATE::CLIENT_STATE()
     now = 0.0;
     initialized = false;
     last_wakeup_time = dtime();
-    device_status_time = 0;
 #ifdef _WIN32
     have_sysmon_msg = false;
 #endif
@@ -481,9 +482,6 @@ int CLIENT_STATE::init() {
 
     srand((unsigned int)time(0));
     now = dtime();
-#ifdef ANDROID
-    device_status_time = dtime();
-#endif
     scheduler_op->url_random = drand();
 
     notices.init();
@@ -1093,7 +1091,9 @@ bool CLIENT_STATE::poll_slow_events() {
     if (get_idle_state) {
         bool old_user_active = user_active;
 #ifdef ANDROID
-        user_active = device_status.user_active;
+        if (device_status_time) {
+            user_active = device_status.user_active;
+        }
 #else
         idle_time = host_info.user_idle_time(check_all_logins);
         user_active = idle_time < global_prefs.idle_time_to_run * 60;

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -101,9 +101,12 @@ struct CLIENT_STATE {
     ACTIVE_TASK_SET active_tasks;
     HOST_INFO host_info;
 
-    // the following used only on Android
+#ifdef ANDROID
     DEVICE_STATUS device_status;
+        // info from GUI, e.g. battery status
     double device_status_time;
+        // time of last RPC from GUI
+#endif
 
     char language[16];                // ISO language code reported by GUI
     char client_brand[256];
@@ -705,8 +708,7 @@ extern void show_wsl_messages();
     // We rely on the GUI to report battery status.
 #define ANDROID_BATTERY_BACKOFF     300
     // Android: if battery is overheated or undercharged,
-    // suspend for at least this long
-    // (avoid rapid start/stop)
+    // suspend computing for at least this long (avoid rapid start/stop)
 
 #ifndef ANDROID
 #define USE_NET_PREFS

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1700,6 +1700,7 @@ static void handle_set_language(GUI_RPC_CONN& grc) {
     grc.mfout.printf("<error>no language found</error>\n");
 }
 
+#ifdef ANDROID
 static void handle_report_device_status(GUI_RPC_CONN& grc) {
     DEVICE_STATUS d;
     while (!grc.xp.get_tag()) {
@@ -1764,6 +1765,8 @@ int DEVICE_STATUS::parse(XML_PARSER& xp) {
     }
     return ERR_XML_PARSE;
 }
+
+#endif      // ANDROID
 
 // Some of the RPCs have empty-element request messages.
 // We accept both <foo/> and <foo></foo>
@@ -1849,7 +1852,9 @@ GUI_RPC gui_rpcs[] = {
     GUI_RPC("read_cc_config", handle_read_cc_config,                true,   false,  false),
     GUI_RPC("read_global_prefs_override", handle_read_global_prefs_override,
                                                                     true,   false,  false),
+#ifdef ANDROID
     GUI_RPC("report_device_status", handle_report_device_status,    true,   false,  false),
+#endif
     GUI_RPC("reset_host_info", handle_reset_host_info,              true,   false,  false),
     GUI_RPC("resume_result", handle_resume_result,                  true,   false,  false),
     GUI_RPC("run_benchmarks", handle_run_benchmarks,                true,   false,  false),


### PR DESCRIPTION
We were doing battery charge/temp checks on startup, before getting an RPC from the GUI giving us battery info.

Also: check for user-active suspend before battery checks. We had moved it after on Android, not sure why.

Also: put all DEVICE_STATUS stuff in #ifdef ANDROID