### PR TITLE
update_stats: decay app versions.expavg_credit

### DIFF
--- a/html/user/apps.php
+++ b/html/user/apps.php
@@ -55,7 +55,7 @@ foreach ($apps as $app) {
                 <th>".tra("Platform")."</th>
                 <th>".tra("Version")."</th>
                 <th>".tra("Created")."</th>
-                <th>".tra("Average computing")."</th>
+                <th style=\"text-align: right\">".tra("Recent average GFLOPS")."</th>
             </tr>
         ";
     }
@@ -82,13 +82,13 @@ foreach ($apps as $app) {
                 }
                 $gf = $av->expavg_credit/200;
                 $total_gf += $gf;
-                $gf = number_format($gf, 0);
+                $gf = number_format($gf, 2);
                 $b = $av->beta?" (beta test)":"";
                 echo "<tr>
                     <td>$platform->user_friendly_name</td>
                     <td>$version_num_f$b</td>
                     <td>$create_time_f</td>
-                    <td align=right>$gf GigaFLOPS</td>
+                    <td align=right>$gf</td>
                     </tr>
                 ";
             }


### PR DESCRIPTION
update_stats updated expavg_credit for users, teams, and hosts. It needs to do it for app versions as well.

Web: improve the way this field is displayed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend update_stats to decay expavg_credit for app versions and improve how this metric is shown in the web UI. Keeps app-version recent average credit current and easier to read.

- **New Features**
  - Added --update_avs to update_stats to decay app versions’ expavg_credit; included by default when no flags are set.
  - Updated help text and logs to cover app versions.
  - Web: renamed column to “Recent average GFLOPS,” right-aligned values, and display to 2 decimals (no unit suffix).

<sup>Written for commit a59a3fa6979971d8fbf52120fd22dacb7ea62702. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

