### PR TITLE
[Draft] Linux idle helper RPC probe + cc_config knobs (fixes #1187 path)

### DIFF
--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -241,6 +241,12 @@ void CC_CONFIG::show() {
     if (fetch_on_update) {
         msg_printf(NULL, MSG_INFO, "Config: fetch on update");
     }
+    if (enable_idle_helper_rpc) {
+        msg_printf(NULL, MSG_INFO,
+            "Config: enable Linux idle helper RPC (%s, timeout %d ms)",
+            idle_helper_socket.c_str(), idle_helper_timeout_ms
+        );
+    }
     if (http_1_0) {
         msg_printf(NULL, MSG_INFO, "Config: use HTTP 1.0");
     }
@@ -420,6 +426,9 @@ int CC_CONFIG::parse_options_client(XML_PARSER& xp) {
         }
         if (xp.parse_bool("fetch_minimal_work", fetch_minimal_work)) continue;
         if (xp.parse_bool("fetch_on_update", fetch_on_update)) continue;
+        if (xp.parse_bool("enable_idle_helper_rpc", enable_idle_helper_rpc)) continue;
+        if (xp.parse_string("idle_helper_socket", idle_helper_socket)) continue;
+        if (xp.parse_int("idle_helper_timeout_ms", idle_helper_timeout_ms)) continue;
         if (xp.parse_string("force_auth", force_auth)) {
             downcase_string(force_auth);
             continue;

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -225,6 +225,9 @@ void CC_CONFIG::defaults() {
     exit_when_idle = false;
     fetch_minimal_work = false;
     fetch_on_update = false;
+    enable_idle_helper_rpc = false;
+    idle_helper_socket = "/run/user/%d/boinc/idle-helper.sock";
+    idle_helper_timeout_ms = 50;
     force_auth = "default";
     http_1_0 = false;
     http_transfer_timeout = 300;
@@ -385,6 +388,9 @@ int CC_CONFIG::parse_options(XML_PARSER& xp) {
         }
         if (xp.parse_bool("fetch_minimal_work", fetch_minimal_work)) continue;
         if (xp.parse_bool("fetch_on_update", fetch_on_update)) continue;
+        if (xp.parse_bool("enable_idle_helper_rpc", enable_idle_helper_rpc)) continue;
+        if (xp.parse_string("idle_helper_socket", idle_helper_socket)) continue;
+        if (xp.parse_int("idle_helper_timeout_ms", idle_helper_timeout_ms)) continue;
         if (xp.parse_string("force_auth", force_auth)) {
             downcase_string(force_auth);
             continue;
@@ -617,6 +623,9 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         "        <exit_when_idle>%d</exit_when_idle>\n"
         "        <fetch_minimal_work>%d</fetch_minimal_work>\n"
         "        <fetch_on_update>%d</fetch_on_update>\n"
+        "        <enable_idle_helper_rpc>%d</enable_idle_helper_rpc>\n"
+        "        <idle_helper_socket>%s</idle_helper_socket>\n"
+        "        <idle_helper_timeout_ms>%d</idle_helper_timeout_ms>\n"
         "        <force_auth>%s</force_auth>\n"
         "        <http_1_0>%d</http_1_0>\n"
         "        <http_transfer_timeout>%d</http_transfer_timeout>\n"
@@ -626,6 +635,9 @@ int CC_CONFIG::write(MIOFILE& out, LOG_FLAGS& log_flags) {
         exit_when_idle,
         fetch_minimal_work,
         fetch_on_update,
+        enable_idle_helper_rpc,
+        idle_helper_socket.c_str(),
+        idle_helper_timeout_ms,
         force_auth.c_str(),
         http_1_0,
         http_transfer_timeout,

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -180,6 +180,9 @@ struct CC_CONFIG {
     bool exit_when_idle;
     bool fetch_minimal_work;
     bool fetch_on_update;
+    bool enable_idle_helper_rpc;
+    std::string idle_helper_socket;
+    int idle_helper_timeout_ms;
     std::string force_auth;
     bool http_1_0;
     int http_transfer_timeout;


### PR DESCRIPTION
## Summary
Phase-1 client-side integration for Linux idle helper RPC (RFC spike for #1187):

- adds optional UNIX-socket probe in `HOST_INFO::user_idle_time()` Linux path
  - request: `GET_IDLE_SECS\n`
  - response parse: `OK <seconds> <source>`
  - short socket timeout and safe fallback to existing logic when unavailable
- keeps existing XScreenSaver (`xss_idle()`) fallback path unchanged
- adds minimal `cc_config.xml` knobs:
  - `<enable_idle_helper_rpc>` (default `0`)
  - `<idle_helper_socket>` (default `/run/user/%d/boinc/idle-helper.sock`)
  - `<idle_helper_timeout_ms>` (default `50`)
- wires parsing/writing/showing of new config fields in both config parsers

## Notes
- Defaults preserve current behavior unless helper RPC is explicitly enabled.
- Could not run a full compile in this environment because bootstrap dependency `m4` is missing (`./_autosetup` fails before build).

Refs: #1187

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional Linux idle helper RPC probe over a UNIX socket with new cc_config knobs, keeping current idle detection as the default. Supports #1187 by querying a helper and safely falling back when unavailable.

- **New Features**
  - Linux: probe idle via UNIX socket (default /run/user/%d/boinc/idle-helper.sock) with short timeout and safe fallback.
  - New cc_config options: enable_idle_helper_rpc (false), idle_helper_socket, idle_helper_timeout_ms (50). Parsed, written, and shown in logs.
  - Idle time now uses min(existing, helper result). XScreenSaver path unchanged; debug logs behind idle_detection_debug.

- **Migration**
  - Off by default. To enable, set <enable_idle_helper_rpc>true</enable_idle_helper_rpc> in cc_config.xml; optionally set <idle_helper_socket> and <idle_helper_timeout_ms>.

<sup>Written for commit d3d5319414a50a37332306cb5fa194f83864057f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

