### PR TITLE
Test updated libnotify library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libnotify/0001-fix-parameter-name-omitted-error.patch
+++ b/3rdParty/vcpkg_ports/ports/libnotify/0001-fix-parameter-name-omitted-error.patch
@@ -1,0 +1,15 @@
+diff --git a/libnotify/launch-context.c b/libnotify/launch-context.c
+index facb43c..9469042 100644
+--- a/libnotify/launch-context.c
++++ b/libnotify/launch-context.c
+@@ -49,8 +49,8 @@ notification_app_launch_context_finalize (GObject *object)
+ 
+ static char *
+ notification_app_launch_context_get_startup_notify_id (GAppLaunchContext *context,
+-                                                       GAppInfo *,
+-                                                       GList *)
++                                                       GAppInfo *gai,
++                                                       GList *gl)
+ {
+         NotificationAppLaunchContext *self = NOTIFICATION_APP_LAUNCH_CONTEXT (context);
+ 

--- a/3rdParty/vcpkg_ports/ports/libnotify/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libnotify/portfile.cmake
@@ -1,0 +1,52 @@
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+vcpkg_download_distfile(ARCHIVE
+    URLS
+        "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+    FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
+    SHA512 0fedd230d3c8b9bd3c783794e690752cf6388fc178854267effe3ba26aaa9248415cdf0ab994f596ace8bef59e0c1e41196f42a225221d7f0e1efc54683c310a
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        0001-fix-parameter-name-omitted-error.patch
+)
+
+vcpkg_list(SET RELEASE_OPTIONS)
+if("introspection" IN_LIST FEATURES)
+    vcpkg_list(APPEND RELEASE_OPTIONS -Dintrospection=enabled)
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    vcpkg_list(APPEND RELEASE_OPTIONS -Dintrospection=disabled)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -Dtests=false
+        -Dman=false
+        -Dgtk_doc=false
+        -Ddocbook_docs=disabled
+    OPTIONS_RELEASE
+        ${RELEASE_OPTIONS}
+    OPTIONS_DEBUG
+        -Dintrospection=disabled
+    ADDITIONAL_BINARIES
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+        "glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'"
+)
+
+vcpkg_install_meson()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+)
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/libnotify/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libnotify/vcpkg.json
@@ -1,0 +1,39 @@
+{
+  "name": "libnotify",
+  "version": "0.8.8",
+  "description": "A library for sending desktop notifications",
+  "homepage": "https://gitlab.gnome.org/GNOME/libnotify",
+  "license": "LGPL-2.1-or-later",
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "gdk-pixbuf",
+      "default-features": false
+    },
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "introspection": {
+      "description": "Enable GObject introspection",
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "gdk-pixbuf",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        },
+        "gobject-introspection"
+      ]
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Linux-only vcpkg port for libnotify 0.8.8 with a small patch to fix a build error in launch-context. Enables optional GObject introspection and trims docs/tests for faster builds.

- **New Features**
  - New vcpkg port: downloads, patches, and builds libnotify via Meson.
  - Fixes build by naming parameters in launch-context to resolve the “parameter name omitted” error.
  - Build settings: disable tests/docs, toggle introspection, set GIR/glib tools, and clean pkg-config/debug dirs.

- **Dependencies**
  - glib (target) and glib (host tools).
  - gdk-pixbuf without default features.
  - vcpkg-tool-meson (host); optional gobject-introspection and gdk-pixbuf[introspection] when the “introspection” feature is enabled.

<sup>Written for commit 8f39d945a4fe2bd3ed49229814e58d95b861e6cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

