### PR TITLE
Fix incorrect links in the linux package installer scripts.

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -505,7 +505,7 @@ jobs:
               echo \"\"\"
               <!--
               This is a configuration file of the BOINC client.
-              For a complete list of options see https://boinc.berkeley.edu/wiki/client_configuration
+              For a complete list of options see https://github.com/BOINC/boinc/wiki/Client-configuration
               -->
               <cc_config>
               </cc_config>

--- a/packages/deb/postinst
+++ b/packages/deb/postinst
@@ -108,7 +108,7 @@ if [ ! -e ${BOINCDIR}/cc_config.xml ] ; then
         echo """
         <!--
         This is a configuration file of the BOINC client.
-        For a complete list of options see https://boinc.berkeley.edu/wiki/client_configuration
+        For a complete list of options see https://github.com/BOINC/boinc/wiki/Client-configuration
         -->
         <cc_config>
         </cc_config>


### PR DESCRIPTION
Fixes #6806


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the cc_config.xml help link in Linux package installer scripts to point to the GitHub wiki, so users see the current client configuration docs.

- **Bug Fixes**
  - Updated .github/workflows/linux-package.yml to link to https://github.com/BOINC/boinc/wiki/Client-configuration.
  - Updated packages/deb/postinst to generate cc_config.xml with the same correct link.

<sup>Written for commit 9220e1b272849ce87545f73ff0c4d6d0be3805cc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

