### PR TITLE
[linux] ensure found compiler has c++11 support.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,44 @@ fi
 dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_CXX
+
+dnl Verify C++11 support
+AC_MSG_CHECKING([whether $CXX supports C++11])
+AC_LANG_PUSH([C++])
+save_CXXFLAGS="$CXXFLAGS"
+for flag in "-std=c++11" "-std=c++0x"; do
+  CXXFLAGS="$save_CXXFLAGS $flag"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+    #include <memory>
+    #include <array>
+    #include <functional>
+    ]],
+    [[
+    auto ptr = std::make_shared<int>(42);
+    std::array<int, 5> arr = {{1, 2, 3, 4, 5}};
+    auto lambda = [](int x) { return x * 2; };
+    return lambda(*ptr) + arr[0];
+    ]])],
+    [have_cxx11=yes],
+    [have_cxx11=no])
+  if test "x$have_cxx11" = "xyes"; then
+    AC_MSG_RESULT([yes, with $flag])
+    CXXFLAGS="$save_CXXFLAGS $flag"
+    break
+  fi
+done
+if test "x$have_cxx11" != "xyes"; then
+  CXXFLAGS="$save_CXXFLAGS"
+  AC_MSG_RESULT([no])
+  AC_MSG_ERROR([
+================================================================================
+ERROR: A C++11 compliant compiler is required to build BOINC.
+Please use a newer compiler version (e.g., GCC 4.8+, Clang 3.3+).
+================================================================================
+  ])
+fi
+AC_LANG_POP([C++])
+
 dnl ------
 dnl Workaround for autoconf >= 2.65 backwards incompatibility
 m4_pattern_allow([AC_PROG_OBJCXX])


### PR DESCRIPTION
Since a while we are require c++11 to be the minimal standard that should be supported by the compiler. This verification is required to ensure that we will not try to build the solution on outdated and/or unsupported c++ compiler.
