### PR TITLE
[linux] Enable release build optimizations

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -541,9 +541,9 @@ jobs:
       - name: Make x64 apps
         if: success() && matrix.type == 'apps'
         run: |
-          export CFLAGS="-O3"
-          export CXXFLAGS="-O3 -std=c++11"
-          export LDFLAGS="-static-libstdc++ -s"
+          export CFLAGS="-O3 -flto"
+          export CXXFLAGS="-O3 -flto -std=c++11"
+          export LDFLAGS="-O3 -flto -static-libstdc++ -s"
           export RELEASE_ARCH=x86_64
           ./configure --enable-apps --enable-apps-vbox --disable-server --disable-client --disable-manager --disable-shared --enable-static
           make -j $(nproc --all)
@@ -551,9 +551,9 @@ jobs:
       - name: Make x86 apps
         if: success() && matrix.type == 'apps-x86'
         run: |
-          export CFLAGS="-O3 -m32"
-          export CXXFLAGS="-O3 -m32 -std=c++11"
-          export LDFLAGS="-static-libstdc++ -s -m32"
+          export CFLAGS="-O3 -flto -m32"
+          export CXXFLAGS="-O3 -flto -m32 -std=c++11"
+          export LDFLAGS="-O3 -flto -static-libstdc++ -s -m32"
           export RELEASE_ARCH=i686
           ./configure --host=i686-linux-gnu --enable-apps --enable-apps-vbox --disable-server --disable-client --disable-manager --disable-shared --enable-static
           make -j $(nproc --all)
@@ -564,9 +564,9 @@ jobs:
           export CC=aarch64-linux-gnu-gcc
           export CXX=aarch64-linux-gnu-g++
           export LD=aarch64-linux-gnu-ld
-          export CFLAGS="-march=armv8-a -O3"
-          export CXXFLAGS="-march=armv8-a -O3 -std=c++11"
-          export LDFLAGS="-march=armv8-a -static-libstdc++ -s"
+          export CFLAGS="-march=armv8-a -O3 -flto"
+          export CXXFLAGS="-march=armv8-a -O3 -flto -std=c++11"
+          export LDFLAGS="-march=armv8-a -O3 -flto -static-libstdc++ -s"
           export RELEASE_ARCH=arm64
           export PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig
           ./configure --host=aarch64-linux --with-boinc-platform="aarch64-unknown-linux-gnu" --with-boinc-alt-platform="arm-unknown-linux-gnueabihf" --enable-apps --disable-server --disable-manager --disable-client --disable-shared --enable-static
@@ -578,9 +578,9 @@ jobs:
           export CC=arm-linux-gnueabihf-gcc
           export CXX=arm-linux-gnueabihf-g++
           export LD=arm-linux-gnueabihf-ld
-          export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3"
-          export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -std=c++11"
-          export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -static-libstdc++ -s"
+          export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto"
+          export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -std=c++11"
+          export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -static-libstdc++ -s"
           export RELEASE_ARCH=armhf
           export PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig:/usr/share/pkgconfig
           ./configure --host=arm-linux-gnueabihf --with-boinc-platform="arm-unknown-linux-gnueabihf" --with-boinc-alt-platform="aarch64-unknown-linux-gnu" --enable-apps --disable-server --disable-manager --disable-client --disable-shared --enable-static

--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,7 @@ sched/delete_file
 sched/fcgi
 sched/fcgi_file_upload_handler
 sched/feeder
+sched/feeder_user
 sched/file_deleter
 sched/file_upload_handler
 sched/get_file

--- a/linux/arm64/ci_configure_apps.sh
+++ b/linux/arm64/ci_configure_apps.sh
@@ -36,10 +36,10 @@ linux/update_vcpkg_apps.sh $TRIPLET
 export CC=aarch64-linux-gnu-gcc
 export CXX=aarch64-linux-gnu-g++
 export LD=aarch64-linux-gnu-ld
-export CFLAGS="-march=armv8-a -O3"
-export CXXFLAGS="-march=armv8-a -O3 -std=c++11"
+export CFLAGS="-march=armv8-a -O3 -flto"
+export CXXFLAGS="-march=armv8-a -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv8-a -static-libstdc++ -s"
+export LDFLAGS="-march=armv8-a -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 export X_EXTRA_LIBS="-I$VCPKG_DIR/include $(pkg-config --libs freeglut)"

--- a/linux/arm64/ci_configure_client.sh
+++ b/linux/arm64/ci_configure_client.sh
@@ -51,10 +51,10 @@ linux/update_vcpkg_client.sh $TRIPLET
 export CC=aarch64-linux-gnu-gcc
 export CXX=aarch64-linux-gnu-g++
 export LD=aarch64-linux-gnu-ld
