### PR TITLE
db_update: remove default from query that adds host.misc

### DIFF
--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1237,7 +1237,7 @@ function update_2_15_2025() {
 }
 
 function update_11_23_2025() {
-    do_query("alter table host add column misc text not null default''");
+    do_query("alter table host add column misc text not null");
 }
 
 // Updates are done automatically if you use "upgrade".


### PR DESCRIPTION
Apparently different mysql/mariadb variants either
- don't allow a default for 'text' fields
- allow it but require default ('')
- allow it but require default ''

So I removed the default '' in the query that adds the field. A default isn't needed because hosts are inserted only from C++ code (i.e. the scheduler), which specifies initial values for all fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the default value from the host.misc TEXT column in the DB update to avoid MySQL/MariaDB incompatibilities. No behavior change; the scheduler sets initial values for this field.

<sup>Written for commit 40748266c63953380dc197f0f821a3fa2ef8e335. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

