### PR TITLE
Web: minor job submission tweaks

### DIFF
--- a/html/inc/result.inc
+++ b/html/inc/result.inc
@@ -728,13 +728,17 @@ function show_result($result, $show_outfile_links=false) {
     row2(tra("Server state"), result_server_state_string($result));
     row2(tra("Outcome"), result_outcome_string($result));
     row2(tra("Client state"), result_client_state_string($result));
-    row2(tra("Exit status"), exit_status_string($result->exit_status));
     row2(tra("Computer ID"), host_link($result->hostid));
-    row2(tra("Run time"), time_diff($result->elapsed_time));
-    row2(tra("CPU time"), time_diff($result->cpu_time));
+    if ($result->server_state == RESULT_SERVER_STATE_OVER) {
+        row2(tra("Exit status"), exit_status_string($result->exit_status));
+    }
+    if ($result->outcome == RESULT_OUTCOME_SUCCESS) {
+        row2(tra("Run time"), time_diff($result->elapsed_time));
+        row2(tra("CPU time"), time_diff($result->cpu_time));
+        row2(tra("Credit"), number_format($result->granted_credit, 2));
+        row2(tra("Validate state"), validate_state_str($result));
+    }
     row2('Priority', $result->priority);
-    row2(tra("Validate state"), validate_state_str($result));
-    row2(tra("Credit"), number_format($result->granted_credit, 2));
     row2(tra("Device peak FLOPS"), number_format($result->flops_estimate/1e9, 2)." GFLOPS");
     row2(tra("Application version"), app_version_string($result));
     if ($result->peak_working_set_size) {

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -184,6 +184,8 @@ function delete_remote_submit_user($user) {
 // TODO: update est_completion_time
 //
 function get_batch_params($batch, $wus) {
+    $batch->njobs_success = 0;
+    $batch->njobs_in_prog = 0;
     if ($batch->state == BATCH_STATE_INIT) {
         // a batch in INIT state has no jobs
         //
@@ -294,6 +296,8 @@ function get_outfile_log_names($result) {
     return $names;
 }
 
+// get output file paths for non-assim-move apps
+//
 function get_outfile_paths($result) {
     $fanout = parse_config(get_config(), "<uldl_dir_fanout>");
     $upload_dir = parse_config(get_config(), "<upload_dir>");
@@ -307,6 +311,20 @@ function get_outfile_paths($result) {
         $paths[] = $path;
     }
     return $paths;
+}
+
+// the path of an output file in the 'assim move' scheme.
+// This must agree with the corresponding assimilators:
+// tools/sample_assimilate.py
+// sched/sample_assimilator.cpp
+// and with tools/query_job
+//
+function assim_move_outfile_path($wu, $index, $log_names) {
+    if (!is_valid_filename($wu->name)) error_page("bad WU name");
+    if (!is_valid_filename($log_names[$index])) error_page("bad logical name");
+    return sprintf('../../results/%d/%s__file_%s',
+        $wu->batch, $wu->name, $log_names[$index]
+    );
 }
 
 function abort_workunit($wu) {
@@ -415,7 +433,8 @@ function batch_state_string($state) {
     }
     return "unknown state $state";
 }
-// get the total size of output files of a batch
+// get the total size of output files of a batch for non-assim-move apps
+// (i.e. files are in the upload hier)
 //
 function batch_output_file_size($batchid) {
     $batch_td_size=0;
@@ -532,6 +551,7 @@ function file_ref_out($i, $fname) {
 }
 
 ////////////// ZIP FILES //////////////
+//
 // our job submission systems (BUDA and autodock)
 // expect zip files that contain files.
 // But some people are used to creating zip files

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -17,7 +17,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// get output files, individually or zipped groups
+// get output files, individually or zipped groups,
+// for apps that use the 'assim move' scheme
 //
 // args:
 // action: get_file or get_batch
@@ -29,26 +30,10 @@
 //      downloads zip of batch's output files
 //      Assumes the layout used by sample_assimilator.cpp
 //      and sample_assimilate.py:
-//      <project>/results/
-//      <batchid>/   (0 if not in a batch)
-//
+//      <project>/results/<batchid>/   (0 if not in a batch)
 
 require_once("../inc/util.inc");
 require_once("../inc/submit_util.inc");
-
-// the path of an output file in the 'assim move' scheme.
-// This must agree with the corresponding assimilators:
-// tools/sample_assimilate.py
-// sched/sample_assimilator.cpp
-// and with tools/query_job
-//
-function outfile_path($wu, $index, $log_names) {
-    if (!is_valid_filename($wu->name)) error_page("bad WU name");
-    if (!is_valid_filename($log_names[$index])) error_page("bad logical name");
-    return sprintf('results/%d/%s__file_%s',
-        $wu->batch, $wu->name, $log_names[$index]
-    );
-}
 
 // show or download a single output file,
 // identified by result ID and file index
@@ -62,7 +47,7 @@ function get_file() {
     if (!$wu) error_page('no workunit');
     $log_names = get_outfile_log_names($result);
     if ($index >= count($log_names)) error_page('bad index');
-    $path = sprintf('../../%s', outfile_path($wu, $index, $log_names));
+    $path = assim_move_outfile_path($wu, $index, $log_names);
 
     if (get_str('download', true)) {
         do_download($path);

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -708,6 +708,7 @@ function handle_query_batch($user) {
     echo "<p>";
     switch ($batch->state) {
     case BATCH_STATE_IN_PROGRESS:
+    case BATCH_STATE_INIT:
         show_button(
             "submit.php?action=abort_batch&batch_id=$batch_id",
             "Abort batch"
@@ -866,8 +867,12 @@ function handle_query_job($user) {
                 $nfiles = count($log_names);
                 for ($i=0; $i<$nfiles; $i++) {
                     $name = $log_names[$i];
+                    $path = assim_move_outfile_path($wu, $i, $log_names);
+
                     // don't show 'view' link if it's a .zip
-                    $y = "$name: ";
+                    $y = sprintf('%s (%s): ',
+                        $name, size_string(filesize($path))
+                    );
                     if (!strstr($name, '.zip')) {
                         $y .= sprintf(
                             '<a href=get_output3.php?action=get_file&result_id=%d&index=%d>view</a> &middot; ',

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -868,21 +868,24 @@ function handle_query_job($user) {
                 for ($i=0; $i<$nfiles; $i++) {
                     $name = $log_names[$i];
                     $path = assim_move_outfile_path($wu, $i, $log_names);
-
-                    // don't show 'view' link if it's a .zip
-                    $y = sprintf('%s (%s): ',
-                        $name, size_string(filesize($path))
-                    );
-                    if (!strstr($name, '.zip')) {
+                    if (file_exists($path)) {
+                        $y = sprintf('%s (%s): ',
+                            $name, size_string(filesize($path))
+                        );
+                        // don't show 'view' link if it's a .zip
+                        if (!strstr($name, '.zip')) {
+                            $y .= sprintf(
+                                '<a href=get_output3.php?action=get_file&result_id=%d&index=%d>view</a> &middot; ',
+                                $result->id, $i
+                            );
+                        }
                         $y .= sprintf(
-                            '<a href=get_output3.php?action=get_file&result_id=%d&index=%d>view</a> &middot; ',
+                            '<a href=get_output3.php?action=get_file&result_id=%d&index=%d&download=1>download</a>',
                             $result->id, $i
                         );
+                    } else {
+                        $y = sprintf('%s: MISSING', $name);
                     }
-                    $y .= sprintf(
-                        '<a href=get_output3.php?action=get_file&result_id=%d&index=%d&download=1>download</a>',
-                        $result->id, $i
-                    );
                     $x[] = $y;
                 }
             } else {


### PR DESCRIPTION
- Job instance page: show only relevant fields
- Job page: show output files size next to download links
- Batch page: fix PHP warnings
- antique_file_deleter: code cleanup (no functional change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves job and batch pages for clarity, adds output file sizes, and cleans up the antique file deleter. Pages now show only relevant fields and avoid PHP warnings.

- **New Features**
  - Show output file sizes next to download links on the job page.
  - Job instance page hides fields until relevant (exit status after completion; run/CPU/credit/validate only on success).
  - Allow aborting batches in INIT state.

- **Bug Fixes & Refactors**
  - Fixed PHP warnings on the batch page by initializing job counters.
  - Consolidated output-file path handling for “assim move” apps; get_output3 and the job page now use the shared helper.
  - Cleaned up antique_file_deleter logs and flow; no functional changes.

<sup>Written for commit 85e1f8eb25b6e453d78e4be29cfa965cb4a4f63b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

