### PR TITLE
[linux] update custom gdk-pixbuf vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
@@ -1,10 +1,13 @@
-vcpkg_from_gitlab(
-    GITLAB_URL https://gitlab.gnome.org/
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO GNOME/gdk-pixbuf
-    REF "${VERSION}"
-    SHA512 f95c92974ed6efac9845790ef5c4ed74dd6e28b182ea3732013c46b016166e92f8bc10c1994358d79ff53e988c615c43cb1a2130c6ef531ef9d84c2fdcc87e52
-    HEAD_REF master
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://download.gnome.org/sources/gdk-pixbuf/${VERSION_MAJOR_MINOR}/gdk-pixbuf-${VERSION}.tar.xz"
+    FILENAME "GNOME-gdk-pixbuf-${VERSION}.tar.xz"
+    SHA512 ae9fcc9b4e8fd10a4c9bf34c3a755205dae7bbfe13fbc93ec4e63323dad10cc862df6a9e2e2e63c84ffa01c5e120a3be06ac9fad2a7c5e58d3dc6ba14d1766e8
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
     PATCHES
         fix_build_error_windows.patch
         loaders-cache.patch

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.12",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch gdk-pixbuf vcpkg port to use GNOME release tarballs instead of GitLab sources for more reliable and reproducible Linux builds. Bumps port-version to 5.

- **Refactors**
  - Replace vcpkg_from_gitlab with vcpkg_download_distfile + vcpkg_extract_source_archive.
  - Derive VERSION_MAJOR_MINOR via regex to build the download URL.
  - Keep existing patches unchanged; library version stays 2.42.12.

<sup>Written for commit 24c1761deaa296caca0cab16cfd7eb4a0468681e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

