### PR TITLE
Skip WSL discovery and fix logging for BOINC running as service

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -250,7 +250,10 @@ void CLIENT_STATE::show_host_info() {
 
 #ifdef _WIN64
     if (host_info.wsl_distros.distros.empty()) {
-        msg_printf(NULL, MSG_INFO, "WSL: no usable distros found");
+        // Don't print this message when running as a service (WSL detection is skipped)
+        if (!executing_as_daemon) {
+            msg_printf(NULL, MSG_INFO, "WSL: no usable distros found");
+        }
     } else {
         msg_printf(NULL, MSG_INFO, "Usable WSL distros:");
         for (auto& wsl : host_info.wsl_distros.distros) {

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -200,6 +200,14 @@ static bool got_both(WSL_DISTRO &wd) {
 // Return nonzero on error
 //
 int get_wsl_information(WSL_DISTROS &distros) {
+    // Skip WSL detection when running as a service since HKEY_CURRENT_USER
+    // registry is not available in service mode
+    if (gstate.executing_as_daemon) {
+        distros.distros.clear();
+        msg_printf(0, MSG_INFO, "WSL detection skipped: running as service");
+        return 0;
+    }
+
     WSL_DISTROS all_distros;
     int retval = get_all_distros(all_distros);
     if (retval) return retval;


### PR DESCRIPTION
Fixes #6693

**Description of the Change**
WSL is no available for Windows services. Therefore, when BOINC runs as a service, we must:
- Skip WSL detection
- Prevent displaying logs that no WSL distros were found

**Alternate Designs**
.

**Release Notes**
Skip WSL discovery and fix logging for BOINC running as service

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip WSL discovery when BOINC runs as a Windows service. Improve logging to avoid false “no usable distros” messages in service mode.

- **Bug Fixes**
  - Skip WSL detection in service mode to avoid HKCU registry access.
  - Log “WSL detection skipped: running as service” and suppress “WSL: no usable distros found” when executing as a daemon.

<sup>Written for commit 449589d65014caa059649d2b717990938644d719. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

