### PR TITLE
Test updated libxi library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxi/fix-configure.patch
+++ b/3rdParty/vcpkg_ports/ports/libxi/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 3351124..1fb3977 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -5,7 +5,6 @@ AC_INIT([libXi], [1.8.2],
+ 	[https://gitlab.freedesktop.org/xorg/lib/libXi/issues], [libXi])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([src/config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/3rdParty/vcpkg_ports/ports/libxi/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxi/portfile.cmake
@@ -1,0 +1,37 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxi"
+    REF "libXi-${VERSION}"
+    SHA512 3928777184c89f93182d5d6b0d8e37e0ec797c37c0e73305ac843a8c874c3c1261e37338d61edf526e9ca74120bf6dcc1832760ebe9af2550e9f8279dd2f6f6f
+    HEAD_REF master
+    PATCHES
+        fix-configure.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+if (VCPKG_CROSSCOMPILING)
+    list(APPEND OPTIONS --enable-malloc0returnsnull)
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS ${OPTIONS}
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxi/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxi/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "libxi",
+  "version": "1.8.2",
+  "description": "Xlib library for the X Input Extension",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxi",
+  "license": null,
+  "dependencies": [
+    "libxext",
+    "libxfixes"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom vcpkg port for libXi 1.8.2 so we can build and test the updated X Input library in our toolchain. Includes a small configure fix and defaults to system packages on non-Windows.

- **New Features**
  - Added ports/libxi with vcpkg.json and portfile.cmake (GitLab source, pkg-config fixups).
  - Applied fix-configure.patch to remove AC_CONFIG_MACRO_DIRS and avoid autoconf issues.
  - On non-Windows, use system packages by default; set X_VCPKG_FORCE_VCPKG_X_LIBRARIES to build via vcpkg.
  - Declares dependencies: libxext, libxfixes.

<sup>Written for commit ae4b3eca125cacadbd0aa905e8eddd7a47849356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

