### PR TITLE
Test updated xtrans library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/xtrans/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/xtrans/portfile.cmake
@@ -1,0 +1,53 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lib/libxtrans
+    REF  xtrans-${VERSION}
+    SHA512 c7037cb6d2fb641486a43c9203949edec2038735ba758f8556add63598dbb3205166a2ec272700639884b1952642c171806e3dab566722cadd4c71ca98c0a1bf
+    HEAD_REF master
+    PATCHES win32.patch
+            symbols.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+vcpkg_configure_make(
+    SOURCE_PATH ${SOURCE_PATH}
+    AUTOCONFIG
+)
+
+vcpkg_install_make()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/xorg")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+# the include folder is moved since it contains source files. It is not meant as a traditional include folder but as a shared files folder for different x libraries.
+file(RENAME "${CURRENT_PACKAGES_DIR}/include" "${CURRENT_PACKAGES_DIR}/share/${PORT}/include")
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/lib")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/pkgconfig/" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+file(RENAME "${CURRENT_PACKAGES_DIR}/share/${PORT}/aclocal/" "${CURRENT_PACKAGES_DIR}/share/xorg/aclocal")
+if(NOT VCPKG_BUILD_TYPE)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/debug/lib")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/${PORT}/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/" "${CURRENT_PACKAGES_DIR}/share/xorg/debug")
+endif()
+vcpkg_fixup_pkgconfig() # must be called after files have been moved
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/xtrans.pc" "includedir=\${prefix}/include" "includedir=\${prefix}/share/${PORT}/include")
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/xtrans.pc" "includedir=\${prefix}/../include" "includedir=\${prefix}/../share/${PORT}/include")
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/usage" "")
+endif()

--- a/3rdParty/vcpkg_ports/ports/xtrans/symbols.patch
+++ b/3rdParty/vcpkg_ports/ports/xtrans/symbols.patch
@@ -1,0 +1,15 @@
+diff --git a/Xtransutil.c b/Xtransutil.c
+index 2aa4686..57c6ce3 100644
+--- a/Xtransutil.c
++++ b/Xtransutil.c
+@@ -60,6 +60,10 @@ from The Open Group.
+ #ifdef WIN32
+ #include <X11/Xlibint.h>
+ #include <X11/Xwinsock.h>
++#ifdef _MSC_VER
++# include <direct.h>
++# define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
++#endif
+ #endif
+
+ #if defined(IPv6) && !defined(AF_INET6)

--- a/3rdParty/vcpkg_ports/ports/xtrans/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/xtrans/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "xtrans",
+  "version": "1.6.0",
+  "description": "xtrans - X Network Transport layer shared code",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxtrans",
+  "license": null,
+  "dependencies": [
+    "xorg-macros"
+  ]
+}

--- a/3rdParty/vcpkg_ports/ports/xtrans/win32.patch
+++ b/3rdParty/vcpkg_ports/ports/xtrans/win32.patch
@@ -1,0 +1,58 @@
+diff --git a/Xtrans.h b/Xtrans.h
+index fbf385e01..e52e7cba2 100644
+--- a/Xtrans.h
++++ b/Xtrans.h
+@@ -50,6 +50,10 @@ from The Open Group.
+ #ifndef _XTRANS_H_
+ #define _XTRANS_H_
+ 
++#if defined(_WIN32) && !defined(WIN32)
++# define WIN32 _WIN32
++#endif
++
+ #include <X11/Xfuncproto.h>
+ #include <X11/Xos.h>
+ #include <X11/Xmd.h>
+diff --git a/Xtransint.h b/Xtransint.h
+index 2156bd52f..735b54301 100644
+--- a/Xtransint.h
++++ b/Xtransint.h
+@@ -72,7 +72,7 @@ from The Open Group.
+ #  define XTRANSDEBUG 1
+ #endif
+ 
+-#ifdef WIN32
++#if defined(WIN32) || defined(_WIN32)
+ # define _WILLWINSOCK_
+ #endif
+ 
+diff --git a/Xtranssock.c b/Xtranssock.c
+index c29390eaa..f2ef365cc 100644
+--- a/Xtranssock.c
++++ b/Xtranssock.c
+@@ -74,6 +74,10 @@ from the copyright holders.
+ #include <X11/Xthreads.h>
+ #endif
+ 
++#if defined(_WIN32) && !defined(WIN32)
++# define WIN32 _WIN32
++#endif
++
+ #ifndef WIN32
+ 
+ #if defined(TCPCONN) || defined(UNIXCONN)
+diff --git a/Xtransutil.c b/Xtransutil.c
+index f15be243c..cc67315e6 100644
+--- a/Xtransutil.c
++++ b/Xtransutil.c
+@@ -54,6 +54,10 @@ from The Open Group.
+  * the internal implementation.
+  */
+ 
++#if defined(_WIN32) && !defined(WIN32)
++# define WIN32 _WIN32
++#endif
++
+ #ifdef XTHREADS
+ #include <X11/Xthreads.h>
+ #endif


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for xtrans 1.6.0 with Windows/MSVC fixes. Enables building xorg-dependent libraries on Windows with correct pkg-config metadata.

- **New Features**
  - New xtrans vcpkg port (autotools) sourced from xorg GitLab; depends on xorg-macros.
  - Applies win32 and symbols patches: map _WIN32 to WIN32, add MSVC includes/defines (e.g., S_ISDIR).
  - Repackages headers to share/xtrans/include; updates xtrans.pc; fixes debug/pkgconfig/aclocal layout.
  - On non-Windows, prefers system xtrans unless X_VCPKG_FORCE_VCPKG_X_LIBRARIES is set.

- **Migration**
  - Use pkg-config xtrans for the include path; do not rely on ${prefix}/include.

<sup>Written for commit ea1863f359b3299971e8048c5245b9866b55ab08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

