### PR TITLE
Test updated webview2 vcpkg library

### DIFF
--- a/3rdParty/vcpkg_ports/ports/webview2/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/webview2/portfile.cmake
@@ -1,0 +1,53 @@
+if(VCPKG_TARGET_IS_UWP)
+    vcpkg_check_linkage(ONLY_DYNAMIC_LIBRARY)
+endif()
+
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://www.nuget.org/api/v2/package/Microsoft.Web.WebView2/${VERSION}"
+    FILENAME "microsoft.web.webview2.${VERSION}.zip"
+    SHA512 10048ce88c166b7f29a563fcdb9487d71bac5723777cd0a98b5c5a0e71cff344551a0bc27410b0cb0f8482a9ecdec7454a45ad0d2a7ae998fc347ead15598889
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    SOURCE_BASE "${VERSION}"
+    NO_REMOVE_ONE_LEVEL
+)
+
+file(COPY
+    "${SOURCE_PATH}/build/native/include/"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    file(COPY
+        "${SOURCE_PATH}/build/native/${VCPKG_TARGET_ARCHITECTURE}/WebView2LoaderStatic.lib"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+else()
+    file(COPY
+        "${SOURCE_PATH}/build/native/include-winrt/"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+    file(COPY
+        "${SOURCE_PATH}/lib/Microsoft.Web.WebView2.Core.winmd"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(COPY
+        "${SOURCE_PATH}/build/native/${VCPKG_TARGET_ARCHITECTURE}/WebView2Loader.dll.lib"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib")
+    file(COPY
+        "${SOURCE_PATH}/build/native/${VCPKG_TARGET_ARCHITECTURE}/WebView2Loader.dll"
+        "${SOURCE_PATH}/runtimes/win-${VCPKG_TARGET_ARCHITECTURE}/native_uap/Microsoft.Web.WebView2.Core.dll"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/bin")
+endif()
+if(NOT VCPKG_BUILD_TYPE)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+        file(COPY "${CURRENT_PACKAGES_DIR}/bin" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
+    endif()
+    file(COPY "${CURRENT_PACKAGES_DIR}/lib" DESTINATION "${CURRENT_PACKAGES_DIR}/debug")
+endif()
+
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/unofficial-webview2-config.cmake"
+    DESTINATION "${CURRENT_PACKAGES_DIR}/share/unofficial-webview2")
+
+# The import libraries for webview fail with "Could not find proper second linker member"
+set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+
+configure_file("${SOURCE_PATH}/LICENSE.txt" "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" COPYONLY)

--- a/3rdParty/vcpkg_ports/ports/webview2/unofficial-webview2-config.cmake
+++ b/3rdParty/vcpkg_ports/ports/webview2/unofficial-webview2-config.cmake
@@ -1,0 +1,21 @@
+get_filename_component(_IMPORT_PREFIX "${CMAKE_CURRENT_LIST_DIR}" PATH)
+get_filename_component(_IMPORT_PREFIX "${_IMPORT_PREFIX}" PATH)
+
+if(NOT TARGET unofficial::webview2::webview2)
+    if(EXISTS "${_IMPORT_PREFIX}/lib/WebView2LoaderStatic.lib")
+        add_library(unofficial::webview2::webview2 STATIC IMPORTED)
+        set_target_properties(unofficial::webview2::webview2
+            PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+                IMPORTED_LOCATION "${_IMPORT_PREFIX}/lib/WebView2LoaderStatic.lib")
+    else()
+        add_library(unofficial::webview2::webview2 SHARED IMPORTED)
+        set_target_properties(unofficial::webview2::webview2
+            PROPERTIES
+                INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
+                IMPORTED_LOCATION "${_IMPORT_PREFIX}/bin/WebView2Loader.dll"
+                IMPORTED_IMPLIB "${_IMPORT_PREFIX}/lib/WebView2Loader.dll.lib")
+    endif()
+endif()
+
+unset(_IMPORT_PREFIX)

--- a/3rdParty/vcpkg_ports/ports/webview2/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/webview2/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "webview2",
+  "version": "1.0.3800.47",
+  "description": "The WebView2 control allows you to embed web technologies (HTML, CSS, and JavaScript) using Microsoft Edge",
+  "homepage": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
+  "documentation": "https://docs.microsoft.com/en-us/microsoft-edge/webview2",
+  "license": "BSD-3-Clause",
+  "supports": "windows & (x86 | x64 | arm64)",
+  "dependencies": [
+    "wil"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for Microsoft WebView2 (1.0.3800.47) to make WebView2 available in our Windows builds via vcpkg. Includes an unofficial CMake config that provides a single imported target for static or shared linking.

- **New Features**
  - Adds vcpkg portfiles and metadata (download from NuGet, version 1.0.3800.47).
  - Provides unofficial::webview2::webview2 imported CMake target that switches between static and shared loader.
  - Copies headers (include and include-winrt), loader libs/DLLs, and winmd; mirrors libs to debug when needed.
  - Enables empty-package policy as a workaround for failing import libraries; includes license.

<sup>Written for commit 0a6a5d859aa9124022acd3b3d112d739852ae44d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

