### PR TITLE
Test updated libcap library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libcap/configure
+++ b/3rdParty/vcpkg_ports/ports/libcap/configure
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+set -e
+
+linkage=shared
+prefix=
+for OPTION; do
+    case "${OPTION}" in
+    --prefix=*)
+        prefix="${OPTION#--prefix=}"
+        ;;
+    --enable-static)
+        linkage=static
+        ;;
+    esac
+done
+
+cat > Makefile.vcpkg <<END_MAKEFILE ;
+
+BUILD_OPTIONS = \
+    "AR=$AR" \
+    "BUILD_CC=$CC" \
+    "CC=$CC" \
+    "OBJCOPY=$OBJCOPY" \
+    "RANLIB=$RANLIB" \
+    "lib=lib" \
+    "prefix=$prefix"
+
+ifeq ($linkage,shared)
+libs := libcap.so libpsx.so
+BUILD_OPTIONS += SHARED=yes
+else
+libs := libcap.a libpsx.a
+BUILD_OPTIONS += SHARED=no
+endif
+
+all: libcap/cap_names.h
+	\$(MAKE) -C libcap pcs \$(libs) \$(BUILD_OPTIONS)
+
+libcap/cap_names.h:
+	\$(MAKE) -C libcap cap_names.h \$(BUILD_OPTIONS)
+
+install: install-cap_names
+	\$(MAKE) -C libcap install-$linkage \$(BUILD_OPTIONS)
+
+install-cap_names:
+	mkdir -p -m 0755 "\$(DESTDIR)$prefix/include/sys/libcap-private"
+	install -m 0644 libcap/cap_names.h "\$(DESTDIR)$prefix/include/sys/libcap-private"
+	install -m 0644 libcap/cap_names.list.h "\$(DESTDIR)$prefix/include/sys/libcap-private"
+
+END_MAKEFILE

--- a/3rdParty/vcpkg_ports/ports/libcap/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libcap/portfile.cmake
@@ -1,0 +1,33 @@
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${VERSION}.tar.xz"
+         "https://www.mirrorservice.org/sites/ftp.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-${VERSION}.tar.xz"
+    FILENAME "libcap-${VERSION}.tar.xz"
+    SHA512 c783cb43ffb40eb005fb880efe18e72667c743af79d647f67ee3201d5ff1e64446f9c850cced935a04b63a8ee3380bbf28dd91e2dfbcbddb561c8d096da610d0
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+)
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/configure" DESTINATION "${SOURCE_PATH}")
+
+if(VCPKG_CROSSCOMPILING)
+    file(TOUCH "${SOURCE_PATH}/libcap/_makenames")
+    file(COPY "${CURRENT_HOST_INSTALLED_DIR}/include/sys/libcap-private/cap_names.list.h" DESTINATION "${SOURCE_PATH}/libcap/")
+    file(COPY "${CURRENT_HOST_INSTALLED_DIR}/include/sys/libcap-private/cap_names.h" DESTINATION "${SOURCE_PATH}/libcap/")
+    file(TOUCH "${SOURCE_PATH}/libcap/cap_names.h")
+endif()
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+set(ENV{OBJCOPY} "${VCPKG_DETECTED_CMAKE_OBJCOPY}")
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    COPY_SOURCE
+)
+vcpkg_make_install(MAKEFILE "Makefile.vcpkg")
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/License")

--- a/3rdParty/vcpkg_ports/ports/libcap/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libcap/vcpkg.json
@@ -1,0 +1,22 @@
+{
+  "name": "libcap",
+  "version": "2.77",
+  "description": "A library for getting and setting POSIX.1e (formerly POSIX 6) draft 15 capabilities.",
+  "homepage": "https://sites.google.com/site/fullycapable/",
+  "license": "BSD-3-Clause OR GPL-2.0-only",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "libcap",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    },
+    {
+      "name": "vcpkg-make",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for libcap 2.77. Updates our Linux capability library and enables consistent builds, including cross-compilation.

- **New Features**
  - Adds Linux-only vcpkg port for libcap 2.77.
  - Supports cross-compiling by pre-generating cap_names and setting OBJCOPY.
  - Builds via vcpkg-make, fixes pkg-config, removes debug includes, installs license; host deps: libcap, vcpkg-cmake-get-vars, vcpkg-make.

<sup>Written for commit a74e341b590df84fc23c7f29fd234672d7351220. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

