### PR TITLE
db_dump: fix typo that broke XML

### DIFF
--- a/sched/db_dump.cpp
+++ b/sched/db_dump.cpp
@@ -479,7 +479,7 @@ void write_host(HOST& host, ZFILE* f, bool detail) {
         "    <p_vendor>%s</p_vendor>\n"
         "    <p_model>%s</p_model>\n"
         "    <os_name>%s</os_name>\n"
-        "    <os_version>%s</os_version>\n",
+        "    <os_version>%s</os_version>\n"
         "    <misc><![CDATA[%s]]></misc>\n",
         host.total_credit,
         host.expavg_credit,


### PR DESCRIPTION
Fixes #6881

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes malformed XML in db_dump host output by removing a stray comma that split the format string, so the <misc> element is emitted and the XML is well-formed.

<sup>Written for commit b892e15962f25e382c7c5da323633929904a3bd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

