### PR TITLE
Mac: update ReadMe to reflect new location of BOINCManager.app

### DIFF
--- a/mac_installer/ReadMe.rtf
+++ b/mac_installer/ReadMe.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2865
+{\rtf1\ansi\ansicpg1252\cocoartf2867
 \cocoascreenfonts1\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;\red251\green2\blue7;\red56\green110\blue255;}
 {\*\expandedcolortbl;;\cssrgb\c100000\c14913\c0;\csgenericrgb\c21961\c43137\c100000;}
@@ -18,7 +18,13 @@ Installing BOINC may take several minutes; please be patient.
 \f1\b0 \
 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
-\cf2 New:\cf0  This version of BOINC restores full support for displaying project screensavers. It also once again enables the BOINC installer to optionally set BOINC as your screensaver, but  only under MacOS 26 or later. Note: due to limitations imposed by MacOS, the BOINC installer will always ask you whether you wish to make BOINC your screensaver even if BOINC is already selected as the screensaver.\
+\cf2 New:\cf0  BOINC version 8.2.7 restores full support for displaying project screensavers. It also once again enables the BOINC installer to optionally set BOINC as your screensaver, but  only under MacOS 26 or later. Note: due to limitations imposed by MacOS, the BOINC installer will always ask you whether you wish to make BOINC your screensaver even if BOINC is already selected as the screensaver.\
+\
+As of version 8.2.6, the installer has moved the BOINC Manager to 
+\f0\b /Library/Application Support/BOINCManager.app
+\f1\b0  and creates a symbolic link (alias) to it at 
+\f0\b /Applications/BOINCManager.app.
+\f1\b0 \
 \
 \cf2 New for Apple Silicon Macs:\cf0  This version of BOINC can run project applications written only for Intel Macs in addition to ones written for Apple Silicon, but only if Apple's Rosetta 2 translation is installed.  (Please do not confuse Apple's Rosetta 2 with the BOINC Rosetta project.) If you have not previously installed Apple's Rosetta 2 translator, the BOINC installer will offer you the option of installing it.\
 \
@@ -66,11 +72,13 @@ The installer sets BOINCManager as a Login item for
 \f0\b \cf0 Other useful information:
 \f1\b0 \
 \
-The installer places two items onto your hard drive: BOINCManager.app in your 
+The installer places three items onto your hard drive: BOINCManager.app in your 
+\f0\b /Library/Application Support 
+\f1\b0 folder, a symbolic link (alias) to it in your 
 \f0\b /Applications
 \f1\b0  folder and BOINCSaver.saver in your 
 \f0\b /Library/Screen Savers
-\f1\b0  folder.  \
+\f1\b0  folder.\
 \
 The installer creates the BOINC Data folder in your 
 \f0\b /Library/Application Support
