### PR TITLE
Mac installer: fix tests for symbolic links per Copilot comments in PR #6618

### DIFF
--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -322,7 +322,7 @@ int main(int argc, char *argv[])
         // under "if (DetectDuplicateInstance())"
         //
         // "rm -rf \"/Applications/GridRepublic Desktop.app\""
-        if (stat(appPath[brandID], &sbuf) == 0) {
+        if (lstat(appPath[brandID], &sbuf) == 0) {
             if (S_ISLNK(sbuf.st_mode)) {
                 if (realpath(appPath[brandID], realPath)) {   // Get path to app from symbolic link
                     sprintf(s, "rm -rf \"%s\"", realPath);
@@ -507,7 +507,7 @@ int main(int argc, char *argv[])
         // under "if (DetectDuplicateInstance())"
         //
         // "rm -rf \"/Applications/GridRepublic Desktop.app\""
-        if (stat(appPath[i], &sbuf) == 0) {
+        if (lstat(appPath[i], &sbuf) == 0) {
             if (S_ISLNK(sbuf.st_mode)) {
                 if (realpath(appPath[i], realPath)) {   // Get path to app from symbolic link
                     sprintf(s, "rm -rf \"%s\"", realPath);


### PR DESCRIPTION
…

Copilot's [comments](https://github.com/BOINC/boinc/pull/6618#pullrequestreview-3380401593) to PR #6618 pointed out that the `S_ISLNK` tests for symbolic links won't work because the code used s`tat()` instead of `lstat()`. This PR corrects that.