### PR TITLE
Test updated libxfixes library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxfixes/fix-configure.patch
+++ b/3rdParty/vcpkg_ports/ports/libxfixes/fix-configure.patch
@@ -1,0 +1,21 @@
+diff --git a/Makefile.am b/Makefile.am
+index c626eaa..54252e7 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -37,4 +37,3 @@ ChangeLog:
+ dist-hook: ChangeLog INSTALL
+ 
+ EXTRA_DIST = README.md meson.build
+-ACLOCAL_AMFLAGS = -I m4
+diff --git a/configure.ac b/configure.ac
+index f70529a..8e3be3f 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -37,7 +37,6 @@ AC_INIT(libXfixes, [6.0.2],
+ 	[libXfixes])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/3rdParty/vcpkg_ports/ports/libxfixes/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxfixes/portfile.cmake
@@ -1,0 +1,31 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxfixes"
+    REF "libXfixes-${VERSION}"
+    SHA512 262fd84eebd663969a30e765fd78b7a1f39731c17797edfb8795ac63a5fa323ba54b0ff8182f999a6d219df754d09bd980ed531e264b13ef35943a4f71327d1d
+    HEAD_REF master
+    PATCHES
+        fix-configure.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxfixes/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxfixes/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "libxfixes",
+  "version": "6.0.2",
+  "description": "Xlib-based library for the XFIXES Extension",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxfixes",
+  "license": null,
+  "dependencies": [
+    "libx11",
+    "xorg-macros",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom vcpkg port for libXfixes 6.0.2 to test the updated Xorg library in our build. Fetches from freedesktop, applies a small configure patch, and installs with correct pkg-config metadata; on non-Windows we default to system libs unless forced.

- **Dependencies**
  - New vcpkg port at 3rdParty/vcpkg_ports/ports/libxfixes with deps: libx11, xorg-macros, xproto.
  - Patch removes ACLOCAL_AMFLAGS/AC_CONFIG_MACRO_DIRS and sets ACLOCAL path; builds on Windows or when X_VCPKG_FORCE_VCPKG_X_LIBRARIES is set, otherwise uses system libs.

<sup>Written for commit 69b1e7905d426301763cb68dbf63362ef342b13b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

