### PR TITLE
include wslinfo only on windows

### DIFF
--- a/lib/util.h
+++ b/lib/util.h
@@ -26,9 +26,9 @@
 #ifdef _WIN32
 #include "boinc_win.h"
 #include "win_util.h"
+#include "wslinfo.h"
 #endif
 #include "common_defs.h"
-#include "wslinfo.h"
 
 extern double dtime();
 extern double dday();


### PR DESCRIPTION
**Description of the Change**
Fixes building libs on Linux via Makefile.am

wslinfo is correctly guarded and not included on non-Windows platforms:
https://github.com/BOINC/boinc/blob/master/lib/Makefile.am#L92
https://github.com/BOINC/boinc/blob/master/lib/util.cpp#L709

However, lib/util.h includes it directly, even if wslinfo is unused. This isn't typically an issue, but if boinc C headers are installed to a different location, wslinfo.h is not included and therefore missing as a dependency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include wslinfo.h only on Windows to fix Linux builds that fail when BOINC headers are installed separately. Aligns lib/util.h with existing platform guards.

- Bug Fixes
  - Moved wslinfo.h include inside _WIN32 guard in lib/util.h to prevent missing header errors on non-Windows builds.

<sup>Written for commit 3ac8e65affa7e2fba916e7584fc9937d87b427c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

