### PR TITLE
Test updated libxau library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxau/fix-configure-ac.patch
+++ b/3rdParty/vcpkg_ports/ports/libxau/fix-configure-ac.patch
@@ -1,0 +1,25 @@
+diff --git a/Makefile.am b/Makefile.am
+index cb3adbe..dd17d48 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -62,6 +62,5 @@ ChangeLog:
+ 
+ dist-hook: ChangeLog INSTALL
+ 
+-ACLOCAL_AMFLAGS = -I m4
+ 
+-EXTRA_DIST = meson.build meson_options.txt
+\ No newline at end of file
++EXTRA_DIST = meson.build meson_options.txt
+diff --git a/configure.ac b/configure.ac
+index e1182b6..97b9d41 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -26,7 +26,6 @@ AC_INIT([libXau], [1.0.12],
+ 	[https://gitlab.freedesktop.org/xorg/lib/libxau/-/issues], [libXau])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ AC_USE_SYSTEM_EXTENSIONS
+ 
+ # Initialize Automake

--- a/3rdParty/vcpkg_ports/ports/libxau/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxau/portfile.cmake
@@ -1,0 +1,33 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxau"
+    REF "libXau-${VERSION}"
+    SHA512 d76ea5a7d5f70159b3d40242cee66b4a763b98ce57b0b5660ce47cac9bc240d51fb20eec969f8fffdfd79fa46ec8e1b9bf2aa4ca9d39d1f45d515e75afb23a7d
+    HEAD_REF master
+    PATCHES
+        fix-configure-ac.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS "${OPTIONS}"
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxau/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxau/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "libxau",
+  "version": "1.0.12",
+  "description": "Functions for handling Xauthority files and entries.",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxau",
+  "license": "MIT-open-group",
+  "dependencies": [
+    "bzip2",
+    "xorg-macros",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for libxau 1.0.12, built with Autotools from X.Org GitLab. On non-Windows, it defers to system packages unless X_VCPKG_FORCE_VCPKG_X_LIBRARIES is set.

- **New Features**
  - Fetches source via vcpkg_from_gitlab (libXau-${VERSION}).
  - Applies fix-configure-ac.patch and sets ACLOCAL to use xorg-macros.
  - Configures and installs with Autotools; fixes pkg-config; cleans debug dirs; installs license.

- **Dependencies**
  - bzip2
  - xorg-macros
  - xproto

<sup>Written for commit 5b68b0adc9d74215eb6febd0e4fa1da055b8310a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

