### PR TITLE
Test updated glib vcpkg library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/glib/libintl.patch
+++ b/3rdParty/vcpkg_ports/ports/glib/libintl.patch
@@ -1,0 +1,16 @@
+diff --git a/meson.build b/meson.build
+index 5677fa8..6407c64 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2307,8 +2307,9 @@ endif
+ # implementations. This could be extended if issues are found in some platforms.
+ libintl_deps = []
+ libintl_prefix = '#include <libintl.h>'
+-libintl = dependency('intl', required: false)
+-if libintl.found() and libintl.type_name() != 'internal'
++libintl = dependency('intl', required : true)
++libintl_deps = [libintl]
++if false
+   # libintl supports different threading APIs, which may not
+   # require additional flags, but it defaults to using pthreads if
+   # found. Meson's "threads" dependency does not allow you to

--- a/3rdParty/vcpkg_ports/ports/glib/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/glib/portfile.cmake
@@ -1,0 +1,163 @@
+string(REGEX MATCH "^([0-9]*[.][0-9]*)" VERSION_MAJOR_MINOR "${VERSION}")
+# https://github.com/GNOME/glib/blob/main/SECURITY.md#supported-versions
+if(NOT VERSION_MAJOR_MINOR MATCHES "[02468]\$")
+    message("${Z_VCPKG_BACKCOMPAT_MESSAGE_LEVEL}" "glib ${VERSION_MAJOR_MINOR} is a not a \"stable release series\".")
+endif()
+# vcpkg_from_* is not used because the project uses submodules and Anubis deployed to GNOME's gitlab
+# causes vcpkg_from_gitlab to fail for several users
+vcpkg_download_distfile(GLIB_ARCHIVE
+    URLS
+        "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
+    FILENAME "${PORT}-${VERSION}.tar.xz"
+    SHA512 13e8beb84f3464f50c9764d0d3c6822a4bb41ae65e6c3ffac4200a5b441acdd2eb6f838a6b0722cae501e367ce9cfd4f8516b684a391c2f088a593172abcacd9
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${GLIB_ARCHIVE}"
+    PATCHES
+        use-libiconv-on-windows.patch
+        libintl.patch
+)
+
+set(LANGUAGES C CXX)
+if(VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_IOS)
+    list(APPEND LANGUAGES OBJC OBJCXX)
+endif()
+
+vcpkg_list(SET OPTIONS)
+if ("selinux" IN_LIST FEATURES)
+    if(NOT EXISTS "/usr/include/selinux")
+        message(WARNING "SELinux was not found in its typical system location. Your build may fail. You can install SELinux with \"apt-get install selinux libselinux1-dev\".")
+    endif()
+    list(APPEND OPTIONS -Dselinux=enabled)
+else()
+    list(APPEND OPTIONS -Dselinux=disabled)
+endif()
+
+if ("libmount" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dlibmount=enabled)
+else()
+    list(APPEND OPTIONS -Dlibmount=disabled)
+endif()
+
+vcpkg_list(SET ADDITIONAL_BINARIES)
+if(VCPKG_HOST_IS_WINDOWS)
+    # Presence of bash and sh enables installation of auxiliary components.
+    vcpkg_list(APPEND ADDITIONAL_BINARIES "bash = ['${CMAKE_COMMAND}', '-E', 'false']")
+    vcpkg_list(APPEND ADDITIONAL_BINARIES "sh = ['${CMAKE_COMMAND}', '-E', 'false']")
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    LANGUAGES ${LANGUAGES}
+    ADDITIONAL_BINARIES
+        ${ADDITIONAL_BINARIES}
+    OPTIONS
+        ${OPTIONS}
+        -Ddocumentation=false
+        -Ddtrace=disabled
+        -Dinstalled_tests=false
+        -Dintrospection=disabled
+        -Dlibelf=disabled
+        -Dman-pages=disabled
+        -Dsysprof=disabled
+        -Dtests=false
+        -Dxattr=false
+)
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+vcpkg_copy_pdbs()
+
+file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+set(GLIB_SCRIPTS
+    gdbus-codegen
+    glib-genmarshal
+    glib-gettextize
+    glib-mkenums
+    gtester-report
+)
+foreach(script IN LISTS GLIB_SCRIPTS)
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/${script}" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/${script}")
+    file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/${script}")
+endforeach()
+
+set(GLIB_TOOLS
+    gapplication
+    gdbus
+    gi-compile-repository
+    gi-decompile-typelib
+    gi-inspect-typelib
+    gio
+    gio-querymodules
+    glib-compile-resources
+    glib-compile-schemas
+    gobject-query
+    gresource
+    gsettings
+    gtester
+)
+if(VCPKG_TARGET_IS_WINDOWS)
+    list(REMOVE_ITEM GLIB_TOOLS gapplication gtester)
+    if(VCPKG_TARGET_ARCHITECTURE MATCHES "x64|arm64")
+        list(APPEND GLIB_TOOLS gspawn-win64-helper gspawn-win64-helper-console)
+    elseif(VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        list(APPEND GLIB_TOOLS gspawn-win32-helper gspawn-win32-helper-console)
+    endif()
+elseif(VCPKG_TARGET_IS_OSX)
+    list(REMOVE_ITEM GLIB_TOOLS gapplication)
+endif()
+vcpkg_copy_tools(TOOL_NAMES ${GLIB_TOOLS} AUTO_CLEAN)
+
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    set(LIBINTL_NAME "intl.lib")
+else()
+    set(LIBINTL_NAME "libintl")
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL dynamic)
+        string(APPEND LIBINTL_NAME "${VCPKG_TARGET_SHARED_LIBRARY_SUFFIX}")
+    else()
+        string(APPEND LIBINTL_NAME "${VCPKG_TARGET_STATIC_LIBRARY_SUFFIX}")
+    endif()
+endif()
+
+set(pc_replace_intl_path gio glib gmodule-no-export gobject gthread)
+foreach(pc_prefix IN LISTS pc_replace_intl_path)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${pc_prefix}-2.0.pc" "\"" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${pc_prefix}-2.0.pc" "\${prefix}/debug/lib/${LIBINTL_NAME}" "-lintl" IGNORE_UNCHANGED)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/${pc_prefix}-2.0.pc" "\${prefix}/lib/${LIBINTL_NAME}" "-lintl" IGNORE_UNCHANGED)
+    if(NOT VCPKG_BUILD_TYPE)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${pc_prefix}-2.0.pc" "\"" "")
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/${pc_prefix}-2.0.pc" "\${prefix}/lib/${LIBINTL_NAME}" "-lintl" IGNORE_UNCHANGED)
+    endif()
+endforeach()
+
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/gio-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/lib/pkgconfig/glib-2.0.pc" "\${bindir}" "\${prefix}/tools/${PORT}")
+if(NOT VCPKG_BUILD_TYPE)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/gio-2.0.pc" "\${bindir}" "\${prefix}/../tools/${PORT}")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig/glib-2.0.pc" "\${bindir}" "\${prefix}/../tools/${PORT}")
+endif()
+
+# Fix python scripts
+set(_file "${CURRENT_PACKAGES_DIR}/tools/${PORT}/gdbus-codegen")
+file(READ "${_file}" _contents)
+string(REPLACE "elif os.path.basename(filedir) == 'bin':" "elif os.path.basename(filedir) == 'tools':" _contents "${_contents}")
+string(REPLACE "path = os.path.join(filedir, '..', 'share', 'glib-2.0')" "path = os.path.join(filedir, '../..', 'share', 'glib-2.0')" _contents "${_contents}")
+string(REPLACE "path = os.path.join(filedir, '..')" "path = os.path.join(filedir, '../../share/glib-2.0')" _contents "${_contents}")
+string(REPLACE "path = os.path.join('${CURRENT_PACKAGES_DIR}/share', 'glib-2.0')" "path = os.path.join('unuseable/share', 'glib-2.0')" _contents "${_contents}")
+file(WRITE "${_file}" "${_contents}")
+
+if(EXISTS "${CURRENT_PACKAGES_DIR}/tools/${PORT}/glib-gettextize")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/tools/${PORT}/glib-gettextize" "${CURRENT_PACKAGES_DIR}" "`dirname $0`/../..")
+endif()
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug/include"
+    "${CURRENT_PACKAGES_DIR}/debug/share"
+    "${CURRENT_PACKAGES_DIR}/share/gdb"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/gio"
+    "${CURRENT_PACKAGES_DIR}/lib/gio"
+)
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/LGPL-2.1-or-later.txt")

