### PR TITLE
[ci] fix wsl_wrapper upload during build

### DIFF
--- a/deploy/prepare_deployment.py
+++ b/deploy/prepare_deployment.py
@@ -79,7 +79,7 @@ mingw_apps_vcpkg_list = [
     './samples/wrappture/wrappture_example.exe',
     './samples/wrappture/fermi.exe',
     './samples/sporadic/sporadic.exe',
-    './samples/wsl_wrapper/wsl_wrapper.exe',
+    './samples/wsl_wrapper/wsl_wrapper*.exe',
     './samples/docker_wrapper/docker_wrapper*.exe',
 ]
 
@@ -160,7 +160,7 @@ windows_apps_list = [
     './win_build/Build/x64/Release/test*.exe',
     './win_build/Build/x64/Release/wrappture*.exe',
     './win_build/Build/x64/Release/crypt_prog.exe',
-    './win_build/Build/x64/Release/wsl_wrapper.exe',
+    './win_build/Build/x64/Release/wsl_wrapper*.exe',
     './win_build/Build/x64/Release/docker_wrapper*.exe',
     './win_build/Build/x64/Release/cudart*.dll',
     './win_build/Build/ARM64/Release/htmlgfx*.exe',
@@ -176,7 +176,7 @@ windows_apps_list = [
     './win_build/Build/ARM64/Release/test*.exe',
     './win_build/Build/ARM64/Release/wrappture*.exe',
     './win_build/Build/ARM64/Release/crypt_prog.exe',
-    './win_build/Build/ARM64/Release/wsl_wrapper.exe',
+    './win_build/Build/ARM64/Release/wsl_wrapper*.exe',
     './win_build/Build/ARM64/Release/docker_wrapper*.exe',
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use wildcard patterns for wsl_wrapper executables in prepare_deployment.py so all variants (wsl_wrapper*.exe) are uploaded during CI builds. Fixes missed artifacts in samples and both x64 and ARM64 Release directories.

<sup>Written for commit c4f9ef1a01347a6e8b4aeec3057afa81e9e0381b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

