### PR TITLE
Menu items sync on skin change

### DIFF
--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -747,6 +747,7 @@ void CSimpleFrame::OnReloadSkin(CFrameEvent& WXUNUSED(event)) {
     wxASSERT(pSkinAdvanced);
 
     m_pBackgroundPanel->ReskinInterface();
+    CreateMenus();
     SetTitle(pSkinAdvanced->GetApplicationName());
     SetIcon(pSkinAdvanced->GetApplicationIcon()->GetIcon(wxDefaultSize));
 


### PR DESCRIPTION
Fixes #6101

**Description of the Change**
On skin change, menus are recreated

<img width="841" height="245" alt="image" src="https://github.com/user-attachments/assets/428f3dcd-be95-45ae-a7fe-85bec47c61d9" />

**Alternate Designs**
More granular update could be implemented, but it feels like overengineering

**Release Notes**
Client: Fix menu items not synced with a chosen skin
