### PR TITLE
BUDA: allow output files to be gzipped.

### DIFF
--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -286,11 +286,13 @@ function get_outfile_phys_names($result) {
 }
 
 function get_outfile_log_names($result) {
-    $names = [];
-    $gzip = [];
     $xml = "<a>".$result->xml_doc_in."</a>";
     $r = simplexml_load_string($xml);
-    if (!$r) return $names;
+    if (!$r) {
+        return [[],[]];
+    }
+    $names = [];
+    $gzip = [];
     foreach ($r->result->file_ref as $fr) {
         $names[] = (string)($fr->open_name);
     }

--- a/html/inc/submit_util.inc
+++ b/html/inc/submit_util.inc
@@ -287,13 +287,17 @@ function get_outfile_phys_names($result) {
 
 function get_outfile_log_names($result) {
     $names = [];
+    $gzip = [];
     $xml = "<a>".$result->xml_doc_in."</a>";
     $r = simplexml_load_string($xml);
     if (!$r) return $names;
     foreach ($r->result->file_ref as $fr) {
         $names[] = (string)($fr->open_name);
     }
-    return $names;
+    foreach ($r->file_info as $fi) {
+        $gzip[] = isset($fi->gzip_when_done);
+    }
+    return [$names, $gzip];
 }
 
 // get output file paths for non-assim-move apps
@@ -319,11 +323,12 @@ function get_outfile_paths($result) {
 // sched/sample_assimilator.cpp
 // and with tools/query_job
 //
-function assim_move_outfile_path($wu, $index, $log_names) {
+function assim_move_outfile_path($wu, $index, $log_names, $gzip) {
     if (!is_valid_filename($wu->name)) error_page("bad WU name");
     if (!is_valid_filename($log_names[$index])) error_page("bad logical name");
-    return sprintf('../../results/%d/%s__file_%s',
-        $wu->batch, $wu->name, $log_names[$index]
+    return sprintf('../../results/%d/%s__file_%s%s',
+        $wu->batch, $wu->name, $log_names[$index],
+        $gzip[$index]?'.gz':''
     );
 }
 
@@ -522,21 +527,25 @@ function file_ref_in($fname) {
         $fname
     ));
 }
-function file_info_out($i, $max_nbytes) {
+function file_info_out($i, $max_nbytes, $gzip_output) {
     if (!$max_nbytes) {
         $max_nbytes = MEGA;
     }
-    return sprintf(
+    $x = sprintf(
 '    <file_info>
         <name><OUTFILE_%d/></name>
         <generated_locally/>
         <upload_when_present/>
         <max_nbytes>%d</max_nbytes>
         <url><UPLOAD_URL/></url>
-    </file_info>
 ',
         $i, $max_nbytes
     );
+    if ($gzip_output) {
+        $x .= "        <gzip_when_done/>\n";
+    }
+    $x .= "    </file_info>\n";
+    return $x;
 }
 
 function file_ref_out($i, $fname) {

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -266,14 +266,16 @@ function create_templates($app, $desc, $dir) {
     $x = "<output_template>\n";
     $i = 0;
     foreach ($desc->output_file_names as $fname) {
-        $x .= file_info_out($i++, $desc->max_nbytes_mb*MEGA);
+        $x .= file_info_out(
+            $i++, $desc->max_nbytes_mb*MEGA, $desc->gzip_output
+        );
     }
-    $x .= "   <result>\n";
+    $x .= "    <result>\n";
     $i = 0;
     foreach ($desc->output_file_names as $fname) {
         $x .= file_ref_out($i++, $fname);
     }
-    $x .= "   </result>\n</output_template>\n";
+    $x .= "    </result>\n</output_template>\n";
     file_put_contents("$dir/template_out", $x);
 }
 
@@ -519,6 +521,13 @@ function app_form($desc=null) {
         'max_nbytes_mb',
         $desc->max_nbytes_mb
     );
+    if (empty($desc->gzip_output)) {
+        $desc->gzip_output = false;
+    }
+    form_checkboxes(
+        'Gzip output files?',
+        [['gzip_output', '', $desc->gzip_output]]
+    );
     form_input_text(
         'Run at most this many total instances of each job',
         'max_total',
@@ -637,6 +646,7 @@ function app_action($user) {
     $desc->max_total = $max_total;
     $desc->max_delay_days = $max_delay_days;
     $desc->description = get_str('description');
+    $desc->gzip_output = get_str('gzip_output', true)?true:false;
     $desc->sci_kw = array_map('intval', get_array('sci_kw'));
     $desc->submitters = [];
     $x = get_str('submitters');
@@ -715,6 +725,10 @@ function app_details($user) {
             $desc->max_nbytes_mb
         );
     }
+    row2(
+        'Gzip output files?',
+        empty($desc->gzip_output)?'no':'yes'
+    );
     if (!empty($desc->max_total)) {
         row2('Max total instances per job:', $desc->max_total);
     } else {

--- a/html/user/get_output2.php
+++ b/html/user/get_output2.php
@@ -67,7 +67,7 @@ function check_auth($auth, $batch) {
 
 function do_result_aux($result, $batch, $file_num=null) {
     $phys_names = get_outfile_phys_names($result);
-    $log_names = get_outfile_log_names($result);
+    [$log_names,] = get_outfile_log_names($result);
     if ($file_num !== null) {
         $path = upload_path($phys_names[$file_num]);
         do_download($path,
@@ -138,7 +138,7 @@ function do_batch($batch_id, $auth) {
     foreach ($wus as $wu) {
         $result = BoincResult::lookup_id($wu->canonical_resultid);
         $phys_names = get_outfile_phys_names($result);
-        $log_names = get_outfile_log_names($result);
+        [$log_names,] = get_outfile_log_names($result);
         if (count($phys_names) == 1) {
             $cmd = sprintf('ln -s %s %s/%s__%s',
                 upload_path($phys_names[0]),

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -86,7 +86,7 @@ function get_batch_tar() {
         die('no batch dir');
     }
     $name = "batch_$batch_id.tar";
-    $cmd = "cd $dir; rm -f $name; tar -cvf $name .";
+    $cmd = "cd $dir; rm -f $name; tar -cf $name .";
     system($cmd);
     do_download("$dir/$name");
     unlink("$dir/$name");

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -86,7 +86,7 @@ function get_batch_tar() {
         die('no batch dir');
     }
     $name = "batch_$batch_id.tar";
-    $cmd = "cd $dir; rm -f $name; tar -cf $name .";
+    $cmd = "cd $dir; rm -f $name; tar -cf $name *";
     system($cmd);
     do_download("$dir/$name");
     unlink("$dir/$name");

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -717,7 +717,8 @@ function handle_query_batch($user) {
 
     echo "<p>";
     if ($is_assim_move) {
-        if (is_batch_gzipped($wus)) {
+        //if (is_batch_gzipped($wus)) {
+        if (true) {
             $url = "get_output3.php?action=get_batch_tar&batch_id=$batch->id";
             show_button($url, "Get tarred output files");
         } else {

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -714,7 +714,6 @@ function handle_query_batch($user) {
         );
     }
     end_table();
-    echo "<p>";
 
     echo "<p>";
     if ($is_assim_move) {

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -892,7 +892,7 @@ function handle_query_job($user) {
                 for ($i=0; $i<$nfiles; $i++) {
                     $name = $log_names[$i];
                     $path = assim_move_outfile_path($wu, $i, $log_names, $gzip);
-                    if (!file_exists($path)) {
+                    if (file_exists($path)) {
                         $y = sprintf('%s (%s): ',
                             $name, size_string(filesize($path))
                         );

--- a/html/user/submit.php
+++ b/html/user/submit.php
@@ -885,6 +885,7 @@ function handle_query_job($user) {
             time_str($result->received_time),
             $result->priority
         ];
+        $files = [];
         if ($is_assim_move) {
             if ($result->id == $wu->canonical_resultid) {
                 [$log_names, $gzip] = get_outfile_log_names($result);
@@ -896,8 +897,8 @@ function handle_query_job($user) {
                         $y = sprintf('%s (%s): ',
                             $name, size_string(filesize($path))
                         );
-                        // don't show 'view' link if it's a .zip
-                        if (!strstr($name, '.zip')) {
+                        // don't show 'view' link if it's zipped
+                        if (!strstr($name, '.zip') && !$gzip[$i]) {
                             $y .= sprintf(
                                 '<a href=get_output3.php?action=get_file&result_id=%d&index=%d>view</a> &middot; ',
                                 $result->id, $i
@@ -910,10 +911,10 @@ function handle_query_job($user) {
                     } else {
                         $y = sprintf('%s: MISSING', $name);
                     }
-                    $x[] = $y;
+                    $files[] = $y;
                 }
             } else {
-                $x[] = '---';
+                $files[] = '---';
             }
         } else {
             if ($result->server_state == RESULT_SERVER_STATE_OVER) {
@@ -931,19 +932,20 @@ function handle_query_job($user) {
                         );
                         $s = stat($path);
                         $size = $s['size'];
-                        $x[] = sprintf('<a href=%s>%s</a> (%s bytes)<br/>',
+                        $files[] = sprintf('<a href=%s>%s</a> (%s bytes)<br/>',
                             $url,
                             $log_names[$i],
                             number_format($size)
                         );
                     } else {
-                        $x[] = sprintf("file '%s' is missing", $log_names[$i]);
+                        $files[] = sprintf("file '%s' is missing", $log_names[$i]);
                     }
                 }
             } else {
-                $x[] = '---';
+                $files[] = '---';
             }
         }
+        $x[] = implode('<br>', $files);
         row_array($x);
     }
     end_table();

--- a/tools/sample_assimilate.py
+++ b/tools/sample_assimilate.py
@@ -18,7 +18,19 @@
 # in the 2nd case, write the error code
 #        to results/<batch_id>/<wu_name>_error
 
-import sys, os
+import sys, os, gzip
+
+def is_gzip(path):
+    if os.path.getsize(path) == 0:
+        return False
+    try:
+        with gzip.open(path, 'rb') as f:
+            f.read(1) 
+        print('is gzip')
+        return True
+    except:
+        print('not gzip')
+        return False
 
 if sys.argv[1] == '--error':
     error_code = sys.argv[2]
@@ -43,8 +55,9 @@ else:
     for i in range(nfiles):
         outfile_path = sys.argv[2*i+3]
         logical_name = sys.argv[2*i+4]
-        cmd = 'mv %s %s/%s__file_%s'%(
-            outfile_path, outdir, wu_name, logical_name
+        cmd = 'mv %s %s/%s__file_%s%s'%(
+            outfile_path, outdir, wu_name, logical_name,
+            '.gz' if is_gzip(outfile_path) else ''
         )
         if os.system(cmd):
             #raise Exception('%s failed'%(cmd))

--- a/tools/sample_assimilate.py
+++ b/tools/sample_assimilate.py
@@ -26,10 +26,8 @@ def is_gzip(path):
     try:
         with gzip.open(path, 'rb') as f:
             f.read(1)
-        print('is gzip')
         return True
     except:
-        print('not gzip')
         return False
 
 if sys.argv[1] == '--error':

--- a/tools/sample_assimilate.py
+++ b/tools/sample_assimilate.py
@@ -25,7 +25,7 @@ def is_gzip(path):
         return False
     try:
         with gzip.open(path, 'rb') as f:
-            f.read(1) 
+            f.read(1)
         print('is gzip')
         return True
     except:


### PR DESCRIPTION
Add a 'gzip output' option for BUDA apps;
if set, add <gzip_when_done/> to output template.

If a batch has gzipped outputs,
provide download as tar file rather than zip file. Less CPU overhead on server.

Sample assimilator (python): if output file is gzipped, append .gz to its name

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional gzip support for BUDA app outputs. Batch outputs (assim-move) now download as tar with temp archives deleted, and access is restricted to the batch owner; UI and file handling use .gz when applicable.

- **New Features**
  - App setting “Gzip output files?” adds <gzip_when_done/> via file_info_out.
  - Batch downloads (assim-move): tar archive (get_batch_tar), temp tar removed after download, and ownership is checked before serving files/archives.
  - Assim-move paths include .gz when outputs are gzipped; UI shows a tar button and hides “view” for gzipped files.
  - Sample assimilator detects gzip and appends .gz to output filenames.

- **Migration**
  - get_output3.php action get_batch is replaced by get_batch_zip and get_batch_tar (UI uses get_batch_tar).
  - get_outfile_log_names now returns [names, gzip_flags]; update callers if used elsewhere.

<sup>Written for commit 211f5a45e51d99c983b43d2be0cb21cc97e22ec1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

