### PR TITLE
back end code: use range-based for

### DIFF
--- a/db/boinc_db.cpp
+++ b/db/boinc_db.cpp
@@ -2367,7 +2367,7 @@ int DB_SCHED_RESULT_ITEM_SET::enumerate() {
     return 0;
 }
 
-int DB_SCHED_RESULT_ITEM_SET::add_result(char* result_name) {
+int DB_SCHED_RESULT_ITEM_SET::add_result(const char* result_name) {
     SCHED_RESULT_ITEM result;
     result.id = 0;
     strcpy2(result.queried_name, result_name);
@@ -2375,7 +2375,7 @@ int DB_SCHED_RESULT_ITEM_SET::add_result(char* result_name) {
     return 0;
 }
 
-int DB_SCHED_RESULT_ITEM_SET::lookup_result(char* result_name, SCHED_RESULT_ITEM** rip) {
+int DB_SCHED_RESULT_ITEM_SET::lookup_result(const char* result_name, SCHED_RESULT_ITEM** rip) {
     unsigned int i;
     for (i=0; i<results.size(); i++) {
         if (!strcmp(results[i].name, result_name)) {

--- a/db/boinc_db.h
+++ b/db/boinc_db.h
@@ -413,14 +413,14 @@ public:
     DB_SCHED_RESULT_ITEM_SET(DB_CONN* p=0);
     std::vector<SCHED_RESULT_ITEM> results;
 
-    int add_result(char* result_name);
+    int add_result(const char* result_name);
 
     int enumerate();
         // using a single SQL query, look up all the reported results,
         // (based on queried_name)
         // and fill in the rest of the entries in the results vector
 
-    int lookup_result(char* result_name, SCHED_RESULT_ITEM** result);
+    int lookup_result(const char* result_name, SCHED_RESULT_ITEM** result);
 
     int update_result(SCHED_RESULT_ITEM& result);
     int update_workunits();

--- a/lib/average.h
+++ b/lib/average.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2010 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -56,7 +56,7 @@ struct AVERAGE {
         return truncated;
     }
 
-    inline double get_avg() {
+    inline double get_avg() const {
         return avg;
     }
 };

--- a/sched/credit.cpp
+++ b/sched/credit.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/credit.cpp
+++ b/sched/credit.cpp
@@ -461,9 +461,9 @@ int hav_lookup(
 DB_APP_VERSION_VAL *av_lookup(
     DB_ID_TYPE id, vector<DB_APP_VERSION_VAL>& app_versions
 ) {
-    for (unsigned int i=0; i<app_versions.size(); i++) {
-        if (app_versions[i].id == id) {
-            return &app_versions[i];
+    for (DB_APP_VERSION_VAL &av: app_versions) {
+        if (av.id == id) {
+            return &av;
         }
     }
     DB_APP_VERSION_VAL av;
@@ -810,18 +810,17 @@ int get_pfc(
 // (reduces the weight of large outliers)
 //
 double low_average(vector<double>& v) {
-    int i;
     int n = v.size();
     if (n == 1) {
         return v[0];
     }
     double sum=0;
-    for (i=0; i<n; i++) {
-        sum += v[i];
+    for (double x: v) {
+        sum += x;
     }
     double total=0;
-    for (i=0; i<n; i++) {
-        total += v[i]*(sum-v[i]);
+    for (double x: v) {
+        total += x*(sum-x);
     }
     return total/((n-1)*sum);
 }
@@ -829,28 +828,27 @@ double low_average(vector<double>& v) {
 // compute the average of number weighted by proximity
 // to another number
 double pegged_average(vector<double>& v, double anchor) {
-    int n=v.size();
-    double weights=0,sum=0,w;
-    int i;
+    int n = v.size();
+    double weights=0, sum=0, w;
     if (n==1) {
         return v[0];
     }
-    for (i=0; i<n; i++) {
-        w=(1.0/(0.1*anchor+fabs(anchor-v[i])));
-        weights+=w;
-        sum+=w*v[i];
+    for (double x: v) {
+        w = (1.0/(0.1*anchor+fabs(anchor-x)));
+        weights += w;
+        sum += w*x;
     }
     return sum/weights;
 }
 
 double vec_min(vector<double>& v) {
-    double x = v[0];
-    for (unsigned int i=1; i<v.size(); i++) {
-        if (v[i] < x) {
-            x = v[i];
+    double m = v[0];
+    for (double x: v) {
+        if (x < m) {
+            m = x;
         }
     }
-    return x;
+    return m;
 }
 
 // Called by validator when canonical result has been selected.
@@ -873,13 +871,12 @@ int assign_credit_set(
     double max_granted_credit,
     double &credit      // out
 ) {
-    unsigned int i;
     int mode, retval;
     double pfc;
     vector<double> normal;
     vector<double> approx;
 
-    for (i=0; i<results.size(); i++) {
+    for (unsigned int i=0; i<results.size(); i++) {
         RESULT &r = results[i];
         if (r.validate_state != VALIDATE_STATE_VALID) {
             continue;
@@ -971,12 +968,10 @@ int assign_credit_set(
 // done at the end of every validator scan.
 //
 int write_modified_app_versions(vector<DB_APP_VERSION_VAL>& app_versions) {
-    unsigned int i, j;
     int retval = 0;
     double now = dtime();
 
-    for (i=0; i<app_versions.size(); i++) {
-        DB_APP_VERSION_VAL &av = app_versions[i];
+    for (DB_APP_VERSION_VAL &av: app_versions) {
         if (av.pfc_samples.empty() && av.credit_samples.empty()) {
             continue;
         }
@@ -984,13 +979,12 @@ int write_modified_app_versions(vector<DB_APP_VERSION_VAL>& app_versions) {
             double pfc_n_orig = av.pfc.n;
             double expavg_credit_orig = av.expavg_credit;
 
-            for (j=0; j<av.pfc_samples.size(); j++) {
+            for (double x: av.pfc_samples) {
                 av.pfc.update(
-                    av.pfc_samples[j],
-                    AV_AVG_THRESH, AV_AVG_WEIGHT, AV_AVG_LIMIT
+                    x, AV_AVG_THRESH, AV_AVG_WEIGHT, AV_AVG_LIMIT
                 );
             }
-            for (j=0; j<av.credit_samples.size(); j++) {
+            for (unsigned int j=0; j<av.credit_samples.size(); j++) {
                 update_average(
                     now,
                     av.credit_times[j], av.credit_samples[j], CREDIT_HALF_LIFE,

--- a/sched/credit_test.cpp
+++ b/sched/credit_test.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2016 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -112,13 +112,13 @@ HOST_APP_VERSION& lookup_host_app_version(int hostid, int avid) {
     return host_app_versions.back();
 }
 
-void print_average(AVERAGE& a) {
+void print_average(const AVERAGE& a) {
     printf("n %f avg %f\n", a.n, a.get_avg());
 }
 
 void print_avs() {
     printf("----- scales --------\n");
-    for (APP_VERSION& av: app_versions) {
+    for (const APP_VERSION& av: app_versions) {
         if (!av.pfc.n) continue;
         PLATFORM* p = lookup_platform(av.platformid);
         printf("app %lu vers %lu (%s %s)\n scale %f ",
@@ -152,7 +152,7 @@ struct RSC_INFO {
         nvers_thresh = 0;
         nvers_total = 0;
     }
-    void update(APP_VERSION& av) {
+    void update(const APP_VERSION& av) {
         nvers_total++;
         if (av.pfc.n > MIN_VERSION_SAMPLES) {
             nvers_thresh++;
@@ -170,7 +170,7 @@ void scale_versions(APP& app, double avg) {
         if (av.appid != app.id) continue;
         if (av.pfc.n < MIN_VERSION_SAMPLES) continue;
 
-        av.pfc_scale= avg/av.pfc.get_avg();
+        av.pfc_scale = avg/av.pfc.get_avg();
         PLATFORM* p = lookup_platform(av.platformid);
         printf("updating scale factor for (%s %s)\n",
              p->name, av.plan_class
@@ -193,7 +193,7 @@ void update_av_scales() {
 
         // find the average PFC of CPU and GPU versions
 
-        for (APP_VERSION& av: app_versions) {
+        for (const APP_VERSION& av: app_versions) {
             if (av.appid != app.id) continue;
             if (strstr(av.plan_class, "cuda") || strstr(av.plan_class, "ati")) {
                 printf("gpu update: %lu %s %f\n", av.id, av.plan_class, av.pfc.get_avg());

--- a/sched/credit_test.cpp
+++ b/sched/credit_test.cpp
@@ -76,18 +76,14 @@ void read_db() {
 }
 
 PLATFORM* lookup_platform(int id) {
-    unsigned int i;
-    for (i=0; i<platforms.size(); i++) {
-        PLATFORM& p = platforms[i];
+    for (PLATFORM& p: platforms) {
         if (p.id == id) return &p;
     }
     return NULL;
 }
 
 APP_VERSION* lookup_av(int id) {
-    unsigned int i;
-    for (i=0; i<app_versions.size(); i++) {
-        APP_VERSION& av = app_versions[i];
+    for (APP_VERSION& av: app_versions) {
         if (av.id == id) return &av;
     }
     printf(" missing app version %d\n", id);
@@ -95,9 +91,7 @@ APP_VERSION* lookup_av(int id) {
 }
 
 APP& lookup_app(int id) {
-    unsigned int i;
-    for (i=0; i<apps.size(); i++) {
-        APP& app = apps[i];
+    for (APP& app: apps) {
         if (app.id == id) return app;
     }
     printf("missing app: %d\n", id);
@@ -106,9 +100,7 @@ APP& lookup_app(int id) {
 }
 
 HOST_APP_VERSION& lookup_host_app_version(int hostid, int avid) {
-    unsigned int i;
-    for (i=0; i<host_app_versions.size(); i++) {
-        HOST_APP_VERSION& hav = host_app_versions[i];
+    for (HOST_APP_VERSION& hav: host_app_versions) {
         if (hav.host_id != hostid) continue;
         if (hav.app_version_id != avid) continue;
         return hav;
@@ -121,15 +113,12 @@ HOST_APP_VERSION& lookup_host_app_version(int hostid, int avid) {
 }
 
 void print_average(AVERAGE& a) {
-    printf("n %f avg %f\n", a.n, a.get_avg()
-    );
+    printf("n %f avg %f\n", a.n, a.get_avg());
 }
 
 void print_avs() {
-    unsigned int i;
     printf("----- scales --------\n");
-    for (i=0; i<app_versions.size(); i++) {
-        APP_VERSION& av = app_versions[i];
+    for (APP_VERSION& av: app_versions) {
         if (!av.pfc.n) continue;
         PLATFORM* p = lookup_platform(av.platformid);
         printf("app %lu vers %lu (%s %s)\n scale %f ",
@@ -177,8 +166,7 @@ struct RSC_INFO {
 };
 
 void scale_versions(APP& app, double avg) {
-    for (unsigned int j=0; j<app_versions.size(); j++) {
-        APP_VERSION& av = app_versions[j];
+    for (APP_VERSION& av: app_versions) {
         if (av.appid != app.id) continue;
         if (av.pfc.n < MIN_VERSION_SAMPLES) continue;
 
@@ -198,17 +186,14 @@ void scale_versions(APP& app, double avg) {
 // and find the min average PFC for each app
 //
 void update_av_scales() {
-    unsigned int i, j;
     printf("----- updating scales --------\n");
-    for (i=0; i<apps.size(); i++) {
-        APP& app = apps[i];
+    for (APP& app: apps) {
         printf("app %lu\n", app.id);
         RSC_INFO cpu_info, gpu_info;
 
         // find the average PFC of CPU and GPU versions
 
-        for (j=0; j<app_versions.size(); j++) {
-            APP_VERSION& av = app_versions[j];
+        for (APP_VERSION& av: app_versions) {
             if (av.appid != app.id) continue;
             if (strstr(av.plan_class, "cuda") || strstr(av.plan_class, "ati")) {
                 printf("gpu update: %lu %s %f\n", av.id, av.plan_class, av.pfc.get_avg());
@@ -247,8 +232,6 @@ void update_av_scales() {
                 accumulate_stats = true;
             }
         }
-
-
     }
     printf("-------------\n");
 }

--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -841,7 +841,6 @@ int tables_file(char* dir) {
 }
 
 int ENUMERATION::make_it_happen(char* output_dir) {
-    unsigned int i;
     int n, retval;
     DB_USER user;
     DB_USER_DELETED user_deleted;
@@ -863,8 +862,7 @@ int ENUMERATION::make_it_happen(char* output_dir) {
 
     sprintf(path, "%s/%s", output_dir, filename);
 
-    for (i=0; i<outputs.size(); i++) {
-        OUTPUT& out = outputs[i];
+    for (OUTPUT& out: outputs) {
         if (out.recs_per_file) {
             out.nzfile = new NUMBERED_ZFILE(
                 tag_name[table], out.compression, path, out.recs_per_file
@@ -944,8 +942,7 @@ int ENUMERATION::make_it_happen(char* output_dir) {
             if (retval) break;
 
             if (!strncmp("deleted", user.authenticator, 7)) continue;
-            for (i=0; i<outputs.size(); i++) {
-                OUTPUT& out = outputs[i];
+            for (OUTPUT& out: outputs) {
                 if (sort == SORT_ID && out.recs_per_file) {
                     out.nzfile->set_id(n++);
                 }
@@ -969,8 +966,7 @@ int ENUMERATION::make_it_happen(char* output_dir) {
             retval = user_deleted.enumerate("order by userid");
             if (retval) break;
             nusers_deleted++;
-            for (i=0; i<outputs.size(); i++) {
-                OUTPUT& out = outputs[i];
+            for (OUTPUT& out: outputs) {
                 if (sort == SORT_ID && out.recs_per_file) {
                     out.nzfile->set_id(n++);
                 }
@@ -1032,8 +1028,7 @@ int ENUMERATION::make_it_happen(char* output_dir) {
             if (retval) break;
             if (!host.userid) continue;
             if (!strncmp("deleted", host.domain_name, 8)) continue;
-            for (i=0; i<outputs.size(); i++) {
-                OUTPUT& out = outputs[i];
+            for (OUTPUT& out: outputs) {
                 if (sort == SORT_ID && out.recs_per_file) {
                     out.nzfile->set_id(n++);
                 }
@@ -1057,8 +1052,7 @@ int ENUMERATION::make_it_happen(char* output_dir) {
             retval = host_deleted.enumerate("order by hostid");
             if (retval) break;
             nhosts_deleted++;
-            for (i=0; i<outputs.size(); i++) {
-                OUTPUT& out = outputs[i];
+            for (OUTPUT& out: outputs) {
                 if (sort == SORT_ID && out.recs_per_file) {
                     out.nzfile->set_id(n++);
                 }
@@ -1087,8 +1081,7 @@ int ENUMERATION::make_it_happen(char* output_dir) {
             retval = team.enumerate(clause);
             if (retval) break;
             nteams++;
-            for (i=0; i<outputs.size(); i++) {
-                OUTPUT& out = outputs[i];
+            for (OUTPUT& out: outputs) {
                 if (sort == SORT_ID && out.recs_per_file) {
                     out.nzfile->set_id(n++);
                 }
@@ -1107,8 +1100,7 @@ int ENUMERATION::make_it_happen(char* output_dir) {
         }
         break;
     }
-    for (i=0; i<outputs.size(); i++) {
-        OUTPUT& out = outputs[i];
+    for (OUTPUT& out: outputs) {
         if (out.zfile) {
           out.zfile->close();
           delete out.zfile;
@@ -1265,9 +1257,7 @@ int main(int argc, char** argv) {
 
     boinc_mkdir(spec.output_dir);
 
-    unsigned int j;
-    for (j=0; j<spec.enumerations.size(); j++) {
-        ENUMERATION& e = spec.enumerations[j];
+    for (ENUMERATION& e: spec.enumerations) {
         e.make_it_happen(spec.output_dir);
     }
 

--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/edf_sim.cpp
+++ b/sched/edf_sim.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -243,7 +243,7 @@ bool check_candidate (
 
     // simulate execution of all queued results and test result
     //
-    for (IP_RESULT& r: ip_results) {
+    for (const IP_RESULT& r: ip_results) {
         // find the CPU that will be free first
         //
         double lowest_booked_time = booked_to[0];

--- a/sched/edf_sim.cpp
+++ b/sched/edf_sim.cpp
@@ -107,9 +107,7 @@ void mark_edf_misses (int ncpus, vector<IP_RESULT>& ip_results){
 
     // simulate edf execution of all queued results
     //
-    for (unsigned int i=0; i<ip_results.size(); i++) {
-        IP_RESULT& r = ip_results[i];
-
+    for (IP_RESULT& r: ip_results) {
         // find the CPU that will be free first
         //
         double lowest_booked_time = booked_to[0];
@@ -150,14 +148,11 @@ void init_ip_results(
     int ncpus,
     vector<IP_RESULT>& ip_results
 ){
-    unsigned int i;
-
     log_msg(DETAIL,
         "[edf_detail] init_ip_results; work_buf_min %.2f ncpus %d:\n",
         work_buf_min/TIME_SCALE, ncpus
     );
-    for (i=0; i<ip_results.size(); i++) {
-        IP_RESULT& r = ip_results[i];
+    for (IP_RESULT& r: ip_results) {
         r.computation_deadline = r.report_deadline - work_buf_min;
         log_msg(DETAIL, "[edf_detail]     %s: deadline %.2f cpu %.2f\n",
             r.name, r.computation_deadline/TIME_SCALE, r.cpu_time_remaining/TIME_SCALE
@@ -248,9 +243,7 @@ bool check_candidate (
 
     // simulate execution of all queued results and test result
     //
-    for (unsigned int i=0; i<ip_results.size(); i++) {
-        IP_RESULT& r = ip_results[i];
-
+    for (IP_RESULT& r: ip_results) {
         // find the CPU that will be free first
         //
         double lowest_booked_time = booked_to[0];

--- a/sched/handle_request.cpp
+++ b/sched/handle_request.cpp
@@ -83,8 +83,8 @@ static bool find_host_by_other(DB_USER& user, HOST req_host, DB_HOST& host) {
     // don't dig through hosts of these users
     // prevents flooding the DB with slow queries from users with many hosts
     //
-    for (unsigned int i=0; i < config.dont_search_host_for_userid.size(); i++) {
-        if (user.id == config.dont_search_host_for_userid[i]) {
+    for (int id: config.dont_search_host_for_userid) {
+        if (user.id == id) {
             return false;
         }
     }
@@ -460,7 +460,7 @@ lookup_user_and_make_new_host:
                     );
                 } else {
                     if ((g_request->allow_multiple_clients != 1)
-                        && (g_request->other_results.size() == 0)
+                        && (g_request->other_results.empty())
                     ) {
                         mark_results_over(host);
                     }
@@ -494,7 +494,7 @@ didnt_find_host:
                 "[HOST#%lu] [USER#%lu] Found similar existing host for this user - assigned.\n",
                 host.id, host.userid
             );
-            if (g_request->other_results.size() == 0) {
+            if (g_request->other_results.empty()) {
                 // mark host's jobs as abandoned
                 // if client has no jobs in progress
                 //
@@ -686,35 +686,34 @@ int send_result_abort() {
     int retval = 0;
     DB_IN_PROGRESS_RESULT result;
     string result_names;
-    unsigned int i;
 
-    if (g_request->other_results.size() == 0) {
+    if (g_request->other_results.empty()) {
         return 0;
     }
 
     // build list of result names
     //
-    for (i=0; i<g_request->other_results.size(); i++) {
-        OTHER_RESULT& orp=g_request->other_results[i];
+    bool first = true;
+    for (OTHER_RESULT& orp: g_request->other_results) {
         orp.abort = true;
             // if the host has a result not in the DB, abort it
         orp.abort_if_not_started = false;
         orp.reason = ABORT_REASON_NOT_FOUND;
-        if (i > 0) result_names.append(", ");
+        if (!first) result_names.append(", ");
         result_names.append("'");
         char buf[1024];
         safe_strcpy(buf, orp.name);
         escape_string(buf, sizeof(buf));
         result_names.append(buf);
         result_names.append("'");
+        first = false;
     }
 
     // look up selected fields from the results and their WUs,
     // and decide if they should be aborted
     //
     while (!(retval = result.enumerate(g_reply->host.id, result_names.c_str()))) {
-        for (i=0; i<g_request->other_results.size(); i++) {
-            OTHER_RESULT& orp = g_request->other_results[i];
+        for (OTHER_RESULT& orp: g_request->other_results) {
             if (!strcmp(orp.name, result.result_name)) {
                 if (result.error_mask&WU_ERROR_CANCELLED ) {
                     // if the WU has been canceled, abort the result
@@ -754,8 +753,7 @@ int send_result_abort() {
 
     // loop through the results and send the appropriate message (if any)
     //
-    for (i=0; i<g_request->other_results.size(); i++) {
-        OTHER_RESULT& orp = g_request->other_results[i];
+    for (OTHER_RESULT& orp: g_request->other_results) {
         if (orp.abort) {
             g_reply->result_aborts.push_back(orp.name);
             log_messages.printf(MSG_NORMAL,
@@ -1043,11 +1041,9 @@ void warn_user_if_core_client_upgrade_scheduled() {
 }
 
 bool unacceptable_os() {
-    unsigned int i;
     char buf[1024];
 
-    for (i=0; i<config.ban_os->size(); i++) {
-        regex_t& re = (*config.ban_os)[i];
+    for (regex_t& re: *config.ban_os) {
         safe_strcpy(buf, g_request->host.os_name);
         safe_strcat(buf, "\t");
         safe_strcat(buf, g_request->host.os_version);
@@ -1069,11 +1065,9 @@ bool unacceptable_os() {
 }
 
 bool unacceptable_cpu() {
-    unsigned int i;
     char buf[1024];
 
-    for (i=0; i<config.ban_cpu->size(); i++) {
-        regex_t& re = (*config.ban_cpu)[i];
+    for (regex_t& re: *config.ban_cpu) {
         safe_strcpy(buf, g_request->host.p_vendor);
         safe_strcat(buf, "\t");
         safe_strcat(buf, g_request->host.p_model);
@@ -1115,13 +1109,11 @@ bool wrong_core_client_version() {
 }
 
 void handle_msgs_from_host() {
-    unsigned int i;
     DB_MSG_FROM_HOST mfh;
     int retval;
 
-    for (i=0; i<g_request->msgs_from_host.size(); i++) {
+    for (MSG_FROM_HOST_DESC& md: g_request->msgs_from_host) {
         g_reply->send_msg_ack = true;
-        MSG_FROM_HOST_DESC& md = g_request->msgs_from_host[i];
         mfh.clear();
         mfh.create_time = time(0);
         safe_strcpy(mfh.variety, md.variety);
@@ -1215,7 +1207,6 @@ void process_request(char* code_sign_key) {
     bool have_no_work = false;
     char buf[256];
     HOST initial_host;
-    unsigned int i;
     time_t t;
 
     memset(&g_reply->wreq, 0, sizeof(g_reply->wreq));
@@ -1235,7 +1226,7 @@ void process_request(char* code_sign_key) {
 
     // if no jobs reported and none to send, return without accessing DB
     //
-    if (!ok_to_send_work && !g_request->results.size()) {
+    if (!ok_to_send_work && g_request->results.empty()) {
         return;
     }
 
@@ -1268,7 +1259,7 @@ void process_request(char* code_sign_key) {
         have_no_work
         && config.nowork_skip
         && requesting_work()
-        && (g_request->results.size() == 0)
+        && g_request->results.empty()
         && (g_request->hostid != 0)
     ) {
         g_reply->insert_message("No work available", "low");
@@ -1376,12 +1367,14 @@ void process_request(char* code_sign_key) {
     // if primary platform is anonymous, ignore alternate platforms
     //
     if (strcmp(g_request->platform.name, "anonymous")) {
-        for (i=0; i<g_request->alt_platforms.size(); i++) {
-            platform = ssp->lookup_platform(g_request->alt_platforms[i].name);
-            if (platform) g_request->platforms.list.push_back(platform);
+        for (CLIENT_PLATFORM &p: g_request->alt_platforms) {
+            platform = ssp->lookup_platform(p.name);
+            if (platform) {
+                g_request->platforms.list.push_back(platform);
+            }
         }
     }
-    if (g_request->platforms.list.size() == 0) {
+    if (g_request->platforms.list.empty()) {
         sprintf(buf, "%s %s",
             _("This project doesn't support computers of type"),
             g_request->platform.name
@@ -1527,8 +1520,7 @@ static void log_incomplete_request() {
 }
 
 static void log_user_messages() {
-    for (unsigned int i=0; i<g_reply->messages.size(); i++) {
-        USER_MESSAGE um = g_reply->messages[i];
+    for (USER_MESSAGE &um: g_reply->messages) {
         log_messages.printf(MSG_NORMAL,
             "[user_messages] [HOST#%lu] MSG(%s) %s\n",
             g_reply->host.id, um.priority.c_str(), um.message.c_str()

--- a/sched/handle_request.cpp
+++ b/sched/handle_request.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -753,7 +753,7 @@ int send_result_abort() {
 
     // loop through the results and send the appropriate message (if any)
     //
-    for (OTHER_RESULT& orp: g_request->other_results) {
+    for (const OTHER_RESULT& orp: g_request->other_results) {
         if (orp.abort) {
             g_reply->result_aborts.push_back(orp.name);
             log_messages.printf(MSG_NORMAL,
@@ -1043,7 +1043,7 @@ void warn_user_if_core_client_upgrade_scheduled() {
 bool unacceptable_os() {
     char buf[1024];
 
-    for (regex_t& re: *config.ban_os) {
+    for (const regex_t& re: *config.ban_os) {
         safe_strcpy(buf, g_request->host.os_name);
         safe_strcat(buf, "\t");
         safe_strcat(buf, g_request->host.os_version);
@@ -1067,7 +1067,7 @@ bool unacceptable_os() {
 bool unacceptable_cpu() {
     char buf[1024];
 
-    for (regex_t& re: *config.ban_cpu) {
+    for (const regex_t& re: *config.ban_cpu) {
         safe_strcpy(buf, g_request->host.p_vendor);
         safe_strcat(buf, "\t");
         safe_strcat(buf, g_request->host.p_model);
@@ -1112,7 +1112,7 @@ void handle_msgs_from_host() {
     DB_MSG_FROM_HOST mfh;
     int retval;
 
-    for (MSG_FROM_HOST_DESC& md: g_request->msgs_from_host) {
+    for (const MSG_FROM_HOST_DESC& md: g_request->msgs_from_host) {
         g_reply->send_msg_ack = true;
         mfh.clear();
         mfh.create_time = time(0);
@@ -1367,7 +1367,7 @@ void process_request(char* code_sign_key) {
     // if primary platform is anonymous, ignore alternate platforms
     //
     if (strcmp(g_request->platform.name, "anonymous")) {
-        for (CLIENT_PLATFORM &p: g_request->alt_platforms) {
+        for (const CLIENT_PLATFORM &p: g_request->alt_platforms) {
             platform = ssp->lookup_platform(p.name);
             if (platform) {
                 g_request->platforms.list.push_back(platform);
@@ -1520,7 +1520,7 @@ static void log_incomplete_request() {
 }
 
 static void log_user_messages() {
-    for (USER_MESSAGE &um: g_reply->messages) {
+    for (const USER_MESSAGE &um: g_reply->messages) {
         log_messages.printf(MSG_NORMAL,
             "[user_messages] [HOST#%lu] MSG(%s) %s\n",
             g_reply->host.id, um.priority.c_str(), um.message.c_str()

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2024 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -286,7 +286,7 @@ bool PLAN_CLASS_SPEC::check(
         }
         downcase_string(buf);
 
-        for (string &s: cpu_features) {
+        for (const string &s: cpu_features) {
             if (!strstr(buf, s.c_str())) {
                 if (config.debug_version_select) {
                     log_messages.printf(MSG_NORMAL,
@@ -1130,7 +1130,7 @@ bool PLAN_CLASS_SPECS::wu_is_infeasible(
     const char* plan_class_name, const WORKUNIT* wu
 ) {
     if (wu_restricted_plan_class) {
-        for (PLAN_CLASS_SPEC& spec: classes) {
+        for (const PLAN_CLASS_SPEC& spec: classes) {
             if(!strcmp(spec.name, plan_class_name)) {
                 return wu_is_infeasible_for_plan_class(&spec, wu);
             }
@@ -1393,7 +1393,7 @@ int main() {
         sreq.coprocs.ati.count = 0;
     }
 
-    for (PLAN_CLASS_SPEC& spec: pcs.classes) {
+    for (const PLAN_CLASS_SPEC& spec: pcs.classes) {
         WORKUNIT wu;
         wu.id = 100;
         wu.batch = 100;

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -286,12 +286,12 @@ bool PLAN_CLASS_SPEC::check(
         }
         downcase_string(buf);
 
-        for (unsigned int i=0; i<cpu_features.size(); i++) {
-            if (!strstr(buf, cpu_features[i].c_str())) {
+        for (string &s: cpu_features) {
+            if (!strstr(buf, s.c_str())) {
                 if (config.debug_version_select) {
                     log_messages.printf(MSG_NORMAL,
                         "[version] plan_class_spec: CPU lacks feature '%s' (got '%s')\n",
-                        cpu_features[i].c_str(), sreq.host.p_features
+                        s.c_str(), sreq.host.p_features
                     );
                 }
                 return false;
@@ -1117,9 +1117,9 @@ bool PLAN_CLASS_SPECS::check(
     SCHEDULER_REQUEST& sreq, const char* plan_class, HOST_USAGE& hu,
     const WORKUNIT* wu
 ) {
-    for (unsigned int i=0; i<classes.size(); i++) {
-        if (!strcmp(classes[i].name, plan_class)) {
-            return classes[i].check(sreq, hu, wu);
+    for (PLAN_CLASS_SPEC& spec: classes) {
+        if (!strcmp(spec.name, plan_class)) {
+            return spec.check(sreq, hu, wu);
         }
     }
     log_messages.printf(MSG_CRITICAL, "Unknown plan class: %s\n", plan_class);
@@ -1129,10 +1129,10 @@ bool PLAN_CLASS_SPECS::check(
 bool PLAN_CLASS_SPECS::wu_is_infeasible(
     const char* plan_class_name, const WORKUNIT* wu
 ) {
-    if(wu_restricted_plan_class) {
-        for (unsigned int i=0; i<classes.size(); i++) {
-            if(!strcmp(classes[i].name, plan_class_name)) {
-                return wu_is_infeasible_for_plan_class(&classes[i], wu);
+    if (wu_restricted_plan_class) {
+        for (PLAN_CLASS_SPEC& spec: classes) {
+            if(!strcmp(spec.name, plan_class_name)) {
+                return wu_is_infeasible_for_plan_class(&spec, wu);
             }
         }
     }
@@ -1393,13 +1393,13 @@ int main() {
         sreq.coprocs.ati.count = 0;
     }
 
-    for (unsigned int i=0; i<pcs.classes.size(); i++) {
+    for (PLAN_CLASS_SPEC& spec: pcs.classes) {
         WORKUNIT wu;
         wu.id = 100;
         wu.batch = 100;
-        bool b = pcs.check(sreq, pcs.classes[i].name, hu, &wu);
+        bool b = pcs.check(sreq, spec.name, hu, &wu);
         if (b) {
-            printf("%s: check succeeded\n", pcs.classes[i].name);
+            printf("%s: check succeeded\n", spec.name);
             printf("\tgpu_usage: %f\n\tgpu_ram: %fMB\n\tavg_ncpus: %f\n\tprojected_flops: %fG\n\tpeak_flops: %fG\n",
                 hu.gpu_usage,
                 hu.gpu_ram/1e6,
@@ -1408,7 +1408,7 @@ int main() {
                 hu.peak_flops/1e9
             );
         } else {
-            printf("%s: check failed\n", pcs.classes[i].name);
+            printf("%s: check failed\n", spec.name);
         }
     }
 }

--- a/sched/sample_assimilator.cpp
+++ b/sched/sample_assimilator.cpp
@@ -73,7 +73,6 @@ int assimilate_handler(
 ) {
     int retval;
     char buf[1024];
-    unsigned int i;
 
     retval = boinc_mkdir(outdir);
     if (retval) return retval;
@@ -84,10 +83,8 @@ int assimilate_handler(
     if (wu.canonical_resultid) {
         vector<OUTPUT_FILE_INFO> output_files;
         get_output_file_infos(canonical_result, output_files);
-        unsigned int n = output_files.size();
         bool file_copied = false;
-        for (i=0; i<n; i++) {
-            OUTPUT_FILE_INFO& fi = output_files[i];
+        for (OUTPUT_FILE_INFO& fi: output_files) {
             sprintf(buf, "%s/%d/%s__file_%s",
                 outdir, wu.batch, wu.name, fi.logical_name.c_str()
             );

--- a/sched/sample_assimilator.cpp
+++ b/sched/sample_assimilator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2015 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -84,7 +84,7 @@ int assimilate_handler(
         vector<OUTPUT_FILE_INFO> output_files;
         get_output_file_infos(canonical_result, output_files);
         bool file_copied = false;
-        for (OUTPUT_FILE_INFO& fi: output_files) {
+        for (const OUTPUT_FILE_INFO& fi: output_files) {
             sprintf(buf, "%s/%d/%s__file_%s",
                 outdir, wu.batch, wu.name, fi.logical_name.c_str()
             );

--- a/sched/sample_bitwise_validator.cpp
+++ b/sched/sample_bitwise_validator.cpp
@@ -90,8 +90,7 @@ int init_result(RESULT& result, void*& data) {
         return retval;
     }
 
-    for (unsigned int i=0; i<files.size(); i++) {
-        OUTPUT_FILE_INFO& fi = files[i];
+    for (OUTPUT_FILE_INFO& fi: files) {
         if (fi.no_validate) continue;
         retval = md5_file(fi.path.c_str(), md5_buf, nbytes, is_gzip);
         if (retval) {

--- a/sched/sample_bitwise_validator.cpp
+++ b/sched/sample_bitwise_validator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -73,7 +73,7 @@ bool files_match(FILE_CKSUM_LIST& f1, FILE_CKSUM_LIST& f2) {
     return true;
 }
 
-int init_result(RESULT& result, void*& data) {
+int init_result(const RESULT& result, void*& data) {
     int retval;
     FILE_CKSUM_LIST* fcl = new FILE_CKSUM_LIST;
     vector<OUTPUT_FILE_INFO> files;
@@ -90,7 +90,7 @@ int init_result(RESULT& result, void*& data) {
         return retval;
     }
 
-    for (OUTPUT_FILE_INFO& fi: files) {
+    for (const OUTPUT_FILE_INFO& fi: files) {
         if (fi.no_validate) continue;
         retval = md5_file(fi.path.c_str(), md5_buf, nbytes, is_gzip);
         if (retval) {

--- a/sched/sample_substr_validator.cpp
+++ b/sched/sample_substr_validator.cpp
@@ -65,8 +65,7 @@ void validate_handler_usage() {
 }
 
 int init_result(RESULT& r, void*&) {
-    for(unsigned int i=0; i<stderr_strings.size(); i++) {
-        char* stderr_string = stderr_strings[i];
+    for(char* stderr_string: stderr_strings) {
         if (strstr(r.stderr_out, stderr_string)) {
             if (reject_if_present) return -1;
         } else {

--- a/sched/sample_substr_validator.cpp
+++ b/sched/sample_substr_validator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -64,7 +64,7 @@ void validate_handler_usage() {
     );
 }
 
-int init_result(RESULT& r, void*&) {
+int init_result(const RESULT& r, void*&) {
     for(char* stderr_string: stderr_strings) {
         if (strstr(r.stderr_out, stderr_string)) {
             if (reject_if_present) return -1;

--- a/sched/sample_trivial_validator.cpp
+++ b/sched/sample_trivial_validator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -31,7 +31,7 @@ void validate_handler_usage() {
     //);
 }
 
-int init_result(RESULT& result, void*&) {
+int init_result(const RESULT& result, void*&) {
     // treat client errors as long-term failures,
     // so that we'll limit the host to 1 job a day
     //

--- a/sched/sched_check.cpp
+++ b/sched/sched_check.cpp
@@ -44,12 +44,10 @@ const char* infeasible_string(int code) {
 // and excluded this app
 //
 bool app_not_selected(int appid) {
-    unsigned int i;
-
-    if (g_wreq->project_prefs.selected_apps.size() == 0) return false;
-    for (i=0; i<g_wreq->project_prefs.selected_apps.size(); i++) {
-        if (appid == g_wreq->project_prefs.selected_apps[i].appid) {
-            g_wreq->project_prefs.selected_apps[i].work_available = true;
+    if (g_wreq->project_prefs.selected_apps.empty()) return false;
+    for (APP_INFO& ai: g_wreq->project_prefs.selected_apps) {
+        if (appid == ai.appid) {
+            ai.work_available = true;
             return false;
         }
     }

--- a/sched/sched_check.cpp
+++ b/sched/sched_check.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2024 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -1044,7 +1044,7 @@ bool app_plan(
 }
 
 void handle_file_xfer_results() {
-    for (RESULT& r: g_request->file_xfer_results) {
+    for (const RESULT& r: g_request->file_xfer_results) {
         log_messages.printf(MSG_NORMAL, "completed file xfer %s\n", r.name);
         g_reply->result_acks.push_back(string(r.name));
     }

--- a/sched/sched_customize.cpp
+++ b/sched/sched_customize.cpp
@@ -1044,11 +1044,8 @@ bool app_plan(
 }
 
 void handle_file_xfer_results() {
-    for (unsigned int i=0; i<g_request->file_xfer_results.size(); i++) {
-        RESULT& r = g_request->file_xfer_results[i];
-        log_messages.printf(MSG_NORMAL,
-            "completed file xfer %s\n", r.name
-        );
+    for (RESULT& r: g_request->file_xfer_results) {
+        log_messages.printf(MSG_NORMAL, "completed file xfer %s\n", r.name);
         g_reply->result_acks.push_back(string(r.name));
     }
 }

--- a/sched/sched_files.cpp
+++ b/sched/sched_files.cpp
@@ -60,8 +60,7 @@ int init_file_delete_regex() {
 }
 
 int do_file_delete_regex() {
-    for (unsigned int i=0; i<g_request->file_infos.size(); i++) {
-        FILE_INFO& fi = g_request->file_infos[i];
+    for (FILE_INFO& fi: g_request->file_infos) {
         bool found = false;
         for (unsigned int j=0; j<file_delete_regex.size(); j++) {
             regex_t& re = file_delete_regex[j];

--- a/sched/sched_files.cpp
+++ b/sched/sched_files.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -60,7 +60,7 @@ int init_file_delete_regex() {
 }
 
 int do_file_delete_regex() {
-    for (FILE_INFO& fi: g_request->file_infos) {
+    for (const FILE_INFO& fi: g_request->file_infos) {
         bool found = false;
         for (unsigned int j=0; j<file_delete_regex.size(); j++) {
             regex_t& re = file_delete_regex[j];

--- a/sched/sched_keyword.cpp
+++ b/sched/sched_keyword.cpp
@@ -80,8 +80,7 @@ double keyword_score_aux(
 ) {
     double score = 0;
 
-    for (unsigned int i=0; i<jks.ids.size(); i++) {
-        int jk = jks.ids[i];
+    for (int jk: jks.ids) {
         if (std::find(uks.yes.begin(), uks.yes.end(), jk) != uks.yes.end()) {
             score += 1;
         } else if (std::find(uks.no.begin(), uks.no.end(), jk) != uks.no.end()) {

--- a/sched/sched_keyword.cpp
+++ b/sched/sched_keyword.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2017 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/sched_limit.h
+++ b/sched/sched_limit.h
@@ -122,16 +122,15 @@ struct JOB_LIMITS {
     //
     inline void reset(int ninstances[]) {
         project_limits.reset(ninstances);
-        for (unsigned int i=0; i<app_limits.size(); i++) {
-            app_limits[i].reset(ninstances);
+        for (JOB_LIMIT& jl: app_limits) {
+            jl.reset(ninstances);
         }
     }
 
     inline JOB_LIMIT* lookup_app(char* name) {
-        for (unsigned int i=0; i<app_limits.size(); i++) {
-            JOB_LIMIT* jlp = &app_limits[i];
-            if (!strcmp(name, jlp->app_name)) {
-                return jlp;
+        for (JOB_LIMIT& jl: app_limits) {
+            if (!strcmp(name, jl.app_name)) {
+                return &jl;
             }
         }
         return NULL;

--- a/sched/sched_limit.h
+++ b/sched/sched_limit.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2010 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/sched_locality.cpp
+++ b/sched/sched_locality.cpp
@@ -155,8 +155,7 @@ bool host_has_file(char *filename, bool skip_last_wu) {
     // loop over files already on host to see if host already has the
     // file
     //
-    for (i=0; i<(int)g_request->file_infos.size(); i++) {
-        FILE_INFO& fi = g_request->file_infos[i];
+    for (FILE_INFO& fi: g_request->file_infos) {
         if (!strcmp(filename, fi.name)) {
             has_file=true;
             break;

--- a/sched/sched_locality.cpp
+++ b/sched/sched_locality.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -155,7 +155,7 @@ bool host_has_file(char *filename, bool skip_last_wu) {
     // loop over files already on host to see if host already has the
     // file
     //
-    for (FILE_INFO& fi: g_request->file_infos) {
+    for (const FILE_INFO& fi: g_request->file_infos) {
         if (!strcmp(filename, fi.name)) {
             has_file=true;
             break;

--- a/sched/sched_main.cpp
+++ b/sched/sched_main.cpp
@@ -675,14 +675,14 @@ void JOB_LIMIT::print_log() {
 void JOB_LIMITS::print_log() {
     log_messages.printf(MSG_NORMAL, "[quota] Overall limits on jobs in progress:\n");
     project_limits.print_log();
-    for (unsigned int i=0; i<app_limits.size(); i++) {
-        if (app_limits[i].any_limit()) {
-            APP* app = ssp->lookup_app_name(app_limits[i].app_name);
+    for (JOB_LIMIT& jl: app_limits) {
+        if (jl.any_limit()) {
+            APP* app = ssp->lookup_app_name(jl.app_name);
             if (!app) continue;
             log_messages.printf(MSG_NORMAL,
                 "[quota] Limits for %s:\n", app->name
             );
-            app_limits[i].print_log();
+            jl.print_log();
         }
     }
 }

--- a/sched/sched_main.cpp
+++ b/sched/sched_main.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/sched_nci.cpp
+++ b/sched/sched_nci.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2014 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -139,7 +139,7 @@ int send_nci() {
     // scan through the list of in-progress jobs,
     // flagging the associated apps as having jobs
     //
-    for (OTHER_RESULT& ores: g_request->other_results) {
+    for (const OTHER_RESULT& ores: g_request->other_results) {
         DB_RESULT r;
         sprintf(buf, "where name='%s'", ores.name);
         retval = r.lookup(buf);

--- a/sched/sched_nci.cpp
+++ b/sched/sched_nci.cpp
@@ -139,17 +139,15 @@ int send_nci() {
     // scan through the list of in-progress jobs,
     // flagging the associated apps as having jobs
     //
-    for (unsigned int i=0; i<g_request->other_results.size(); i++) {
+    for (OTHER_RESULT& ores: g_request->other_results) {
         DB_RESULT r;
-        OTHER_RESULT &ores = g_request->other_results[i];
         sprintf(buf, "where name='%s'", ores.name);
         retval = r.lookup(buf);
         if (retval) {
             log_messages.printf(MSG_NORMAL, "No such result: %s\n", ores.name);
             continue;
         }
-        for (unsigned int j=0; j<nci_apps.size(); j++) {
-            APP& app = nci_apps[j];
+        for (APP& app: nci_apps) {
             if (app.id == r.appid) {
                 app.have_job = true;
                 break;
@@ -159,8 +157,7 @@ int send_nci() {
 
     // For each NCI app w/o a job, try to send one
     //
-    for (unsigned int i=0; i<nci_apps.size(); i++) {
-        APP& app = nci_apps[i];
+    for (APP& app: nci_apps) {
         if (app.have_job) {
             if (config.debug_send) {
                 log_messages.printf(MSG_NORMAL,

--- a/sched/sched_resend.cpp
+++ b/sched/sched_resend.cpp
@@ -99,7 +99,6 @@ static int possibly_give_result_new_deadline(
 bool resend_lost_work() {
     SCHED_DB_RESULT result;
     std::vector<DB_RESULT>results;
-    unsigned int i;
     char buf[256];
     char warning_msg[256];
     bool did_any = false;
@@ -119,8 +118,7 @@ bool resend_lost_work() {
         }
 
         bool found = false;
-        for (i=0; i<g_request->other_results.size(); i++) {
-            OTHER_RESULT& orp = g_request->other_results[i];
+        for (OTHER_RESULT& orp: g_request->other_results) {
             if (!strcmp(orp.name, result.name)) {
                 found = true;
                 break;

--- a/sched/sched_resend.cpp
+++ b/sched/sched_resend.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -118,7 +118,7 @@ bool resend_lost_work() {
         }
 
         bool found = false;
-        for (OTHER_RESULT& orp: g_request->other_results) {
+        for (const OTHER_RESULT& orp: g_request->other_results) {
             if (!strcmp(orp.name, result.name)) {
                 found = true;
                 break;

--- a/sched/sched_result.cpp
+++ b/sched/sched_result.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -118,7 +118,7 @@ int handle_results() {
     // copy reported results to a separate vector, "result_handler",
     // initially with only the "name" field present
     //
-    for (SCHED_DB_RESULT& r: g_request->results) {
+    for (const SCHED_DB_RESULT& r: g_request->results) {
         result_handler.add_result(r.name);
     }
 
@@ -151,7 +151,7 @@ int handle_results() {
     // In other words, the only time we don't ack a result is when
     // it looks OK but the update failed.
     //
-    for (SCHED_DB_RESULT& r: g_request->results) {
+    for (const SCHED_DB_RESULT& r: g_request->results) {
         retval = result_handler.lookup_result(r.name, &srip);
         if (retval) {
             log_messages.printf(MSG_CRITICAL,

--- a/sched/sched_result.cpp
+++ b/sched/sched_result.cpp
@@ -102,9 +102,7 @@ static inline void got_bad_result(SCHED_RESULT_ITEM& sri) {
 int handle_results() {
     DB_SCHED_RESULT_ITEM_SET result_handler;
     SCHED_RESULT_ITEM* srip;
-    unsigned int i;
     int retval;
-    RESULT* rp;
 
     if (g_request->results.size() == 0) return 0;
 
@@ -120,8 +118,8 @@ int handle_results() {
     // copy reported results to a separate vector, "result_handler",
     // initially with only the "name" field present
     //
-    for (i=0; i<g_request->results.size(); i++) {
-        result_handler.add_result(g_request->results[i].name);
+    for (SCHED_DB_RESULT& r: g_request->results) {
+        result_handler.add_result(r.name);
     }
 
     // read results from database into "result_handler".
@@ -153,17 +151,15 @@ int handle_results() {
     // In other words, the only time we don't ack a result is when
     // it looks OK but the update failed.
     //
-    for (i=0; i<g_request->results.size(); i++) {
-        rp = &g_request->results[i];
-
-        retval = result_handler.lookup_result(rp->name, &srip);
+    for (SCHED_DB_RESULT& r: g_request->results) {
+        retval = result_handler.lookup_result(r.name, &srip);
         if (retval) {
             log_messages.printf(MSG_CRITICAL,
                 "[HOST#%lu] [RESULT#? %s] reported result not in DB\n",
-                g_reply->host.id, rp->name
+                g_reply->host.id, r.name
             );
 
-            g_reply->result_acks.push_back(std::string(rp->name));
+            g_reply->result_acks.push_back(std::string(r.name));
             continue;
         }
 
@@ -237,7 +233,7 @@ int handle_results() {
                     );
                 }
                 srip->id = 0;
-                g_reply->result_acks.push_back(std::string(rp->name));
+                g_reply->result_acks.push_back(std::string(r.name));
                 continue;
             }
         }
@@ -248,7 +244,7 @@ int handle_results() {
                 g_reply->host.id, srip->id, srip->workunitid, srip->server_state
             );
             srip->id = 0;
-            g_reply->result_acks.push_back(std::string(rp->name));
+            g_reply->result_acks.push_back(std::string(r.name));
             continue;
         }
 
@@ -259,7 +255,7 @@ int handle_results() {
                 time_to_string(srip->received_time)
             );
             srip->id = 0;
-            g_reply->result_acks.push_back(std::string(rp->name));
+            g_reply->result_acks.push_back(std::string(r.name));
             continue;
         }
 
@@ -277,7 +273,7 @@ int handle_results() {
                     srip->id, srip->workunitid, srip->hostid
                 );
                 srip->id = 0;
-                g_reply->result_acks.push_back(std::string(rp->name));
+                g_reply->result_acks.push_back(std::string(r.name));
                 continue;
             } else if (result_host.userid != g_reply->host.userid) {
                 log_messages.printf(MSG_CRITICAL,
@@ -285,7 +281,7 @@ int handle_results() {
                     g_reply->host.userid, g_reply->host.id, srip->id, srip->workunitid, result_host.userid
                 );
                 srip->id = 0;
-                g_reply->result_acks.push_back(std::string(rp->name));
+                g_reply->result_acks.push_back(std::string(r.name));
                 continue;
             } else {
                 log_messages.printf(MSG_CRITICAL,
@@ -302,12 +298,12 @@ int handle_results() {
         srip->hostid = g_reply->host.id;
         srip->teamid = g_reply->user.teamid;
         srip->received_time = time(0);
-        srip->client_state = rp->client_state;
-        srip->cpu_time = rp->cpu_time;
-        srip->elapsed_time = rp->elapsed_time;
-        srip->peak_working_set_size = rp->peak_working_set_size;
-        srip->peak_swap_size = rp->peak_swap_size;
-        srip->peak_disk_usage = rp->peak_disk_usage;
+        srip->client_state = r.client_state;
+        srip->cpu_time = r.cpu_time;
+        srip->elapsed_time = r.elapsed_time;
+        srip->peak_working_set_size = r.peak_working_set_size;
+        srip->peak_swap_size = r.peak_swap_size;
+        srip->peak_disk_usage = r.peak_disk_usage;
 
         // elapsed time is used to compute credit.
         // do various sanity checks on it.
@@ -381,12 +377,12 @@ int handle_results() {
             srip->cpu_time = srip->elapsed_time*g_reply->host.p_ncpus;
         }
 
-        srip->exit_status = rp->exit_status;
-        srip->app_version_num = rp->app_version_num;
+        srip->exit_status = r.exit_status;
+        srip->app_version_num = r.app_version_num;
         srip->server_state = RESULT_SERVER_STATE_OVER;
 
-        strlcpy(srip->stderr_out, rp->stderr_out, sizeof(srip->stderr_out));
-        strlcpy(srip->xml_doc_out, rp->xml_doc_out, sizeof(srip->xml_doc_out));
+        strlcpy(srip->stderr_out, r.stderr_out, sizeof(srip->stderr_out));
+        strlcpy(srip->xml_doc_out, r.xml_doc_out, sizeof(srip->xml_doc_out));
 
         if ((srip->client_state == RESULT_FILES_UPLOADED) && (srip->exit_status == 0)) {
             srip->outcome = RESULT_OUTCOME_SUCCESS;
@@ -423,8 +419,7 @@ int handle_results() {
     // Update the result records
     // (skip items that we previously marked to skip)
     //
-    for (i=0; i<result_handler.results.size(); i++) {
-        SCHED_RESULT_ITEM& sri = result_handler.results[i];
+    for (SCHED_RESULT_ITEM& sri: result_handler.results) {
         if (sri.id == 0) continue;
         retval = result_handler.update_result(sri);
         if (retval) {

--- a/sched/sched_score.cpp
+++ b/sched/sched_score.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/sched_score.cpp
+++ b/sched/sched_score.cpp
@@ -306,7 +306,7 @@ void send_work_score_type(int rt) {
     std::sort(jobs.begin(), jobs.end(), job_compare);
 
     bool sema_locked = false;
-    for (unsigned int i=0; i<jobs.size(); i++) {
+    for (JOB& job: jobs) {
 
         // check limit on total jobs
         //
@@ -319,7 +319,6 @@ void send_work_score_type(int rt) {
         if (!g_wreq->need_proc_type(rt)) {
             break;
         }
-        JOB& job = jobs[i];
 
         // check limits on jobs for this (app, processor type)
         //

--- a/sched/sched_send.cpp
+++ b/sched/sched_send.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -64,7 +64,7 @@ const double DEFAULT_RAM_SIZE = 64000000;
 int selected_app_message_index=0;
 
 static inline bool file_present_on_host(const char* name) {
-    for (FILE_INFO& fi: g_request->file_infos) {
+    for (const FILE_INFO& fi: g_request->file_infos) {
         if (!strstr(name, fi.name)) {
             return true;
         }
@@ -769,7 +769,7 @@ int update_wu_on_send(WORKUNIT wu, time_t x, APP& app, BEST_APP_VERSION& bav) {
 // return true iff a result for same WU is already being sent
 //
 bool wu_already_in_reply(WORKUNIT& wu) {
-    for (SCHED_DB_RESULT &r: g_reply->results) {
+    for (const SCHED_DB_RESULT &r: g_reply->results) {
         if (wu.id == r.workunitid) {
             return true;
         }
@@ -1320,7 +1320,7 @@ static void send_user_messages() {
 
             // Inform the user about applications with no work
             //
-            for (APP_INFO& ai: g_wreq->project_prefs.selected_apps) {
+            for (const APP_INFO& ai: g_wreq->project_prefs.selected_apps) {
                 if (!ai.work_available) {
                     APP* app = ssp->lookup_app(ai.appid);
                     // don't write message if the app is deprecated
@@ -1359,7 +1359,7 @@ static void send_user_messages() {
 
         // Tell the user about applications with no work
         //
-        for (APP_INFO& ai: g_wreq->project_prefs.selected_apps) {
+        for (const APP_INFO& ai: g_wreq->project_prefs.selected_apps) {
             if (!ai.work_available) {
                 APP* app = ssp->lookup_app(ai.appid);
                 // don't write message if the app is deprecated
@@ -1372,7 +1372,7 @@ static void send_user_messages() {
             }
         }
 
-        for (USER_MESSAGE& um: g_wreq->no_work_messages){
+        for (const USER_MESSAGE& um: g_wreq->no_work_messages){
             g_reply->insert_message(um);
         }
 
@@ -1478,7 +1478,7 @@ void send_work_setup() {
         for (int i=0; i<NPROC_TYPES; i++) {
             g_wreq->client_has_apps_for_proc_type[i] = false;
         }
-        for (CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
+        for (const CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
             int pt = cav.host_usage.proc_type;
             g_wreq->client_has_apps_for_proc_type[pt] = true;
         }
@@ -1512,7 +1512,7 @@ void send_work_setup() {
         }
     }
 
-    for (OTHER_RESULT& r: g_request->other_results) {
+    for (const OTHER_RESULT& r: g_request->other_results) {
         APP* app = NULL;
         int proc_type = PROC_TYPE_CPU;
         bool have_cav = false;
@@ -1585,7 +1585,7 @@ void send_work_setup() {
             log_messages.printf(MSG_NORMAL,
                 "[send] Anonymous platform app versions:\n"
             );
-            for (CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
+            for (const CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
                 char buf[256];
                 strcpy(buf, "");
                 int pt = cav.host_usage.proc_type;
@@ -1627,7 +1627,7 @@ int update_host_app_versions(vector<SCHED_DB_RESULT>& results, int hostid) {
     vector<DB_HOST_APP_VERSION> new_havs;
     int retval;
 
-    for (SCHED_DB_RESULT& r: results) {
+    for (const SCHED_DB_RESULT& r: results) {
         int gavid = generalized_app_version_id(r.app_version_id, r.appid);
         DB_HOST_APP_VERSION* havp = gavid_to_havp(gavid);
         if (!havp) {

--- a/sched/sched_send.cpp
+++ b/sched/sched_send.cpp
@@ -64,8 +64,7 @@ const double DEFAULT_RAM_SIZE = 64000000;
 int selected_app_message_index=0;
 
 static inline bool file_present_on_host(const char* name) {
-    for (unsigned i=0; i<g_request->file_infos.size(); i++) {
-        FILE_INFO& fi = g_request->file_infos[i];
+    for (FILE_INFO& fi: g_request->file_infos) {
         if (!strstr(name, fi.name)) {
             return true;
         }
@@ -330,8 +329,7 @@ static void get_reliability_and_trust() {
         multiplier = 1.8;
     }
 
-    for (unsigned int i=0; i<g_wreq->host_app_versions.size(); i++) {
-        DB_HOST_APP_VERSION& hav = g_wreq->host_app_versions[i];
+    for (DB_HOST_APP_VERSION& hav: g_wreq->host_app_versions) {
         get_reliability_version(hav, multiplier);
         set_trust(hav);
     }
@@ -496,8 +494,7 @@ double estimate_duration(WORKUNIT& wu, BEST_APP_VERSION& bav) {
 }
 
 void update_n_jobs_today() {
-    for (unsigned int i=0; i<g_wreq->host_app_versions.size(); i++) {
-        DB_HOST_APP_VERSION& hav = g_wreq->host_app_versions[i];
+    for (DB_HOST_APP_VERSION& hav: g_wreq->host_app_versions) {
         update_quota(hav);
     }
 }
@@ -772,9 +769,8 @@ int update_wu_on_send(WORKUNIT wu, time_t x, APP& app, BEST_APP_VERSION& bav) {
 // return true iff a result for same WU is already being sent
 //
 bool wu_already_in_reply(WORKUNIT& wu) {
-    unsigned int i;
-    for (i=0; i<g_reply->results.size(); i++) {
-        if (wu.id == g_reply->results[i].workunitid) {
+    for (SCHED_DB_RESULT &r: g_reply->results) {
+        if (wu.id == r.workunitid) {
             return true;
         }
     }
@@ -942,17 +938,6 @@ inline static DB_ID_TYPE get_app_version_id(BEST_APP_VERSION* bavp) {
     } else {
         return bavp->cavp->host_usage.resource_type();
     }
-}
-
-static bool wu_has_plan_class(WORKUNIT &wu, char* buf) {
-    char *p = strstr(wu.xml_doc, "<plan_class>");
-    if (!p) return false;
-    p += strlen("<plan_class>");
-    strncpy(buf, p, 256);
-    p = strstr(buf, "</plan_class>");
-    if (!p) return false;
-    *p = 0;
-    return true;
 }
 
 int add_result_to_reply(
@@ -1316,8 +1301,6 @@ void send_gpu_messages() {
 //
 static void send_user_messages() {
     char buf[512];
-    unsigned int i;
-    int j;
 
     // GPU messages aren't relevant if anonymous platform
     //
@@ -1337,16 +1320,16 @@ static void send_user_messages() {
 
             // Inform the user about applications with no work
             //
-            for (i=0; i<g_wreq->project_prefs.selected_apps.size(); i++) {
-                if (!g_wreq->project_prefs.selected_apps[i].work_available) {
-                    APP* app = ssp->lookup_app(g_wreq->project_prefs.selected_apps[i].appid);
+            for (APP_INFO& ai: g_wreq->project_prefs.selected_apps) {
+                if (!ai.work_available) {
+                    APP* app = ssp->lookup_app(ai.appid);
                     // don't write message if the app is deprecated
                     //
                     if (app) {
                         char explanation[256];
                         sprintf(explanation,
                             "No tasks are available for %s",
-                            find_user_friendly_name(g_wreq->project_prefs.selected_apps[i].appid)
+                            find_user_friendly_name(ai.appid)
                         );
                         g_reply->insert_message( explanation, "low");
                     }
@@ -1355,7 +1338,7 @@ static void send_user_messages() {
 
             // Tell the user about applications they didn't qualify for
             //
-            for (j=0; j<selected_app_message_index; j++){
+            for (int j=0; j<selected_app_message_index; j++){
                 g_reply->insert_message(g_wreq->no_work_messages.at(j));
             }
             g_reply->insert_message(
@@ -1376,23 +1359,21 @@ static void send_user_messages() {
 
         // Tell the user about applications with no work
         //
-        for (i=0; i<g_wreq->project_prefs.selected_apps.size(); i++) {
-            if (!g_wreq->project_prefs.selected_apps[i].work_available) {
-                APP* app = ssp->lookup_app(g_wreq->project_prefs.selected_apps[i].appid);
+        for (APP_INFO& ai: g_wreq->project_prefs.selected_apps) {
+            if (!ai.work_available) {
+                APP* app = ssp->lookup_app(ai.appid);
                 // don't write message if the app is deprecated
                 if (app != NULL) {
                     sprintf(buf, "No tasks are available for %s",
-                        find_user_friendly_name(
-                            g_wreq->project_prefs.selected_apps[i].appid
-                        )
+                        find_user_friendly_name(ai.appid)
                     );
                     g_reply->insert_message(buf, "low");
                 }
             }
         }
 
-        for (i=0; i<g_wreq->no_work_messages.size(); i++){
-            g_reply->insert_message(g_wreq->no_work_messages.at(i));
+        for (USER_MESSAGE& um: g_wreq->no_work_messages){
+            g_reply->insert_message(um);
         }
 
         if (g_wreq->no_allowed_apps_available) {
@@ -1437,7 +1418,7 @@ static void send_user_messages() {
                 "Not sending tasks because newer client version required\n"
             );
         }
-        for (i=0; i<NPROC_TYPES; i++) {
+        for (int i=0; i<NPROC_TYPES; i++) {
             if (g_wreq->project_prefs.dont_use_proc_type[i] && ssp->have_apps_for_proc_type[i]) {
                 sprintf(buf,
                     _("Tasks for %s are available, but your preferences are set to not accept them"),
@@ -1478,8 +1459,6 @@ static double clamp_req_sec(double x) {
 // decipher request type, fill in WORK_REQ
 //
 void send_work_setup() {
-    unsigned int i;
-
     g_wreq->seconds_to_fill = clamp_req_sec(g_request->work_req_seconds);
     g_wreq->req_secs[PROC_TYPE_CPU] = clamp_req_sec(g_request->cpu_req_secs);
     g_wreq->req_instances[PROC_TYPE_CPU] = g_request->cpu_req_instances;
@@ -1496,16 +1475,15 @@ void send_work_setup() {
     if (g_wreq->anonymous_platform) {
         estimate_flops_anon_platform();
 
-        for (i=0; i<NPROC_TYPES; i++) {
+        for (int i=0; i<NPROC_TYPES; i++) {
             g_wreq->client_has_apps_for_proc_type[i] = false;
         }
-        for (i=0; i<g_request->client_app_versions.size(); i++) {
-            CLIENT_APP_VERSION& cav = g_request->client_app_versions[i];
+        for (CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
             int pt = cav.host_usage.proc_type;
             g_wreq->client_has_apps_for_proc_type[pt] = true;
         }
     }
-    for (i=1; i<NPROC_TYPES; i++) {
+    for (int i=1; i<NPROC_TYPES; i++) {
         gpu_requirements[i].clear();
     }
 
@@ -1516,7 +1494,7 @@ void send_work_setup() {
 
     // do sanity checking on GPU scheduling parameters
     //
-    for (i=1; i<NPROC_TYPES; i++) {
+    for (int i=1; i<NPROC_TYPES; i++) {
         COPROC* cp = g_request->coprocs.proc_type_to_coproc(i);
         if (cp && cp->count) {
             g_wreq->req_secs[i] = clamp_req_sec(cp->req_secs);
@@ -1527,15 +1505,14 @@ void send_work_setup() {
         }
     }
     g_wreq->rsc_spec_request = false;
-    for (i=0; i<NPROC_TYPES; i++) {
+    for (int i=0; i<NPROC_TYPES; i++) {
         if (g_wreq->req_secs[i]) {
             g_wreq->rsc_spec_request = true;
             break;
         }
     }
 
-    for (i=0; i<g_request->other_results.size(); i++) {
-        OTHER_RESULT& r = g_request->other_results[i];
+    for (OTHER_RESULT& r: g_request->other_results) {
         APP* app = NULL;
         int proc_type = PROC_TYPE_CPU;
         bool have_cav = false;
@@ -1577,7 +1554,7 @@ void send_work_setup() {
             g_wreq->req_instances[PROC_TYPE_CPU],
             g_request->cpu_estimated_delay
         );
-        for (i=1; i<NPROC_TYPES; i++) {
+        for (int i=1; i<NPROC_TYPES; i++) {
             COPROC* cp = g_request->coprocs.proc_type_to_coproc(i);
             if (cp && cp->count) {
                 log_messages.printf(MSG_NORMAL,
@@ -1608,8 +1585,7 @@ void send_work_setup() {
             log_messages.printf(MSG_NORMAL,
                 "[send] Anonymous platform app versions:\n"
             );
-            for (i=0; i<g_request->client_app_versions.size(); i++) {
-                CLIENT_APP_VERSION& cav = g_request->client_app_versions[i];
+            for (CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
                 char buf[256];
                 strcpy(buf, "");
                 int pt = cav.host_usage.proc_type;
@@ -1649,17 +1625,14 @@ void send_work_setup() {
 //
 int update_host_app_versions(vector<SCHED_DB_RESULT>& results, int hostid) {
     vector<DB_HOST_APP_VERSION> new_havs;
-    unsigned int i, j;
     int retval;
 
-    for (i=0; i<results.size(); i++) {
-        RESULT& r = results[i];
+    for (SCHED_DB_RESULT& r: results) {
         int gavid = generalized_app_version_id(r.app_version_id, r.appid);
         DB_HOST_APP_VERSION* havp = gavid_to_havp(gavid);
         if (!havp) {
             bool found = false;
-            for (j=0; j<new_havs.size(); j++) {
-                DB_HOST_APP_VERSION& hav = new_havs[j];
+            for (DB_HOST_APP_VERSION& hav: new_havs) {
                 if (hav.app_version_id == gavid) {
                     found = true;
                     hav.n_jobs_today++;
@@ -1678,9 +1651,7 @@ int update_host_app_versions(vector<SCHED_DB_RESULT>& results, int hostid) {
 
     // create new records
     //
-    for (i=0; i<new_havs.size(); i++) {
-        DB_HOST_APP_VERSION& hav = new_havs[i];
-
+    for (DB_HOST_APP_VERSION& hav: new_havs) {
         retval = hav.insert();
         if (retval) {
             log_messages.printf(MSG_CRITICAL,

--- a/sched/sched_shmem.cpp
+++ b/sched/sched_shmem.cpp
@@ -205,8 +205,7 @@ int SCHED_SHMEM::scan_tables() {
                     }
                 }
             }
-            for (unsigned int k=0; k<avs.size(); k++) {
-                APP_VERSION& av1 = avs[k];
+            for (APP_VERSION& av1: avs) {
                 if (sapp.min_version) {
                     if (av1.version_num < sapp.min_version) {
                         boinc::fprintf(stderr, "version too small %d < %d\n",

--- a/sched/sched_shmem.cpp
+++ b/sched/sched_shmem.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -263,7 +263,7 @@ int SCHED_SHMEM::scan_tables() {
     return 0;
 }
 
-PLATFORM* SCHED_SHMEM::lookup_platform(char* name) {
+PLATFORM* SCHED_SHMEM::lookup_platform(const char* name) {
     for (int i=0; i<nplatforms; i++) {
         if (!strcmp(platforms[i].name, name)) {
             return &platforms[i];

--- a/sched/sched_shmem.h
+++ b/sched/sched_shmem.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2023 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -136,7 +136,7 @@ struct SCHED_SHMEM {
         return x;
     }
     PLATFORM* lookup_platform_id(DB_ID_TYPE);
-    PLATFORM* lookup_platform(char*);
+    PLATFORM* lookup_platform(const char*);
 };
 
 #endif

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -229,8 +229,8 @@ void PROJECT_PREFS::parse() {
 }
 
 void WORK_REQ::add_no_work_message(const char* message) {
-    for (unsigned int i=0; i<no_work_messages.size(); i++) {
-        if (!strcmp(message, no_work_messages.at(i).message.c_str())){
+    for (USER_MESSAGE& m: no_work_messages) {
+        if (!strcmp(message, m.message.c_str())){
             return;
         }
     }
@@ -467,8 +467,8 @@ const char* SCHEDULER_REQUEST::parse(XML_PARSER& xp) {
             // Shouldn't happen, but if it does bad things will happen
             //
             bool found = false;
-            for (unsigned int i=0; i<results.size(); i++) {
-                if (!strcmp(results[i].name, result.name)) {
+            for (SCHED_DB_RESULT& r: results) {
+                if (!strcmp(r.name, result.name)) {
                     found = true;
                     break;
                 }
@@ -595,8 +595,6 @@ const char* SCHEDULER_REQUEST::parse(XML_PARSER& xp) {
 // Why not copy the request message directly?
 //
 int SCHEDULER_REQUEST::write(FILE* fout) {
-    unsigned int i;
-
     boinc::fprintf(fout,
         "<scheduler_request>\n"
         "  <authenticator>%s</authenticator>\n"
@@ -631,14 +629,14 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
         is_anonymous(platforms.list[0])?"true":"false"
     );
 
-    for (i=0; i<client_app_versions.size(); i++) {
+    for (CLIENT_APP_VERSION& cav: client_app_versions) {
         boinc::fprintf(fout,
             "  <app_version>\n"
             "    <app_name>%s</app_name>\n"
             "    <version_num>%d</version_num>\n"
             "  </app_version>\n",
-            client_app_versions[i].app_name,
-            client_app_versions[i].version_num
+            cav.app_name,
+            cav.version_num
         );
     }
 
@@ -674,7 +672,7 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
         host.d_boinc_max
     );
 
-    for (i=0; i<results.size(); i++) {
+    for (SCHED_DB_RESULT& r: results) {
         boinc::fprintf(fout,
             "  <result>\n"
             "    <name>%s</name>\n"
@@ -683,31 +681,31 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
             "    <exit_status>%d</exit_status>\n"
             "    <app_version_num>%d</app_version_num>\n"
             "  </result>\n",
-            results[i].name,
-            results[i].client_state,
-            results[i].cpu_time,
-            results[i].exit_status,
-            results[i].app_version_num
+            r.name,
+            r.client_state,
+            r.cpu_time,
+            r.exit_status,
+            r.app_version_num
         );
     }
 
-    for (i=0; i<msgs_from_host.size(); i++) {
+    for (MSG_FROM_HOST_DESC& m: msgs_from_host) {
         boinc::fprintf(fout,
             "  <msg_from_host>\n"
             "    <variety>%s</variety>\n"
             "    <msg_text>%s</msg_text>\n"
             "  </msg_from_host>\n",
-            msgs_from_host[i].variety,
-            msgs_from_host[i].msg_text.c_str()
+            m.variety,
+            m.msg_text.c_str()
         );
     }
 
-    for (i=0; i<file_infos.size(); i++) {
+    for (FILE_INFO& fi: file_infos) {
         boinc::fprintf(fout,
             "  <file_info>\n"
             "    <name>%s</name>\n"
             "  </file_info>\n",
-            file_infos[i].name
+            fi.name
         );
         boinc::fprintf(fout, "</scheduler_request>\n");
     }
@@ -758,7 +756,6 @@ static bool have_apps_for_client() {
 }
 
 int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
-    unsigned int i;
     char buf[BLOB_SIZE];
 
     // Note: at one point we had
@@ -808,8 +805,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
     if (sreq.core_client_version <= 41900) {
         string msg;
         string pri = "low";
-        for (i=0; i<messages.size(); i++) {
-            USER_MESSAGE& um = messages[i];
+        for (USER_MESSAGE& um: messages) {
             msg += um.message + string(" ");
             if (um.priority == "notice") {
                 pri = "notice";
@@ -831,8 +827,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
         }
     } else if (sreq.core_client_version <= 61100) {
         char prio[256];
-        for (i=0; i<messages.size(); i++) {
-            USER_MESSAGE& um = messages[i];
+        for (USER_MESSAGE& um: messages) {
             safe_strcpy(prio, um.priority.c_str());
             if (!strcmp(prio, "notice")) {
                 strcpy(prio, "high");
@@ -844,8 +839,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
             );
         }
     } else {
-        for (i=0; i<messages.size(); i++) {
-            USER_MESSAGE& um = messages[i];
+        for (USER_MESSAGE& um: messages) {
             boinc::fprintf(fout,
                 "<message priority=\"%s\">%s</message>\n",
                 um.priority.c_str(),
@@ -961,52 +955,52 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
 
     // acknowledge results
     //
-    for (i=0; i<result_acks.size(); i++) {
+    for (string &s: result_acks) {
         boinc::fprintf(fout,
             "<result_ack>\n"
             "    <name>%s</name>\n"
             "</result_ack>\n",
-            result_acks[i].c_str()
+            s.c_str()
         );
     }
 
     // abort results
     //
-    for (i=0; i<result_aborts.size(); i++) {
+    for (string &s: result_aborts) {
         boinc::fprintf(fout,
             "<result_abort>\n"
             "    <name>%s</name>\n"
             "</result_abort>\n",
-            result_aborts[i].c_str()
+            s.c_str()
         );
     }
 
     // abort results not started
     //
-    for (i=0; i<result_abort_if_not_starteds.size(); i++) {
+    for (string &s: result_abort_if_not_starteds) {
         boinc::fprintf(fout,
             "<result_abort_if_not_started>\n"
             "    <name>%s</name>\n"
             "</result_abort_if_not_started>\n",
-            result_abort_if_not_starteds[i].c_str()
+            s.c_str()
         );
     }
 
-    for (i=0; i<apps.size(); i++) {
-        apps[i].write(fout);
+    for (APP &a: apps) {
+        a.write(fout);
     }
 
-    for (i=0; i<app_versions.size(); i++) {
-        app_versions[i].write(fout);
+    for (APP_VERSION &av: app_versions) {
+        av.write(fout);
     }
 
-    for (i=0; i<wus.size(); i++) {
-        boinc::fputs(wus[i].xml_doc, fout);
+    for (WORKUNIT &wu: wus) {
+        boinc::fputs(wu.xml_doc, fout);
         boinc::fputs("\n", fout);  // for old clients
     }
 
-    for (i=0; i<results.size(); i++) {
-        results[i].write_to_client(fout);
+    for (SCHED_DB_RESULT &r: results) {
+        r.write_to_client(fout);
     }
 
     if (strlen(code_sign_key)) {
@@ -1025,8 +1019,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
         boinc::fputs("<message_ack/>\n", fout);
     }
 
-    for (i=0; i<msgs_to_host.size(); i++) {
-        MSG_TO_HOST& md = msgs_to_host[i];
+    for (MSG_TO_HOST& md: msgs_to_host) {
         boinc::fprintf(fout, "%s\n", md.xml);
     }
 
@@ -1042,14 +1035,14 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
         boinc::fprintf(fout, "<verify_files_on_app_start/>\n");
     }
 
-    for (i=0; i<file_deletes.size(); i++) {
+    for (FILE_INFO &fi: file_deletes) {
         boinc::fprintf(fout,
             "<delete_file_info>%s</delete_file_info>\n",
-            file_deletes[i].name
+            fi.name
         );
     }
-    for (i=0; i<file_transfer_requests.size(); i++) {
-        boinc::fprintf(fout, "%s", file_transfer_requests[i].c_str());
+    for (string &s: file_transfer_requests) {
+        boinc::fprintf(fout, "%s", s.c_str());
     }
 
     // before writing no_X_apps elements,
@@ -1073,7 +1066,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
 
         // write modern form.
         //
-        for (i=0; i<NPROC_TYPES; i++) {
+        for (int i=0; i<NPROC_TYPES; i++) {
             if (i>0) {
                 // skip types that the client doesn't have
                 //
@@ -1123,25 +1116,22 @@ void SCHEDULER_REPLY::set_delay(double delay) {
 
 
 void SCHEDULER_REPLY::insert_app_unique(APP& app) {
-    unsigned int i;
-    for (i=0; i<apps.size(); i++) {
-        if (app.id == apps[i].id) return;
+    for (APP &a: apps) {
+        if (app.id == a.id) return;
     }
     apps.push_back(app);
 }
 
 void SCHEDULER_REPLY::insert_app_version_unique(APP_VERSION& av) {
-    unsigned int i;
-    for (i=0; i<app_versions.size(); i++) {
-        if (av.id == app_versions[i].id) return;
+    for (APP_VERSION &av2: app_versions) {
+        if (av2.id == av.id) return;
     }
     app_versions.push_back(av);
 }
 
 void SCHEDULER_REPLY::insert_workunit_unique(WORKUNIT& wu) {
-    unsigned int i;
-    for (i=0; i<wus.size(); i++) {
-        if (wu.id == wus[i].id) return;
+    for (WORKUNIT &wu2: wus) {
+        if (wu.id == wu2.id) return;
     }
     wus.push_back(wu);
 }
@@ -1617,8 +1607,7 @@ void read_host_app_versions() {
 }
 
 DB_HOST_APP_VERSION* gavid_to_havp(DB_ID_TYPE gavid) {
-    for (unsigned int i=0; i<g_wreq->host_app_versions.size(); i++) {
-        DB_HOST_APP_VERSION& hav = g_wreq->host_app_versions[i];
+    for (DB_HOST_APP_VERSION& hav: g_wreq->host_app_versions) {
         if (hav.app_version_id == gavid) return &hav;
     }
     return NULL;
@@ -1651,8 +1640,7 @@ DB_HOST_APP_VERSION* BEST_APP_VERSION::host_app_version() {
 // return some HAV for which quota was exceeded
 //
 DB_HOST_APP_VERSION* quota_exceeded_version() {
-    for (unsigned int i=0; i<g_wreq->host_app_versions.size(); i++) {
-        DB_HOST_APP_VERSION& hav = g_wreq->host_app_versions[i];
+    for (DB_HOST_APP_VERSION& hav: g_wreq->host_app_versions) {
         if (hav.daily_quota_exceeded) return &hav;
     }
     return NULL;

--- a/sched/sched_types.cpp
+++ b/sched/sched_types.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2024 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -229,7 +229,7 @@ void PROJECT_PREFS::parse() {
 }
 
 void WORK_REQ::add_no_work_message(const char* message) {
-    for (USER_MESSAGE& m: no_work_messages) {
+    for (const USER_MESSAGE& m: no_work_messages) {
         if (!strcmp(message, m.message.c_str())){
             return;
         }
@@ -467,7 +467,7 @@ const char* SCHEDULER_REQUEST::parse(XML_PARSER& xp) {
             // Shouldn't happen, but if it does bad things will happen
             //
             bool found = false;
-            for (SCHED_DB_RESULT& r: results) {
+            for (const SCHED_DB_RESULT& r: results) {
                 if (!strcmp(r.name, result.name)) {
                     found = true;
                     break;
@@ -629,7 +629,7 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
         is_anonymous(platforms.list[0])?"true":"false"
     );
 
-    for (CLIENT_APP_VERSION& cav: client_app_versions) {
+    for (const CLIENT_APP_VERSION& cav: client_app_versions) {
         boinc::fprintf(fout,
             "  <app_version>\n"
             "    <app_name>%s</app_name>\n"
@@ -672,7 +672,7 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
         host.d_boinc_max
     );
 
-    for (SCHED_DB_RESULT& r: results) {
+    for (const SCHED_DB_RESULT& r: results) {
         boinc::fprintf(fout,
             "  <result>\n"
             "    <name>%s</name>\n"
@@ -689,7 +689,7 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
         );
     }
 
-    for (MSG_FROM_HOST_DESC& m: msgs_from_host) {
+    for (const MSG_FROM_HOST_DESC& m: msgs_from_host) {
         boinc::fprintf(fout,
             "  <msg_from_host>\n"
             "    <variety>%s</variety>\n"
@@ -700,7 +700,7 @@ int SCHEDULER_REQUEST::write(FILE* fout) {
         );
     }
 
-    for (FILE_INFO& fi: file_infos) {
+    for (const FILE_INFO& fi: file_infos) {
         boinc::fprintf(fout,
             "  <file_info>\n"
             "    <name>%s</name>\n"
@@ -805,7 +805,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
     if (sreq.core_client_version <= 41900) {
         string msg;
         string pri = "low";
-        for (USER_MESSAGE& um: messages) {
+        for (const USER_MESSAGE& um: messages) {
             msg += um.message + string(" ");
             if (um.priority == "notice") {
                 pri = "notice";
@@ -827,7 +827,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
         }
     } else if (sreq.core_client_version <= 61100) {
         char prio[256];
-        for (USER_MESSAGE& um: messages) {
+        for (const USER_MESSAGE& um: messages) {
             safe_strcpy(prio, um.priority.c_str());
             if (!strcmp(prio, "notice")) {
                 strcpy(prio, "high");
@@ -839,7 +839,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
             );
         }
     } else {
-        for (USER_MESSAGE& um: messages) {
+        for (const USER_MESSAGE& um: messages) {
             boinc::fprintf(fout,
                 "<message priority=\"%s\">%s</message>\n",
                 um.priority.c_str(),
@@ -955,7 +955,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
 
     // acknowledge results
     //
-    for (string &s: result_acks) {
+    for (const string &s: result_acks) {
         boinc::fprintf(fout,
             "<result_ack>\n"
             "    <name>%s</name>\n"
@@ -966,7 +966,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
 
     // abort results
     //
-    for (string &s: result_aborts) {
+    for (const string &s: result_aborts) {
         boinc::fprintf(fout,
             "<result_abort>\n"
             "    <name>%s</name>\n"
@@ -977,7 +977,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
 
     // abort results not started
     //
-    for (string &s: result_abort_if_not_starteds) {
+    for (const string &s: result_abort_if_not_starteds) {
         boinc::fprintf(fout,
             "<result_abort_if_not_started>\n"
             "    <name>%s</name>\n"
@@ -1019,7 +1019,7 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
         boinc::fputs("<message_ack/>\n", fout);
     }
 
-    for (MSG_TO_HOST& md: msgs_to_host) {
+    for (const MSG_TO_HOST& md: msgs_to_host) {
         boinc::fprintf(fout, "%s\n", md.xml);
     }
 
@@ -1035,13 +1035,13 @@ int SCHEDULER_REPLY::write(FILE* fout, SCHEDULER_REQUEST& sreq) {
         boinc::fprintf(fout, "<verify_files_on_app_start/>\n");
     }
 
-    for (FILE_INFO &fi: file_deletes) {
+    for (const FILE_INFO &fi: file_deletes) {
         boinc::fprintf(fout,
             "<delete_file_info>%s</delete_file_info>\n",
             fi.name
         );
     }
-    for (string &s: file_transfer_requests) {
+    for (const string &s: file_transfer_requests) {
         boinc::fprintf(fout, "%s", s.c_str());
     }
 
@@ -1116,21 +1116,21 @@ void SCHEDULER_REPLY::set_delay(double delay) {
 
 
 void SCHEDULER_REPLY::insert_app_unique(APP& app) {
-    for (APP &a: apps) {
+    for (const APP &a: apps) {
         if (app.id == a.id) return;
     }
     apps.push_back(app);
 }
 
 void SCHEDULER_REPLY::insert_app_version_unique(APP_VERSION& av) {
-    for (APP_VERSION &av2: app_versions) {
+    for (const APP_VERSION &av2: app_versions) {
         if (av2.id == av.id) return;
     }
     app_versions.push_back(av);
 }
 
 void SCHEDULER_REPLY::insert_workunit_unique(WORKUNIT& wu) {
-    for (WORKUNIT &wu2: wus) {
+    for (const WORKUNIT &wu2: wus) {
         if (wu.id == wu2.id) return;
     }
     wus.push_back(wu);
@@ -1144,7 +1144,7 @@ void SCHEDULER_REPLY::insert_message(const char* msg, const char* prio) {
     messages.push_back(USER_MESSAGE(msg, prio));
 }
 
-void SCHEDULER_REPLY::insert_message(USER_MESSAGE& um) {
+void SCHEDULER_REPLY::insert_message(const USER_MESSAGE& um) {
     messages.push_back(um);
 }
 

--- a/sched/sched_types.h
+++ b/sched/sched_types.h
@@ -570,7 +570,7 @@ struct SCHEDULER_REPLY {
     void insert_workunit_unique(WORKUNIT&);
     void insert_result(SCHED_DB_RESULT&);
     void insert_message(const char* msg, const char* prio);
-    void insert_message(USER_MESSAGE&);
+    void insert_message(const USER_MESSAGE&);
     void set_delay(double);
 };
 

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -74,8 +74,7 @@ static bool need_this_resource(
 }
 
 static DB_HOST_APP_VERSION* lookup_host_app_version(DB_ID_TYPE gavid) {
-    for (unsigned int i=0; i<g_wreq->host_app_versions.size(); i++) {
-        DB_HOST_APP_VERSION& hav = g_wreq->host_app_versions[i];
+    for (DB_HOST_APP_VERSION& hav: g_wreq->host_app_versions) {
         if (hav.app_version_id == gavid) return &hav;
     }
     return NULL;
@@ -167,7 +166,6 @@ bool daily_quota_exceeded(BEST_APP_VERSION* bavp) {
 CLIENT_APP_VERSION* get_app_version_anonymous(
     APP& app, bool need_64b, bool reliable_only
 ) {
-    unsigned int i;
     CLIENT_APP_VERSION* best = NULL;
     bool found = false;
     char message[256];
@@ -178,8 +176,7 @@ CLIENT_APP_VERSION* get_app_version_anonymous(
             app.name, reliable_only?" (reliable only)":""
         );
     }
-    for (i=0; i<g_request->client_app_versions.size(); i++) {
-        CLIENT_APP_VERSION& cav = g_request->client_app_versions[i];
+    for (CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
         if (!cav.app) continue;
         if (cav.app->id != app.id) {
             continue;
@@ -283,9 +280,7 @@ CLIENT_APP_VERSION* get_app_version_anonymous(
 // called at start of send_work().
 //
 void estimate_flops_anon_platform() {
-    unsigned int i;
-    for (i=0; i<g_request->client_app_versions.size(); i++) {
-        CLIENT_APP_VERSION& cav = g_request->client_app_versions[i];
+    for (CLIENT_APP_VERSION& cav: g_request->client_app_versions) {
         if (!cav.app) continue;
 
         cav.rsc_fpops_scale = 1;
@@ -511,8 +506,7 @@ static BEST_APP_VERSION* check_homogeneous_app_version(
         // SCHEDULER_REPLY::old_app_versions
         //
         found = false;
-        for (unsigned int i=0; i<g_reply->old_app_versions.size(); i++) {
-            APP_VERSION& av = g_reply->old_app_versions[i];
+        for (APP_VERSION& av: g_reply->old_app_versions) {
             if (av.id == wu.app_version_id) {
                 avp = &av;
                 found = true;
@@ -531,8 +525,7 @@ static BEST_APP_VERSION* check_homogeneous_app_version(
     // see if this host supports the version's platform
     //
     found = false;
-    for (unsigned int i=0; i<g_request->platforms.list.size(); i++) {
-        PLATFORM* p = g_request->platforms.list[i];
+    for (PLATFORM* p: g_request->platforms.list) {
         if (p->id == avp->platformid) {
             found = true;
             bav.avp = avp;
@@ -585,7 +578,6 @@ static BEST_APP_VERSION* check_homogeneous_app_version(
 BEST_APP_VERSION* get_app_version(
     const WORKUNIT& wu, bool check_req, bool reliable_only
 ) {
-    unsigned int i;
     int j;
     BEST_APP_VERSION* bavp;
     char buf[256];
@@ -739,9 +731,8 @@ BEST_APP_VERSION* get_app_version(
 
     bavp->host_usage.projected_flops = 0;
     bavp->avp = NULL;
-    for (i=0; i<g_request->platforms.list.size(); i++) {
+    for (PLATFORM* p: g_request->platforms.list) {
         bool found_feasible_version = false;
-        PLATFORM* p = g_request->platforms.list[i];
         if (job_needs_64b && !is_64b_platform(p->name)) {
             continue;
         }
@@ -982,8 +973,7 @@ BEST_APP_VERSION* get_app_version(
             log_messages.printf(MSG_NORMAL,
                 "[version] returning NULL; platforms:\n"
             );
-            for (i=0; i<g_request->platforms.list.size(); i++) {
-                PLATFORM* p = g_request->platforms.list[i];
+            for (PLATFORM* p: g_request->platforms.list) {
                 log_messages.printf(MSG_NORMAL,
                     "[version] %s\n",
                     p->name

--- a/sched/sched_version.cpp
+++ b/sched/sched_version.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2016 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/script_assimilator.cpp
+++ b/sched/script_assimilator.cpp
@@ -97,14 +97,13 @@ int assimilate_handler(
 ) {
     int retval;
     char cmd[4096], buf[256];
-    unsigned int i;
 
     if (wu.canonical_resultid) {
         sprintf(cmd, "../bin/%s", script_args[0].c_str());
         vector<OUTPUT_FILE_INFO> fis;
         retval = get_output_file_infos(canonical_result, fis);
         if (retval) return retval;
-        for (i=1; i<script_args.size(); i++) {
+        for (unsigned i=1; i<script_args.size(); i++) {
             string& s = script_args[i];
             if (s == "files") {
                 for (OUTPUT_FILE_INFO &fi: fis) {

--- a/sched/script_assimilator.cpp
+++ b/sched/script_assimilator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2015 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/sched/script_validator.cpp
+++ b/sched/script_validator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2020 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -110,7 +110,7 @@ void validate_handler_usage() {
 //
 // any other nonzero return means the result is not valid
 //
-int init_result(RESULT& result, void*&) {
+int init_result(const RESULT& result, void*&) {
     if (init_script.empty()) {
         return 0;
     }

--- a/sched/script_validator.cpp
+++ b/sched/script_validator.cpp
@@ -115,7 +115,6 @@ int init_result(RESULT& result, void*&) {
         return 0;
     }
 
-    unsigned int i, j;
     char buf[256];
     vector<string> paths;
     int retval;
@@ -128,10 +127,10 @@ int init_result(RESULT& result, void*&) {
 
     char cmd[4096];
     sprintf(cmd, "../bin/%s", init_script[0].c_str());
-    for (i=1; i<init_script.size(); i++) {
+    for (unsigned i=1; i<init_script.size(); i++) {
         string& s = init_script[i];
         if (s == "files") {
-            for (j=0; j<paths.size(); j++) {
+            for (unsigned j=0; j<paths.size(); j++) {
                 strcat(cmd, " ");
                 strcat(cmd, paths[j].c_str());
             }
@@ -168,7 +167,6 @@ int compare_results(RESULT& r1, void*, RESULT const& r2, void*, bool& match) {
         return 0;
     }
 
-    unsigned int i, j;
     char buf[256];
     vector<string> paths1, paths2;
     int retval;
@@ -186,15 +184,15 @@ int compare_results(RESULT& r1, void*, RESULT const& r2, void*, bool& match) {
 
     char cmd[4096];
     sprintf(cmd, "../bin/%s", compare_script[0].c_str());
-    for (i=1; i<compare_script.size(); i++) {
+    for (unsigned i=1; i<compare_script.size(); i++) {
         string& s = compare_script[i];
         if (s == "files") {
-            for (j=0; j<paths1.size(); j++) {
+            for (unsigned j=0; j<paths1.size(); j++) {
                 strcat(cmd, " ");
                 strcat(cmd, paths1[j].c_str());
             }
         } else if (s == "files2") {
-            for (j=0; j<paths2.size(); j++) {
+            for (unsigned j=0; j<paths2.size(); j++) {
                 strcat(cmd, " ");
                 strcat(cmd, paths2[j].c_str());
             }

--- a/sched/single_job_assimilator.cpp
+++ b/sched/single_job_assimilator.cpp
@@ -57,7 +57,6 @@ int assimilate_handler(
 ) {
     int retval;
     char buf[1024], filename[MAXPATHLEN], job_dir[MAXPATHLEN], job_dir_file[MAXPATHLEN];
-    unsigned int i;
 
     // delete the template files
     //
@@ -119,9 +118,7 @@ int assimilate_handler(
         vector<OUTPUT_FILE_INFO> output_files;
         char copy_path[MAXPATHLEN];
         get_output_file_infos(canonical_result, output_files);
-        unsigned int n = output_files.size();
-        for (i=0; i<n; i++) {
-            OUTPUT_FILE_INFO& fi = output_files[i];
+        for (OUTPUT_FILE_INFO& fi: output_files) {
             string logical_name;
             retval = get_logical_name(canonical_result, fi.path, logical_name);
             if (retval) {

--- a/sched/single_job_assimilator.cpp
+++ b/sched/single_job_assimilator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2015 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -118,7 +118,7 @@ int assimilate_handler(
         vector<OUTPUT_FILE_INFO> output_files;
         char copy_path[MAXPATHLEN];
         get_output_file_infos(canonical_result, output_files);
-        for (OUTPUT_FILE_INFO& fi: output_files) {
+        for (const OUTPUT_FILE_INFO& fi: output_files) {
             string logical_name;
             retval = get_logical_name(canonical_result, fi.path, logical_name);
             if (retval) {

--- a/sched/transitioner.cpp
+++ b/sched/transitioner.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -498,7 +498,7 @@ int handle_wu(
     bool all_over_and_ready_to_assimilate = true;
         // used for the defer assimilation
     double most_recently_returned = 0;
-    for (TRANSITIONER_ITEM& res_item: items) {
+    for (const TRANSITIONER_ITEM& res_item: items) {
         if (!res_item.res_id) continue;
         if (res_item.res_server_state == RESULT_SERVER_STATE_OVER) {
             if (res_item.res_received_time > most_recently_returned) {
@@ -626,7 +626,7 @@ int handle_wu(
 
     // handle timeout of in-progress results
     //
-    for (TRANSITIONER_ITEM& res_item: items) {
+    for (const TRANSITIONER_ITEM& res_item: items) {
         if (!res_item.res_id) continue;
         if (res_item.res_server_state == RESULT_SERVER_STATE_IN_PROGRESS) {
             x = res_item.res_report_deadline;

--- a/sched/transitioner.cpp
+++ b/sched/transitioner.cpp
@@ -152,11 +152,10 @@ int handle_wu(
 ) {
     int ntotal, nerrors, retval, ninprogress, nsuccess;
     int nunsent, ncouldnt_send, nover, ndidnt_need, nno_reply;
-    int canonical_result_index, j;
+    int canonical_result_index;
     char suffix[256];
     time_t now = time(0), x;
     bool all_over_and_validated, have_new_result_to_validate, do_delete;
-    unsigned int i;
 
     TRANSITIONER_ITEM& wu_item = items[0];
     TRANSITIONER_ITEM wu_item_original = wu_item;
@@ -181,7 +180,7 @@ int handle_wu(
     //
     canonical_result_index = -1;
     if (wu_item.canonical_resultid) {
-        for (i=0; i<items.size(); i++) {
+        for (unsigned int i=0; i<items.size(); i++) {
             TRANSITIONER_ITEM& res_item = items[i];
             if (!res_item.res_id) continue;
             if (res_item.res_id == wu_item.canonical_resultid) {
@@ -214,9 +213,7 @@ int handle_wu(
     // 4) see if we have a new result to validate
     //    (outcome SUCCESS and validate_state INIT)
     //
-    for (i=0; i<items.size(); i++) {
-        TRANSITIONER_ITEM& res_item = items[i];
-
+    for (TRANSITIONER_ITEM& res_item: items) {
         if (!res_item.res_id) continue;
         ntotal++;
 
@@ -397,8 +394,7 @@ int handle_wu(
     // and trigger assimilation if needed
     //
     if (wu_item.error_mask) {
-        for (i=0; i<items.size(); i++) {
-            TRANSITIONER_ITEM& res_item = items[i];
+        for (TRANSITIONER_ITEM& res_item: items) {
             if (!res_item.res_id) continue;
             bool update_result = false;
             switch(res_item.res_server_state) {
@@ -457,7 +453,7 @@ int handle_wu(
                 wu_item.id, wu_item.name, n_new_results_needed,
                 wu_item.target_nresults, nunsent, ninprogress, nsuccess
             );
-            for (j=0; j<n_new_results_needed; j++) {
+            for (int j=0; j<n_new_results_needed; j++) {
                 sprintf(suffix, "%d", max_result_suffix+j+1);
                 const char *rtfpath = config.project_path("%s", wu_item.result_template_file);
                 int priority_increase = 0;
@@ -502,8 +498,7 @@ int handle_wu(
     bool all_over_and_ready_to_assimilate = true;
         // used for the defer assimilation
     double most_recently_returned = 0;
-    for (i=0; i<items.size(); i++) {
-        TRANSITIONER_ITEM& res_item = items[i];
+    for (TRANSITIONER_ITEM& res_item: items) {
         if (!res_item.res_id) continue;
         if (res_item.res_server_state == RESULT_SERVER_STATE_OVER) {
             if (res_item.res_received_time > most_recently_returned) {
@@ -559,7 +554,7 @@ int handle_wu(
             // output of error results can be deleted immediately;
             // output of success results can be deleted if validated
             //
-            for (i=0; i<items.size(); i++) {
+            for (unsigned i=0; i<items.size(); i++) {
                 TRANSITIONER_ITEM& res_item = items[i];
 
                 // can delete canonical result outputs only if all successful
@@ -631,8 +626,7 @@ int handle_wu(
 
     // handle timeout of in-progress results
     //
-    for (i=0; i<items.size(); i++) {
-        TRANSITIONER_ITEM& res_item = items[i];
+    for (TRANSITIONER_ITEM& res_item: items) {
         if (!res_item.res_id) continue;
         if (res_item.res_server_state == RESULT_SERVER_STATE_IN_PROGRESS) {
             x = res_item.res_report_deadline;

--- a/sched/validate_util.cpp
+++ b/sched/validate_util.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -150,7 +150,7 @@ int get_output_file_paths(RESULT const& result, vector<string>& paths) {
     int retval = get_output_file_infos(result, fis);
     if (retval) return retval;
     paths.clear();
-    for (OUTPUT_FILE_INFO& fi: fis) {
+    for (const OUTPUT_FILE_INFO& fi: fis) {
         paths.push_back(fi.path);
     }
     return 0;
@@ -195,7 +195,7 @@ struct FILE_REF {
 
 // given a path returned by the above, get the corresponding logical name
 //
-int get_logical_name(RESULT& result, string& path, string& name) {
+int get_logical_name(RESULT& result, const string& path, string& name) {
     char buf[1024], phys_name[1024];
     MIOFILE mf;
     int retval;

--- a/sched/validate_util.cpp
+++ b/sched/validate_util.cpp
@@ -150,8 +150,8 @@ int get_output_file_paths(RESULT const& result, vector<string>& paths) {
     int retval = get_output_file_infos(result, fis);
     if (retval) return retval;
     paths.clear();
-    for (unsigned int i=0; i<fis.size(); i++) {
-        paths.push_back(fis[i].path);
+    for (OUTPUT_FILE_INFO& fi: fis) {
+        paths.push_back(fi.path);
     }
     return 0;
 }

--- a/sched/validate_util.h
+++ b/sched/validate_util.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -47,7 +47,7 @@ extern int get_output_file_paths(
     RESULT const& result, std::vector<std::string>&
 );
 extern int get_logical_name(
-    RESULT& result, std::string& path, std::string& name
+    RESULT& result, const std::string& path, std::string& name
 );
 
 extern int get_credit_from_wu(WORKUNIT&, std::vector<RESULT>& results, double&);

--- a/sched/validate_util2.h
+++ b/sched/validate_util2.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2008 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -37,7 +37,7 @@
     // Retry validation later.
     // ERR_OPENDIR is also treated this way.
 
-extern int init_result(RESULT&, void*&);
+extern int init_result(const RESULT&, void*&);
 extern int compare_results(RESULT &, void*, RESULT const&, void*, bool&);
 extern int cleanup_result(RESULT const&, void*);
 

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -192,8 +192,8 @@ void scan_punitive(vector<VALIDATOR_ITEM>& items) {
     void* data=NULL;
     char buf[256];
 
-    for (unsigned int i=0; i<items.size(); i++) {
-        RESULT& result = items[i].res;
+    for (VALIDATOR_ITEM& vi: items) {
+        RESULT& result = vi.res;
         if (result.server_state != RESULT_SERVER_STATE_OVER) continue;
         if (result.outcome != RESULT_OUTCOME_CLIENT_ERROR) continue;
         if (init_result(result, data) == VAL_RESULT_LONG_TERM_FAIL) {
@@ -237,7 +237,6 @@ int handle_wu(
     int retval = 0, x;
     DB_ID_TYPE canonicalid = 0;
     double credit = 0;
-    unsigned int i;
 
     WORKUNIT& wu = items[0].wu;
     g_wup = &wu;
@@ -255,9 +254,9 @@ int handle_wu(
         // Here if WU already has a canonical result.
         // Get unchecked results and see if they match the canonical result
         //
-        for (i=0; i<items.size(); i++) {
-            RESULT& result = items[i].res;
-
+        for (unsigned int i=0; i<items.size(); i++) {
+            VALIDATOR_ITEM& vi = items[i];
+            RESULT& result = vi.res;
             if (result.id == wu.canonical_resultid) {
                 canonical_result_index = i;
             }
@@ -274,8 +273,8 @@ int handle_wu(
 
         // scan this WU's results, and check the unchecked ones
         //
-        for (i=0; i<items.size(); i++) {
-            RESULT& result = items[i].res;
+        for (VALIDATOR_ITEM& vi: items) {
+            RESULT& result = vi.res;
 
             if (result.server_state != RESULT_SERVER_STATE_OVER) continue;
             if (result.outcome !=  RESULT_OUTCOME_SUCCESS) continue;
@@ -429,8 +428,8 @@ int handle_wu(
         // make a vector of the "viable" (i.e. possibly canonical) results,
         // and a parallel vector of host_app_versions
         //
-        for (i=0; i<items.size(); i++) {
-            RESULT& result = items[i].res;
+        for (VALIDATOR_ITEM& vi: items) {
+            RESULT& result = vi.res;
 
             if (result.server_state != RESULT_SERVER_STATE_OVER) continue;
             if (result.outcome != RESULT_OUTCOME_SUCCESS) continue;
@@ -503,8 +502,7 @@ int handle_wu(
                     // is within range
                     //
                     vector<double> cc;
-                    for (i=0; i<viable_results.size(); i++) {
-                        RESULT& result = viable_results[i];
+                    for (RESULT& result: viable_results) {
                         if (result.flops_estimate == 1e9) {
                             result.flops_estimate = AVG_CPU_FPOPS;
                         }
@@ -544,8 +542,7 @@ int handle_wu(
                     }
                 } else if (post_assigned_credit) {
                     credit = 0;
-                    for (i=0; i<viable_results.size(); i++) {
-                        RESULT& result = viable_results[i];
+                    for (RESULT& result: viable_results) {
                         if (result.id != canonicalid) {
                             continue;
                         }
@@ -573,7 +570,7 @@ int handle_wu(
             // or validate_state INVALID)
             //
             int n_viable_results = 0;
-            for (i=0; i<viable_results.size(); i++) {
+            for (unsigned i=0; i<viable_results.size(); i++) {
                 RESULT& result = viable_results[i];
                 DB_HOST_APP_VERSION& hav = host_app_versions[i];
                 DB_HOST_APP_VERSION& hav_orig = host_app_versions_orig[i];
@@ -703,8 +700,8 @@ int handle_wu(
 
                 // don't need to send any more results
                 //
-                for (i=0; i<items.size(); i++) {
-                    RESULT& result = items[i].res;
+                for (VALIDATOR_ITEM& vi: items) {
+                    RESULT& result = vi.res;
 
                     if (result.server_state != RESULT_SERVER_STATE_UNSENT) {
                         continue;

--- a/sched/validator.cpp
+++ b/sched/validator.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2019 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -192,8 +192,8 @@ void scan_punitive(vector<VALIDATOR_ITEM>& items) {
     void* data=NULL;
     char buf[256];
 
-    for (VALIDATOR_ITEM& vi: items) {
-        RESULT& result = vi.res;
+    for (const VALIDATOR_ITEM& vi: items) {
+        const RESULT& result = vi.res;
         if (result.server_state != RESULT_SERVER_STATE_OVER) continue;
         if (result.outcome != RESULT_OUTCOME_CLIENT_ERROR) continue;
         if (init_result(result, data) == VAL_RESULT_LONG_TERM_FAIL) {
@@ -542,7 +542,7 @@ int handle_wu(
                     }
                 } else if (post_assigned_credit) {
                     credit = 0;
-                    for (RESULT& result: viable_results) {
+                    for (const RESULT& result: viable_results) {
                         if (result.id != canonicalid) {
                             continue;
                         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored scheduler backend to use range-based for and improve const correctness for clearer, safer iteration. No functional changes.

- **Refactors**
  - Replaced index-based loops with range-based for across sched modules (credit, request handling, validation, sending, transitioner, shmem, etc.).
  - Tightened const correctness: added const to loop references, method qualifiers (e.g., get_avg()), and function params (e.g., const char*, const RESULT&); updated call sites.
  - Switched size checks to empty(), iterated by (const) reference, removed unused counters, minor string building cleanups.

<sup>Written for commit 6f669fb7041ef5f05fad08582f421eb82b7d3412. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

