### PR TITLE
client: parse container names correctly

### DIFF
--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -823,6 +823,7 @@ int DOCKER_CONN::parse_container_name(string line, string &name) {
     char *p = strrchr(buf, ' ');
     if (!p) return -1;
     name = (string)(p+1);
+    strip_whitespace(name);
     return 0;
 }
 


### PR DESCRIPTION
We were failing to strip the final \n.
This caused the client to try to remove the container, producing a confusing error message.