### PR TITLE
scheduler: send msg to client if max_jobs_per_day limit reached

### DIFF
--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -146,6 +146,11 @@ inline bool daily_quota_exceeded(DB_ID_TYPE gavid, HOST_USAGE& hu) {
             );
         }
         havp->daily_quota_exceeded = true;
+        char message[1024];
+        snprintf(message, sizeof(message),
+            "Daily job limit (%d) has been reached", q
+        );
+        add_no_work_message(message);
         return true;
     }
     return false;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send a clear “no work” message to clients when the daily job limit (max_jobs_per_day) is reached, so users know why no tasks are assigned. This improves transparency and reduces confusion when quotas block new work.

<sup>Written for commit cf3ed3f0b83c10b88eac9c9d1f02c9a91799a13a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

