### PR TITLE
Test updated libxrandr library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxrandr/fix-configure.patch
+++ b/3rdParty/vcpkg_ports/ports/libxrandr/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 99e3944..d6e6159 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -34,7 +34,6 @@ AC_INIT([libXrandr], [1.5.4],
+         [libXrandr])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/3rdParty/vcpkg_ports/ports/libxrandr/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxrandr/portfile.cmake
@@ -1,0 +1,37 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in the triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxrandr"
+    REF "libXrandr-${VERSION}"
+    SHA512 50b92b5c62ced66418381d816f6b61d9d3eb7e7b2794f7b2c58b263875ff6001a57e1750e32b9317a0d5e3e311bf0657156dfe5b4875d863499583b25b700b68
+    HEAD_REF master
+    PATCHES
+        fix-configure.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+if (VCPKG_CROSSCOMPILING)
+    list(APPEND OPTIONS --enable-malloc0returnsnull)
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS ${OPTIONS}
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxrandr/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxrandr/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "libxrandr",
+  "version": "1.5.4",
+  "description": "Xlib Resize, Rotate and Reflection (RandR) extension library",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxrandr",
+  "license": null,
+  "dependencies": [
+    "bzip2",
+    "libx11",
+    "libxext",
+    "libxrender",
+    "xorg-macros",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom vcpkg port for libXrandr 1.5.4 to build and test the updated library across environments. Includes a small configure fix and correct Xorg dependencies.

- **New Features**
  - Adds vcpkg port (portfile.cmake, vcpkg.json) sourcing libXrandr 1.5.4 from GitLab with SHA512 pin.
  - Applies configure.ac patch removing AC_CONFIG_MACRO_DIRS to unblock autoconf.
  - Configures build with aclocal Xorg path, supports cross-compile (malloc0returnsnull), and runs pkgconfig fixup.
  - Prefers system libs on non-Windows; set X_VCPKG_FORCE_VCPKG_X_LIBRARIES to use this port.
  - Declares deps: bzip2, libx11, libxext, libxrender, xorg-macros, xproto.

<sup>Written for commit 43d3499750c743edbfe267365ccf3d10792c1f91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

