### PR TITLE
Test updated freeglut library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/freeglut/android.patch
+++ b/3rdParty/vcpkg_ports/ports/freeglut/android.patch
@@ -1,0 +1,12 @@
+diff --git a/src/android/native_app_glue/android_native_app_glue.c b/src/android/native_app_glue/android_native_app_glue.c
+index be8d941..6ddae78 100644
+--- a/src/android/native_app_glue/android_native_app_glue.c
++++ b/src/android/native_app_glue/android_native_app_glue.c
+@@ -18,6 +18,7 @@
+ #include <jni.h>
+ 
+ #include <errno.h>
++#include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
+ #include <sys/resource.h>

--- a/3rdParty/vcpkg_ports/ports/freeglut/fix-debug-macro.patch
+++ b/3rdParty/vcpkg_ports/ports/freeglut/fix-debug-macro.patch
@@ -1,0 +1,35 @@
+diff --git a/include/GL/freeglut_std.h b/include/GL/freeglut_std.h
+index a658c7c..a5efb3b 100644
+--- a/include/GL/freeglut_std.h
++++ b/include/GL/freeglut_std.h
+@@ -70,7 +70,7 @@
+ 
+         /* Link with Win32 static freeglut lib */
+ #       if FREEGLUT_LIB_PRAGMAS
+-#           ifdef NDEBUG
++#           if defined(NDEBUG) || !defined(_DEBUG)
+ #              pragma comment (lib, "freeglut_static.lib")
+ #           else
+ #              pragma comment (lib, "freeglut_staticd.lib")
+@@ -88,7 +88,7 @@
+ 
+             /* Link with Win32 shared freeglut lib */
+ #           if FREEGLUT_LIB_PRAGMAS
+-#               ifdef NDEBUG
++#               if defined(NDEBUG) || !defined(_DEBUG)
+ #                   pragma comment (lib, "freeglut.lib")
+ #               else
+ #                   pragma comment (lib, "freeglutd.lib")
+diff --git a/src/blackberry/fg_main_blackberry.c b/src/blackberry/fg_main_blackberry.c
+index a1b9cbb..a20c53d 100644
+--- a/src/blackberry/fg_main_blackberry.c
++++ b/src/blackberry/fg_main_blackberry.c
+@@ -31,7 +31,7 @@
+ #include "fg_internal.h"
+ #include "egl/fg_window_egl.h"
+ 
+-#ifdef NDEBUG
++#if defined(NDEBUG) || !defined(_DEBUG)
+ #define LOGI(...)
+ #endif
+ 

