### PR TITLE
server: fix batch acceleration problem

### DIFF
--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -503,12 +503,18 @@ struct WORKUNIT {
     int target_nresults;
         // try to get this many "viable" results,
         // i.e. candidate for canonical result.
+        // should always be at least min_quorum.
         // may be > min_quorum to get consensus quicker or reflect loss rate
-    int max_error_results;      // WU error if < #error results
-    int max_total_results;      // WU error if < #total results
-        // (need this in case results are never returned)
-    int max_success_results;    // WU error if < #success results
-        // without consensus (i.e. WU is nondeterministic)
+    int max_error_results;
+        // transitioner: if # results without client compute error exceeds this,
+        // mark WU as WU_ERROR_TOO_MANY_ERROR_RESULTS
+    int max_total_results;
+        // transitioner: if we need more instances but it would exceed this,
+        // mark WU as WU_ERROR_TOO_MANY_TOTAL_RESULTS
+    int max_success_results;
+        // validator: if #success results exceeds this without consensus
+        // (i.e. WU seems nondeterministic)
+        // mark WU as WU_ERROR_TOO_MANY_SUCCESS_RESULTS
     char result_template_file[64];
     int priority;
     char mod_time[20];

--- a/html/ops/batch_accel.php
+++ b/html/ops/batch_accel.php
@@ -56,6 +56,11 @@ function do_batch($batch, $wus) {
                 'id, server_state, sent_time, priority',
                 "workunitid=$wu->id"
             );
+
+            // create a new (high priority) result if
+            // - we're not at the max # of result
+            // - there are no unsent or recently sent results
+            //
             $make_another_result = false;
             if (count($results) < $wu->max_total_results) {
                 $make_another_result = true;
@@ -74,7 +79,7 @@ function do_batch($batch, $wus) {
                     case RESULT_SERVER_STATE_IN_PROGRESS:
                         $age = $now - $r->sent_time;
                         if ($age<$batch->expire_time) {
-                            echo "   have recent in-progress result\n";
+                            echo "   have recent in-progress result $r->id\n";
                             $make_another_result = false;
                         }
                         break;
@@ -86,6 +91,9 @@ function do_batch($batch, $wus) {
                 echo "   creating another instance\n";
                 $query[] = sprintf(
                     'target_nresults=%d', $wu->target_nresults+1
+                );
+                $query[] = sprintf(
+                    'max_total_results=%d', $wu->max_total_results+1
                 );
                 $query[] = sprintf(
                     'transition_time=%f', $now

--- a/html/user/workunit.php
+++ b/html/user/workunit.php
@@ -46,7 +46,7 @@ function show_wu($wu) {
 
     start_table();
     row2(tra("name"), $wu->name);
-    row2(tra("application"), $app->user_friendly_name);
+    row2(tra("application"), "<a href=apps.php?app_id=$app->id>$app->user_friendly_name</a>");
     if ($wu->batch) {
         row2('batch',
             "<a href=submit.php?action=query_batch&batch_id=$wu->batch>$wu->batch</a>"
@@ -73,7 +73,7 @@ function show_wu($wu) {
         end_table();
     } else {
         row2(tra("minimum quorum"), $wu->min_quorum);
-        row2(tra("initial replication"), $wu->target_nresults);
+        row2(tra("target #results"), $wu->target_nresults);
         row2(tra("max # of error/total/success tasks"),
             "$wu->max_error_results, $wu->max_total_results, $wu->max_success_results"
         );

--- a/lib/msg_log.cpp
+++ b/lib/msg_log.cpp
@@ -46,11 +46,9 @@ using std::string;
 // a multi-line string (it's broken up into lines
 // to get the prefix on each line), or a file (also broken up into lines).
 
-// Scheduler functions should use "sched_messages" which is an instance of
-// SCHED_MSG_LOG.  Client functions should use "client_messages",
-// which is an instance of CLIENT_MSG_LOG.
-
-// See sched/sched_msg_log.C and client/client_msg_log.C for those classes.
+// Base class for SCHED_MSG_LOG, used by scheduler components.
+// See sched/sched_msg_log.cpp
+// Client functions use CLIENT_MSG_LOG.
 
 MSG_LOG::MSG_LOG(FILE* output_) {
     debug_level = 0;
@@ -74,7 +72,7 @@ void MSG_LOG::set_indent_level(const int new_indent_level) {
 
 void MSG_LOG::vprintf(int kind, const char* format, va_list va) {
     char buf[256];
-    const char* now_timestamp = precision_time_to_string(dtime());
+    const char* now_timestamp = precision_time_to_string(dtime(), true);
     if (!v_message_wanted(kind)) return;
     if (pid) {
         snprintf(buf, sizeof(buf), " [PID=%-5d]", pid);
@@ -97,7 +95,7 @@ void MSG_LOG::vprintf_multiline(
     if (prefix_format) {
         vsnprintf(sprefix, sizeof(sprefix),prefix_format, va);
     }
-    const char* now_timestamp = precision_time_to_string(dtime());
+    const char* now_timestamp = precision_time_to_string(dtime(), true);
     const char* skind = v_format_kind(kind);
 
     string line;
@@ -124,7 +122,7 @@ void MSG_LOG::vprintf_file(
     if (prefix_format) {
         vsnprintf(sprefix, sizeof(sprefix), prefix_format, va);
     }
-    const char* now_timestamp = precision_time_to_string(dtime());
+    const char* now_timestamp = precision_time_to_string(dtime(), true);
     const char* skind = v_format_kind(kind);
 
     FILE* f = boinc::fopen(filename, "r");

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -404,34 +404,40 @@ void collapse_whitespace(char *str) {
     strcpy(str, s.c_str());
 }
 
-char* time_to_string(double t) {
+char* time_to_string(double t, bool utc) {
     static char buf[100];
     if (!t) {
         safe_strcpy(buf, "---");
     } else {
         time_t x = (time_t)t;
-        struct tm* tm = localtime(&x);
+        struct tm* tm = utc ? gmtime(&x) : localtime(&x);
         strftime(buf, sizeof(buf)-1, "%d-%b-%Y %H:%M:%S", tm);
+        if (utc) {
+            safe_strcat(buf, " UTC");
+        }
     }
     return buf;
 }
 
-char* precision_time_to_string(double t) {
+char* precision_time_to_string(double t, bool utc) {
     static char buf[100];
     char finer[16];
-    int hundreds_of_microseconds=(int)(10000*(t-(int)t));
+    int hundreds_of_microseconds = (int)(10000*(t - (int)t));
     if (hundreds_of_microseconds == 10000) {
         // paranoia -- this should never happen!
         //
-        hundreds_of_microseconds=0;
-        t+=1.0;
+        hundreds_of_microseconds = 0;
+        t += 1.0;
     }
     time_t x = (time_t)t;
-    struct tm* tm = localtime(&x);
+    struct tm* tm = utc ? gmtime(&x) : localtime(&x);
 
     strftime(buf, sizeof(buf)-1, "%Y-%m-%d %H:%M:%S", tm);
     snprintf(finer, sizeof(finer), ".%04d", hundreds_of_microseconds);
     safe_strcat(buf, finer);
+    if (utc) {
+        safe_strcat(buf, " UTC");
+    }
     return buf;
 }
 

--- a/lib/str_util.h
+++ b/lib/str_util.h
@@ -36,8 +36,8 @@ extern void strip_quotes(std::string&);
 extern void unescape_os_release(char *str);
 extern void collapse_whitespace(char *str);
 extern void collapse_whitespace(std::string&);
-extern char* time_to_string(double);
-extern char* precision_time_to_string(double);
+extern char* time_to_string(double, bool utc=false);
+extern char* precision_time_to_string(double, bool utc=false);
 extern void secs_to_hmsf(double, char*);
 extern std::string timediff_format(double);
 

--- a/sched/transitioner.cpp
+++ b/sched/transitioner.cpp
@@ -365,7 +365,9 @@ int handle_wu(
     // see how many new results we need to make
     //
     int n_new_results_needed = wu_item.target_nresults - nunsent - ninprogress - nsuccess;
-    if (n_new_results_needed < 0) n_new_results_needed = 0;
+    if (n_new_results_needed < 0) {
+        n_new_results_needed = 0;
+    }
     int n_new_results_allowed = wu_item.max_total_results - ntotal;
 
     // if we're already at the limit and need more, error out the WU
@@ -386,6 +388,11 @@ int handle_wu(
         log_messages.printf(MSG_NORMAL,
             "[WU#%lu %s] WU has too many total results (%d)\n",
             wu_item.id, wu_item.name, ntotal
+        );
+        log_messages.printf(MSG_NORMAL,
+            "   target_nresults=%d nunsent=%d ninprogress=%d nsuccess=%d new_needed=%d new_allowed=%d\n",
+            wu_item.target_nresults, nunsent, ninprogress, nsuccess,
+            n_new_results_needed, n_new_results_allowed
         );
         wu_item.error_mask |= WU_ERROR_TOO_MANY_TOTAL_RESULTS;
     }


### PR DESCRIPTION
Problem: batch acceleration creates additional instances, perhaps several, for a job.
This causes the job to get flagged as 'too many results', and some instances don't get credit.

Solution: when creating a new instance, increment max_total_results.

Also: change server log timestamps to use UTC.
Web pages show UTC, and we need consistency.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes batch acceleration creating extra results by increasing max_total_results when adding a new task, preventing “too many results” errors and lost credit. Also switches server log timestamps to UTC to match the web UI.

- **Bug Fixes**
  - Batch accel: increment max_total_results alongside target_nresults; only create a new result if under the cap and no unsent/recently sent task exists.
  - Transitioner: guard against exceeding max_total_results and add detailed diagnostics when a WU hits the limit.

- **Refactors**
  - Server logs now use UTC; time formatting helpers accept a utc flag and callers updated.
  - Workunit page tweaks: app name links to its page, label changed to “target #results”; clarified WU limit field comments.

<sup>Written for commit 94850e8d1ade8cf8be709da46e60a45497fbf638. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

