### PR TITLE
web: various small fixes

### DIFF
--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -316,7 +316,7 @@ function docker_desc($misc) {
 // return a human-readable version of the GPU info
 //
 function gpu_desc($misc) {
-    if (!isset($misc->gpus)) return '---';
+    if (empty($misc->gpus)) return '---';
     $gpus = [];
     foreach ($misc->gpus as $g) {
         if (empty($g->count)) $g->count = 1;

--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -269,7 +269,7 @@ function host_nresults($host) {
 function vbox_desc($misc) {
     if (!isset($misc->vbox)) return '---';
     $v = $misc->vbox;
-    $x = sprintf('Virtualbox %s', $v->version);
+    $x = sprintf('Virtualbox %s', htmlspecialchars($v->version));
     if (isset($v->hw_accel)) {
         $x .= sprintf('<br>HW acceleration: %s', $v->hw_accel?'yes':'no');
     }
@@ -284,7 +284,7 @@ function docker_desc($misc) {
     $d = $misc->docker;
     $x = sprintf('%s version %s',
         $d->type==1?"Docker":"Podman",
-        $d->version
+        htmlspecialchars($d->version)
     );
     if (isset($d->wsl_distro)) {
         if (empty($d->boinc_buda_runner_version)) {
@@ -312,7 +312,6 @@ function docker_desc($misc) {
     return $x;
 }
 
-
 // return a human-readable version of the GPU info
 //
 function gpu_desc($misc) {
@@ -325,7 +324,9 @@ function gpu_desc($misc) {
             $x .= sprintf('; %s RAM', size_string($g->ram_mb*MEGA));
         }
         if (!empty($g->driver_version)) {
-            $x .= "; Driver: $g->driver_version";
+            $x .= sprintf('; Driver: %s',
+                htmlspecialchars($g->driver_version)
+            );
         }
         if (!empty($g->opencl_version)) {
             $x .= sprintf('; OpenCL: %d.%d',
@@ -344,9 +345,11 @@ function boinc_version($misc) {
     if (!isset($misc->client_version)) {
         return '---';
     }
-    $x = $misc->client_version;
+    $x = htmlspecialchars($misc->client_version);
     if (!empty($misc->client_brand)) {
-        $x .= " ($misc->client_brand)";
+        $x .= sprintf(' (%s)',
+            htmlspecialchars($misc->client_brand)
+        );
     }
     return $x;
 }

--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -267,26 +267,26 @@ function host_nresults($host) {
 }
 
 function vbox_desc($misc) {
-    if (empty($misc->vbox)) return '---';
+    if (!isset($misc->vbox)) return '---';
     $v = $misc->vbox;
     $x = sprintf('Virtualbox %s', $v->version);
-    if (!empty($v->hw_accel)) {
+    if (isset($v->hw_accel)) {
         $x .= sprintf('<br>HW acceleration: %s', $v->hw_accel?'yes':'no');
     }
-    if (!empty($v->hw_accel_enabled)) {
+    if (isset($v->hw_accel_enabled)) {
         $x .= sprintf('<br>Enabled: %s', $v->hw_accel_enabled?'yes':'no');
     }
     return $x;
 }
 
 function docker_desc($misc) {
-    if (empty($misc->docker)) return '---';
+    if (!isset($misc->docker)) return '---';
     $d = $misc->docker;
     $x = sprintf('%s version %s',
         $d->type==1?"Docker":"Podman",
         $d->version
     );
-    if (!empty($d->wsl_distro)) {
+    if (isset($d->wsl_distro)) {
         if (empty($d->boinc_buda_runner_version)) {
             $x .= sprintf(
                 '<br>WSL distro: %s',
@@ -300,7 +300,7 @@ function docker_desc($misc) {
             );
         }
     }
-    if (!empty($misc->config)) {
+    if (isset($misc->config)) {
         $c = $misc->config;
         if (!empty($c->dont_use_wsl)) {
             $x .= "<br>Config: don't use WSL";
@@ -316,7 +316,7 @@ function docker_desc($misc) {
 // return a human-readable version of the GPU info
 //
 function gpu_desc($misc) {
-    if (empty($misc->gpus)) return '---';
+    if (!isset($misc->gpus)) return '---';
     $gpus = [];
     foreach ($misc->gpus as $g) {
         if (empty($g->count)) $g->count = 1;
@@ -341,7 +341,7 @@ function gpu_desc($misc) {
 // Given the same string as above, return the BOINC version
 //
 function boinc_version($misc) {
-    if (empty($misc->client_version)) {
+    if (!isset($misc->client_version)) {
         return '---';
     }
     $x = $misc->client_version;

--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -269,12 +269,14 @@ function host_nresults($host) {
 function vbox_desc($misc) {
     if (empty($misc->vbox)) return '---';
     $v = $misc->vbox;
-    return sprintf(
-        'Virtualbox %s<br>HW acceleration: %s<br>Enabled: %s',
-        $v->version,
-        $v->hw_accel?'yes':'no',
-        $v->hw_accel_enabled?'yes':'no'
-    );
+    $x = sprintf('Virtualbox %s', $v->version);
+    if (!empty($v->hw_accel)) {
+        $x .= sprintf('<br>HW acceleration: %s', $v->hw_accel?'yes':'no');
+    }
+    if (!empty($v->hw_accel_enabled)) {
+        $x .= sprintf('<br>Enabled: %s', $v->hw_accel_enabled?'yes':'no');
+    }
+    return $x;
 }
 
 function docker_desc($misc) {
@@ -317,15 +319,19 @@ function gpu_desc($misc) {
     if (empty($misc->gpus)) return '---';
     $gpus = [];
     foreach ($misc->gpus as $g) {
-        $x = sprintf(
-            '%d %s; %dMB RAM',
-            $g->count, $g->model, $g->ram_mb
-        );
+        if (empty($g->count)) $g->count = 1;
+        $x = sprintf('%d %s', $g->count, $g->model);
+        if (!empty($g->ram_mb)) {
+            $x .= sprintf('; %s RAM', size_string($g->ram_mb*MEGA));
+        }
         if (!empty($g->driver_version)) {
             $x .= "; Driver: $g->driver_version";
         }
         if (!empty($g->opencl_version)) {
-            $x .= "; OpenCL: $g->opencl_version";
+            $x .= sprintf('; OpenCL: %d.%d',
+                $g->opencl_version/100,
+                $g->opencl_version%100
+            );
         }
         $gpus[] = $x;
     }

--- a/html/inc/notify.inc
+++ b/html/inc/notify.inc
@@ -40,7 +40,7 @@ function show_notify_rss_item($notify) {
         pm_rss($notify, $title, $msg, $url);
         break;
     case NOTIFY_SUBSCRIBED_THREAD:
-        [$title, $msg, $url] = subscribe_rss($notify);
+        [$title, $msg, $url] = subscribed_thread_rss($notify);
         break;
     }
     if (!$msg) {

--- a/html/ops/hostinfo.php
+++ b/html/ops/hostinfo.php
@@ -71,20 +71,23 @@ function to_struct($p) {
             }
             break;
         case 'CUDA':
-            $g = make_gpu('nvidia', $x);
-            if ($g) $gpus[] = $g;
+            $gpus[] = make_gpu('nvidia', $x);
             break;
         case 'CAL':
-            $g = make_gpu('amd', $x);
-            if ($g) $gpus[] = $g;
+            $gpus[] = make_gpu('amd', $x);
             break;
         case 'INTEL':
-            $g = make_gpu('intel', $x);
-            if ($g) $gpus[] = $g;
+            $gpus[] = make_gpu('intel', $x);
+            break;
+        case 'ARM':
+            $gpus[] = make_gpu('arm', $x);
+            break;
+        case 'Microsoft':
             break;
         case 'apple_gpu':
+        case 'Apple':
             $g = make_gpu('apple', $x);
-            if ($g) $gpus[] = $g;
+            $gpus[] = $g;
             break;
         case 'opencl_gpu':
             if (stristr($x[1], 'apple')) {

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -67,7 +67,11 @@ function show_app($app_dir) {
     global $buda_root;
     $desc = null;
     $desc_path = "$buda_root/$app_dir/desc.json";
-    $desc = json_decode(file_get_contents($desc_path));
+    $desc = @json_decode(file_get_contents($desc_path));
+    if (!$desc) {
+        echo "$app_dir: No desc.json file";
+        return;
+    }
     echo '<hr>';
     echo sprintf('<h3>%s</h3><p>', $desc->long_name);
     show_button_small(

--- a/tools/backend_lib.cpp
+++ b/tools/backend_lib.cpp
@@ -414,8 +414,8 @@ int get_file_xml(
         file_name,
         max_nbytes
     );
-    for (unsigned int i=0; i<urls.size(); i++) {
-        sprintf(buf, "    <url>%s</url>\n", urls[i]);
+    for (const char *url: urls) {
+        sprintf(buf, "    <url>%s</url>\n", url);
         strcat(out, buf);
     }
     sprintf(buf,
@@ -492,8 +492,8 @@ int put_file_xml(
         "    <name>%s</name>\n",
         file_name
     );
-    for (unsigned int i=0; i<urls.size(); i++) {
-        sprintf(buf, "    <url>%s</url>\n", urls[i]);
+    for (const char* url: urls) {
+        sprintf(buf, "    <url>%s</url>\n", url);
         strcat(out, buf);
     }
     sprintf(buf,

--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -258,7 +258,7 @@ void get_wu_template(JOB_DESC& jd2) {
 
 // if a buffer is full after a fgets(), it was too small
 //
-void check_buffer(char *p, int len) {
+void check_buffer(char *p, size_t len) {
     if (strlen(p) == len-1) {
         fprintf(stderr, "fgets() buffer was too small\n");
         exit(1);
@@ -612,7 +612,7 @@ void JOB_DESC::create() {
     if (assign_flag) {
         wu.transitioner_flags = assign_multi?TRANSITION_NONE:TRANSITION_NO_NEW_RESULTS;
     }
-    char additional_xml[256], kwbuf[256];
+    char additional_xml[256];
     additional_xml[0] = 0;
     if (strlen(sub_appname)) {
         snprintf(additional_xml, sizeof(additional_xml),

--- a/tools/remote_submit_test.cpp
+++ b/tools/remote_submit_test.cpp
@@ -35,8 +35,7 @@ void test_query_batches() {
         printf("Error: %d (%s)\n", retval, error_msg.c_str());
         return;
     }
-    for (unsigned int i=0; i<batches.size(); i++) {
-        BATCH_STATUS& bs = batches[i];
+    for (BATCH_STATUS &bs: batches) {
         bs.print();
     }
 }
@@ -53,8 +52,7 @@ void test_query_batch() {
         printf("Error: %d (%s)\n", retval, error_msg.c_str());
         return;
     }
-    for (unsigned int i=0; i<jobs.size(); i++) {
-        JOB_STATE& js = jobs[i];
+    for (JOB_STATE& js: jobs) {
         js.print();
     }
 }


### PR DESCRIPTION
- fix PHP warnings
- show GPU info more clearly
- show message if BUDA desc.json missing

Fixes #6817

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves host and BUDA pages with clearer GPU details, a corrected RSS handler for subscribed threads, and a visible message when app metadata is missing. Also sanitizes client strings and guards optional fields to reduce warnings and prevent XSS.

- **Bug Fixes**
  - GPU parsing and display: recognize ARM/Apple vendors; show count, human-readable RAM, and OpenCL as major.minor; default count to 1; include driver only when present.
  - Host info: guard optional fields and escape client-provided strings (VirtualBox, Docker, BOINC version) to avoid warnings and XSS.
  - Notifications: use subscribed_thread_rss for subscribed thread items.
  - BUDA: show “No desc.json file” when an app lacks metadata.

<sup>Written for commit e688c75ef461911d941e9561c8ae679596948a58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

