### PR TITLE
client: fix crashing bug

### DIFF
--- a/client/app_config.cpp
+++ b/client/app_config.cpp
@@ -96,6 +96,10 @@ int APP_CONFIGS::config_app_versions(PROJECT* p, bool show_warnings) {
         }
     }
 
+    // update resource usage of this project's non-running jobs
+    //
+    gstate.init_result_resource_usage(p);
+
     if (showed_notice) return ERR_XML_PARSE;
     return 0;
 }

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -2473,25 +2473,26 @@ bool CLIENT_STATE::abort_sequence_done() {
 
 #endif  // !SIM
 
-// for each result not currently running, copy resource usage either from
+// copy result.resource_usage either from
 // - workunit if present there (e.g. BUDA jobs)
 // - app version otherwise
 //
 // call this
-// - on startup
+// - on startup (project = NULL)
 // - after reread app_config.xml (which can change app version resource usage)
 // - after scheduler RPC (which can change app version resource usage)
-//
-// For running jobs, we've already populated resource_usage,
-// and we can't change it without restarting the job
+//  in the latter 2 cases, only change non-running jobs
+//  since we can't restart running jobs
 //
 void CLIENT_STATE::init_result_resource_usage(PROJECT *p) {
     for (RESULT* rp: results) {
-        if (p && rp->project != p) {
-            continue;
-        }
-        if (lookup_active_task_by_result(rp)) {
-            continue;
+        if (p) {
+            if (rp->project != p) {
+                continue;
+            }
+            if (rp->running()) {
+                continue;
+            }
         }
         rp->init_resource_usage();
         if (rp->resource_usage.missing_coproc) {

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -633,6 +633,12 @@ bool RESULT::downloading() {
     return true;
 }
 
+bool RESULT::running() {
+    ACTIVE_TASK *atp = gstate.lookup_active_task_by_result(this);
+    if (!atp) return false;
+    return atp->task_state() != PROCESS_UNINITIALIZED;
+}
+
 double RESULT::estimated_runtime_uncorrected() {
     return wup->rsc_fpops_est/resource_usage.flops;
 }

--- a/client/result.h
+++ b/client/result.h
@@ -180,6 +180,7 @@ struct RESULT {
         if (avp->dont_throttle) return true;
         return false;
     }
+    bool running();
     // make a string describing resource usage
     inline void rsc_string(char* buf, int len) {
         if (resource_usage.rsc_type) {


### PR DESCRIPTION
Need to init result.resource_usage on startup even if it has active task. Fix logic for updating result.resource_usage


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a client crash by initializing result.resource_usage on startup even when a task is active. Updated the refresh logic to only skip truly running jobs after app_config or scheduler changes.

- **Bug Fixes**
  - Initialize resource usage for all results on startup (project == NULL).
  - Added RESULT::running() to accurately detect running tasks.
  - Refresh resource usage for non-running jobs when rereading app_config.xml or after scheduler RPCs.

<sup>Written for commit 4ba11bd68e26f535d4e1dd962dce5904649985b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

