### PR TITLE
[ci] update actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload coverage report
         if: ${{ matrix.task == 'jacocoTestReportDebug' }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 2
 
       - name: Cache dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
           key: ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -218,7 +218,7 @@ jobs:
           ./tests/integration_test/installTestSuite.sh
 
       - name: Cache dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: |
             3rdParty/buildCache
@@ -478,7 +478,7 @@ jobs:
 
       - name: Upload coverage report
         if: success() && matrix.type == 'unit-test'
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -40,14 +40,14 @@ jobs:
     name: build-dependencies
     runs-on: macos-latest
     steps:
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Cache dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: 3rdParty/buildCache
           key: osx-${{ hashFiles('.github/workflows/osx.yml', '3rdParty/buildMacDependencies.sh', 'mac_build/dependencyNames.sh', 'mac_build/buildc-ares.sh', 'mac_build/buildcurl.sh', 'mac_build/buildfreetype.sh', 'mac_build/buildFTGL.sh', 'mac_build/buildopenssl.sh', 'mac_build/buildWxMac.sh') }}
@@ -64,14 +64,14 @@ jobs:
         type: [manager, samples-makefile]
       fail-fast: false
     steps:
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Cache dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: 3rdParty/buildCache
           key: osx-${{ hashFiles('.github/workflows/osx.yml', '3rdParty/buildMacDependencies.sh', 'mac_build/dependencyNames.sh', 'mac_build/buildc-ares.sh', 'mac_build/buildcurl.sh', 'mac_build/buildfreetype.sh', 'mac_build/buildFTGL.sh', 'mac_build/buildopenssl.sh', 'mac_build/buildWxMac.sh') }}
@@ -134,7 +134,7 @@ jobs:
         triplet: [x64-osx, arm64-osx]
       fail-fast: false
     steps:
-      - uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -34,7 +34,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           path: test-reports
           pattern: '*_tests_results'
-      - uses: dorny/test-reporter@3d76b34a4535afbd0600d347b09a6ee5deb3ed7f
+      - uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2
         with:
           name: 'Tests Report'
           path: 'test-reports/**/*.xml'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,7 +74,7 @@ jobs:
           Start-Process "${{github.workspace}}\temp\OpenCppCoverageSetup-x64-${{ env.OpenCppCoverageVersion }}.exe" -ArgumentList "/verysilent /dir=${{github.workspace}}\temp\OpenCppCoverage" -Wait
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57
 
       - name: Check if build is running from origin repo
         if: ${{success() && env.AWS_ACCESS_KEY_ID != 0 && env.AWS_SECRET_ACCESS_KEY != 0}}
@@ -90,7 +90,7 @@ jobs:
         run: vcpkg.exe integrate remove
 
       - name: Cache dependencies
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
         with:
           path: |
             ${{github.workspace}}\3rdParty\Windows\cuda\
@@ -201,7 +201,7 @@ jobs:
 
       - name: Upload coverage report
         if: success() && matrix.platform == 'x64' && matrix.configuration == 'Release'
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+        uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -318,7 +318,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57
 
       - name: Check if build is running from origin repo
         if: ${{success() && env.AWS_ACCESS_KEY_ID != 0 && env.AWS_SECRET_ACCESS_KEY != 0}}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated pinned GitHub Actions SHAs to current versions across CI for security and reliability. This touches Android, Linux, macOS, Windows, and test-report workflows with no logic changes.

Updated actions: `actions/cache`, `codecov/codecov-action`, `maxim-lobanov/setup-xcode`, `microsoft/setup-msbuild`, `dorny/test-reporter`.

<sup>Written for commit ca13c8e32b269a9c551fd3d4aeca8085582bfdf7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

