### PR TITLE
Test updated libxrandr vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libxrandr/fix-configure.patch
+++ b/3rdParty/vcpkg_ports/ports/libxrandr/fix-configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index 99e3944..d6e6159 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -34,7 +34,6 @@ AC_INIT([libXrandr], [1.5.4],
+         [libXrandr])
+ AC_CONFIG_SRCDIR([Makefile.am])
+ AC_CONFIG_HEADERS([config.h])
+-AC_CONFIG_MACRO_DIRS([m4])
+ 
+ # Initialize Automake
+ AM_INIT_AUTOMAKE([foreign dist-xz])

--- a/3rdParty/vcpkg_ports/ports/libxrandr/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxrandr/portfile.cmake
@@ -1,0 +1,37 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in the triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxrandr"
+    REF "libXrandr-${VERSION}"
+    SHA512 32983bbc173923f016bed8b6920319a6df6583d1a1cb37013e54413244b46501828c9b3136dd37bf46fd95d889045c1e68868f6a9e692356f54bc5db221005f3
+    HEAD_REF master
+    PATCHES
+        fix-configure.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+if (VCPKG_CROSSCOMPILING)
+    list(APPEND OPTIONS --enable-malloc0returnsnull)
+endif()
+
+vcpkg_configure_make(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTOCONFIG
+    OPTIONS ${OPTIONS}
+)
+
+vcpkg_install_make()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxrandr/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxrandr/vcpkg.json
@@ -1,0 +1,15 @@
+{
+  "name": "libxrandr",
+  "version": "1.5.5",
+  "description": "Xlib Resize, Rotate and Reflection (RandR) extension library",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxrandr",
+  "license": null,
+  "dependencies": [
+    "bzip2",
+    "libx11",
+    "libxext",
+    "libxrender",
+    "xorg-macros",
+    "xproto"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a custom vcpkg port for libXrandr 1.5.5 to allow vendoring the RandR library when needed. On non-Windows, it prefers system packages unless forced via X_VCPKG_FORCE_VCPKG_X_LIBRARIES.

- **New Features**
  - New libXrandr 1.5.5 port with autoconf/make build.
  - Patch removes AC_CONFIG_MACRO_DIRS from configure.ac to fix autoreconf in vcpkg.
  - Empty package on non-Windows by default; set X_VCPKG_FORCE_VCPKG_X_LIBRARIES to build from vcpkg.

- **Dependencies**
  - bzip2, libx11, libxext, libxrender, xorg-macros, xproto.

<sup>Written for commit 4b0ca1aa03624da3bf4b256179f381faeb7ec967. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

