### PR TITLE
Add Fedora 43 linux package

### DIFF
--- a/.github/workflows/linux-package-stable-release.yml
+++ b/.github/workflows/linux-package-stable-release.yml
@@ -97,7 +97,7 @@ jobs:
       image: fedora:38
     strategy:
       matrix:
-        os: [fc37, fc38, fc39, fc40, fc41, fc42, suse15_4, suse15_5, suse15_6, suse16_0]
+        os: [fc37, fc38, fc39, fc40, fc41, fc42, fc43, suse15_4, suse15_5, suse15_6, suse16_0]
       fail-fast: false
     env:
       PUBKEY_HASH: D4460B4F0EEDE2C0662092F640254C9B29853EA6

--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -276,7 +276,7 @@ jobs:
     needs: prepare-binaries
     strategy:
       matrix:
-        os: [fc37, fc38, fc39, fc40, fc41, fc42, suse15_4, suse15_5, suse15_6, suse16_0]
+        os: [fc37, fc38, fc39, fc40, fc41, fc42, fc43, suse15_4, suse15_5, suse15_6, suse16_0]
         type: [client, manager]
         arch: [arm64, amd64]
       fail-fast: false
@@ -385,7 +385,7 @@ jobs:
             BOINCDIR=/var/lib/boinc
 
             case ${{ matrix.os }} in
-            "fc37" | "fc38" | "fc39" | "fc40" | "fc41" | "fc42")
+            "fc37" | "fc38" | "fc39" | "fc40" | "fc41" | "fc42" | "fc43")
               CA_BUNDLE="/etc/ssl/certs/ca-certificates.crt"
               ;;
             "suse15_4" | "suse15_5" | "suse15_6" | "suse16_0")
@@ -824,7 +824,7 @@ jobs:
     needs: build-rpm-package
     strategy:
       matrix:
-        os: [37, 38, 39, 40, 41, 42]
+        os: [37, 38, 39, 40, 41, 42, 43]
         type: [install, upgrade, upgrade-from-alpha, upgrade-from-stable]
         arch: [amd64]
       fail-fast: false
@@ -844,7 +844,7 @@ jobs:
           dnf install -y boinc-client boinc-manager
 
       - name: Install distro package for further upgrade from the alpha for Fedora < 41
-        if: success() && matrix.type == 'upgrade-from-alpha' && matrix.os != '41' && matrix.os != '42'
+        if: success() && matrix.type == 'upgrade-from-alpha' && matrix.os != '41' && matrix.os != '42' && matrix.os != '43'
         run: |
           dnf install -y dnf-plugins-core
           dnf config-manager --add-repo https://boinc.berkeley.edu/dl/linux/alpha/fc${{ matrix.os }}
@@ -864,7 +864,7 @@ jobs:
           dnf install -y boinc-client-${client_version} boinc-manager-${manager_version}
 
       - name: Install distro package for further upgrade from the stable for Fedora < 41
-        if: success() && matrix.type == 'upgrade-from-stable' && matrix.os != '41' && matrix.os != '42'
+        if: success() && matrix.type == 'upgrade-from-stable' && matrix.os != '41' && matrix.os != '42' && matrix.os != '43'
         run: |
           dnf install -y dnf-plugins-core
           dnf config-manager --add-repo https://boinc.berkeley.edu/dl/linux/stable/fc${{ matrix.os }}
@@ -896,13 +896,13 @@ jobs:
           name: linux-package_manager_${{ matrix.arch }}_fc${{ matrix.os }}_${{ github.event.pull_request.head.sha }}
 
       - name: Install client and manager for Fedora < 41
-        if: success() && matrix.os != '41' && matrix.os != '42'
+        if: success() && matrix.os != '41' && matrix.os != '42' && matrix.os != '43'
         run: |
           yum localinstall -y --allowerasing $(find ./ -type f -name "boinc-client*.rpm" -printf "%p\n")
           yum localinstall -y --allowerasing $(find ./ -type f -name "boinc-manager*.rpm" -printf "%p\n")
 
       - name: Install client and manager for Fedora >= 41
