### PR TITLE
[ci] fix scrutinizer failure

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: 7.2.0
+        php: 7.4
     nodes:
         analysis:
             dependencies:
@@ -13,8 +13,6 @@ build:
                     - '3rdParty/buildCache'
             tests:
                 override:
-                    - command: phpcs-run
-                      use_website_config: true
                     - php-scrutinizer-run
                     - js-scrutinizer-run
 filter:
@@ -59,107 +57,3 @@ checks:
         security_vulnerabilities: false
         no_exit: false
     javascript: true
-coding_style:
-    php:
-        indentation:
-            general:
-                use_tabs: false
-                size: 4
-            switch:
-                indent_case: false
-        spaces:
-            general:
-                linefeed_character: newline
-            before_parentheses:
-                function_declaration: false
-                closure_definition: false
-                function_call: false
-                if: true
-                for: true
-                while: true
-                switch: true
-                catch: true
-                array_initializer: false
-            around_operators:
-                assignment: true
-                logical: true
-                equality: true
-                relational: true
-                bitwise: false
-                additive: true
-                multiplicative: false
-                shift: true
-                unary_additive: false
-                concatenation: false
-                negation: false
-            before_left_brace:
-                class: true
-                function: true
-                if: true
-                else: true
-                for: true
-                while: true
-                do: true
-                switch: true
-                try: true
-                catch: true
-                finally: true
-            before_keywords:
-                else: true
-                while: true
-                catch: true
-                finally: true
-            within:
-                brackets: false
-                array_initializer: false
-                grouping: false
-                function_call: false
-                function_declaration: false
-                if: false
-                for: false
-                while: false
-                switch: false
-                catch: false
-                type_cast: false
-            ternary_operator:
-                before_condition: true
-                after_condition: true
-                before_alternative: true
-                after_alternative: true
-                in_short_version: false
-            other:
-                before_comma: false
-                after_comma: true
-                before_semicolon: false
-                after_semicolon: true
-                after_type_cast: false
-        braces:
-            classes_functions:
-                class: end-of-line
-                function: end-of-line
-                closure: end-of-line
-            if:
-                opening: end-of-line
-                always: false
-                else_on_new_line: false
-            for:
-                opening: end-of-line
-                always: true
-            while:
-                opening: end-of-line
-                always: true
-            do_while:
-                opening: end-of-line
-                always: true
-                while_on_new_line: false
-            switch:
-                opening: end-of-line
-            try:
-                opening: end-of-line
-                catch_on_new_line: false
-                finally_on_new_line: false
-        upper_lower_casing:
-            keywords:
-                general: lower
-            constants:
-                true_false_null: lower


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Scrutinizer CI failures by updating the environment to PHP 7.4 and simplifying .scrutinizer.yml. Removed phpcs-run and the legacy coding_style config to align with Scrutinizer’s current defaults.

<sup>Written for commit acbb2ad57334d94746871ce8726f37d6be131cc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

