### PR TITLE
Fix deadlock on WSL removal after installing Docker

### DIFF
--- a/lib/win_util.cpp
+++ b/lib/win_util.cpp
@@ -266,6 +266,7 @@ int WSL_CMD::setup_podman(const char* distro_name) {
 int WSL_CMD::run_program_in_wsl(
     const string distro_name, const string command, bool use_cwd
 ) {
+    proc_handle = NULL;
     HRESULT ret = pWslLaunch(
         boinc_ascii_to_wide(distro_name).c_str(),
         boinc_ascii_to_wide(command).c_str(),
@@ -273,7 +274,9 @@ int WSL_CMD::run_program_in_wsl(
         &proc_handle
     );
     if (ret != S_OK) {
-        fprintf(stderr, "pWslLaunch failed: %d\n", ret);
+        fprintf(stderr, "pWslLaunch failed: 0x%08lx\n", ret);
+        proc_handle = NULL;
+        return ERR_NOT_FOUND;
     }
     return 0;
 }


### PR DESCRIPTION
Fixes #6296

**Description of the Change**
Prevents BOINC from stucking if WSL was before and then was disabled. BOINC works fine w/o WSL, so it may ignore WSL/distros absence and work as usual. Basically, return 0 instead of -1.

Let me if there could be side effects. Tested on Win 11

**Alternate Designs**
.

**Release Notes**
Fix deadlock on WSL removal after installing Docker
