### PR TITLE
update_versions: change security warning

### DIFF
--- a/sched/sample_dummy_assimilator.cpp
+++ b/sched/sample_dummy_assimilator.cpp
@@ -15,8 +15,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// A sample assimilator that only writes a log message.
-// But WUs are marked as assimilated, which means file deleter
+// A sample assimilator that writes a log message
+// but doesn't do anything with the output files.
+// WUs are marked as assimilated, so the file deleter
 // will delete output files unless you mark them as no_delete,
 // or include 'no_delete' in the WU name
 

--- a/tools/update_versions
+++ b/tools/update_versions
@@ -228,12 +228,10 @@ function confirm_sig_gen($name) {
     if ($sig_gen_confirmed) return true;
 
     echo "
-    NOTICE: You have not provided a signature file for $name,
-    and your project's code-signing private key is on your server.
-
-    IF YOUR PROJECT IS PUBLICLY ACCESSIBLE, THIS IS A SECURITY VULNERABILITY.
-    PLEASE STOP YOUR PROJECT IMMEDIATELY AND READ:
-    https://github.com/BOINC/boinc/wiki/CodeSigning
+    NOTICE: files will be signed with your project's code-signing private key
+    (keys/code_sign_private).
+    We recommend that you encrypt it when done; see
+    https://github.com/BOINC/boinc/wiki/Code-signing
 
     Continue (y/n)? ";
 


### PR DESCRIPTION
update_versions prints an alarming message if it finds the code-signing private key,
based on the assumption that code-signing must be
done on a separate, disconnected machine.
However, this is so inconvenient that few (if any) projects do it.

A more feasible approach is to keep the key encrypted (e.g. using gpg and a passphrase) except when running update_versions. Change the message (and the wiki doc) accordingly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `tools/update_versions` security notice to recommend encrypting the code-signing key and only decrypting for signing, with a link to the updated Code-signing wiki. Also clarify the sample assimilator comment.

- **Refactors**
  - Replace the alarming warning with a clear notice that files will be signed using keys/code_sign_private and to re-encrypt the key after use (link to Code-signing wiki).
  - Tighten comments in sched/sample_dummy_assimilator.cpp to state it only logs and marks WUs as assimilated.

<sup>Written for commit ae3133c1659c431f9fbb94c1ac0148fee76f2141. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