-export CFLAGS="-march=armv8-a -O3"
-export CXXFLAGS="-march=armv8-a -O3 -std=c++11"
+export CFLAGS="-march=armv8-a -O3 -flto"
+export CXXFLAGS="-march=armv8-a -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv8-a -static-libstdc++ -s"
+export LDFLAGS="-march=armv8-a -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 

--- a/linux/arm64/ci_configure_libs.sh
+++ b/linux/arm64/ci_configure_libs.sh
@@ -36,10 +36,10 @@ linux/update_vcpkg_libs.sh $TRIPLET
 export CC=aarch64-linux-gnu-gcc
 export CXX=aarch64-linux-gnu-g++
 export LD=aarch64-linux-gnu-ld
-export CFLAGS="-march=armv8-a -O3"
-export CXXFLAGS="-march=armv8-a -O3 -std=c++11"
+export CFLAGS="-march=armv8-a -O3 -flto"
+export CXXFLAGS="-march=armv8-a -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv8-a -static-libstdc++ -s"
+export LDFLAGS="-march=armv8-a -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 

--- a/linux/arm64/ci_configure_manager.sh
+++ b/linux/arm64/ci_configure_manager.sh
@@ -53,10 +53,10 @@ linux/update_vcpkg_manager.sh $TRIPLET
 export CC=aarch64-linux-gnu-gcc
 export CXX=aarch64-linux-gnu-g++
 export LD=aarch64-linux-gnu-ld
-export CFLAGS="-march=armv8-a -O3"
-export CXXFLAGS="-march=armv8-a -O3 -std=c++11"
+export CFLAGS="-march=armv8-a -O3 -flto"
+export CXXFLAGS="-march=armv8-a -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv8-a -static-libstdc++ -s"
+export LDFLAGS="-march=armv8-a -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 
 ./configure --host=aarch64-linux-gnu --with-boinc-platform="aarch64-unknown-linux-gnu" --with-boinc-alt-platform="arm-unknown-linux-gnueabihf" --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg)" $exec_prefix

--- a/linux/armhf/ci_configure_apps.sh
+++ b/linux/armhf/ci_configure_apps.sh
@@ -35,10 +35,10 @@ linux/update_vcpkg_apps.sh $TRIPLET
 export CC=arm-linux-gnueabihf-gcc
 export CXX=arm-linux-gnueabihf-g++
 export LD=arm-linux-gnueabihf-ld
-export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3"
-export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -std=c++11"
+export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto"
+export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -static-libstdc++ -s"
+export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 export X_EXTRA_LIBS="-I$VCPKG_DIR/include $(pkg-config --libs freeglut)"

--- a/linux/armhf/ci_configure_client.sh
+++ b/linux/armhf/ci_configure_client.sh
@@ -51,10 +51,10 @@ linux/update_vcpkg_client.sh $TRIPLET
 export CC=arm-linux-gnueabihf-gcc
 export CXX=arm-linux-gnueabihf-g++
 export LD=arm-linux-gnueabihf-ld
-export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3"
-export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -std=c++11"
+export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto"
+export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -static-libstdc++ -s"
+export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 

--- a/linux/armhf/ci_configure_libs.sh
+++ b/linux/armhf/ci_configure_libs.sh
@@ -35,10 +35,10 @@ linux/update_vcpkg_libs.sh $TRIPLET
 export CC=arm-linux-gnueabihf-gcc
 export CXX=arm-linux-gnueabihf-g++
 export LD=arm-linux-gnueabihf-ld
-export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3"
-export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -std=c++11"
+export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto"
+export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -static-libstdc++ -s"
+export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 

--- a/linux/armhf/ci_configure_manager.sh
+++ b/linux/armhf/ci_configure_manager.sh
@@ -53,10 +53,10 @@ linux/update_vcpkg_manager.sh $TRIPLET
 export CC=arm-linux-gnueabihf-gcc
 export CXX=arm-linux-gnueabihf-g++
 export LD=arm-linux-gnueabihf-ld
-export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3"
-export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -std=c++11"
+export CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto"
+export CXXFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -std=c++11"
 export CPPFLAGS="-I$VCPKG_DIR/include"
-export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -static-libstdc++ -s"
+export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 
 ./configure --host=arm-linux-gnueabihf --with-boinc-platform="arm-unknown-linux-gnueabihf" --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg)" $exec_prefix

