### PR TITLE
Test updated pthread-stubs library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/pthread-stubs/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/pthread-stubs/portfile.cmake
@@ -1,0 +1,53 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+vcpkg_from_gitlab(
+    GITLAB_URL https://gitlab.freedesktop.org/xorg
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO lib/pthread-stubs
+    REF libpthread-stubs-${VERSION}
+    SHA512 b2429828f51cc6c9bbb9879c9933ff747354574626ff8fcfbec22c41ded1e9bdf4049715485f580e72c561dfd54d48d731c1f6ae9fff229976890361e3276f2e
+    HEAD_REF master
+)
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig(SYSTEM_LIBRARIES pthread)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+file(INSTALL "${SOURCE_PATH}/COPYING" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)
+
+set(_file "${CURRENT_PACKAGES_DIR}/lib/pkgconfig/pthread-stubs.pc")
+file(READ "${_file}" _contents)
+string(REPLACE "Cflags: -pthread" "Cflags: " _contents "${_contents}")
+if(EXISTS "${CURRENT_INSTALLED_DIR}/lib/pthreadVC3.lib")
+    string(REPLACE "Libs: -pthread" "Libs: -lpthreadVC3" _contents "${_contents}")
+endif()
+if(EXISTS "${CURRENT_INSTALLED_DIR}/lib/pthreadGC3.lib")
+    string(REPLACE "Libs: -pthread" "Libs: -lpthreadGC3" _contents "${_contents}")
+endif()
+file(WRITE "${_file}" "${_contents}")
+
+if(NOT VCPKG_BUILD_TYPE)
+    set(_file "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/pthread-stubs.pc")
+    file(READ "${_file}" _contents)
+    string(REPLACE "Cflags: -pthread" "Cflags: " _contents "${_contents}")
+    if(EXISTS "${CURRENT_INSTALLED_DIR}/debug/lib/pthreadVC3.lib")
+        string(REPLACE "Libs: -pthread" "Libs: -lpthreadVC3" _contents "${_contents}")
+    endif()
+    if(EXISTS "${CURRENT_INSTALLED_DIR}/debug/lib/pthreadGC3.lib")
+        string(REPLACE "Libs: -pthread" "Libs: -lpthreadGC3" _contents "${_contents}")
+    endif()
+    if(EXISTS "${CURRENT_INSTALLED_DIR}/debug/lib/pthreadVC3d.lib")
+        string(REPLACE "Libs: -pthread" "Libs: -lpthreadVC3d" _contents "${_contents}")
+    endif()
+    if(EXISTS "${CURRENT_INSTALLED_DIR}/debug/lib/pthreadGC3d.lib")
+        string(REPLACE "Libs: -pthread" "Libs: -lpthreadGC3d" _contents "${_contents}")
+    endif()
+    file(WRITE "${_file}" "${_contents}")
+endif()

--- a/3rdParty/vcpkg_ports/ports/pthread-stubs/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/pthread-stubs/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "pthread-stubs",
+  "version": "0.5",
+  "description": "Stub replacements for POSIX Threads functions.",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/pthread-stubs",
+  "license": "X11-distribute-modifications-variant",
+  "dependencies": [
+    "pthread"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom vcpkg port for pthread-stubs 0.5 to test the updated library. Fix pkg-config on Windows so linking resolves to pthreads-w32 libs and removes the unsupported -pthread Cflag.

- **Dependencies**
  - Adds pthread-stubs 0.5 via vcpkg_from_gitlab and make install.
  - Rewrites pkg-config: replaces "Libs: -pthread" with -lpthreadVC3/-lpthreadGC3 (incl. debug variants) and strips "Cflags: -pthread".

<sup>Written for commit 4630ba8c08df41f99bc9357c03606578ff5483ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

