### PR TITLE
Test updated libmount library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libmount/hide-private-symbols.diff
+++ b/3rdParty/vcpkg_ports/ports/libmount/hide-private-symbols.diff
@@ -1,0 +1,15 @@
+diff --git a/include/strutils.h b/include/strutils.h
+index e9f8a0c..2f6d285 100644
+--- a/include/strutils.h
++++ b/include/strutils.h
+@@ -16,6 +16,10 @@
+ 
+ #include "c.h"
+ 
++// private, and clashing with libsystemd.
++#define parse_size ul__parse_size
++#define parse_range ul__parse_range
++
+ /* initialize a custom exit code for all *_or_err functions */
+ extern void strutils_set_exitcode(int exit_code);
+ 

--- a/3rdParty/vcpkg_ports/ports/libmount/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libmount/portfile.cmake
@@ -1,0 +1,57 @@
+string(REGEX MATCH "^([0-9]+\\.[0-9]+)" VERSION_SHORT "${VERSION}")
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v${VERSION_SHORT}/util-linux-${VERSION}.tar.xz"
+    FILENAME "util-linux-${VERSION}.tar.xz"
+    SHA512 3d299f0e05a4c982a04dbcbaaeff1222152feedf51c56c5dbdeb75999c68269d652a994f5cdf4c1ee42bb7b28475dd0792192c299fd9bc3b45198c5b153dad00
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    SOURCE_BASE ${VERSION}
+    PATCHES
+        hide-private-symbols.diff
+)
+
+set(ENV{GTKDOCIZE} true)
+
+vcpkg_list(SET options)
+if("nls" IN_LIST FEATURES)
+    vcpkg_list(APPEND options "--enable-nls")
+else()
+    set(ENV{AUTOPOINT} true) # true, the program
+    vcpkg_list(APPEND options "--disable-nls")
+endif()
+if(VCPKG_TARGET_ARCHITECTURE STREQUAL "arm")
+    vcpkg_list(APPEND options "--disable-year2038")
+endif()
+
+vcpkg_configure_make(
+    AUTOCONFIG
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${options}
+        --disable-asciidoc
+        --disable-all-programs
+        --disable-dependency-tracking
+        --enable-libmount
+        --enable-libblkid
+        "--mandir=${CURRENT_PACKAGES_DIR}/share/man"
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/bin"
+    "${CURRENT_PACKAGES_DIR}/debug/sbin"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/bin"
+    "${CURRENT_PACKAGES_DIR}/sbin"
+    "${CURRENT_PACKAGES_DIR}/share"
+    "${CURRENT_PACKAGES_DIR}/tools"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/README.licensing" "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/libmount/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libmount/vcpkg.json
@@ -1,0 +1,23 @@
+{
+  "name": "libmount",
+  "version": "2.41.3",
+  "description": "Block device identification library from util-linux",
+  "homepage": "https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/about/",
+  "license": null,
+  "supports": "linux",
+  "features": {
+    "nls": {
+      "description": "Enable native language support",
+      "dependencies": [
+        {
+          "name": "gettext",
+          "host": true,
+          "features": [
+            "tools"
+          ]
+        },
+        "gettext-libintl"
+      ]
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Linux-only vcpkg port for util-linux 2.41.3 to build libmount and libblkid. This lets us consume these libraries via vcpkg.

- **New Features**
  - Adds a custom port that builds only libmount/libblkid, disables programs/docs, and supports optional NLS (via gettext); disables year2038 on ARM.
  - Applies hide-private-symbols.diff to rename parse_size/parse_range to ul__parse_size/ul__parse_range to avoid clashes with libsystemd.
  - Cleans installed package (removes bin/sbin/share/tools) and includes licensing; vcpkg.json restricts support to Linux.

<sup>Written for commit 0f9a751c5af36c17f9d93496b14984b4676e181f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

