### PR TITLE
[ci][linux] fix vcpkg build, install python3-venv as a dependency

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git python3 python3-distutils python3-jinja2 curl zip unzip tar bison p7zip-full dbus
+          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git python3 python3-distutils python3-jinja2 python3-venv curl zip unzip tar bison p7zip-full dbus
 
       - name: Install dependencies for arm64
         if: matrix.arch == 'arm64'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -95,6 +95,7 @@ parts:
     - software-properties-common
     - cmake
     - dbus
+    - python3-venv
     source: .
     plugin: autotools
     build-environment:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure vcpkg builds succeed on Linux by installing python3-venv in CI and Snap packaging. Adds python3-venv to apt dependencies in the linux-package workflow and to snapcraft build-packages to prevent Python environment errors during build.

<sup>Written for commit 913ba2c5c6e42aa5884d104c8189cfb21953f4a4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

