### PR TITLE
server: delete result/x from disk when delete batch record

### DIFF
--- a/html/ops/delete_batches.php
+++ b/html/ops/delete_batches.php
@@ -35,6 +35,8 @@ function main() {
         if (!$wus) {
             echo "deleting batch $batch->id\n";
             $batch->delete();
+            $dir = "../../results/$batch->id";
+            system("/bin/rm -rf $dir");
         }
     }
     echo "------- Finished at ".time_str(time())."-------\n";

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -507,7 +507,12 @@ function app_form($desc=null) {
         implode(' ', $desc->input_file_names)
     );
     form_input_text(
-        'Output file names<br><small>Space-separated</small>',
+        'Output file names<br><small>
+            Space-separated.
+            <br>The app must generate all of these.
+            They are uploaded to the server.
+            Do not include checkpoint or temp files.
+        </small>',
         'output_file_names',
         implode(' ', $desc->output_file_names)
     );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Delete on-disk results for a batch when its record is removed to prevent orphaned directories and save space. Also clarifies the app form help text for “Output file names” to list only final, space-separated outputs that the app generates and are uploaded (exclude checkpoint/temp files).

<sup>Written for commit bdc23e2cda60f74a3593ad53d8b7621d2bc78b89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

