### PR TITLE
Fix ci

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Ignore mirrors when building arm64 or armhf
         if: success() && (endsWith(matrix.type, 'arm64') || endsWith(matrix.type, 'armhf'))
         run: |
-          sudo sed -i 's|priority:1|priority:100|' /etc/apt/apt-mirrors.txt
+          sudo sed -i '/azure/d' /etc/apt/apt-mirrors.txt
 
       - name: Install dependencies
         if: matrix.type != 'coverity' || (github.ref == 'refs/heads/master' && github.event_name == 'schedule')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the Azure apt mirror for arm64/armhf CI jobs to stabilize package installs and reduce flaky builds.

- **Bug Fixes**
  - Delete 'azure' lines in /etc/apt/apt-mirrors.txt instead of changing mirror priorities.
  - Scope limited to arm64 and armhf jobs.

<sup>Written for commit 0d4f5fb6aaa7202afcc3c8c13d4f20e6efe68361. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

