### PR TITLE
Web RPCs: disallow XML external entity injection (XXE) in XML parsing

### DIFF
--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -51,7 +51,7 @@ function get_other_projects($user) {
             $xml_object = null;
             $f = @file_get_contents($url);
             if ($f) {
-                $xml_object = @simplexml_load_string($f);
+                $xml_object = @safe_simplexml_load_string($f);
             }
             ini_set('default_socket_timeout', $old_timeout);
             if (!$xml_object) {
@@ -67,7 +67,7 @@ function get_other_projects($user) {
             $rawxml = @curl_exec($ch);
             $xml_object = null;
             if ($rawxml) {
-                $xml_object = @simplexml_load_string($rawxml);
+                $xml_object = @safe_simplexml_load_string($rawxml);
             }
             curl_close($ch);
             if (!$xml_object) {

--- a/html/inc/util_basic.inc
+++ b/html/inc/util_basic.inc
@@ -283,4 +283,16 @@ define('MEGA', 1024*KILO);
 define('GIGA', 1024*MEGA);
 define('TERA', 1024*GIGA);
 
+// disallow 'external entities'
+//
+function safe_simplexml_load_file($name) {
+    @libxml_disable_entity_loader(true);
+        // deprecated in PHP 8; hide warning
+    return simplexml_load_file($name, 'SimpleXMLElement', LIBXML_NONET);
+}
+function safe_simplexml_load_string($str) {
+    @libxml_disable_entity_loader(true);
+    return simplexml_load_string($str, 'SimpleXMLElement', LIBXML_NONET);
+}
+
 ?>

--- a/html/user/job_file.php
+++ b/html/user/job_file.php
@@ -297,7 +297,7 @@ if ($request_log) {
 
 xml_header();
 $req = $_POST['request'];
-$r = simplexml_load_string($req);
+$r = safe_simplexml_load_string($req);
 if (!$r) {
     xml_error(-1, "can't parse request message: ".htmlspecialchars($req), __FILE__, __LINE__);
 }

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -1098,7 +1098,7 @@ if ($request_log) {
     }
 }
 
-$r = simplexml_load_string($req);
+$r = safe_simplexml_load_string($req);
 if (!$r) {
     log_write("----- RPC request: can't parse request message: $req");
     xml_error(-1, "can't parse request message: ".htmlspecialchars($req));


### PR DESCRIPTION
... in cases where the XML is coming from outside the project (RPC requests, and return from free-dc.org project lookup). It's not clear to me why XML parsing
would have these capabilities in the first place.

Fixes #6938

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks XML External Entity (XXE) attacks in web RPCs and external XML lookups by switching to safe XML parsing with network access disabled. Hardens request handling and the free-dc.org project lookup without changing valid XML behavior.

- **Bug Fixes**
  - Added `safe_simplexml_load_string()` and `safe_simplexml_load_file()` using `LIBXML_NONET` and `libxml_disable_entity_loader(true)`.
  - Replaced `simplexml_load_string()` in RPC handlers and free-dc.org lookup with the safe wrappers.
  - Suppressed PHP 8 deprecation warning for `libxml_disable_entity_loader()`.

<sup>Written for commit 40961870eb10405b89b7d30c8ec4e1aecb0f18b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

