### PR TITLE
Test updated libxdmcp library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxdmcp/configure.ac.patch
+++ b/3rdParty/vcpkg_ports/ports/libxdmcp/configure.ac.patch
@@ -1,0 +1,21 @@
+diff --git a/configure.ac b/configure.ac
+index 61df441..3fc6d53 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -26,7 +26,6 @@ AC_INIT([libXdmcp], [1.1.5],
+         [https://gitlab.freedesktop.org/xorg/lib/libxdmcp/-/issues], [libXdmcp])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Set common system defines for POSIX extensions, such as _GNU_SOURCE
+ # Must be called before any macros that run the compiler (like LT_INIT)
+@@ -60,7 +59,7 @@ AC_CHECK_HEADERS([sys/random.h])
+ AC_SEARCH_LIBS([recvfrom],[socket])
+ 
+ case $host_os in
+-     *mingw*)
++     *mingw* | *msys* )
+         AC_CHECK_LIB([ws2_32],[main])
+         ;;
+      *)

--- a/3rdParty/vcpkg_ports/ports/libxdmcp/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxdmcp/portfile.cmake
@@ -1,0 +1,36 @@
+#SET(VCPKG_POLICY_DLLS_WITHOUT_LIBS enabled) # this is a lie but the lib has a different name than the dll
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxdmcp"
+    REF  libXdmcp-${VERSION}
+    SHA512 e56baff7e7556954e10d1702b469c42fccae218692a9379306b08b513a7453d504dcbd39d03acdfe23f8f9f3f7b0fec5ae517ce17f3aa0fd5f1947d04cb73663
+    HEAD_REF master
+    PATCHES configure.ac.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(OPTIONS --disable-dependency-tracking)
+    string(APPEND VCPKG_C_FLAGS "/showIncludes ")
+    string(APPEND VCPKG_CXX_FLAGS "/showIncludes ")
+endif()
+vcpkg_configure_make(
+    SOURCE_PATH ${SOURCE_PATH}
+    AUTOCONFIG
+    OPTIONS ${OPTIONS} --enable-unit-tests=no
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxdmcp/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxdmcp/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "libxdmcp",
+  "version": "1.1.5",
+  "description": "X Display Manager Control Protocol library",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxdmcp",
+  "license": "MIT-open-group",
+  "dependencies": [
+    "liblzma",
+    "xorg-macros",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add libXdmcp 1.1.5 as a local vcpkg port and patch configure to support MSYS/MinGW builds. This enables building and testing the updated library via vcpkg.

- **Dependencies**
  - Add custom vcpkg port for libXdmcp 1.1.5 (fetch from xorg GitLab, configure/make, pkg-config fixup).
  - Patch configure.ac to support MSYS/MinGW (link ws2_32) and remove m4 macro dir config.
  - Define deps: liblzma, xorg-macros, xproto; set Windows flags and disable unit tests.

<sup>Written for commit 22f9efd5f64fdf4c111f5bfb0d08718f2cc56386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

