### PR TITLE
client: allow projects to change resource usage of app versions

### DIFF
--- a/client/app_config.cpp
+++ b/client/app_config.cpp
@@ -96,10 +96,6 @@ int APP_CONFIGS::config_app_versions(PROJECT* p, bool show_warnings) {
         }
     }
 
-    // copy new app version resource usage to results
-    //
-    gstate.init_result_resource_usage();
-
     if (showed_notice) return ERR_XML_PARSE;
     return 0;
 }

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -2485,8 +2485,11 @@ bool CLIENT_STATE::abort_sequence_done() {
 // For running jobs, we've already populated resource_usage,
 // and we can't change it without restarting the job
 //
-void CLIENT_STATE::init_result_resource_usage() {
+void CLIENT_STATE::init_result_resource_usage(PROJECT *p) {
     for (RESULT* rp: results) {
+        if (p && rp->project != p) {
+            continue;
+        }
         if (lookup_active_task_by_result(rp)) {
             continue;
         }

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -307,7 +307,7 @@ struct CLIENT_STATE {
     void clear_absolute_times();
     void set_now();
     void log_show_projects();
-    void init_result_resource_usage();
+    void init_result_resource_usage(PROJECT *p = NULL);
 
 // --------------- cpu_sched.cpp:
     double total_resource_share();

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -1226,7 +1226,7 @@ int CLIENT_STATE::handle_scheduler_reply(
 
     // copy resource usages to non-running jobs in case app versions changed
     //
-    gstate.init_result_resource_usage();
+    gstate.init_result_resource_usage(project);
 
     // make sure we don't set no_rsc_apps[] for all processor types
     //


### PR DESCRIPTION
A scheduler reply can have new resource usage for an existing app version. One project implements #cpus user prefs this way.

The resource usages of non-running jobs (including those in the scheduler reply) are updated. Running jobs are not affected; we don't want to restart them.

Resource usages specified in app_config.xml (local config) override this.

Fixes #6803

This undoes #6081; the bug that was intended to fix (#6072) doesn't seem to exist anymore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow scheduler replies to update resource usage for existing app versions and apply it to queued tasks without restarting running work. Local app_config.xml still overrides server values. Fixes #6803.

- **New Features**
  - Update app version resource_usage from scheduler reply (e.g., user #cpus); only resource_usage is mutable.
  - After each scheduler RPC, propagate the new usage to non-running tasks; running tasks are skipped.
  - app_config.xml values take precedence over server-provided values.

<sup>Written for commit b0978882e2a59bb6f87c90236b03b8cb956a3fb2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

