### PR TITLE
web: minor improvements to apps and CPU list web pages

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -791,6 +791,8 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
         }
 
 #ifdef USE_NET_PREFS
+        // Prefs stuff - not used on Android
+
         bool read_prefs = false;
         if (strlen(host_venue) && strcmp(host_venue, gstate.main_host_venue)) {
             safe_strcpy(gstate.main_host_venue, host_venue);
@@ -827,7 +829,7 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
         if (read_prefs) {
             gstate.read_global_prefs();
         }
-#endif
+#endif  // USE_NET_PREFS
 
         handle_sr_feeds(rss_feeds, &gstate.acct_mgr_info);
 
@@ -850,7 +852,7 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
     gstate.acct_mgr_info.write_info();
     gstate.set_client_state_dirty("account manager RPC");
 }
-#endif
+#endif  // not SIM
 
 // write AM info to files.
 // This is done after each AM RPC.

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -348,7 +348,10 @@ struct HOST {
     char venue[256];        // home/work/school
     int nresults_today;     // results sent since midnight
     double avg_turnaround;  // recent average result turnaround time
-    char host_cpid[256];    // host cross-project ID
+    char host_cpid[256];    // external host cross-project ID
+        // the client generates an 'internal' host CPID;
+        // the server hashes this with email addr to avoid spoofing
+        // See https://github.com/BOINC/boinc/wiki/Host-identification
     char external_ip_addr[256]; // IP address seen by scheduler
     int _max_results_day;
         // MRD is dynamically adjusted to limit work sent to bad hosts.

--- a/html/user/apps.php
+++ b/html/user/apps.php
@@ -76,8 +76,10 @@ function show_apps_xml() {
 
 function show_apps() {
     page_head(tra("Applications"));
+    text_start();
     echo tra("%1 currently has the following applications. When you participate in %1, tasks for one or more of these applications will be assigned to your computer. The current version of the application will be downloaded to your computer. This happens automatically; you don't have to do anything.", PROJECT)."<br><br>
     ";
+    text_end();
 
     $apps = BoincApp::enum("deprecated=0");
     start_table('table-striped');

--- a/html/user/cpu_list.php
+++ b/html/user/cpu_list.php
@@ -66,10 +66,6 @@ function get_cpu_list() {
     $x->cpus = $m2;
     $x->time = time();
     return $x;
-    foreach ($m2 as $x) {
-        $g = $x->p_fpops/1e9;
-        echo "$x->model: $g gflops $x->mean_ncores cores $x->nhosts hosts \n";
-    }
 }
 
 function show_cpu_list($data) {
@@ -80,7 +76,7 @@ function show_cpu_list($data) {
         of computers participating in this project.
         <p>
     ";
-    start_table();
+    start_table('table-striped');
     row_heading_array(
         array(
             "CPU model",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polished the Apps and CPU List pages for readability: wrapped the Apps intro text in `text_start()/text_end()` and switched the CPU List to a `table-striped` table. Removed unreachable debug output in `cpu_list.php` and clarified `#endif` labels and `HOST::host_cpid` comments (no behavior changes).

<sup>Written for commit ffe795dc124273fc903c138a67bdd165de649d18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

