### PR TITLE
server (job submission): speed up batch output file download

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -1042,17 +1042,20 @@ function credit_to_gflop_hours($c) {
     return $c/(200/24);
 }
 
-function do_download($path) {
-    $name=basename($path);
+function download_header($name, $nbytes) {
     header('Content-Description: File Transfer');
     header('Content-Type: application/octet-stream');
-    header('Content-Disposition: attachment; filename='.$name);
+    header("Content-Disposition: attachment; filename=$name");
     header('Content-Transfer-Encoding: binary');
     header('Expires: 0');
     header('Cache-Control: must-revalidate, post-check=0, pre-check=0');
     header('Pragma: public');
-    header('Content-Length: ' . filesize($path));
+    header("Content-Length: $nbytes");
     flush();
+}
+
+function do_download($path) {
+    download_header(basename($path), filesize($path));
     readfile($path);
 }
 

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -145,6 +145,7 @@ function get_batch_tar() {
         echo $data;
         flush();
     }
+    pclose($f);
 }
 
 $action = get_str('action');

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -110,6 +110,7 @@ function get_batch_tar() {
     //
     $cmd = "cd $dir; tar --totals -cf /dev/null * 2>&1";
     $f = popen($cmd, "r");
+    $nbytes = -1;
     while (1) {
         $out = fgets($f);
         if (!$out) break;
@@ -118,6 +119,9 @@ function get_batch_tar() {
             $nbytes = $x[0];
             break;
         }
+    }
+    if ($nbytes<0) {
+        error_page('tar --totals failed');
     }
     pclose($f);
 

--- a/html/user/get_output3.php
+++ b/html/user/get_output3.php
@@ -110,6 +110,9 @@ function get_batch_tar() {
     //
     $cmd = "cd $dir; tar --totals -cf /dev/null * 2>&1";
     $f = popen($cmd, "r");
+    if (!$f) {
+        error_page('tar --totals failed');
+    }
     $nbytes = -1;
     while (1) {
         $out = fgets($f);
@@ -121,7 +124,7 @@ function get_batch_tar() {
         }
     }
     if ($nbytes<0) {
-        error_page('tar --totals failed');
+        error_page('tar --totals didn't produce result');
     }
     pclose($f);
 
@@ -129,8 +132,11 @@ function get_batch_tar() {
     //
     $name = "batch_$batch_id.tar";
     download_header($name, $nbytes);
-    $cmd = " cd $dir; tar -cf - *";
+    $cmd = "cd $dir; tar -cf - *";
     $f = popen($cmd, "r");
+    if (!$f) {
+        error_page('tar failed');
+    }
     while (1) {
         $data = fread($f, 256*1024);
         if (!$data) {


### PR DESCRIPTION
Old: create a tar file, output it to HTTP reply, delete it
Does 3 disk I/Os: read file, write to tar, read from tar

New: direct output of tar directly to HTTP reply.
Does just 1 disk I/O.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up batch output file downloads by streaming a tar directly to the HTTP response, removing the temporary archive. Reduces disk I/O from 3 to 1 and improves reliability for large batches.

- **Performance**
  - Stream tar to the response instead of writing and reading a temp file.
  - Set accurate Content-Length via tar --totals; validate output, check popen() success, and pclose() tar processes for clean shutdown; fail if unavailable.
  - Read and flush in 256 KB chunks for smoother delivery.

- **Permissions**
  - Allow users with manage-all access to download batch outputs even if they’re not the owner.

<sup>Written for commit 230d134a13667b53fd920ea2f159d6a2216ff748. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

