### PR TITLE
[linux] Add custom gtk3 vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/gtk3/0001-build.patch
+++ b/3rdParty/vcpkg_ports/ports/gtk3/0001-build.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 397ea07..dd6b888 100644
+--- a/meson.build
++++ b/meson.build
+@@ -997,7 +997,7 @@ subdir('docs/reference')
+ 
+ install_data('m4macros/gtk-3.0.m4', install_dir: join_paths(get_option('datadir'), 'aclocal'))
+ 
+-if not meson.is_cross_build()
++if false
+   gnome.post_install(
+     glib_compile_schemas: true,
+     gio_querymodules: gio_module_dirs,

--- a/3rdParty/vcpkg_ports/ports/gtk3/cairo-cpp-linkage.patch
+++ b/3rdParty/vcpkg_ports/ports/gtk3/cairo-cpp-linkage.patch
@@ -1,0 +1,62 @@
+diff --git a/gtk/meson.build b/gtk/meson.build
+index ea866d8..0d312f3 100644
+--- a/gtk/meson.build
++++ b/gtk/meson.build
+@@ -1102,6 +1102,7 @@ gtk_query_settings = executable(
+   'gtk-query-settings.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_query_settings
+@@ -1111,6 +1112,7 @@ gtk_builder_tool = executable(
+   'gtk-builder-tool.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_builder_tool
+@@ -1143,6 +1145,7 @@ gtk_update_icon_cache = executable(
+   extra_update_icon_cache_objs,
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_update_icon_cache
+@@ -1153,6 +1156,7 @@ gtk_query_immodules = executable(
+   'gtkutils.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_query_immodules
+@@ -1162,6 +1166,7 @@ gtk_encode_symbolic_svg = executable(
+   'encodesymbolic.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_encode_symbolic_svg
+@@ -1171,6 +1176,7 @@ gtk_launch = executable(
+   'gtk-launch.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_launch
+diff --git a/meson.build b/meson.build
+index dd6b888..e60ad30 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,4 +1,4 @@
+-project('gtk', 'c',
++project('gtk', 'c', 'cpp',
+   version: '3.24.51',
+   default_options: [
+     'buildtype=debugoptimized',

--- a/3rdParty/vcpkg_ports/ports/gtk3/egl-conditional.diff
+++ b/3rdParty/vcpkg_ports/ports/gtk3/egl-conditional.diff
@@ -1,0 +1,56 @@
+diff --git a/gdk/win32/gdkglcontext-win32.c b/gdk/win32/gdkglcontext-win32.c
+index b1cbfa2c047dac8a73002120ffe4130f557cf82f..0021f8cdb5000d2ae0b70a22f6539c47e79a5e9d 100644
+--- a/gdk/win32/gdkglcontext-win32.c
++++ b/gdk/win32/gdkglcontext-win32.c
+@@ -833,7 +833,7 @@ gdk_win32_gl_context_realize_wgl (GdkGLContext  *context,
+   return TRUE;
+ }
+ 
+-static gboolean
++gboolean
+ gdk_win32_display_is_wgl_context_current (GdkDisplay   *display,
+                                           GdkGLContext *context)
+ {
+@@ -1313,7 +1313,8 @@ gdk_win32_window_invalidate_egl_framebuffer (GdkWindow *window)
+     }
+ }
+ 
+-static gboolean
++#ifdef GDK_WIN32_ENABLE_EGL
++gboolean
+ gdk_win32_display_is_egl_context_current (GdkDisplay   *display,
+                                           GdkGLContext *context)
+ {
+@@ -1321,6 +1322,9 @@ gdk_win32_display_is_egl_context_current (GdkDisplay   *display,
+ 
+   return context_egl->egl_context == eglGetCurrentContext ();
+ }
++#else
++#define gdk_win32_display_is_egl_context_current(disp,ctx) FALSE
++#endif
+ 
+ static gboolean
+ gdk_win32_display_make_egl_context_current (GdkDisplay   *display,
+diff --git a/gdk/win32/gdkglcontext-win32.h b/gdk/win32/gdkglcontext-win32.h
+index 793a3ef4ffaa1fa2ba3d46b5a0ecfdf2ccb576fa..69d5d63166287360115aeec5cafbce264653f04c 100644
+--- a/gdk/win32/gdkglcontext-win32.h
++++ b/gdk/win32/gdkglcontext-win32.h
+@@ -61,6 +61,18 @@ gboolean
+ gdk_win32_display_is_gl_context_current     (GdkDisplay     *display,
+                                              GdkGLContext   *context);
+ 
++gboolean
++gdk_win32_display_is_wgl_context_current    (GdkDisplay     *display,
++                                             GdkGLContext   *context);
++
++#ifdef GDK_WIN32_ENABLE_EGL
++gboolean
++gdk_win32_display_is_egl_context_current    (GdkDisplay     *display,
++                                             GdkGLContext   *context);
++#else
++#define gdk_win32_display_is_egl_context_current(disp,ctx) FALSE
++#endif
++
+ gboolean
+ gdk_win32_display_make_gl_context_current   (GdkDisplay     *display,
+                                              GdkGLContext   *context);

--- a/3rdParty/vcpkg_ports/ports/gtk3/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/gtk3/portfile.cmake
@@ -1,0 +1,96 @@
+set(warning_length 24)
+string(LENGTH "${CURRENT_BUILDTREES_DIR}" buildtrees_path_length)
+if(buildtrees_path_length GREATER warning_length AND CMAKE_HOST_WIN32)
+    message(WARNING "${PORT}'s buildsystem uses very long paths and may fail on your system.\n"
+        "We recommend moving vcpkg to a short path such as 'C:\\vcpkg' or using the subst command."
+    )
+endif()
+
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+vcpkg_download_distfile(ARCHIVE
+    URLS
+        "https://download.gnome.org/sources/gtk/${VERSION_MAJOR_MINOR}/gtk-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/gtk/${VERSION_MAJOR_MINOR}/gtk-${VERSION}.tar.xz"
+    FILENAME "GNOME-gtk-${VERSION}.tar.xz"
+    SHA512 f96ee1c586284af315709ec38e841bd1b2558d09e2162834a132ffc4bbcddca272a92a828550a3accaa3e4da1964ad32b3b48291e929a108a913bd18c61cd73b
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        0001-build.patch
+        cairo-cpp-linkage.patch
+        egl-conditional.diff # https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/9067
+)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+get_filename_component(PKGCONFIG_DIR "${PKGCONFIG}" DIRECTORY )
+vcpkg_add_to_path("${PKGCONFIG_DIR}") # Post install script runs pkg-config so it needs to be on PATH
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/glib/")
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gdk-pixbuf")
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin")
+
+
+if("introspection" IN_LIST FEATURES)
+    list(APPEND OPTIONS_RELEASE -Dintrospection=true)
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND OPTIONS_RELEASE -Dintrospection=false)
+endif()
+
+list(APPEND OPTIONS -Dwayland_backend=false)
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -Ddemos=false
+        -Dexamples=false
+        -Dtests=false
+        -Dgtk_doc=false
+        -Dman=false
+        -Dxinerama=no               # Enable support for the X11 Xinerama extension
+        -Dcloudproviders=false      # Enable the cloudproviders support
+        -Dprofiler=false            # include tracing support for sysprof
+        -Dtracker3=false            # Enable Tracker3 filechooser search
+        -Dcolord=no                 # Build colord support for the CUPS printing backend
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    OPTIONS_DEBUG
+        -Dintrospection=false
+    ADDITIONAL_BINARIES
+        "glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'"
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+        "glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'"
+        "gdbus-codegen='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/gdbus-codegen'"
+        "glib-compile-schemas='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-schemas${VCPKG_HOST_EXECUTABLE_SUFFIX}'"
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
+)
+
+# Reduce command line lengths, in particular for static windows builds.
+foreach(dir IN ITEMS "${TARGET_TRIPLET}-dbg" "${TARGET_TRIPLET}-rel")
+    if(EXISTS "${CURRENT_BUILDTREES_DIR}/${dir}/build.ninja")
+        vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${dir}/build.ninja" "/${dir}/../src/" "/src/")
+    endif()
+endforeach()
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+set(GTK_TOOLS
+    gtk-builder-tool
+    gtk-encode-symbolic-svg
+    gtk-launch
+    gtk-query-immodules-3.0
+    gtk-query-settings
+    gtk-update-icon-cache
+)
+vcpkg_copy_tools(TOOL_NAMES ${GTK_TOOLS} AUTO_CLEAN)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/etc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/gtk3/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/gtk3/vcpkg.json
@@ -1,0 +1,88 @@
+{
+  "name": "gtk3",
+  "version": "3.24.51",
+  "port-version": 1,
+  "description": "Portable library for creating graphical user interfaces.",
+  "homepage": "https://www.gtk.org/",
+  "license": null,
+  "supports": "!android",
+  "dependencies": [
+    {
+      "name": "at-spi2-atk",
+      "platform": "linux"
+    },
+    "atk",
+    {
+      "name": "cairo",
+      "default-features": false,
+      "features": [
+        "gobject"
+      ]
+    },
+    {
+      "name": "cairo",
+      "default-features": false,
+      "features": [
+        "x11"
+      ],
+      "platform": "linux | freebsd | openbsd"
+    },
+    {
+      "name": "gdk-pixbuf",
+      "host": true
+    },
+    "gdk-pixbuf",
+    {
+      "name": "gettext",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
+    },
+    "gettext-libintl",
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    "libepoxy",
+    "libxi",
+    "libxrandr",
+    "pango",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "introspection": {
+      "description": "Build with introspection",
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "atk",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        },
+        {
+          "name": "gdk-pixbuf",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        },
+        "gobject-introspection",
+        {
+          "name": "pango",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom gtk3 vcpkg port (GTK 3.24.51) to fix Linux build issues and align dependencies. Patches Meson to avoid post-install steps and ensure GTK tools link cleanly.

- **Bug Fixes**
  - Disable gnome.post_install to prevent schema/module actions in vcpkg.
  - Link GTK tools as C++ to resolve cairo runtime linkage.
  - Make EGL checks conditional on GDK_WIN32_ENABLE_EGL (from upstream MR 9067).

- **Dependencies**
  - Adds vcpkg.json with atk, cairo (gobject/x11), glib, pango, libepoxy, X11 libs, and host tools (Meson, glib, gettext). Introspection is optional for non-static builds.

<sup>Written for commit f38314181af4a04868137775f618b778f957a52a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

