### PR TITLE
Test updated pango library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/pango/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/pango/portfile.cmake
@@ -1,0 +1,53 @@
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" VERSION_MAJOR_MINOR "${VERSION}")
+vcpkg_download_distfile(SOURCE_ARCHIVE
+    URLS
+        "https://download.gnome.org/sources/pango/${VERSION_MAJOR_MINOR}/pango-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+    FILENAME "pango-${VERSION}.tar.xz"
+    SHA512 e3d251e0c2d5cb7f2e9d26e675aa2fae0c3cedce9e73b77f92a4abbeff55eaa819811e4c064ca036d3964a3ee4592f596ebfa7c0a760189b9d8c38a5f3a4ea3a
+)
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${SOURCE_ARCHIVE}"
+    PATCHES
+        relax-gi-requirement.diff
+)
+
+if("introspection" IN_LIST FEATURES)
+    list(APPEND OPTIONS_RELEASE -Dintrospection=enabled)
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND OPTIONS_RELEASE -Dintrospection=disabled)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Ddocumentation=false
+        -Dman-pages=false
+        -Dbuild-testsuite=false
+        -Dbuild-examples=false
+        -Dfontconfig=enabled # Build with FontConfig support.
+        -Dsysprof=disabled # include tracing support for sysprof
+        -Dlibthai=disabled # Build with libthai support
+        -Dcairo=enabled # Build with cairo support
+        -Dxft=disabled # Build with xft support
+        -Dfreetype=enabled # Build with freetype support
+        ${OPTIONS}
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    OPTIONS_DEBUG
+        -Dintrospection=disabled
+    ADDITIONAL_BINARIES
+        "glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'"
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
+)
+
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+vcpkg_fixup_pkgconfig()
+vcpkg_copy_pdbs()
+
+vcpkg_copy_tools(TOOL_NAMES pango-view pango-list pango-segmentation AUTO_CLEAN)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/pango/relax-gi-requirement.diff
+++ b/3rdParty/vcpkg_ports/ports/pango/relax-gi-requirement.diff
@@ -1,0 +1,25 @@
+diff --git a/meson.build b/meson.build
+index b8098c1..10033c8 100644
+--- a/meson.build
++++ b/meson.build
+@@ -209,7 +209,7 @@ glib_major_req = 2
+ glib_minor_req = 82
+ 
+ glib_req       = '>= @0@.@1@'.format(glib_major_req, glib_minor_req)
+-gi_req         = '>= 1.83.2'
++gi_req         = '>= 1.82.0'
+ fribidi_req    = '>= 1.0.6'
+ libthai_req    = '>= 0.1.9'
+ harfbuzz_req   = '>= 8.4.0'
+diff --git a/pango/meson.build b/pango/meson.build
+index f3c6d70..674b702 100644
+--- a/pango/meson.build
++++ b/pango/meson.build
+@@ -132,7 +132,6 @@ pango_dep_sources = [pango_enum_h]
+ if build_gir
+   gir_args = [
+     '--quiet',
+-    '--doc-format=gi-docgen',
+   ]
+   harfbuzz_gobject_dep = dependency('harfbuzz-gobject',
+                                     version: harfbuzz_req,

--- a/3rdParty/vcpkg_ports/ports/pango/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/pango/vcpkg.json
@@ -1,0 +1,61 @@
+{
+  "name": "pango",
+  "version": "1.57.0",
+  "description": "Text and font handling library.",
+  "homepage": "https://ftp.gnome.org/pub/GNOME/sources/pango/",
+  "license": "LGPL-2.0-or-later",
+  "supports": "!xbox",
+  "dependencies": [
+    {
+      "name": "cairo",
+      "features": [
+        "gobject"
+      ]
+    },
+    "fontconfig",
+    "freetype",
+    "fribidi",
+    {
+      "name": "gettext",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
+    },
+    "gettext-libintl",
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    "harfbuzz",
+    {
+      "name": "harfbuzz",
+      "features": [
+        "coretext"
+      ],
+      "platform": "osx"
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "introspection": {
+      "description": "Build with introspection",
+      "supports": "!static",
+      "dependencies": [
+        "gobject-introspection",
+        {
+          "name": "harfbuzz",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for Pango 1.57.0 with Meson build settings and a patch to relax gobject-introspection requirements for broader CI compatibility.

- **New Features**
  - New vcpkg port: pango 1.57.0 (vcpkg.json, portfile.cmake).
  - Patch lowers gobject-introspection to >=1.82.0 and removes gi-docgen arg.
  - Meson: enable cairo/fontconfig/freetype; disable docs, man pages, tests, examples; optional introspection (off in Debug).
  - Installs tools (pango-view, pango-list, pango-segmentation) and fixes pkg-config files.

<sup>Written for commit bbb58aed00e174e81366228246b24094af350f49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

