### PR TITLE
web: app-level access control for BUDA

### DIFF
--- a/html/inc/buda.inc
+++ b/html/inc/buda.inc
@@ -50,4 +50,27 @@ function variant_name($desc) {
     }
 }
 
+// can user submit job to BUDA app?
+//
+function user_can_submit($user, $app_desc) {
+    if ($app_desc->user_id == $user->id) {
+        return true;
+    }
+    if (!empty($app_desc->submitters)
+        && in_array($user->id, $app_desc->submitters)
+    ) {
+        return true;
+    }
+    return false;
+}
+
+// can user edit app or variants?
+//
+function user_can_manage($user, $app_desc) {
+    if ($app_desc->user_id == $user->id) {
+        return true;
+    }
+    return false;
+}
+
 ?>


### PR DESCRIPTION
Each BUDA app has a creator, and also a list of 'submitter' user IDs.

Only the creator can edit the app, or create or edit variants. The creator can add or remove submitters
(but they have to have submit access to BUDA as a whole).

Only the creator and submitters can submit jobs to the app.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds app-level access control to BUDA. Only the app creator can manage apps/variants, and only the creator or approved submitters can submit jobs.

- **New Features**
  - Added user_can_submit and user_can_manage helpers.
  - App and variant edit actions/buttons are creator-only.
  - Submit UI shows only apps the user can submit; blocks unauthorized submits.
  - App form now includes “Additional submitters” (user IDs) with validation for BUDA submit access.

- **Migration**
  - For existing apps, add user IDs to “Additional submitters” if others should submit jobs. Otherwise, only the creator can submit.

<sup>Written for commit 53ba5854a451f2d56fd2828658225bc78279b74a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

