### PR TITLE
fix: prevent XXE in job_file.php XML parsing

### DIFF
--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -297,7 +297,9 @@ if ($request_log) {
 
 xml_header();
 $req = $_POST['request'];
-$r = simplexml_load_string($req);
+// Prevent XXE: disable external entity loading
+libxml_disable_entity_loader(true);
+$r = simplexml_load_string($req, 'SimpleXMLElement', LIBXML_NOENT | LIBXML_NONET);
 if (!$r) {
     xml_error(-1, "can't parse request message: ".htmlspecialchars($req), __FILE__, __LINE__);
 }


### PR DESCRIPTION
## Summary

Prevent XML External Entity (XXE) injection in `html/user/job_file.php` by disabling external entity loading before parsing user-supplied XML.

## Problem

The job file handler parses user-supplied XML from POST data without XXE protection:

```php
$req = $_POST['request'];
$r = simplexml_load_string($req);  // No XXE protection!
```

An attacker can exploit this to:

### 1. Read arbitrary files (A04 - Insecure Design)
```xml
<?xml version="1.0"?>
<!DOCTYPE foo [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>
<query_files><batch_id>&xxe;</batch_id></query_files>
```

### 2. Server-Side Request Forgery (A10 - SSRF)
```xml
<!DOCTYPE foo [<!ENTITY xxe SYSTEM "http://169.254.169.254/latest/meta-data/">]>
```

### 3. Denial of Service via billion laughs
```xml
<!DOCTYPE foo [
  <!ENTITY lol "lol">
  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
  ...
]>
```

## Fix

Added `libxml_disable_entity_loader(true)` and `LIBXML_NONET` flag to prevent external entity loading:

```php
libxml_disable_entity_loader(true);
$r = simplexml_load_string($req, 'SimpleXMLElement', LIBXML_NOENT | LIBXML_NONET);
```

**Note**: `libxml_disable_entity_loader` is deprecated in PHP 8.0+ (where external entities are disabled by default), but this fix ensures protection on PHP 7.x installations.

## Impact

- **Type**: XML External Entity Injection (CWE-611)
- **OWASP**: A04:2021 — Insecure Design, A10:2021 — SSRF
- **Affected endpoint**: `html/user/job_file.php`
- **Risk**: Arbitrary file read, SSRF, denial of service

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent XXE in `html/user/job_file.php` by disabling external entity loading and blocking network access when parsing user XML. This closes file read, SSRF, and DoS vectors.

- **Bug Fixes**
  - Disable external entity loading before parsing POSTed XML.
  - Use `LIBXML_NONET` with `simplexml_load_string` to prevent external resource fetches (compatible with PHP 7.x; safe on PHP 8+).

<sup>Written for commit 225c6ae5321beb531a362c1d8b75d21ea835a346. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