-        if: success() && (matrix.os == '41' || matrix.os == '42')
+        if: success() && (matrix.os == '41' || matrix.os == '42' || matrix.os == '43')
         run: |
           dnf5 install -y --allowerasing $(find ./ -type f -name "boinc-client*.rpm" -printf "%p\n")
           dnf5 install -y --allowerasing $(find ./ -type f -name "boinc-manager*.rpm" -printf "%p\n")
@@ -1090,7 +1090,7 @@ jobs:
     needs: [test-fedora-rpm-package, test-opensuse-rpm-package]
     strategy:
       matrix:
-        os: [fc37, fc38, fc39, fc40, fc41, fc42, suse15_4, suse15_5, suse15_6, suse16_0]
+        os: [fc37, fc38, fc39, fc40, fc41, fc42, fc43, suse15_4, suse15_5, suse15_6, suse16_0]
       fail-fast: false
     env:
       PUBKEY_HASH: D4460B4F0EEDE2C0662092F640254C9B29853EA6

--- a/.github/workflows/rpmrepo/package_depends.sh
+++ b/.github/workflows/rpmrepo/package_depends.sh
@@ -25,7 +25,7 @@ function exit_usage() {
 
 case "$1_$2" in
 # fedora distros
-"fc37_linux_client" | "fc38_linux_client" | "fc39_linux_client" | "fc40_linux_client" | "fc41_linux_client" | "fc42_linux_client")
+"fc37_linux_client" | "fc38_linux_client" | "fc39_linux_client" | "fc40_linux_client" | "fc41_linux_client" | "fc42_linux_client" | "fc43_linux_client")
     echo "glibc,libXScrnSaver >= 1.2.3,ca-certificates"
     ;;
 # opensuse distros

--- a/.github/workflows/rpmrepo/package_filelist.sh
+++ b/.github/workflows/rpmrepo/package_filelist.sh
@@ -18,7 +18,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 case "$1_$2" in
-"fc37_linux_client" | "fc38_linux_client" | "fc39_linux_client" | "fc40_linux_client" | "fc41_linux_client" | "fc42_linux_client" | "suse15_4_linux_client" | "suse15_5_linux_client" | "suse15_6_linux_client" | "suse16_0_linux_client")
+"fc37_linux_client" | "fc38_linux_client" | "fc39_linux_client" | "fc40_linux_client" | "fc41_linux_client" | "fc42_linux_client" | "fc43_linux_client" | "suse15_4_linux_client" | "suse15_5_linux_client" | "suse15_6_linux_client" | "suse16_0_linux_client")
     echo """/etc/default/*
 /etc/init.d/*
 /etc/bash_completion.d/*
@@ -31,7 +31,7 @@ case "$1_$2" in
 """
     ;;
 
-"fc37_linux_manager" | "fc38_linux_manager" | "fc39_linux_manager" | "fc40_linux_manager" | "fc41_linux_manager" | "fc42_linux_manager" | "suse15_4_linux_manager" | "suse15_5_linux_manager" | "suse15_6_linux_manager" | "suse16_0_linux_manager")
+"fc37_linux_manager" | "fc38_linux_manager" | "fc39_linux_manager" | "fc40_linux_manager" | "fc41_linux_manager" | "fc42_linux_manager" | "fc43_linux_manager" | "suse15_4_linux_manager" | "suse15_5_linux_manager" | "suse15_6_linux_manager" | "suse16_0_linux_manager")
     echo """/usr/local/bin/*
 /usr/local/share/applications/*
 /usr/local/share/boinc-manager/*


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Fedora 43 support to our RPM build, test, and release workflows so we can build, test, and publish packages for this distro. Also update repo scripts and install logic to treat Fedora 43 correctly.

- **New Features**
  - Added fc43 to build, test, and release matrices in linux-package and stable workflows.
  - Updated install/upgrade steps to handle Fedora 43 with dnf5 and exclude it from legacy (<41) paths.
  - Included fc43 in rpmrepo scripts (package_depends.sh, package_filelist.sh) for client and manager.

<sup>Written for commit 2e7b6c3f1991d008450d01b719bc82764f90c25b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

