### PR TITLE
add script to generate hash for guix package

### DIFF
--- a/release_tools/get_release_hash_for_guix.sh
+++ b/release_tools/get_release_hash_for_guix.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# This file is part of BOINC.
+# https://boinc.berkeley.edu
+# Copyright (C) 2025 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+# check working directory because the script needs to be called like: ./release_tools/get_release_hash_for_guix.sh
+if [ ! -d "release_tools" ]; then
+    echo "start this script in the source root directory"
+    exit 1
+fi
+
+guix hash -x -S nar .


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add release_tools/get_release_hash_for_guix.sh to compute the Guix nar hash for the source tree. The script validates it’s run from the repo root and then calls guix hash -x -S nar .

<sup>Written for commit 90127194497eaa6525a95892bf2801426090888c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