--- a/linux/ci_configure_apps.sh
+++ b/linux/ci_configure_apps.sh
@@ -15,5 +15,8 @@ linux/update_vcpkg_apps.sh
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 export X_EXTRA_LIBS="-I$VCPKG_DIR/include $(pkg-config --libs freeglut)"
+export CFLAGS="-O3 -flto"
+export CXXFLAGS="-O3 -flto"
+export LDFLAGS="-O3 -flto -static-libstdc++ -s"
 
 ./configure --with-libcurl=$VCPKG_DIR --with-ssl=$VCPKG_DIR --enable-apps --enable-apps-vcpkg --enable-apps-vbox --enable-apps-gui --disable-server --disable-client --disable-manager CPPFLAGS="-I$VCPKG_DIR/include"

--- a/linux/ci_configure_client.sh
+++ b/linux/ci_configure_client.sh
@@ -46,7 +46,9 @@ export VCPKG_DIR="$VCPKG_ROOT/installed/x64-linux"
 
 linux/update_vcpkg_client.sh
 
-export LDFLAGS="-static-libstdc++ -s"
+export CFLAGS="-O3 -flto"
+export CXXFLAGS="-O3 -flto"
+export LDFLAGS="-O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 

--- a/linux/ci_configure_libs.sh
+++ b/linux/ci_configure_libs.sh
@@ -31,6 +31,9 @@ export VCPKG_DIR="$VCPKG_ROOT/installed/x64-linux"
 
 linux/update_vcpkg_libs.sh
 
+export CFLAGS="-O3 -flto"
+export CXXFLAGS="-O3 -flto"
+export LDFLAGS="-O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 ./configure --with-libcurl=$VCPKG_DIR --with-ssl=$VCPKG_DIR --disable-server --disable-client --disable-manager

--- a/linux/ci_configure_manager.sh
+++ b/linux/ci_configure_manager.sh
@@ -47,7 +47,9 @@ export VCPKG_DIR="$VCPKG_ROOT/installed/x64-linux"
 
 linux/update_vcpkg_manager.sh
 
-export LDFLAGS="-static-libstdc++ -s"
+export CFLAGS="-O3 -flto"
+export CXXFLAGS="-O3 -flto"
+export LDFLAGS="-O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 

--- a/samples/condor/Makefile
+++ b/samples/condor/Makefile
@@ -20,6 +20,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -73,7 +83,7 @@ distclean: clean
 distclean-recursive: clean
 
 boinc_gahp: boinc_gahp.cpp $(BOINC_SOURCE_LIB_DIR)/remote_submit.h $(BOINC_SOURCE_LIB_DIR)/remote_submit.cpp $(BOINC_DIR)/svn_version.h $(BOINC_DIR)/version.h $(MAKEFILE_STDLIB)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MINGW_FLAGS) -g -O3 \
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) $(MINGW_FLAGS) \
 	-o boinc_gahp boinc_gahp.cpp $(BOINC_SOURCE_LIB_DIR)/remote_submit.cpp \
 	-lcurl -lssl -lcrypto -lboinc $(CURL_EXTRA_LDFLAGS) $(MAKEFILE_LDFLAGS) $(STDCPPTC)
 

--- a/samples/docker_wrapper/Makefile
+++ b/samples/docker_wrapper/Makefile
@@ -36,7 +36,17 @@ BOINC_LIB_DIR = $(BOINC_SOURCE_LIB_DIR)
 MAKEFILE_LDFLAGS = -lpthread libstdc++.a
 MAKEFILE_STDLIB  = libstdc++.a
 
-CXXFLAGS += -g \
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
+CXXFLAGS += \
 	-Wall -W -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \

--- a/samples/example_app/Makefile
+++ b/samples/example_app/Makefile
@@ -24,6 +24,16 @@ BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 BOINC_SOURCE_ZIP_DIR = $(BOINC_DIR)/zip
 FREETYPE_DIR = /usr/include/freetype2
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -40,7 +50,7 @@ else
   MAKEFILE_STDLIB  = libstdc++.a
 endif
 
-CXXFLAGS += -g \
+CXXFLAGS += \
 	-Wall -W -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common \
     -DAPP_GRAPHICS \
     -I$(BOINC_DIR) \

--- a/samples/multi_thread/Makefile
+++ b/samples/multi_thread/Makefile
@@ -32,6 +32,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -46,7 +56,7 @@ else
   MAKEFILE_STDLIB  = libstdc++.a
 endif
 
-CXXFLAGS += -g \
+CXXFLAGS += \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \
     -I$(BOINC_SOURCE_LIB_DIR) \

