### PR TITLE
Mac fix podman homebrew

### DIFF
--- a/client/Run_Podman.cpp
+++ b/client/Run_Podman.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
     fflush(stdout);
 #endif
 
-    // While the official Podman installer puts the porman executable at
+    // While the official Podman installer puts the Podman executable at
     // "/opt/podman/bin/podman", other installation methods (e.g. brew) might not
 
     // The Mac installer wrote path to podman executable in Path_to_podman.txt
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
         fgets(Podman_Path, sizeof(Podman_Path), f);
         fclose(f);
         char * p=strstr(Podman_Path, "\n");
-        if (p) *p='\0'; // Remove the newline character
+        if (p) *p = '\0'; // Remove the newline character
     }
     if (stat((const char*)Podman_Path, &sbuf)!= 0) {
         Podman_Path[0] = 0;
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     if (Podman_Path[0] == 0) {
         // If we couldn't get it from that file, use default if installed using Podman installer
         strlcpy(Podman_Path, "/opt/podman/bin/podman", sizeof(Podman_Path));
-        if (stat((const char*)Podman_Path, &sbuf)!= 0) {
+        if (stat((const char*)Podman_Path, &sbuf) != 0) {
             Podman_Path[0] = 0;
         }
     }
@@ -109,7 +109,7 @@ int main(int argc, char *argv[])
 #else
         strlcpy(Podman_Path, "/usr/local/bin/podman", sizeof(Podman_Path));
 #endif
-        if (stat((const char*)Podman_Path, &sbuf)!= 0) {
+        if (stat(Podman_Path, &sbuf) != 0) {
             Podman_Path[0] = 0;
         }
     }
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
             fgets(Podman_Path, sizeof(Podman_Path), f);
             pclose(f);
             char * p=strstr(Podman_Path, "\n");
-            if (p) *p='\0'; // Remove the newline character
+            if (p) *p = '\0'; // Remove the newline character
 #if VERBOSE
             fprintf(debug_file, "popen returned podman path = \"%s\"\n", Podman_Path);
 #endif

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -309,7 +309,7 @@ if [ -f ss_config.xml ] ; then
     set_perm ss_config.xml boinc_master boinc_master 0664
 fi
 
-# Though "BOINC podman" directory is not  used on older
+# Though "BOINC podman" directory is not used on older
 # versions of BOINC, it doesn't hurt to add it to them
 if [ ! -d "../BOINC podman" ] ; then
     mkdir "../BOINC podman"
@@ -318,7 +318,7 @@ fi
 # their owner and group
 chown -R boinc_project:boinc_project "../BOINC podman"
 # Set owner and permissions for the BOINC podman directory itself
-# itself but not its contents.
+# but not its contents.
 set_perm "../BOINC podman" boinc_master boinc_project 0770
 
 if [ -x /Applications/BOINCManager.app/Contents/MacOS/BOINCManager ] ; then


### PR DESCRIPTION
Although my tests indicate that the BOINC installer already finds Podman when Podman was installed using _Homebrew_, for added safety this PR adds code to the _Run_Podman_ executable to make extra checks in the default locations used by _Homebrew_ if not present where expected, and to try to find Podman dynamically if all else fails.

This PR also adds code to the _Mac_SA_Secure.sh_ utility to create the _BOINC podman_ directory and _Path_to_podman.txt_ file for bare client users (if not already present), since the BOINC installer is not used for bare client installs.