### PR TITLE
[linux] fix updated custom vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/xcb-util/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/xcb-util/portfile.cmake
@@ -1,0 +1,32 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lib/libxcb-util
+    REF  bffd8df1725c0fae9105a097e75b466e2f49d7bd #v0.4.1
+    SHA512 59ab4e34b44d720484b0d949bf26bac8ce56bf53f82d090b9229cda2f9c761cbad279774ab644a7a77b861674cdb173b7b597ae2b5860fbc9dfde8f5db3ab30e
+    HEAD_REF master
+    PATCHES
+        ssize.patch
+)
+
+file(TOUCH "${SOURCE_PATH}/m4/dummy")
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/xcb-util/ssize.patch
+++ b/3rdParty/vcpkg_ports/ports/xcb-util/ssize.patch
@@ -1,0 +1,15 @@
+diff --git a/src/event.c b/src/event.c
+index 88058c4e7..3bc0d635f 100644
+--- a/src/event.c
++++ b/src/event.c
+@@ -38,6 +38,10 @@
+ 
+ #include <sys/types.h>
+ 
++#if !defined ssize_t && defined(_WIN32)
++    #define ssize_t ptrdiff_t
++#endif
++
+ #define ssizeof(foo)            (ssize_t)sizeof(foo)
+ #define countof(foo)            (ssizeof(foo) / ssizeof(foo[0]))
+ 

--- a/3rdParty/vcpkg_ports/ports/xcb-util/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/xcb-util/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "xcb-util",
+  "version": "0.4.1",
+  "port-version": 1,
+  "description": "C interface to the X Window System protocol, which replaces the traditional Xlib interface.",
+  "homepage": "https://xcb.freedesktop.org/",
+  "license": null,
+  "dependencies": [
+    "xcb",
+    "xcb-util-m4",
+    "xorg-macros"
+  ]
+}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix the custom vcpkg port for xcb-util to improve cross-platform builds. Linux now prefers system packages unless forced, and Windows builds are fixed with a ssize_t patch.

- **Bug Fixes**
  - Added local xcb-util port (v0.4.1) fetched from freedesktop GitLab with an autoconf build.
  - Default to system-provided X libraries on Linux unless X_VCPKG_FORCE_VCPKG_X_LIBRARIES is set.
  - Patched event.c to define ssize_t on Windows to prevent build errors.
  - Applied pkg-config fixups and removed unwanted debug include/share dirs.
  - Declared dependencies: xcb, xcb-util-m4, xorg-macros.

<sup>Written for commit 136e180999d97d06a9cea0c29cb497c77abb2d05. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



