### PR TITLE
Test updated libxext vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxext/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxext/portfile.cmake
@@ -1,0 +1,31 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxext"
+    REF  "libXext-${VERSION}"
+    SHA512 0318c3bf5b6cc00d65c810986fcc8c1458dce370ec9a4d6fda4a6fe9d57d865feb4197b571cd4a12a51118106819b848c0bca7265737d96dd0081261632646a3
+    HEAD_REF master
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS xorg_cv_malloc0_returns_null=yes
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxext/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxext/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "libxext",
+  "version": "1.3.7",
+  "description": "Xlib-based library for common extensions to the X11 protocol",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxext",
+  "license": null,
+  "dependencies": [
+    "libx11",
+    "xorg-macros",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom vcpkg port for libXext 1.3.7 to support Windows builds and optional vcpkg builds on Unix-like systems. Defaults to system packages on non-Windows targets.

- **New Features**
  - Builds libXext via autotools; fixes pkg-config files.
  - Respects X_VCPKG_FORCE_VCPKG_X_LIBRARIES to allow vcpkg build on non-Windows.
  - Declares dependencies: libx11, xorg-macros, xproto.

- **Migration**
  - On Linux/macOS, install system libXext or set X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet to build via vcpkg.

<sup>Written for commit d22f702f0715dcbd0acd0d900f632e1eda900518. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

