### PR TITLE
db_update.php: fix an update that would otherwise fail

### DIFF
--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1079,7 +1079,7 @@ function update_3_8_2018() {
 
 function update_4_5_2018() {
     do_query("create table token (
-        token                   varchar(255)    not null,
+        token                   varchar(64)    not null,
         userid                  integer         not null,
         type                    char            not null,
         create_time             integer         not null,


### PR DESCRIPTION
You can't create an indexed varchar(255) field with 4-byte chars. Change it to 64 (it gets changed in a later update anyway)
