### PR TITLE
web: get jquery from jquery.com rather than googleapis.com

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -29,6 +29,8 @@ require_once("../inc/translation.inc");
 require_once("../inc/profile.inc");
 require_once("../inc/bootstrap.inc");
 
+define('JQUERY_URL', 'https://code.jquery.com/jquery-3.7.1.slim.min.js');
+
 function master_url() {
     return parse_config(get_config() , "<master_url>");
 }
@@ -166,7 +168,7 @@ function send_cookie($name, $value, $permanent, $ops=false) {
     setcookie($name, $value, $expire, $path,
         '',
         is_https(),     // if this page is secure, make cookie secure
-        true            // httponly; no JS access
+        true            // use cookie for HTTP only; no JS access
     );
 }
 
@@ -292,7 +294,7 @@ function page_head(
         <html lang="en">
         <head>
     ';
-    echo '<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>';
+    echo sprintf('<script src="%s"></script>', JQUERY_URL);
 
     if (defined('GLOBAL_HEAD_EXTRA')) {
         echo GLOBAL_HEAD_EXTRA;

--- a/html/inc/util_ops.inc
+++ b/html/inc/util_ops.inc
@@ -48,13 +48,13 @@ function admin_page_head($title) {
 function admin_page_tail() {
     echo sprintf('
         <hr><center><a href=index.php>Main page</a></center>
-        <script src="%s/jquery.min.js"></script>
+        <script src="%s"></script>
         <script src="%s/bootstrap.min.js"></script>
         </div>
         </body>
         </html>
         ',
-        secure_url_base(),
+        JQUERY_URL,
         secure_url_base()
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched jQuery to load from code.jquery.com and centralized the URL with a JQUERY_URL constant. Removes the googleapis.com dependency and standardizes jQuery loading across public and admin pages.

- **Dependencies**
  - jQuery now served from https://code.jquery.com/jquery-3.7.1.slim.min.js.
  - Replaced hardcoded script tags in util.inc and util_ops.inc with JQUERY_URL.

<sup>Written for commit e65abfed6e2ed4de2deade9ba84949379e52849d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