--- a/samples/openclapp/Makefile
+++ b/samples/openclapp/Makefile
@@ -22,6 +22,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifndef ANDROID
   BOINC_API_DIR = $(BOINC_SOURCE_API_DIR)
   BOINC_LIB_DIR = $(BOINC_SOURCE_LIB_DIR)
@@ -30,7 +40,7 @@ else
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
 endif
 
-CXXFLAGS += -g \
+CXXFLAGS += \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \
     -I$(BOINC_SOURCE_LIB_DIR) \

--- a/samples/sleeper/Makefile
+++ b/samples/sleeper/Makefile
@@ -22,6 +22,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -37,7 +47,7 @@ else
 endif
 
 CXX ?= g++
-CXXFLAGS += -g \
+CXXFLAGS += \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \
     -I$(BOINC_SOURCE_LIB_DIR) \

--- a/samples/sporadic/Makefile
+++ b/samples/sporadic/Makefile
@@ -20,6 +20,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -34,7 +44,7 @@ else
   MAKEFILE_STDLIB  = libstdc++.a
 endif
 
-CXXFLAGS += -g \
+CXXFLAGS += \
 	-Wall -W -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \

--- a/samples/vboxmonitor/Makefile
+++ b/samples/vboxmonitor/Makefile
@@ -23,6 +23,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -37,7 +47,7 @@ else
   MAKEFILE_STDLIB  = libstdc++.a
 endif
 
-CXXFLAGS += -g \
+CXXFLAGS += \
 	-Wall -W -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \

--- a/samples/vboxwrapper/Makefile
+++ b/samples/vboxwrapper/Makefile
@@ -33,6 +33,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -47,7 +57,7 @@ else
   MAKEFILE_STDLIB  = libstdc++.a
 endif
 
-CXXFLAGS += -g \
+CXXFLAGS += \
 	-Wall -W -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \

--- a/samples/worker/Makefile
+++ b/samples/worker/Makefile
@@ -11,6 +11,16 @@ else
 	endif
 endif
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 PROGS = worker$(WORKER_RELEASE_SUFFIX)
 
 all: $(PROGS)

--- a/samples/wrapper/Makefile
+++ b/samples/wrapper/Makefile
@@ -33,6 +33,16 @@ BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 BOINC_SOURCE_ZIP_DIR = $(BOINC_DIR)/zip
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -49,7 +59,7 @@ else
   MAKEFILE_STDLIB  = libstdc++.a
 endif
 
-CXXFLAGS += -g -O0 \
+CXXFLAGS += \
 	-Wall -W -Wshadow -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings -fno-common \
     -I$(BOINC_DIR) \
     -I$(BOINC_LIB_DIR) \

--- a/samples/wrappture/Makefile
+++ b/samples/wrappture/Makefile
@@ -23,6 +23,16 @@ BOINC_DIR = ../..
 BOINC_SOURCE_API_DIR = $(BOINC_DIR)/api
 BOINC_SOURCE_LIB_DIR = $(BOINC_DIR)/lib
 
+ifdef RELEASE_ARCH
+  CFLAGS += -O3 -flto
+  CXXFLAGS += -O3 -flto
+  LDFLAGS += -O3 -flto -s -static-libstdc++
+else
+  CFLAGS += -O0 -g
+  CXXFLAGS += -O0 -g
+  LDFLAGS += -O0 -g
+endif
+
 ifdef ANDROID
   BOINC_API_DIR = $(TCINCLUDES)/lib
   BOINC_LIB_DIR = $(TCINCLUDES)/lib
@@ -39,7 +49,7 @@ endif
 
 RAPPTURE_DIR ?= $(VCPKG_DIR)/include/rappture
 
-CXXFLAGS += -g \
+CXXFLAGS += \
     -I$(BOINC_DIR) \
     -I$(BOINC_SOURCE_API_DIR) \
     -I$(BOINC_SOURCE_LIB_DIR) \


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable -O3 and LTO for Linux builds in CI and configure scripts, and apply release flags in sample Makefiles. This standardizes flags, reduces binary size, and improves runtime performance.

- **Refactors**
  - Linux CI/configure: set -O3 -flto in CFLAGS/CXXFLAGS/LDFLAGS (x86_64, i686, armhf, arm64); keep arch flags; link static libstdc++ and strip.
  - Samples: gate release flags with RELEASE_ARCH; remove hardcoded -g/-O; use -O3 -flto -s -static-libstdc++ in release.
  - .gitignore: add sched/feeder_user.

- **Migration**
  - Requires toolchains with LTO support (clang/lld or gcc/binutils); linking may take longer.
  - For sample apps, set RELEASE_ARCH to build with release flags.

<sup>Written for commit 595368f890394faa13fd942f0be877a7c4176d5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