--- a/3rdParty/vcpkg_ports/ports/glib/use-libiconv-on-windows.patch
+++ b/3rdParty/vcpkg_ports/ports/glib/use-libiconv-on-windows.patch
@@ -1,0 +1,28 @@
+diff --git a/glib/gconvert.c b/glib/gconvert.c
+index 53b2065..3e29bee 100644
+--- a/glib/gconvert.c
++++ b/glib/gconvert.c
+@@ -33,7 +33,8 @@
+ 
+ #ifdef G_OS_WIN32
+ #include <windows.h>
+-#include "win_iconv.c"
++#define USE_LIBICONV_GNU
++#include <iconv.h>
+ #endif
+ 
+ #include "gconvert.h"
+diff --git a/meson.build b/meson.build
+index f30ca58..5677fa8 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2233,7 +2233,8 @@ glibconfig_conf.set10('G_HAVE_GROWING_STACK', growing_stack)
+ if host_system == 'windows'
+   # We have a #include "win_iconv.c" in gconvert.c on Windows, so we don't need
+   # any external library for it
+-  libiconv = []
++  libiconv = [cc.find_library('iconv')]
++  found_iconv = true
+ else
+   libiconv = dependency('iconv')
+ endif

--- a/3rdParty/vcpkg_ports/ports/glib/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/glib/vcpkg.json
@@ -1,0 +1,41 @@
+{
+  "name": "glib",
+  "version": "2.86.4",
+  "description": "Portable, general-purpose utility library.",
+  "homepage": "https://developer.gnome.org/glib/",
+  "license": "LGPL-2.1-or-later",
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    "dirent",
+    {
+      "name": "gettext",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
+    },
+    "gettext-libintl",
+    "libffi",
+    "libiconv",
+    "pcre2",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    "zlib"
+  ],
+  "features": {
+    "libmount": {
+      "description": "Build with libmount support.",
+      "supports": "linux",
+      "dependencies": [
+        "libmount"
+      ]
+    },
+    "selinux": {
+      "description": "Build with selinux support.",
+      "supports": "linux"
+    }
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for GLib 2.86.4 with a Meson build and proper Windows linking for intl/iconv. Packages GLib tools under tools/glib and fixes pkg-config and script paths.

- **New Features**
  - Force libintl (intl) and link as -lintl in pkg-config files.
  - Use GNU libiconv on Windows; update Meson to find and link iconv.
  - Meson portfile: disable docs/tests/introspection, handle helper binaries, move CLI tools to tools/glib, and patch Python script paths.
  - Optional features: selinux and libmount (Linux only).
  - Dependencies: gettext (host tools), gettext-libintl, libiconv, libffi, pcre2, zlib, and vcpkg-tool-meson (host).

<sup>Written for commit 19e3eba828eb55d3cc32eab2425a161b1908da26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

