### PR TITLE
[windows][installer] Add project_init.xml test

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -213,7 +213,7 @@ jobs:
       matrix:
         type: [install, upgrade_from_alpha, upgrade_from_stable]
         platform: [x64, arm64]
-        installation_type: [normal, service, test_acct_mgr_login, test_client_auth_file]
+        installation_type: [normal, service, test_acct_mgr_login, test_client_auth_file, test_proj_init_file]
         include:
           - platform: x64
             runner: windows-latest
@@ -239,6 +239,11 @@ jobs:
             argument_list_release: "/quiet /qn /norestart /l*v release.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
             argument_list_install: "/quiet /qn /norestart /l*v install.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1 BOINC_PROJECT_USERNAME=test_user BOINC_PROJECT_PASSWORD=qwerty123456!@#$%^"
             argument_list_prepare: '--create-user --username test_user --password "qwerty123456!@#$%^"'
+          - installation_type: test_proj_init_file
+            argument_list_alpha: "/quiet /qn /l*v alpha.log"
+            argument_list_release: "/quiet /qn /l*v release.log"
+            argument_list_install: "/quiet /qn /l*v install.log PROJINIT_URL=https://test.com PROJINIT_NAME=test PROJINIT_AUTH=abcdef1234567890"
+            argument_list_prepare: ""
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Windows installer integration test that validates project_init.xml and updates CI to run a new installation type with PROJINIT parameters. Ensures the file exists and the XML has the expected fields and values.

- **New Features**
  - Added test_proj_init_file to parse C:\ProgramData\BOINC\project_init.xml and check root tag, url, name, account_key, and embedded=0.
  - Extended windows.yml with installation_type=test_proj_init_file and MSI args for PROJINIT_URL, PROJINIT_NAME, PROJINIT_AUTH.
  - Updated CLI help to include the new installation type.

<sup>Written for commit 47b59bc5d6cb968e2f2627053b02948643ef0004. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

