### PR TITLE
[ci] revert fixed vcpkg hash

### DIFF
--- a/.github/workflows/vcpkg_test.yml
+++ b/.github/workflows/vcpkg_test.yml
@@ -329,7 +329,6 @@ jobs:
         - name: Set up vcpkg
           run: |
             git clone https://github.com/microsoft/vcpkg.git
-            git -C vcpkg checkout 43f6bb399bae64df9b937e377e3a8aae8cd7a15f
             ./vcpkg/bootstrap-vcpkg.sh
 
         - name: Prepare build

--- a/osx/bootstrap_vcpkg_cmake.sh
+++ b/osx/bootstrap_vcpkg_cmake.sh
@@ -18,5 +18,4 @@ if [ ! -d $VCPKG_ROOT ]; then
 fi
 
 git -C $VCPKG_ROOT pull
-git -C $VCPKG_ROOT checkout 43f6bb399bae64df9b937e377e3a8aae8cd7a15f
 $VCPKG_ROOT/bootstrap-vcpkg.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the fixed vcpkg commit checkout in CI and macOS bootstrap scripts to use the latest vcpkg. This avoids failures from stale hashes and reduces maintenance.

<sup>Written for commit 436a3a9a007bf658b65845f581aa749df932a083. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