--- a/3rdParty/vcpkg_ports/ports/freeglut/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/freeglut/portfile.cmake
@@ -1,0 +1,67 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO FreeGLUTProject/freeglut
+    REF "v${VERSION}"
+    SHA512 5e891e838a11ffbd5c2aea1f39004be6a0ccc1da11d661a37302c316734e0986ed86622f174ae91f40572ce9d0fbe9c43e0976ee8636f2de25aa8e1ecf256785
+    HEAD_REF master
+    PATCHES
+        android.patch
+        x11-dependencies-export.patch
+        fix-debug-macro.patch
+        windows-output-name.patch
+)
+
+if(VCPKG_TARGET_IS_OSX)
+    message("Freeglut currently requires Xquartz for macOS.")
+elseif(NOT VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_ANDROID)
+    message("Freeglut currently requires the following libraries from the system package manager:\n    opengl\n    glu\n    libx11\n    xrandr\n    xi\n    xxf86vm\n\nThese can be installed on Ubuntu systems via apt-get install libxi-dev libgl1-mesa-dev libglu1-mesa-dev mesa-common-dev libxrandr-dev libxxf86vm-dev")
+endif()
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" FREEGLUT_STATIC)
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "dynamic" FREEGLUT_DYNAMIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DFREEGLUT_BUILD_STATIC_LIBS=${FREEGLUT_STATIC}
+        -DFREEGLUT_BUILD_SHARED_LIBS=${FREEGLUT_DYNAMIC}
+        -DFREEGLUT_REPLACE_GLUT=ON
+        -DFREEGLUT_BUILD_DEMOS=OFF
+        -DINSTALL_PDB=OFF # Installing pdbs failed on debug static. So, disable it and let vcpkg_copy_pdbs() do it
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/FreeGLUT)
+vcpkg_fixup_pkgconfig()
+
+file(GLOB pc_files "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/*.pc"  "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/*.pc")
+foreach(file IN LISTS pc_files)
+    vcpkg_replace_string("${file}" ";-D" " -D" IGNORE_UNCHANGED)
+endforeach()
+
+if(NOT VCPKG_TARGET_IS_ANDROID)
+    file(COPY_FILE "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/glut.pc" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/freeglut.pc")
+    if(NOT VCPKG_BUILD_TYPE)
+        if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
+            vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glut.pc" " -lfreeglut" " -lfreeglutd" IGNORE_UNCHANGED)
+        endif()
+        file(COPY_FILE "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glut.pc" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/freeglut.pc")
+    endif()
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    vcpkg_replace_string(
+        "${CURRENT_PACKAGES_DIR}/include/GL/freeglut_std.h"
+        "ifdef FREEGLUT_STATIC"
+        "if 1 //ifdef FREEGLUT_STATIC"
+    )
+endif()
+
+# Clean
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/glut")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/freeglut/usage
+++ b/3rdParty/vcpkg_ports/ports/freeglut/usage
@@ -1,0 +1,9 @@
+freeglut provides CMake targets:
+
+    find_package(FreeGLUT CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE $<IF:$<TARGET_EXISTS:FreeGLUT::freeglut>,FreeGLUT::freeglut,FreeGLUT::freeglut_static>)
+
+freeglut is compatible with built-in CMake targets:
+
+    find_package(GLUT REQUIRED)
+    target_link_libraries(main PRIVATE GLUT::GLUT)

--- a/3rdParty/vcpkg_ports/ports/freeglut/vcpkg-cmake-wrapper.cmake
+++ b/3rdParty/vcpkg_ports/ports/freeglut/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,37 @@
+_find_package(${ARGS})
+if(GLUT_FOUND AND UNIX AND NOT ANDROID)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0012 NEW)
+    cmake_policy(SET CMP0054 NEW)
+    cmake_policy(SET CMP0057 NEW)
+
+    if(GLUT_LINK_LIBRARIES)
+        # Since CMake 3.22, FindGLUT.cmake loads the glut pkg-config module.
+        # We need `-lglut` resolved to an absolute path.
+        set(GLUT_LIBRARIES "${GLUT_LINK_LIBRARIES}")
+    else()
+        find_package(X11)
+        # Before CMake 3.14, FindX11.cmake doesn't create imported targets.
+        # For X11, we simply assume shared linkage of system libs,
+        # so order and transitive usage requirements don't matter.
+        if(X11_FOUND AND NOT "X11" IN_LIST GLUT_LIBRARIES)
+            list(APPEND GLUT_LIBRARIES "${X11_X11_LIB}")
+            set_property(TARGET GLUT::GLUT APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${X11_X11_LIB}")
+        endif()
+        if(X11_Xrandr_FOUND AND NOT "Xrandr" IN_LIST GLUT_LIBRARIES)
+            list(APPEND GLUT_LIBRARIES "${X11_Xrandr_LIB}")
+            set_property(TARGET GLUT::GLUT APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${X11_Xrandr_LIB}")
+        endif()
+        # X11_xf86vmode_FOUND for CMake < 3.14
+        if((X11_Xxf86vm_FOUND OR X11_xf86vmode_FOUND) AND NOT "Xxf86vm" IN_LIST GLUT_LIBRARIES)
+            list(APPEND GLUT_LIBRARIES "${X11_Xxf86vm_LIB}")
+            set_property(TARGET GLUT::GLUT APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${X11_Xxf86vm_LIB}")
+        endif()
+        if(X11_Xi_FOUND AND NOT GLUT_Xi_LIBRARY AND NOT "Xi" IN_LIST GLUT_LIBRARIES)
+            list(APPEND GLUT_LIBRARIES "${X11_Xi_LIB}")
+            set_property(TARGET GLUT::GLUT APPEND PROPERTY INTERFACE_LINK_LIBRARIES "${X11_Xi_LIB}")
+        endif()
+    endif()
+
+    cmake_policy(POP)
+endif()

--- a/3rdParty/vcpkg_ports/ports/freeglut/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/freeglut/vcpkg.json
@@ -1,0 +1,19 @@
+{
+  "name": "freeglut",
+  "version": "3.8.0",
+  "description": "A free OpenGL utility toolkit, the open-sourced alternative to the GLUT library.",
+  "homepage": "https://sourceforge.net/projects/freeglut/",
+  "license": null,
+  "supports": "!ios",
+  "dependencies": [
+    "opengl",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}

--- a/3rdParty/vcpkg_ports/ports/freeglut/windows-output-name.patch
+++ b/3rdParty/vcpkg_ports/ports/freeglut/windows-output-name.patch
@@ -1,0 +1,35 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 99957a1..9a5fb2b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -533,12 +533,12 @@ IF(WIN32)
+     LIST(APPEND LIBS winmm gdi32)
+     IF(FREEGLUT_BUILD_SHARED_LIBS)
+         TARGET_COMPILE_DEFINITIONS(freeglut PRIVATE FREEGLUT_EXPORTS)
+-        SET_TARGET_PROPERTIES(freeglut PROPERTIES OUTPUT_NAME ${LIBNAME})
++        SET_TARGET_PROPERTIES(freeglut PROPERTIES OUTPUT_NAME freeglut)
+     ENDIF()
+     IF(FREEGLUT_BUILD_STATIC_LIBS)
+         TARGET_COMPILE_DEFINITIONS(freeglut_static PUBLIC FREEGLUT_STATIC)
+         IF(FREEGLUT_REPLACE_GLUT)
+-            SET_TARGET_PROPERTIES(freeglut_static PROPERTIES OUTPUT_NAME ${LIBNAME})
++            SET_TARGET_PROPERTIES(freeglut_static PROPERTIES OUTPUT_NAME freeglut)
+         ENDIF()
+         # need to set machine:x64 for linker, at least for VC10, and
+         # doesn't hurt for older compilers:
+diff --git a/include/GL/freeglut_std.h b/include/GL/freeglut_std.h
+index e5da4ce..4eea6eb 100644
+--- a/include/GL/freeglut_std.h
++++ b/include/GL/freeglut_std.h
+@@ -71,9 +71,9 @@
+         /* Link with Win32 static freeglut lib */
+ #       if FREEGLUT_LIB_PRAGMAS
+ #           if defined(NDEBUG) || !defined(_DEBUG)
+-#              pragma comment (lib, "freeglut_static.lib")
++#              pragma comment (lib, "freeglut.lib")
+ #           else
+-#              pragma comment (lib, "freeglut_staticd.lib")
++#              pragma comment (lib, "freeglutd.lib")
+ #           endif
+ #       endif
+ 

--- a/3rdParty/vcpkg_ports/ports/freeglut/x11-dependencies-export.patch
+++ b/3rdParty/vcpkg_ports/ports/freeglut/x11-dependencies-export.patch
@@ -1,0 +1,20 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5568b63..bec3de5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -620,6 +620,15 @@ ELSE()
+     SET(PC_LIBS_PRIVATE "-lX11 -lXxf86vm -lXrandr -lGL -lm")
+   ENDIF()
+ ENDIF()
++if(NOT X11_Xrandr_FOUND)
++    string(REPLACE " -lXrandr" "" PC_LIBS_PRIVATE "${PC_LIBS_PRIVATE}")
++endif()
++if(NOT X11_xf86vmode_FOUND)
++    string(REPLACE " -lXxf86vm" "" PC_LIBS_PRIVATE "${PC_LIBS_PRIVATE}")
++endif()
++if(X11_Xinput_FOUND)
++    string(REPLACE "-lX11 " "-lX11 -lXi " PC_LIBS_PRIVATE "${PC_LIBS_PRIVATE}")
++endif()
+ # Client applications need to define FreeGLUT GLES version to
+ # bootstrap headers inclusion in freeglut_std.h:
+ SET(PC_LIBNAME ${LIBNAME})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a vcpkg port for FreeGLUT 3.8.0 with a CMake wrapper and patches to ensure consistent names and correct linkage on Windows, Linux/X11, and Android. This makes using FreeGLUT via find_package (FreeGLUT or GLUT) straightforward and fixes several build/link issues.

- **New Features**
  - Added vcpkg port for FreeGLUT 3.8.0 with config fixups and usage docs.
  - CMake wrapper supports both FreeGLUT and GLUT targets and resolves X11 linkage.
  - Normalized Windows output names to freeglut/freeglutd to match pragma expectations.

- **Bug Fixes**
  - Corrected debug macro checks to pick the right lib on Windows and quiet logs on BlackBerry.
  - Fixed pkg-config entries and conditionally exported X11 libs to avoid missing symbols.
  - Added stdlib include in Android native glue for clean builds.

<sup>Written for commit a415cdf7ce71098a4a550a6c5a04ca7c4606e373. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

