### PR TITLE
Fix credit accounting when using Science United

### DIFF
--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -801,6 +801,11 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
                     if (acct.suspend.present && acct.suspend.value) {
                         pp->suspend();
                     }
+
+                    // The AM supplies initial accounting info
+                    // (in case the client was previously attached,
+                    // then detached).
+                    //
                     if (gstate.acct_mgr_info.dynamic) {
                         pp->user_expavg_credit = acct.user_avg_ec;
                         pp->user_total_credit = acct.user_total_ec;

--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -300,6 +300,8 @@ int AM_ACCOUNT::parse(XML_PARSER& xp) {
     safe_strcpy(url_signature, "");
     authenticator.clear();
     resource_share.init();
+    user_avg_ec = 0;
+    user_total_ec = 0;
 
     while (!xp.get_tag()) {
         if (!xp.is_tag) {
@@ -325,6 +327,8 @@ int AM_ACCOUNT::parse(XML_PARSER& xp) {
         if (xp.parse_string("authenticator", authenticator)) continue;
         if (xp.parse_bool("detach", detach)) continue;
         if (xp.parse_bool("update", update)) continue;
+        if (xp.parse_double("user_avg_ec", user_avg_ec)) continue;
+        if (xp.parse_double("user_total_ec", user_total_ec)) continue;
         if (xp.parse_bool("no_cpu", btemp)) {
             handle_no_rsc("CPU", btemp);
             continue;
@@ -652,6 +656,10 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
         for (const AM_ACCOUNT& acct: accounts) {
             pp = gstate.lookup_project(acct.url.c_str());
             if (pp) {
+                if (gstate.acct_mgr_info.dynamic) {
+                    pp->user_expavg_credit = acct.user_avg_ec;
+                    pp->user_total_credit = acct.user_total_ec;
+                }
                 if (acct.detach) {
                     if (pp->attached_via_acct_mgr) {
                         gstate.detach_project(pp);
@@ -780,6 +788,10 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
                     }
                     if (acct.suspend.present && acct.suspend.value) {
                         pp->suspend();
+                    }
+                    if (gstate.acct_mgr_info.dynamic) {
+                        pp->user_expavg_credit = acct.user_avg_ec;
+                        pp->user_total_credit = acct.user_total_ec;
                     }
                 } else {
                     msg_printf(NULL, MSG_INTERNAL_ERROR,

--- a/client/acct_mgr.cpp
+++ b/client/acct_mgr.cpp
@@ -302,6 +302,12 @@ int AM_ACCOUNT::parse(XML_PARSER& xp) {
     resource_share.init();
     user_avg_ec = 0;
     user_total_ec = 0;
+    cpu_ec = 0;
+    cpu_time = 0;
+    gpu_ec = 0;
+    gpu_time = 0;
+    njobs_success = 0;
+    njobs_error = 0;
 
     while (!xp.get_tag()) {
         if (!xp.is_tag) {
@@ -329,6 +335,12 @@ int AM_ACCOUNT::parse(XML_PARSER& xp) {
         if (xp.parse_bool("update", update)) continue;
         if (xp.parse_double("user_avg_ec", user_avg_ec)) continue;
         if (xp.parse_double("user_total_ec", user_total_ec)) continue;
+        if (xp.parse_double("cpu_ec", cpu_ec)) continue;
+        if (xp.parse_double("cpu_time", cpu_time)) continue;
+        if (xp.parse_double("gpu_ec", gpu_ec)) continue;
+        if (xp.parse_double("gpu_time", gpu_time)) continue;
+        if (xp.parse_int("njobs_success", njobs_success)) continue;
+        if (xp.parse_int("njobs_error", njobs_error)) continue;
         if (xp.parse_bool("no_cpu", btemp)) {
             handle_no_rsc("CPU", btemp);
             continue;
@@ -792,6 +804,12 @@ void ACCT_MGR_OP::handle_reply(int http_op_retval) {
                     if (gstate.acct_mgr_info.dynamic) {
                         pp->user_expavg_credit = acct.user_avg_ec;
                         pp->user_total_credit = acct.user_total_ec;
+                        pp->cpu_ec = acct.cpu_ec;
+                        pp->cpu_time = acct.cpu_time;
+                        pp->gpu_ec = acct.gpu_ec;
+                        pp->gpu_time = acct.gpu_time;
+                        pp->njobs_success = acct.njobs_success;
+                        pp->njobs_error = acct.njobs_error;
                     }
                 } else {
                     msg_printf(NULL, MSG_INTERNAL_ERROR,

--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -161,6 +161,13 @@ struct AM_ACCOUNT {
     OPTIONAL_BOOL abort_not_started;
     double user_avg_ec;
     double user_total_ec;
+    // the following present if client not already attached
+    double cpu_ec;
+    double cpu_time;
+    double gpu_ec;
+    double gpu_time;
+    int njobs_success;
+    int njobs_error;
 
     void handle_no_rsc(const char*, bool);
     int parse(XML_PARSER&);

--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -81,8 +81,11 @@ struct ACCT_MGR_INFO : PROJ_AM {
 
     bool password_error;
     bool dynamic;
-        // This AM dynamically decides what projects to assign.
-        // - send EC in AM RPCs
+        // This AM dynamically decides what projects to assign,
+        // and has a single user per project.
+        // Like Science United.
+        // - send EC in AM RPC requests
+        // - RPC replies will include user_avg_ec, user_total_ec per project
         // - send starvation info if idle resources
         // - network preferences are those from AM
     USER_KEYWORDS user_keywords;
@@ -156,6 +159,8 @@ struct AM_ACCOUNT {
     OPTIONAL_DOUBLE resource_share;
     OPTIONAL_BOOL suspend;
     OPTIONAL_BOOL abort_not_started;
+    double user_avg_ec;
+    double user_total_ec;
 
     void handle_no_rsc(const char*, bool);
     int parse(XML_PARSER&);

--- a/client/acct_mgr.h
+++ b/client/acct_mgr.h
@@ -161,7 +161,8 @@ struct AM_ACCOUNT {
     OPTIONAL_BOOL abort_not_started;
     double user_avg_ec;
     double user_total_ec;
-    // the following present if client not already attached
+    // the following supplied by dynamic AM if client not already attached
+    // to the project
     double cpu_ec;
     double cpu_time;
     double gpu_ec;

--- a/client/project.h
+++ b/client/project.h
@@ -200,6 +200,7 @@ struct PROJECT : PROJ_AM {
         // Used for a clean exit to a project,
         // or if a user wants to pause doing work for the project
     bool attached_via_acct_mgr;
+        // if set, don't let user remove project directly
     bool detach_when_done;
         // when no results for this project, detach it.
         // if using AM, do AM RPC before detaching

--- a/client/project.h
+++ b/client/project.h
@@ -121,7 +121,9 @@ struct PROJECT : PROJ_AM {
         // and this should go to 1.
         // But we need to keep it around for older projects
 
-    // accounting info for dynamic account managers;
+    // accounting info for use with dynamic account managers;
+    // obtained from the AM on attach,
+    // updated by the client, and reported in AM RPCs
     //
     double cpu_ec;      // estimated credit
     double cpu_time;    // device/seconds

--- a/client/project.h
+++ b/client/project.h
@@ -121,12 +121,14 @@ struct PROJECT : PROJ_AM {
         // and this should go to 1.
         // But we need to keep it around for older projects
 
-    // accounting info; estimated credit and time for CPU and GPU
+    // accounting info for dynamic account managers;
     //
-    double cpu_ec;
-    double cpu_time;
+    double cpu_ec;      // estimated credit
+    double cpu_time;    // device/seconds
     double gpu_ec;
     double gpu_time;
+    int njobs_success;
+    int njobs_error;
 
     // stuff related to scheduler RPCs and master fetch
     //
@@ -154,6 +156,7 @@ struct PROJECT : PROJ_AM {
         // computed by get_disk_usages()
     double disk_share;
         // computed by get_disk_shares();
+    bool dont_use_dcf;
 
     ///////  END OF ITEMS STORED IN client_state.xml
 
@@ -191,8 +194,6 @@ struct PROJECT : PROJ_AM {
     int send_job_log;
         // if nonzero, send this project's job log from that point on
     bool send_full_workload;
-
-    bool dont_use_dcf;
 
     bool suspended_via_gui;
     bool dont_request_more_work;
@@ -315,11 +316,6 @@ struct PROJECT : PROJ_AM {
     // app config stuff
     //
     APP_CONFIGS app_configs;
-
-    // job counting
-    //
-    int njobs_success;
-    int njobs_error;
 
     // total elapsed time of this project's jobs (for export to GUI)
     //

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -614,10 +614,11 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
         }
     }
 
-    // if project is attached via a dynamic AM (like Science United)
-    // we get user credit from the AM, not the project
+    // if project is attached via a dynamic AM (like Science United),
+    // ignore project-supplied user credit;
+    // we get it from the AM, not the project
     //
-    bool ignore_host_credit = project->attached_via_acct_mgr && gstate.acct_mgr_info.dynamic;
+    bool ignore_user_credit = project->attached_via_acct_mgr && gstate.acct_mgr_info.dynamic;
 
     // First line should either be tag (HTTP 1.0) or
     // hex length of response (HTTP 1.1)
@@ -673,8 +674,8 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
         }
         else if (xp.parse_str("symstore", project->symstore, sizeof(project->symstore))) continue;
         else if (xp.parse_str("user_name", project->user_name, sizeof(project->user_name))) continue;
-        else if (!ignore_host_credit && xp.parse_double("user_total_credit", project->user_total_credit)) continue;
-        else if (!ignore_host_credit && xp.parse_double("user_expavg_credit", project->user_expavg_credit)) continue;
+        else if (!ignore_user_credit && xp.parse_double("user_total_credit", project->user_total_credit)) continue;
+        else if (!ignore_user_credit && xp.parse_double("user_expavg_credit", project->user_expavg_credit)) continue;
         else if (xp.parse_double("user_create_time", project->user_create_time)) continue;
         else if (xp.parse_double("cpid_time", cpid_time)) continue;
         else if (xp.parse_str("team_name", project->team_name, sizeof(project->team_name))) continue;

--- a/client/scheduler_op.cpp
+++ b/client/scheduler_op.cpp
@@ -614,6 +614,11 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
         }
     }
 
+    // if project is attached via a dynamic AM (like Science United)
+    // we get user credit from the AM, not the project
+    //
+    bool ignore_host_credit = project->attached_via_acct_mgr && gstate.acct_mgr_info.dynamic;
+
     // First line should either be tag (HTTP 1.0) or
     // hex length of response (HTTP 1.1)
     //
@@ -668,8 +673,8 @@ int SCHEDULER_REPLY::parse(FILE* in, PROJECT* project) {
         }
         else if (xp.parse_str("symstore", project->symstore, sizeof(project->symstore))) continue;
         else if (xp.parse_str("user_name", project->user_name, sizeof(project->user_name))) continue;
-        else if (xp.parse_double("user_total_credit", project->user_total_credit)) continue;
-        else if (xp.parse_double("user_expavg_credit", project->user_expavg_credit)) continue;
+        else if (!ignore_host_credit && xp.parse_double("user_total_credit", project->user_total_credit)) continue;
+        else if (!ignore_host_credit && xp.parse_double("user_expavg_credit", project->user_expavg_credit)) continue;
         else if (xp.parse_double("user_create_time", project->user_create_time)) continue;
         else if (xp.parse_double("cpid_time", cpid_time)) continue;
         else if (xp.parse_str("team_name", project->team_name, sizeof(project->team_name))) continue;


### PR DESCRIPTION
Fixed two issues:

1) The user's credit on a given project (summed over all their hosts),
as shown in the Manager, was being taken from the reply of a scheduler RPC to that project.
Since SU uses a single account per project, this was a huge number.
Instead, get the user credit from the reply of an AM RPC to SU
(I modified SU's RPC handler to include this info).

2) If SU detached a project P, and later reattached it,
the client would set P's accounting info (cpu_ec, njobs_success etc.) to zero.
Instead, have the AM RPC reply include this info when a project is being reattached,
and have the client parse it and use it to initialize the project.
(I modified SU's RPC handler to do this).

fixes #5675

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect user credit display and preserves per-project stats when using Science United. Credit now comes from the account manager (AM) reply, and stats are restored on reattach.

- **Bug Fixes**
  - For dynamic AMs (`acct_mgr_info.dynamic`), ignore scheduler-reported `user_total_credit` and `user_expavg_credit`; set them from AM RPC fields `user_total_ec` and `user_avg_ec`.
  - Parse and apply AM RPC fields on add/reattach: `cpu_ec`, `cpu_time`, `gpu_ec`, `gpu_time`, `njobs_success`, `njobs_error` to initialize project accounting.
  - Prevents zeroed stats when Science United detaches and later reattaches a project.
  - Added the above fields to `AM_ACCOUNT` and `PROJECT` and extended AM/scheduler reply parsing accordingly.

<sup>Written for commit 296b5611506c6d6397e43b0d0f35f511a0fc0856. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

