### PR TITLE
Test updated libxrender library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxrender/fix-configure.patch
+++ b/3rdParty/vcpkg_ports/ports/libxrender/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 6bc1c90..28e1ac5 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -34,7 +34,6 @@ AC_INIT(libXrender, [0.9.12],
+ 	[libXrender])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ PACKAGE_BRIEF="Library for the Render Extension to the X11 protocol"
+ AC_SUBST(PACKAGE_BRIEF)

--- a/3rdParty/vcpkg_ports/ports/libxrender/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxrender/portfile.cmake
@@ -1,0 +1,37 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxrender"
+    REF "libXrender-${VERSION}"
+    SHA512 681ddad409bf9a16810a43cca9fde22a352310acb7262a5d634b05f235e51ca8e6023a8874110eb97b5f00c87a7a2466f4d8a6afcf0321fc3c4f3c0676d516a6
+    HEAD_REF master
+    PATCHES
+        fix-configure.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+if (VCPKG_CROSSCOMPILING)
+    list(APPEND OPTIONS --enable-malloc0returnsnull)
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS ${OPTIONS}
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxrender/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxrender/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "libxrender",
+  "version": "0.9.12",
+  "description": "library for the Render Extension to the X11 protocol",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxrender",
+  "license": null,
+  "dependencies": [
+    "libx11",
+    "xorg-macros"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for libXrender 0.9.12 and patches configure.ac (drops AC_CONFIG_MACRO_DIRS) to build cleanly with xorg-macros and pkg-config. Source is fetched from freedesktop GitLab and built via vcpkg make helpers with pkg-config fixups.

- **Migration**
  - On non-Windows, set X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet to use this vcpkg build; otherwise the port is an empty package.

- **Dependencies**
  - libx11
  - xorg-macros

<sup>Written for commit 78fd87fd8379a48a75445be5d58d7c7eeabc5791. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

