### PR TITLE
[client] fix android issue when the client was requested to exit immediately after start

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -160,7 +160,7 @@ CLIENT_STATE::CLIENT_STATE()
     client_disk_usage = 0.0;
     total_disk_usage = 0.0;
 #ifdef ANDROID
-    device_status_time = 0;
+    device_status_time = dtime();
 #endif
 
     rec_interval_start = 0;


### PR DESCRIPTION
… that lead to the Android GUI appllication to stuck on the splash screen
