### PR TITLE
[tests] update boinc vcpkg port from the vcpkg upstream

### DIFF
--- a/tests/vcpkg/ports/boinc/portfile.cmake
+++ b/tests/vcpkg/ports/boinc/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO BOINC/boinc
     REF "client_release/${MAJOR_MINOR}/${VERSION}"
-    SHA512 0e0c4f7647325f8f1e8a87da0d7ff43d1a3e5d3ef0dc3daf1fb974a47c0e4fb7318b3fdde77d0ae6ec4f3d30be113a5ceff33658facc8f3c2c325c8c61942698
+    SHA512 5d38adcaefc99bd79d54e7e47bcc38099844157802852b9de9eb910ce80e2f6d6b333b3ece3f6c619e3c66d9dda9a9c5a8290ce583f77e1727bd7064e81b11af
     HEAD_REF master
 )
 

--- a/tests/vcpkg/ports/boinc/vcpkg.json
+++ b/tests/vcpkg/ports/boinc/vcpkg.json
@@ -1,11 +1,15 @@
 {
   "name": "boinc",
-  "version": "8.0.4",
+  "version": "8.2.8",
   "description": "Open-source software for volunteer computing and grid computing.",
   "homepage": "https://boinc.berkeley.edu/",
   "license": "LGPL-3.0-or-later",
   "supports": "!(windows & arm) & !uwp & !xbox",
   "dependencies": [
+    {
+      "name": "libzip",
+      "default-features": false
+    },
     "openssl",
     {
       "name": "vcpkg-cmake",
@@ -14,10 +18,6 @@
     {
       "name": "vcpkg-cmake-config",
       "host": true
-    },
-    {
-      "name": "libzip",
-      "default-features": false
     }
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated BOINC vcpkg test port to upstream 8.2.8 and refreshed the source SHA512. Synced the manifest with vcpkg upstream to keep tests aligned and builds reproducible.

<sup>Written for commit 5eb556f3127e442359aa1d76e9f2955ea71c77cf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

