### PR TITLE
[ci] fix macos build

### DIFF
--- a/.github/workflows/vcpkg_test.yml
+++ b/.github/workflows/vcpkg_test.yml
@@ -329,6 +329,7 @@ jobs:
         - name: Set up vcpkg
           run: |
             git clone https://github.com/microsoft/vcpkg.git
+            git -C vcpkg checkout 43f6bb399bae64df9b937e377e3a8aae8cd7a15f
             ./vcpkg/bootstrap-vcpkg.sh
 
         - name: Prepare build

--- a/osx/bootstrap_vcpkg_cmake.sh
+++ b/osx/bootstrap_vcpkg_cmake.sh
@@ -18,4 +18,5 @@ if [ ! -d $VCPKG_ROOT ]; then
 fi
 
 git -C $VCPKG_ROOT pull
+git -C $VCPKG_ROOT checkout 43f6bb399bae64df9b937e377e3a8aae8cd7a15f
 $VCPKG_ROOT/bootstrap-vcpkg.sh


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pinned vcpkg to commit 43f6bb399bae64df9b937e377e3a8aae8cd7a15f to fix macOS build failures. Applied in the GitHub Actions vcpkg_test workflow and the osx bootstrap script to avoid upstream changes breaking builds.

<sup>Written for commit 32cd0eedb42d841a60d8ed66b5f315b913444561. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



