### PR TITLE
Test BOINC installation on Windows 11 ARM64

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -136,15 +136,6 @@ jobs:
         if: success() && !startsWith(github.ref, 'refs/tags/') && matrix.configuration == 'Release'
         run: python ./tests/msi_validation.py "C:\Program Files (x86)\MsiVal2\MsiVal2.exe" "${{github.workspace}}\win_build\Build\${{matrix.platform}}\${{matrix.configuration}}\boinc.msi" "${{github.workspace}}\installer\darice.cub"
 
-      - name: Run installation
-        if: success() && matrix.platform == 'x64' && matrix.configuration == 'Release'
-        shell: powershell
-        run: Start-Process "msiexec.exe" -ArgumentList "/i ${{github.workspace}}\win_build\Build\x64\${{matrix.configuration}}\boinc.msi /quiet /qn /l*v ${{github.workspace}}\win_build\Build\x64\${{matrix.configuration}}\install.log" -Wait
-
-      - name: Run installation tests
-        if: success() && matrix.platform == 'x64' && matrix.configuration == 'Release'
-        run: python ./tests/windows_installer_integration_tests.py
-
       - name: Prepare logs on failure
         if: ${{failure()}}
         run: |
@@ -213,6 +204,73 @@ jobs:
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  msbuild-test:
+    name: ${{matrix.platform}}-${{matrix.type}}-msbuild-test
+    runs-on: ${{matrix.runner}}
+    needs: msbuild
+    strategy:
+      matrix:
+        type: [install, upgrade_from_alpha, upgrade_from_stable]
+        platform: [x64, arm64]
+        include:
+          - platform: x64
+            runner: windows-latest
+          - platform: arm64
+            runner: windows-11-arm
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          fetch-depth: 2
+
+      - name: Install previous alpha version
+        if: success() && matrix.type == 'upgrade_from_alpha'
+        shell: powershell
+        run: |
+          python ./tests/download_boinc_installer.py ${{matrix.platform}} alpha
+          if (Test-Path "./${{matrix.platform}}_alpha.exe") {
+            Start-Process "./${{matrix.platform}}_alpha.exe" -ArgumentList "/quiet /qn /l*v alpha.log" -Wait
+          }
+
+      - name: Install previous stable version
+        if: success() && matrix.type == 'upgrade_from_stable'
+        shell: powershell
+        run: |
+          python ./tests/download_boinc_installer.py ${{matrix.platform}} release
+          if (Test-Path "./${{matrix.platform}}_release.exe") {
+            Start-Process "./${{matrix.platform}}_release.exe" -ArgumentList "/quiet /qn /l*v release.log" -Wait
+          }
+
+      - name: Download installer artifact
+        if: success()
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          name: win_installer_${{matrix.platform}}_${{github.event.pull_request.head.sha}}
+
+      - name: Extract installer artifact
+        if: success()
+        run: |
+          7z x win_installer.7z
+
+      - name: Run installation
+        if: success()
+        shell: powershell
+        run: Start-Process "./installer_setup.exe" -ArgumentList "/quiet /qn /l*v install.log" -Wait
+
+      - name: Run installation tests
+        if: success()
+        run: python ./tests/windows_installer_integration_tests.py
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: windows_installer_test_logs_${{matrix.platform}}_${{matrix.type}}_${{github.event.pull_request.head.sha}}
+          path: |
+            install.log
+            alpha.log
+            release.log
 
   cmake:
     name: ${{matrix.configuration}}-${{matrix.platform}}-cmake

