### PR TITLE
client: don't complain about projects/virtualbox; we created it

### DIFF
--- a/client/cs_files.cpp
+++ b/client/cs_files.cpp
@@ -105,7 +105,7 @@ int CLIENT_STATE::make_project_dirs() {
     DirScanner dir(PROJECTS_DIR);
     while (dir.scan(name)) {
         if (name == "app_test") continue;
-        if (name == "virtualbox") continue;
+        if (!strcasecmp(name.c_str(), "virtualbox")) continue;
         snprintf(path, sizeof(path), "projects/%s", name.c_str());
         if (std::find(pds.begin(), pds.end(), path) != pds.end()) {
             continue;


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip the "virtualbox" directory (case-insensitive) when scanning projects so the client doesn’t warn about a folder it creates. Mirrors the existing exception for "app_test".

<sup>Written for commit 72606e7dbdc3d577e266a544f2029067f64449ab. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



