### PR TITLE
[ci] update custom vcpkg ports

### DIFF
--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
@@ -1,7 +1,9 @@
 string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.gnome.org/sources/gdk-pixbuf/${VERSION_MAJOR_MINOR}/gdk-pixbuf-${VERSION}.tar.xz"
-    FILENAME "GNOME-gdk-pixbuf-${VERSION}.tar.xz"
+    URLS
+        "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+    FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
     SHA512 ae9fcc9b4e8fd10a4c9bf34c3a755205dae7bbfe13fbc93ec4e63323dad10cc862df6a9e2e2e63c84ffa01c5e120a3be06ac9fad2a7c5e58d3dc6ba14d1766e8
 )
 

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "gdk-pixbuf",
   "version": "2.42.12",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",

--- a/3rdParty/vcpkg_ports/ports/librsvg/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/librsvg/portfile.cmake
@@ -2,8 +2,9 @@
 
 string(REGEX REPLACE "^([0-9]*[.][0-9]*)[.].*" "\\1" MAJOR_MINOR "${VERSION}")
 vcpkg_download_distfile(ARCHIVE
-    URLS "https://download.gnome.org/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
-         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
+    URLS
+        "https://download.gnome.org/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/librsvg/${MAJOR_MINOR}/librsvg-${VERSION}.tar.xz"
     FILENAME "librsvg-${VERSION}.tar.xz"
     SHA512 db0563d8e0edaae642a6b2bcd239cf54191495058ac8c7ff614ebaf88c0e30bd58dbcd41f58d82a9d5ed200ced45fc5bae22f2ed3cf3826e9348a497009e1280
 )

--- a/3rdParty/vcpkg_ports/ports/librsvg/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/librsvg/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "librsvg",
   "version": "2.40.21",
-  "port-version": 1,
+  "port-version": 2,
   "description": "A small library to render Scalable Vector Graphics (SVG)",
   "homepage": "https://gitlab.gnome.org/GNOME/librsvg",
   "license": "LGPL-2.0-or-later",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update custom vcpkg ports to improve CI reliability by adding a GNOME mirror and standardizing source URLs. Bumps port-versions for gdk-pixbuf and librsvg.

- **Dependencies**
  - gdk-pixbuf: use ${PORT} URL pattern, add GNOME mirror, update archive filename; port-version 6.
  - librsvg: format URL list explicitly (no behavior change); port-version 2.

<sup>Written for commit 72833edb175aaa631506cbb6e36f3e441896af83. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