@@ -80,8 +88,8 @@ All users who log in on the same Macintosh will share one set of BOINC Data, ens
 \
 You can move (
 \f0\b not
-\f1\b0  copy) BOINCManager to any folder you wish on the same disk drive or partition.  If you do so, you will need to update the information in each user's Login Items.  In most cases, the BOINC screen saver should still work properly.  If it does not, move BOINCManager back to the 
-\f0\b /Applications
+\f1\b0  copy) BOINCManager to any folder you wish on the same disk drive or partition, using the method described in {\field{\*\fldinst{HYPERLINK "https://boinc.berkeley.edu/wiki/Tools_for_MacOS"}}{\fldrslt https://boinc.berkeley.edu/wiki/Tools_for_MacOS}}.  In most cases, the BOINC screen saver should still work properly.  If it does not, move BOINCManager back to the 
+\f0\b /Library/Application Support
 \f1\b0  folder.\
 \
 \pard\pardeftab720\partightenfactor0

--- a/mac_installer/wcgrid-ReadMe.rtf
+++ b/mac_installer/wcgrid-ReadMe.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf2865
+{\rtf1\ansi\ansicpg1252\cocoartf2867
 \cocoascreenfonts1\cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica-Bold;\f1\fswiss\fcharset0 Helvetica;}
 {\colortbl;\red255\green255\blue255;\red251\green2\blue7;\red217\green11\blue0;\red56\green110\blue255;
 }
@@ -30,7 +30,16 @@
 \f1\b0 \cf0 \ulnone World Community Grid is enabled by the Berkeley Open Infrastructure for Network Computing (BOINC) open source distributed computing platform.\
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
 \cf0 \
-\cf2 New:\cf0  This version of BOINC restores full support for displaying project screensavers. It also once again enables the BOINC installer to optionally set BOINC as your screensaver, but  only under MacOS 26 or later. Note: due to limitations imposed by MacOS, the BOINC installer will always ask you whether you wish to make BOINC your screensaver even if BOINC is already selected as the screensaver.\
+\cf2 New:\cf0  BOINC version 8.2.7 restores full support for displaying project screensavers. It also once again enables the BOINC installer to optionally set BOINC as your screensaver, but  only under MacOS 26 or later. Note: due to limitations imposed by MacOS, the BOINC installer will always ask you whether you wish to make BOINC your screensaver even if BOINC is already selected as the screensaver.\
+\
+As of version 8.2.6, the installer has moved the BOINC Manager to 
+\f0\b /Library/Application Support/World Community Grid.app 
+\f1\b0 and creates a symbolic link (alias) to it at 
+\f0\b /Applications/World Community Grid.app.
+\f1\b0 \
+\
+\
+This version of BOINC restores full support for displaying project screensavers. It also once again enables the BOINC installer to optionally set BOINC as your screensaver, but  only under MacOS 26 or later. Note: due to limitations imposed by MacOS, the BOINC installer will always ask you whether you wish to make BOINC your screensaver even if BOINC is already selected as the screensaver.\
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardeftab720\ri0\partightenfactor0
 \cf0 \
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\partightenfactor0
@@ -88,7 +97,9 @@ The installer sets World Community Grid as a Login item for
 \f0\b \cf0 Other useful information:
 \f1\b0 \
 \
-The installer places two items onto your hard drive: \'93World Community Grid.app\'94 in your 
+The installer places three items onto your hard drive: \'93World Community Grid.app\'94  in your 
+\f0\b /Library/Application Support 
+\f1\b0 folder, a symbolic link (alias) to it in your 
 \f0\b /Applications
 \f1\b0  folder and \'93World Community Grid.saver\'94 in your 
 \f0\b /Library/Screen Savers
@@ -102,8 +113,8 @@ All users who log in on the same Macintosh will share one set of BOINC Data, ens
 \
 You can move (
 \f0\b not
-\f1\b0  copy) World Community Grid to any folder you wish on the same disk drive or partition.  If you do so, you will need to update the information in each user's Login Items.  In most cases, the World Community Grid screen saver should still work properly.  If it does not, move World Community Grid back to the 
-\f0\b /Applications
+\f1\b0  copy) \'93World Community Grid.app\'94  to any folder you wish on the same disk drive or partition, using the method described in {\field{\*\fldinst{HYPERLINK "https://boinc.berkeley.edu/wiki/Tools_for_MacOS"}}{\fldrslt https://boinc.berkeley.edu/wiki/Tools_for_MacOS}}.  In most cases, the World Community Grid screen saver should still work properly.  If it does not, move World Community Grid back to the 
+\f0\b /Library/Application Support
 \f1\b0  folder.\
 \
 \pard\pardeftab720\partightenfactor0


### PR DESCRIPTION
 Update Mac installer ReadMe to reflect new location of _BOINCManager.app_ in response to Discussion #6701. This PR is ready to be merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Mac installer ReadMe files to reflect the new location of BOINC Manager and World Community Grid apps in /Library/Application Support, with a symlink in /Applications.
Also clarified BOINC 8.2.7 screensaver support and updated move instructions to link to the Tools_for_MacOS page.

<sup>Written for commit a2ac6ee5f35a18aaed9ca2be9b60c993c5f29848. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

