### PR TITLE
Increase timer_thread stack limit from 32KiB to 64KiB

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -1605,7 +1605,7 @@ int start_timer_thread() {
     worker_thread_handle = pthread_self();
     pthread_attr_t thread_attrs;
     pthread_attr_init(&thread_attrs);
-    pthread_attr_setstacksize(&thread_attrs, 32768);
+    pthread_attr_setstacksize(&thread_attrs, 65536);
     int retval = pthread_create(&timer_thread_handle, &thread_attrs, timer_thread, NULL);
     if (retval) {
         fprintf(stderr,


### PR DESCRIPTION
**Description of the Change**
Current setting of 32KiB is too low in some cases, it leads to SIGSEGV for some Einstein@home apps on x86-64 Ubuntu 20.04 with stack exhaustion deep inside printf call. Verified that this change fixes the problem, no more crashes inside timer thread.

**Alternate Designs**
Not sure if stack limit is needed at all in 2026. Maybe we can increase it right away to something like 256KiB to be future-proof.

**Release Notes**
Fix rare crashes caused by stack exhaustion in timer thread


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent rare timer thread crashes by increasing its stack size from 32KiB to 64KiB. Resolves stack exhaustion SIGSEGVs seen in some apps (e.g., Einstein@home on x86-64 Ubuntu 20.04) during deep printf calls.

<sup>Written for commit 859c4160c47e4d61ecccdf36df2adf57f977a1bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

