### PR TITLE
[windows][installer] add client_auth.xml creation test

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # http://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -213,7 +213,7 @@ jobs:
       matrix:
         type: [install, upgrade_from_alpha, upgrade_from_stable]
         platform: [x64, arm64]
-        installation_type: [normal, service, test_acct_mgr_login]
+        installation_type: [normal, service, test_acct_mgr_login, test_client_auth_file]
         include:
           - platform: x64
             runner: windows-latest
@@ -223,14 +223,22 @@ jobs:
             argument_list_alpha: "/quiet /qn /l*v alpha.log"
             argument_list_release: "/quiet /qn /l*v release.log"
             argument_list_install: "/quiet /qn /l*v install.log"
+            argument_list_prepare: ""
           - installation_type: service
             argument_list_alpha: "/quiet /qn /norestart /l*v alpha.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
             argument_list_release: "/quiet /qn /norestart /l*v release.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
             argument_list_install: "/quiet /qn /norestart /l*v install.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_prepare: ""
           - installation_type: test_acct_mgr_login
             argument_list_alpha: "/quiet /qn /l*v alpha.log"
             argument_list_release: "/quiet /qn /l*v release.log"
             argument_list_install: "/quiet /qn /l*v install.log ACCTMGR_LOGIN=test ACCTMGR_PASSWORDHASH=0123456789abcdef"
+            argument_list_prepare: ""
+          - installation_type: test_client_auth_file
+            argument_list_alpha: "/quiet /qn /norestart /l*v alpha.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_release: "/quiet /qn /norestart /l*v release.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_install: "/quiet /qn /norestart /l*v install.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1 BOINC_PROJECT_USERNAME=test_user BOINC_PROJECT_PASSWORD=qwerty123456!@#$%^"
+            argument_list_prepare: '--create-user --username test_user --password "qwerty123456!@#$%^"'
       fail-fast: false
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
@@ -266,6 +274,11 @@ jobs:
         run: |
           7z x win_installer.7z
 
+      - name: Prepare installation for further testing
+        if: success() && matrix.argument_list_prepare != ''
+        shell: cmd
+        run: python ./tests/windows_installer_integration_tests_prepare.py ${{matrix.argument_list_prepare}}
+
       - name: Run installation
         if: success()
         shell: powershell
@@ -273,13 +286,13 @@ jobs:
 
       - name: Run installation tests
         if: success()
-        run: python ./tests/windows_installer_integration_tests.py --installation-type ${{matrix.installation_type}}
+        run: python ./tests/windows_installer_integration_tests.py --installation-type ${{matrix.installation_type}} --type ${{matrix.type}}
 
       - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
-          name: windows_installer_test_logs_${{matrix.platform}}_${{matrix.type}}_${{github.event.pull_request.head.sha}}
+          name: windows_installer_test_logs_${{matrix.platform}}_${{matrix.type}}_${{matrix.installation_type}}_${{github.event.pull_request.head.sha}}
           path: |
             install.log
             alpha.log

--- a/tests/windows_installer_integration_tests_prepare.py
+++ b/tests/windows_installer_integration_tests_prepare.py
@@ -1,0 +1,115 @@
+# This file is part of BOINC.
+# https://boinc.berkeley.edu
+# Copyright (C) 2026 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Windows Installer Integration Tests Preparation Script
+
+This script prepares the Windows environment for installer integration tests.
+Currently supports creating test users on Windows.
+"""
+
+import argparse
+import platform
+import subprocess
+import sys
+
+
+def check_windows():
+    """Verify that the script is running on Windows."""
+    if platform.system() != 'Windows':
+        print("Error: This script must be run on Windows.", file=sys.stderr)
+        sys.exit(1)
+
+
+def create_windows_user(username, password):
+    """
+    Create a new Windows user account.
+
+    Args:
+        username: The username for the new account
+        password: The password for the new account
+
+    Returns:
+        bool: True if user was created successfully, False otherwise
+    """
+    try:
+        # Use net user command to create a new local user account
+        cmd = ['net', 'user', username, password, '/add', '/y']
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False
+        )
+
+        if result.returncode == 0:
+            print(f"Successfully created user: {username}")
+            return True
+        else:
+            error_msg = result.stderr.strip() or result.stdout.strip() or "Unknown error occurred"
+            print(f"Error creating user: {error_msg}", file=sys.stderr)
+            return False
+
+    except Exception as e:
+        print(f"Exception while creating user: {e}", file=sys.stderr)
+        return False
+
+
+def main():
+    """Main entry point for the script."""
+    parser = argparse.ArgumentParser(
+        description='Prepare Windows environment for installer integration tests'
+    )
+
+    parser.add_argument(
+        '--create-user',
+        action='store_true',
+        help='Create a new Windows user account'
+    )
+
+    parser.add_argument(
+        '--username',
+        type=str,
+        help='Username for the new account (required with --create-user)'
+    )
+
+    parser.add_argument(
+        '--password',
+        type=str,
+        help='Password for the new account (required with --create-user)'
+    )
+
+    args = parser.parse_args()
+
+    # Check if running on Windows
+    check_windows()
+
+    # Validate arguments
+    if args.create_user:
+        if not args.username or not args.password:
+            parser.error('--create-user requires both --username and --password')
+
+        # Create the user
+        success = create_windows_user(args.username, args.password)
+        sys.exit(0 if success else 1)
+    else:
+        parser.print_help()
+        sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Windows installer integration test that verifies client_auth.xml is created and populated as expected. CI runs on x64 and arm64, creates a test user when needed, and uploads logs on failure.

- **New Features**
  - Added test_client_auth_file to validate C:\ProgramData\BOINC\client_auth.xml (root=client_authorization; boinc_project/username=test_user; password=cXdlcnR5MTIzNDU2IUAjJCVe). On fresh installs, also assert only 'boinc_master' exists (no 'boinc_project').
  - Updated windows.yml to add installation_type=test_client_auth_file with protected execution; pass BOINC_PROJECT_USERNAME/PASSWORD; run a conditional prepare step (tests/windows_installer_integration_tests_prepare.py) to create the user; pass --type to tests to distinguish install vs upgrades; include installation_type in artifact names.

<sup>Written for commit 483ee016e042a2a5186853450835443484da9030. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

