### PR TITLE
[windows][installer] add acct_mgr_login test

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -213,7 +213,7 @@ jobs:
       matrix:
         type: [install, upgrade_from_alpha, upgrade_from_stable]
         platform: [x64, arm64]
-        installation_type: [normal, service]
+        installation_type: [normal, service, test_acct_mgr_login]
         include:
           - platform: x64
             runner: windows-latest
@@ -227,6 +227,10 @@ jobs:
             argument_list_alpha: "/quiet /qn /norestart /l*v alpha.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
             argument_list_release: "/quiet /qn /norestart /l*v release.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
             argument_list_install: "/quiet /qn /norestart /l*v install.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+          - installation_type: test_acct_mgr_login
+            argument_list_alpha: "/quiet /qn /l*v alpha.log"
+            argument_list_release: "/quiet /qn /l*v release.log"
+            argument_list_install: "/quiet /qn /l*v install.log ACCTMGR_LOGIN=test ACCTMGR_PASSWORDHASH=0123456789abcdef"
       fail-fast: false
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Windows installer integration test to verify acct_mgr_login.xml is created and correctly populated when ACCTMGR_LOGIN and ACCTMGR_PASSWORDHASH are passed. Updates the CI matrix to run this new case.

- **New Features**
  - Added test_acct_mgr_login to check file existence and XML contents (root tag, login, password_hash).
  - Extended windows.yml matrix with installation_type=test_acct_mgr_login and installer args to set ACCTMGR_LOGIN=test and ACCTMGR_PASSWORDHASH=0123456789abcdef.

<sup>Written for commit c41f61ea32eb6e4dd5729c7be7a028ae04d2b754. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