--- a/tests/download_boinc_installer.py
+++ b/tests/download_boinc_installer.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+# This file is part of BOINC.
+# https://boinc.berkeley.edu
+# Copyright (C) 2026 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Download BOINC installer for Windows based on platform and version type.
+
+Usage:
+    python3 download_boinc_installer.py <platform> <type>
+
+    platform: x64 or arm64
+    type: release or alpha
+
+Examples:
+    python3 download_boinc_installer.py x64 release
+    python3 download_boinc_installer.py arm64 alpha
+"""
+
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+
+
+def download_file(url, filename):
+    """Download a file from URL and save it with the given filename."""
+    print(f"Downloading {url}...")
+    urllib.request.urlretrieve(url, filename)
+    print(f"Successfully downloaded to {filename}")
+
+
+def get_download_url(xml_content, platform, version_type):
+    """
+    Parse XML and extract download URL based on platform and version type.
+
+    Args:
+        xml_content: XML content as string
+        platform: 'x64' or 'arm64'
+        version_type: 'release' or 'alpha'
+
+    Returns:
+        URL string or None if not found
+    """
+    root = ET.fromstring(xml_content)
+
+    # Map input parameters to XML values
+    platform_map = {
+        'x64': 'Windows Intel-compatible 64-bit',
+        'arm64': 'Windows ARM 64-bit'
+    }
+
+    version_map = {
+        'release': 'Recommended version',
+        'alpha': 'Development version'
+    }
+
+    target_platform = platform_map.get(platform)
+    target_version = version_map.get(version_type)
+
+    if not target_platform or not target_version:
+        print(f"Error: Invalid platform '{platform}' or type '{version_type}'")
+        return None
+
+    # Find matching version entry
+    for version in root.findall('version'):
+        platform_elem = version.find('platform')
+        description_elem = version.find('description')
+        url_elem = version.find('url')
+
+        if (platform_elem is not None and platform_elem.text == target_platform and
+            description_elem is not None and description_elem.text == target_version and
+            url_elem is not None):
+            return url_elem.text
+
+    return None
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python3 download_boinc_installer.py <platform> <type>")
+        print("  platform: x64 or arm64")
+        print("  type: release or alpha")
+        sys.exit(1)
+
+    platform = sys.argv[1].lower()
+    version_type = sys.argv[2].lower()
+
+    if platform not in ['x64', 'arm64']:
+        print(f"Error: Invalid platform '{platform}'. Use 'x64' or 'arm64'")
+        sys.exit(1)
+
+    if version_type not in ['release', 'alpha']:
+        print(f"Error: Invalid type '{version_type}'. Use 'release' or 'alpha'")
+        sys.exit(1)
+
+    xml_url = 'https://boinc.berkeley.edu/download_all.php?xml=1'
+
+    print(f"Fetching version information from {xml_url}...")
+    try:
+        with urllib.request.urlopen(xml_url) as response:
+            xml_content = response.read().decode('utf-8')
+    except Exception as e:
+        print(f"Error downloading XML: {e}")
+        sys.exit(1)
+
+    download_url = get_download_url(xml_content, platform, version_type)
+
+    if not download_url:
+        if version_type == 'alpha':
+            print(f"Development version for {platform} is not available. This is normal.")
+            sys.exit(0)
+        else:
+            print(f"Error: Could not find download URL for {platform} {version_type}")
+            sys.exit(1)
+
+    output_filename = f"{platform}_{version_type}.exe"
+
+    try:
+        download_file(download_url, output_filename)
+        print(f"Download completed successfully: {output_filename}")
+    except Exception as e:
+        print(f"Error downloading file: {e}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a dedicated CI job to validate BOINC installation and upgrade paths on Windows x64 and Windows 11 ARM64. It downloads the installer artifact, performs a quiet install, and runs integration tests.

- **New Features**
  - Run clean install and upgrade tests (from previous alpha and stable) on Windows x64 and Windows 11 ARM64.
  - Use the packaged installer artifact (7z extraction + installer_setup.exe) with logging; add a helper script to fetch previous installers from the official feed.

- **Refactors**
  - Move installation and test steps out of the msbuild job into a separate msbuild-test job that depends on msbuild.
  - Expand the matrix to platform (x64, ARM64) and type (install, upgrade_from_alpha, upgrade_from_stable); disable fail-fast.

<sup>Written for commit 74b89e4608c14d51d35c0c4ec5aeece3cb1bb539. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

