### PR TITLE
[ci] get guix release hash during the release build

### DIFF
--- a/.github/workflows/guix_get_release_hash.yml
+++ b/.github/workflows/guix_get_release_hash.yml
@@ -1,0 +1,49 @@
+# This file is part of BOINC.
+# https://boinc.berkeley.edu
+# Copyright (C) 2026 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+name: Get Guix Release Hash
+on:
+  push:
+    tags: [ 'client_release/**' ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  get-guix-release-hash:
+    name: get-guix-release-hash
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 2
+
+      - name: Install dependencies
+        if: ${{ success() }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y guix
+
+      - name: Get Guix Release Hash
+        if: ${{ success() }}
+        run: |
+          ./release_tools/get_release_hash_for_guix.sh


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a GitHub Actions workflow to compute the Guix release hash during release builds for packaging. It runs on `client_release/**` tags and PRs to `master`, pins `actions/checkout`, installs `guix`, runs `./release_tools/get_release_hash_for_guix.sh`, and uses concurrency to avoid duplicate runs.

<sup>Written for commit 21be58c76c8d14414b42584a238970c94ddc84dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

