### PR TITLE
Test updated xcb-util-m4 library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/xcb-util-m4/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/xcb-util-m4/portfile.cmake
@@ -1,0 +1,15 @@
+set(VCPKG_POLICY_EMPTY_INCLUDE_FOLDER enabled)
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "util/xcb-util-m4"
+    REF c617eee22ae5c285e79e81ec39ce96862fd3262f
+    SHA512 d2d977574a106ca59207988e3e4ec12ecbcf30852df46456f7ec5284983e49f31ee85025f404d863f8e3d766f193e6a79508f26a3dcd33173d7bbefccdb279fa
+    HEAD_REF master
+)
+
+file(GLOB_RECURSE M4_FILES "${SOURCE_PATH}/*.m4")
+file(INSTALL ${M4_FILES} DESTINATION "${CURRENT_PACKAGES_DIR}/share/xorg/aclocal")
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+file(TOUCH "${CURRENT_PACKAGES_DIR}/share/xcb-util-m4/copyright")

--- a/3rdParty/vcpkg_ports/ports/xcb-util-m4/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/xcb-util-m4/vcpkg.json
@@ -1,0 +1,7 @@
+{
+  "name": "xcb-util-m4",
+  "version-date": "2022-07-01",
+  "description": "GNU autoconf macros shared across XCB projects",
+  "homepage": "https://gitlab.freedesktop.org/xorg/util/xcb-util-m4",
+  "license": null
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a new vcpkg port for xcb-util-m4 to provide shared XCB autoconf macros. This helps configure XCB-related projects correctly during builds.

- **New Features**
  - Fetches xcb-util-m4 from freedesktop GitLab and installs .m4 files to share/xorg/aclocal.
  - Sets VCPKG_POLICY_EMPTY_INCLUDE_FOLDER and creates the package share directory with a copyright placeholder.
  - Adds vcpkg.json with basic metadata; source is pinned and checksum-verified for reproducible builds.

<sup>Written for commit 91a26c6aab21de043829cc85031d1b0b9fcbea6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

