### PR TITLE
client: need -f arg for docker rm container on cleanup

### DIFF
--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -425,7 +425,7 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
             if (retval) continue;
             if (!docker_is_boinc_name(name.c_str())) continue;
             if (info.container_present(name)) continue;
-            sprintf(cmd, "rm %s", name.c_str());
+            sprintf(cmd, "rm -f %s", name.c_str());
             retval = dc.command(cmd, out2);
             if (retval) {
                 fprintf(stderr, "Docker command failed: %s\n", cmd);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force-remove Docker containers during client cleanup by switching from "docker rm" to "docker rm -f". This prevents cleanup from failing when BOINC-named containers are running, paused, or stuck.

<sup>Written for commit ed505661843974202da2363bb01d6544ba90bd93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

