### PR TITLE
Fix duplicate running  manager instance checker on Linux

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -855,6 +855,11 @@ bool CBOINCGUIApp::DetectDuplicateInstance() {
     m_pInstanceChecker = new wxSingleInstanceChecker(
             wxTheApp->GetAppName() + '-' + wxGetUserId(),
             wxFileName::GetHomeDir() + "/Library/Application Support/BOINC"
+            );
+#elif defined(__WXGTK__)
+    m_pInstanceChecker = new wxSingleInstanceChecker(
+            wxTheApp->GetAppName() + '-' + wxGetUserId(),
+            wxFileName::GetTempDir()
             );
 #else
     m_pInstanceChecker = new wxSingleInstanceChecker();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate instance detection on Linux by creating the single-instance lock in the system temp directory when running under wxGTK. This prevents multiple BOINC Manager instances from starting for the same user.

<sup>Written for commit 10b1e8c9b3beaaa04b0f1f3a700d02e3ddf684ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

