### PR TITLE
server: fix possible WSS attack in private messages

### DIFF
--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -261,7 +261,12 @@ function pm_web_line($notify) {
     $pm = BoincPrivateMessage::lookup_id($notify->opaque);
     $from_user = BoincUser::lookup_id($pm->senderid);
     if (!$pm || !$from_user) return null;
-    return "<a href=pm.php>".tra("Private message%1 from %2, subject:" , "</a>", $from_user->name ).htmlspecialchars($pm->subject);
+    return "<a href=pm.php>"
+        .tra("Private message%1 from %2, subject:" ,
+            "</a>",
+            htmlspecialchars($from_user->name)
+        )
+        .htmlspecialchars($pm->subject);
 }
 
 // Add a PM to the database, and notify the recipient.

--- a/html/inc/pm.inc
+++ b/html/inc/pm.inc
@@ -220,22 +220,29 @@ function pm_form_page($replyto, $userid, $error = null) {
 function send_pm_notification_email(
     $logged_in_user, $to_user, $subject, $content
 ) {
-    $message  = "
-You have received a new private message at ".PROJECT.".
+    $message  = sprintf('
+You have received a new private message at %s.
 
-From: $logged_in_user->name (ID $logged_in_user->id)
-Subject: $subject
-
-$content
+From: %s (ID %d)
+Subject: %s
+Message:
+%s
 
 --------------------------
 To delete or respond to this message, visit:
-".secure_url_base()."pm.php
+%spm.php
 
 To change email preferences, visit:
-".secure_url_base()."edit_forum_preferences_form.php
+%sedit_forum_preferences_form.php
+
 Do not reply to this message.
-" ;
+',
+        PROJECT, $logged_in_user->name, $logged_in_user->id,
+        $subject,
+        $content,
+        secure_url_base(),
+        secure_url_base()
+    );
     send_email($to_user, "[".PROJECT."] - private message", $message);
 }
 
@@ -243,18 +250,27 @@ function pm_email_line($notify) {
     $pm = BoincPrivateMessage::lookup_id($notify->opaque);
     $from_user = BoincUser::lookup_id($pm->senderid);
     if (!$pm || !$from_user) return null;
-    return "$from_user->name ".tra("sent you a private message; subject:")." '$pm->subject'";
+    return sprintf('%s %s "%s"',
+        $from_user->name,
+        tra("sent you a private message; subject:"),
+        $pm->subject
+    );
 }
 
 function pm_web_line($notify) {
     $pm = BoincPrivateMessage::lookup_id($notify->opaque);
     $from_user = BoincUser::lookup_id($pm->senderid);
     if (!$pm || !$from_user) return null;
-    return "<a href=pm.php>".tra("Private message%1 from %2, subject:" , "</a>", $from_user->name )." $pm->subject";
+    return "<a href=pm.php>".tra("Private message%1 from %2, subject:" , "</a>", $from_user->name ).htmlspecialchars($pm->subject);
 }
 
+// Add a PM to the database, and notify the recipient.
+// Note: the subject and content can have HTML tags,
+// and thus potential XSS stuff.
+// We need to use htmlspecialchars() whenever displaying these
+//
 function pm_send_msg($from_user, $to_user, $subject, $content, $send_email) {
-    $sql_subject = BoincDb::escape_string(sanitize_tags($subject));
+    $sql_subject = BoincDb::escape_string($subject);
     $sql_content = BoincDb::escape_string($content);
     $mid = BoincPrivateMessage::insert("(userid, senderid, date, subject, content) VALUES ($to_user->id, $from_user->id, UNIX_TIMESTAMP(), '$sql_subject', '$sql_content')");
     if (!$mid) {

--- a/html/user/pm.php
+++ b/html/user/pm.php
@@ -129,7 +129,10 @@ function do_inbox($logged_in_user) {
             if (!$msg->opened) {
                 $msg->update("opened=1");
             }
-            echo "<td valign=top> $checkbox $msg->subject </td>\n";
+            echo sprintf("<td valign=top>%s %s </td>\n",
+                $checkbox,
+                htmlspecialchars($msg->subject)
+            );
             echo "<td valign=top>".user_links($sender, BADGE_HEIGHT_SMALL);
             show_block_link($msg->senderid);
             echo "<br>".time_str($msg->date)."</td>\n";
@@ -151,38 +154,6 @@ function do_inbox($logged_in_user) {
         ";
         end_table();
         echo "</form>\n";
-    }
-    page_tail();
-}
-
-// the following isn't currently used - we never show single messages
-//
-function do_read($logged_in_user) {
-    $id = get_int("id");
-    $message = BoincPrivateMessage::lookup_id($id);
-    if (!$message || $message->userid != $logged_in_user->id) {
-        error_page(tra("no such message"));
-    }
-    page_head(tra("Private messages")." : ".$message->subject);
-    pm_header();
-
-    $sender = BoincUser::lookup_id($message->senderid);
-
-    start_table();
-    echo "<tr><th>".tra("Subject")."</th><td>".$message->subject."</td></tr>";
-    echo "<tr><th>".tra("Sender")."</th><td>".user_links($sender, BADGE_HEIGHT_SMALL);
-    show_block_link($message->senderid);
-    echo "</td></tr>";
-    echo "<tr><th>".tra("Date")."</th><td>".time_str($message->date)."</td></tr>";
-    echo "<tr><th>".tra("Message")."</th><td>".output_transform($message->content, $options)."</td></tr>";
-    echo "<tr><td></td><td>\n";
-    echo "<a href=\"pm.php?action=new&amp;replyto=$id\">".tra("Reply")."</a>\n";
-    echo " &middot; <a href=\"pm.php?action=delete&amp;id=$id\">".tra("Delete")."</a>\n";
-    echo " &middot; <a href=\"pm.php?action=inbox\">".tra("Inbox")."</a>\n";
-    end_table();
-
-    if ($message->opened == 0) {
-        $message->update("opened=1");
     }
     page_tail();
 }
@@ -421,8 +392,6 @@ if (!$action) {
 
 if ($action == "inbox") {
     do_inbox($logged_in_user);
-} elseif ($action == "read") {
-    do_read($logged_in_user);
 } elseif ($action == "new") {
     if (!$teamid) $teamid = post_int("teamid", true);
     if ($teamid) {


### PR DESCRIPTION
Private messages have a subject and body.
These can legitimately contain HTML tags.
When showing messages on the web we must use htmlspecialchars(). I fixed an instance where this wasn't being done.

When we include PM text in email messages we don't need to do this.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Escapes private message subjects and sender names when shown on the web to prevent XSS. Also cleaned up email notifications and removed an unused single-message view.

- **Bug Fixes**
  - Use htmlspecialchars when rendering PM subjects and sender names in the inbox and web notifications.
  - Preserve HTML in subjects at storage; escape only on display.

- **Refactors**
  - Simplified notification email formatting, added a "Message:" label, and used secure links.
  - Removed the unused "read" action/view.

<sup>Written for commit a1a464f30b388f03db7cc100bcf4ec72aba1e920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

