### PR TITLE
BUDA: remove job parameters from app form

### DIFF
--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -33,7 +33,7 @@ display_errors();
 
 $buda_root = "../../buda_apps";
 
-// job parameters; can override in project.inc
+// job parameters; can override in project.inc (include that first)
 
 if (!defined('MIN_QUORUM')) {
     define('MIN_QUORUM', 1);
@@ -49,6 +49,12 @@ if (!defined('MAX_TOTAL_RESULTS')) {
 }
 if (!defined('MAX_SUCCESS_RESULTS')) {
     define('MAX_SUCCESS_RESULTS', 3);
+}
+
+if (MIN_QUORUM > TARGET_NRESULTS
+    || TARGET_NRESULTS > MAX_TOTAL_RESULTS
+) {
+    error_page("bad job parameters");
 }
 
 // show list of BUDA apps and variants,

--- a/sched/buda.cpp
+++ b/sched/buda.cpp
@@ -105,18 +105,13 @@ bool BUDA_APP::read_json() {
         );
         return false;
     }
-    if (d.find("name") == d.end()
-        || d.find("min_nsuccess") == d.end()
-        || d.find("max_total") == d.end()
-    ) {
+    if (d.find("name") == d.end()) {
         log_messages.printf(MSG_CRITICAL,
             "BUDA app: missing element in %s\n", path
         );
         return false;
     }
     name = d["name"].get<string>();
-    min_nsuccess = d["min_nsuccess"].get<int>();
-    max_total = d["max_total"].get<int>();
 
     sprintf(path, "%s/%s",
         BUDA_APPS_DIR,


### PR DESCRIPTION
BUDA submitters shouldn't have to know about them. Defaults:
min_quorum 1
target_nresults 1
max_error_results 2
max_total_results 3
max_success_results 3
(can override these in project.inc)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide job replication parameters in the BUDA app form and use safe defaults. Also fixes a cubic issue in the scheduler and adds sanity checks for job params.

- **Refactors**
  - Define and sanity-check defaults: MIN_QUORUM=1, TARGET_NRESULTS=1, MAX_ERROR_RESULTS=2, MAX_TOTAL_RESULTS=3, MAX_SUCCESS_RESULTS=3; error if MIN_QUORUM > TARGET_NRESULTS or TARGET_NRESULTS > MAX_TOTAL_RESULTS.
  - Generate replication params from these constants; BUDA app JSON no longer requires min_nsuccess or max_total.
  - Remove form inputs, validation, and details display for min_nsuccess and max_total.

<sup>Written for commit 1a20099a4752b48f4cd3357415cb8b7ba13c24b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

