### PR TITLE
Test updated opengl-registry vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/opengl-registry/copyright
+++ b/3rdParty/vcpkg_ports/ports/opengl-registry/copyright
@@ -1,0 +1,2 @@
+The files installed by the `opengl-registry` port are using different licenses.
+Each file defines its license in a comment at the top of the file.

--- a/3rdParty/vcpkg_ports/ports/opengl-registry/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/opengl-registry/portfile.cmake
@@ -1,0 +1,32 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO KhronosGroup/OpenGL-Registry
+  REF 0b449b97cdf1043eef5e1f0e235cbbab6ec10c86
+  SHA512 148e1bfe4cc199bcc2c23b22d0b3e4988a29389d7f510ba4a6340672dbb7ab99bb836d2c08587499484df704d51a1adf4f0dc3a30d5ad8977ee0ad339163b17e
+  HEAD_REF master
+)
+
+file(COPY "${SOURCE_PATH}/api/GL" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/api/GLES" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/api/GLES2" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/api/GLES3" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/api/GLSC" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+file(COPY "${SOURCE_PATH}/api/GLSC2" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+file(GLOB reg_files "${SOURCE_PATH}/xml/*.xml" "${SOURCE_PATH}/xml/readme.pdf" "${SOURCE_PATH}/xml/*.rnc" "${SOURCE_PATH}/xml/reg.py")
+file(COPY
+  ${reg_files}
+  DESTINATION "${CURRENT_PACKAGES_DIR}/share/opengl"
+)
+
+vcpkg_install_copyright(FILE_LIST "${CURRENT_PORT_DIR}/copyright")
+
+# pc layout from cygwin (consumed in xserver!)
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/pkgconfig/khronos-opengl-registry.pc" [=[
+prefix=${pcfiledir}/../..
+datadir=${prefix}/share
+specdir=${datadir}/opengl
+Name: khronos-opengl-registry
+Description: Khronos OpenGL registry
+Version: git3530768138c5ba3dfbb2c43c830493f632f7ea33
+]=])

--- a/3rdParty/vcpkg_ports/ports/opengl-registry/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/opengl-registry/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "opengl-registry",
+  "version-date": "2026-01-26",
+  "description": "OpenGL, OpenGL ES, and OpenGL ES-SC API and Extension Registry",
+  "homepage": "https://github.com/KhronosGroup/OpenGL-Registry",
+  "supports": "!xbox",
+  "dependencies": [
+    "egl-registry"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom vcpkg port for the Khronos OpenGL Registry to install headers and XML specs. Includes a pkg-config file so downstream builds (e.g., xserver) can find the registry data.

- **New Features**
  - Pinned fetch of KhronosGroup/OpenGL-Registry via vcpkg_from_github.
  - Installs API headers: GL, GLES, GLES2, GLES3, GLSC, GLSC2 under include/.
  - Packages XML specs, RNC, readme.pdf, and reg.py under share/opengl/.
  - Adds pkg-config file: share/pkgconfig/khronos-opengl-registry.pc pointing to share/opengl.
  - vcpkg metadata with version-date, dependency on egl-registry, and !xbox support.
  - Includes license notice for installed files.

<sup>Written for commit ab817466803eb43c72e4cdf3e7218b6de123e7b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

