### PR TITLE
Test updated libxext library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxext/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxext/portfile.cmake
@@ -1,0 +1,31 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxext"
+    REF  "libXext-${VERSION}"
+    SHA512 6b92082fea4b7b74f59206bacf96845d0bdea7a1aa8ad37b765288790079e99684285e3b3ed92a6d2f75d52064da4b2ef7a2cc89da49c41f81e4b82aa15b903b
+    HEAD_REF master
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS xorg_cv_malloc0_returns_null=yes
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxext/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxext/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "libxext",
+  "version": "1.3.6",
+  "description": "Xlib-based library for common extensions to the X11 protocol",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxext",
+  "license": null,
+  "dependencies": [
+    "libx11",
+    "xorg-macros",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a vcpkg port for libXext 1.3.6 to test the updated library and make it available via vcpkg. On non-Windows, system packages are used unless X_VCPKG_FORCE_VCPKG_X_LIBRARIES is set.

- **Dependencies**
  - libx11
  - xorg-macros
  - xproto

<sup>Written for commit c07fd5b33485222e76fd50c2668036878d7706ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

