### PR TITLE
[linux] add libxkbcommon library dependency to the vcpkg build

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git python3 python3-distutils python3-jinja2 python3-venv curl zip unzip tar bison p7zip-full dbus
+          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git python3 python3-distutils python3-jinja2 python3-venv curl zip unzip tar bison p7zip-full dbus flex
 
       - name: Install dependencies for arm64
         if: matrix.arch == 'arm64'

--- a/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
@@ -29,6 +29,12 @@
         },
         "libnotify",
         "xcb-util",
-        "pixbufloader-svg"
+        "pixbufloader-svg",
+        "libxkbcommon",
+        {
+          "name": "wayland-protocols",
+          "features": ["force-build"],
+          "default-features": false
+        }
     ]
 }

--- a/3rdParty/vcpkg_ports/triplets/ci/arm-linux-release.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/arm-linux-release.cmake
@@ -19,6 +19,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/arm-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 
 if(PORT STREQUAL "dbus")
     if(NOT $ENV{TMPDIR} STREQUAL "")

--- a/3rdParty/vcpkg_ports/triplets/ci/arm64-linux-release.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/arm64-linux-release.cmake
@@ -19,6 +19,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/arm64-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 
 if(PORT STREQUAL "dbus")
     if(NOT $ENV{TMPDIR} STREQUAL "")

--- a/3rdParty/vcpkg_ports/triplets/ci/snap-linux-amd64.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/snap-linux-amd64.cmake
@@ -19,3 +19,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/x64-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)

--- a/3rdParty/vcpkg_ports/triplets/ci/snap-linux-arm64.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/snap-linux-arm64.cmake
@@ -19,6 +19,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/arm64-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 
 if(PORT STREQUAL "dbus")
     if(NOT $ENV{TMPDIR} STREQUAL "")

--- a/3rdParty/vcpkg_ports/triplets/ci/x64-linux.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/x64-linux.cmake
@@ -19,4 +19,5 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/x64-linux.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 set(VCPKG_BUILD_TYPE release)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,7 @@ parts:
     - cmake
     - dbus
     - python3-venv
+    - flex
     source: .
     plugin: autotools
     build-environment:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added libxkbcommon, enabled Wayland libs, and added flex to fix missing XKB support and Linux build/link errors.

<sup>Written for commit 4c96819d933c97c9cfa7f7644516a6d0ecbaea3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

