### PR TITLE
Mac: If Manager is hidden on system light / dark mode switch,  don't unhide it

### DIFF
--- a/clientgui/AdvancedFrame.cpp
+++ b/clientgui/AdvancedFrame.cpp
@@ -2032,13 +2032,6 @@ void CAdvancedFrame::OnDarkModeChanged( wxSysColourChangedEvent& WXUNUSED(event)
     // TODO: figure out how to preserve notices tab (currentPage == VW_NOTIF) scrolled position
 
     StartTimers();
-
-    CDlgEventLog*   eventLog = wxGetApp().GetEventLog();
-    if (eventLog) {
-        wxGetApp().OnEventLogClose();
-        delete eventLog;    // eventLog->Destroy() creates a race condition if used here.
-        wxGetApp().DisplayEventLog();
-    }
 #endif  // #if SUPPORTDARKMODE
 }
 


### PR DESCRIPTION
Fixes a small bug in BOINC Manager Dark Mode support on Macintosh. If the Manager was hidden with the Event Log enabled when the system's Light / Dark Mode changed, it incorrectly showed (unhid) the Manager.

This PR is ready to be merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents BOINC Manager on macOS from unhiding when the system switches between Light and Dark Mode while the Event Log is open. Keeps the Manager hidden and avoids unnecessary UI churn.

- **Bug Fixes**
  - Preserve hidden state during system theme changes.
  - Remove Event Log close/reopen logic on theme change to avoid forced unhide and potential race conditions.

<sup>Written for commit a55e8e5565cf2a761256899dd8bb80e80c167ead. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

