### PR TITLE
client: improve 'non-BOINC total CPU usage' measurement

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -594,7 +594,7 @@ void ACTIVE_TASK_SET::get_memory_usage() {
                         total_cpu_time_now, brc, nbrc, delta_nbrc, delta_t
                     );
                 }
-			}
+            }
         }
         prev_nbrc = nbrc;
     } else

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -192,7 +192,7 @@ void procinfo_non_boinc(PROCINFO& procinfo, PROC_MAP& pm) {
 //
 void boinc_related_cpu_time(
     PROC_MAP& pm, bool vbox_app_running,
-    double &brc, bool &reset
+    double& brc, bool& reset
 ) {
     static double prev_boinc_app = 0;
     static double prev_low_prio = 0;
@@ -236,7 +236,7 @@ void boinc_related_cpu_time(
         || (docker < prev_docker);
     if (reset) {
         //fprintf(stderr, "boinc_related_cpu_time: reset\n");
-	}
+    }
     prev_boinc_app = boinc_app;
     prev_low_prio = low_prio;
     prev_vbox = vbox;

--- a/lib/procinfo.h
+++ b/lib/procinfo.h
@@ -88,7 +88,7 @@ extern double total_cpu_time();
     // total user-mode CPU time, as reported by OS
 
 extern void boinc_related_cpu_time(
-    PROC_MAP&, bool vbox_app_running, double& brc, bool &reset
+    PROC_MAP&, bool vbox_app_running, double& brc, bool& reset
 );
     // return total CPU of
     // - BOINC processes


### PR DESCRIPTION
We compute this as (total CPU usage) - (BOINC-related total CPU usage)
where the latter is the sum of several sets of processes:
- BOINC tasks
- low-priority processes
- Vbox processes, i.e. VboxSVC.exe
- (Win/Mac) the VM processes that Docker/Podman containers run in

We compute this every 10 seconds.

This works fine until a process exits.
Suppose e.g. a low-priority process with X CPU seconds exits.
Then BOINC-related total CPU usage will drop by X,
so non-BOINC total CPU usage will (incorrectly) increase by X,
and the client will possibly (incorrectly) suspend computing for 20 seconds.

Solution: compute the CPU usage of each of the above 4 types separately.
If any of them decreases (e.g. because a process has exited)
don't compute non-BOINC CPU usage this time.

This isn't 100% accurate.
For example, if a low-priority process runs and exits
entirely in a 10-second period,
it will incorrectly be counted as non-BOINC CPU time.
