### PR TITLE
fix bug in python assimilator handler

### DIFF
--- a/tools/sample_assimilate.py
+++ b/tools/sample_assimilate.py
@@ -53,7 +53,7 @@ else:
     for i in range(nfiles):
         outfile_path = sys.argv[2*i+3]
         if not os.path.exists(outfile_path):
-            print('file not found: ', outfile_path)
+            sys.stderr.write('file not found: %s\n'%(outfile_path))
             continue
         logical_name = sys.argv[2*i+4]
         cmd = 'mv %s %s/%s__file_%s%s'%(

--- a/tools/sample_assimilate.py
+++ b/tools/sample_assimilate.py
@@ -52,6 +52,9 @@ else:
     nfiles = (len(sys.argv) - 3)//2
     for i in range(nfiles):
         outfile_path = sys.argv[2*i+3]
+        if not os.path.exists(outfile_path):
+            print('file not found: ', outfile_path)
+            continue
         logical_name = sys.argv[2*i+4]
         cmd = 'mv %s %s/%s__file_%s%s'%(
             outfile_path, outdir, wu_name, logical_name,


### PR DESCRIPTION
check for existence of output file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle missing output files in the Python assimilator handler by checking existence before moving. Missing files are logged to stderr and skipped to prevent crashes.

- **Bug Fixes**
  - Added os.path.exists check around the move in tools/sample_assimilate.py; writes "file not found" to stderr and continues.

<sup>Written for commit 0e05f01ecf1bc3063db4e3fc0f8ea13120e17564. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

