### PR TITLE
Test updated libxtst library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxtst/fix-configure.patch
+++ b/3rdParty/vcpkg_ports/ports/libxtst/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index e0d2256..6113dfd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -26,7 +26,6 @@ AC_INIT([libXtst], [1.2.5],
+ 	[https://gitlab.freedesktop.org/xorg/lib/libxtst/-/issues], [libXtst])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/3rdParty/vcpkg_ports/ports/libxtst/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxtst/portfile.cmake
@@ -1,0 +1,32 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxtst"
+    REF "libXtst-${VERSION}"
+    SHA512 d48df671f212a1784ef1aefe69b16bc42395ff4ae083b7087dc55827fa6f8635b17adb5e26d976c8f8c7f02aeeb51f66c9808a037ef783c44139483c1c76ce3e
+    HEAD_REF master
+    PATCHES
+        fix-configure.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxtst/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxtst/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "libxtst",
+  "version": "1.2.5",
+  "description": "Xlib-based library for XTEST & RECORD extensions",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxtst",
+  "license": null,
+  "dependencies": [
+    "libx11",
+    "libxext",
+    "libxi",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a vcpkg port for libXtst 1.2.5 to build the library from X.Org when needed. Includes a configure fix so autoconf runs cleanly.

- **New Features**
  - New vcpkg port fetching from GitLab with make-based build and pkg-config fixup.
  - Patch removes AC_CONFIG_MACRO_DIRS from configure.ac to avoid m4 lookup issues.
  - Uses system X libraries by default on non-Windows; set X_VCPKG_FORCE_VCPKG_X_LIBRARIES in the triplet to build via vcpkg.
  - Declares dependencies: libx11, libxext, libxi, xproto.

<sup>Written for commit 394cc5c24d98d4e1893810b94a2302e68e29e52c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

