### PR TITLE
[windows][isntaller] test login_token.txt file present after installation

### DIFF
--- a/installer/installer_setup/main.cpp
+++ b/installer/installer_setup/main.cpp
@@ -244,10 +244,15 @@ bool ExtractResourceAndExecute(UINT ResourceID, std::string OutputFileName,
         CloseHandle(hFilemap);
         CloseHandle(hFile);
 
+        const auto bMode = CmdParameters == "" ? SW_SHOWNORMAL : SW_HIDE;
+        char self[MAX_PATH];
+        if (GetModuleFileName(nullptr, self, MAX_PATH) != 0) {
+            CmdParameters += " SETUPEXENAME=\"" +
+                std::filesystem::path(self).filename().string() + "\"";
+        }
         auto hInstance = ShellExecute(nullptr, "open",
             (outputDir / OutputFileName).string().c_str(),
-            CmdParameters.c_str(), nullptr,
-            CmdParameters == "" ? SW_SHOWNORMAL : SW_HIDE);
+            CmdParameters.c_str(), nullptr, bMode);
         if (reinterpret_cast<INT_PTR>(hInstance) <= 32) {
             Log("Failed to execute installer");
             MessageBox(NULL, "Failed to execute the installer!", "Error",

--- a/tests/windows_installer_integration_tests.py
+++ b/tests/windows_installer_integration_tests.py
@@ -34,6 +34,7 @@ class IntegrationTests:
         self.result &= self.test_version()
         self.result &= self.test_files_exist()
         self.result &= self.test_registry_records_exist()
+        self.result &= self.test_login_token_file()
         if self.installation_type == "service":
             self.result &= self.test_service_exists()
             self.result &= self.test_service_users_exist()
@@ -229,6 +230,21 @@ class IntegrationTests:
                 ts.expect_true(False, f"Test XML file is well-formed (Parse error: {e})")
             except Exception as e:
                 ts.expect_true(False, f"Test XML file can be processed (Error: {e})")
+
+        return ts.result()
+
+    def test_login_token_file(self):
+        ts = testset.TestSet("Test login token file")
+        login_token_file = self._get_test_data_file_path("login_token.txt")
+        ts.expect_true(os.path.exists(login_token_file), "Test 'login_token.txt' file exists in 'C:\\ProgramData\\BOINC\\'")
+
+        if os.path.exists(login_token_file):
+            try:
+                with open(login_token_file, 'r') as f:
+                    content = f.read()
+                    ts.expect_equal("installer_setup.exe", content.strip(), "Test 'login_token.txt' contains 'installer_setup.exe' line")
+            except Exception as e:
+                ts.expect_true(False, f"Test 'login_token.txt' can be read (Error: {e})")
 
         return ts.result()
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a Windows installer integration test that checks login_token.txt is created at C:\ProgramData\BOINC and contains "installer_setup.exe".
Update installer_setup to pass its own filename to the child installer via SETUPEXENAME (using GetModuleFileName) so the token is written; the test fails if the file is missing or unreadable.

<sup>Written for commit 4db521a403f5d8854f6052cedaf60e351a648d3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

