### PR TITLE
client (Unix): abort job if shared-mem creation fails

### DIFF
--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -996,7 +996,7 @@ int ACTIVE_TASK::start() {
                     "ACTIVE_TASK::start(): can't create memory-mapped file: %s",
                     boincerror(retval)
                 );
-                return retval;
+                return ERR_MMAP;
             }
         } else {
             // Use shmget() shared memory
@@ -1211,9 +1211,6 @@ int ACTIVE_TASK::resume_or_start(bool first_time) {
     case PROCESS_UNINITIALIZED:
         str = (first_time)?"Starting":"Restarting";
         retval = start();
-        if ((retval == ERR_SHMGET) || (retval == ERR_SHMAT)) {
-            return retval;
-        }
         if (retval) {
             set_task_state(PROCESS_COULDNT_START, "resume_or_start1");
             return retval;

--- a/lib/error_numbers.h
+++ b/lib/error_numbers.h
@@ -214,9 +214,11 @@
 #define ERR_NEED_HTTPS      -238
 #define ERR_CHMOD           -239
 #define ERR_STAT            -240
+    // or fstat()
 #define ERR_FCLOSE          -241
 #define ERR_ACCT_REQUIRE_CONSENT -242
 #define ERR_INVALID_STATE   -243
+#define ERR_MMAP            -244
 
 // PLEASE: add a text description of your error to
 // the text description function boincerror() in str_util.cpp.

--- a/lib/shmem.cpp
+++ b/lib/shmem.cpp
@@ -302,7 +302,9 @@ int create_shmem_mmap(const char *path, size_t size, void** pp) {
 
     // Return NULL pointer if create_shmem fails
     *pp = 0;
-    if (size == 0) return ERR_SHMGET;
+    if (size == 0) {
+        return ERR_NULL;
+    }
 
     // NOTE: in principle it should be 0660, not 0666
     // (i.e. Apache should belong to the same group as the
@@ -313,12 +315,14 @@ int create_shmem_mmap(const char *path, size_t size, void** pp) {
     // and it's not a significant security issue.
     //
     fd = open(path, O_RDWR | O_CREAT, 0666);
-    if (fd < 0) return ERR_SHMGET;
+    if (fd < 0) {
+        return ERR_OPEN;
+    }
 
     retval = fstat(fd, &sbuf);
     if (retval) {
         close(fd);
-        return ERR_SHMGET;
+        return ERR_STAT;
     }
     if (sbuf.st_size < (long)size) {
         // The following 2 lines extend the file and clear its new
@@ -326,9 +330,9 @@ int create_shmem_mmap(const char *path, size_t size, void** pp) {
         // See the lseek man page for details.
         lseek(fd, size-1, SEEK_SET);
         if (1 != write(fd, "\0", 1)) {
-	    close(fd);
-	    return ERR_SHMGET;
-	}
+            close(fd);
+            return ERR_WRITE;
+        }
     }
 
     *pp = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_FILE | MAP_SHARED, fd, 0);

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -624,6 +624,7 @@ const char* boincerror(int which_error) {
         case ERR_STAT : return "stat() failed";
         case ERR_FCLOSE : return "fclose() failed";
         case ERR_INVALID_STATE: return "invalid state";
+        case ERR_MMAP: return "mmap() failed";
         case HTTP_STATUS_NOT_FOUND: return "HTTP file not found";
         case HTTP_STATUS_PROXY_AUTH_REQ: return "HTTP proxy authentication failure";
         case HTTP_STATUS_RANGE_REQUEST_ERROR: return "HTTP range request error";


### PR DESCRIPTION
Mac OS has a limit of 32 shared-mem segments (not sure why). So a long time ago we added logic so that when shmem attach fails, we postpone the job instead of aborting it.
There are 2 problems with this:

- The logic is for all Unix, even though it's relevant only to Mac OS
- At some point we switched to memory-mapped files (rather than shmget) and there are no limits for these.

This could lead to a situation (on any Unix) where
- the client exits or dies
- some apps keep running, hanging onto their shmem segments
- when the client restarts, the mmaps fail and nothing ever gets run

So, abort jobs where the mmap fails (on all Unix).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Abort jobs on Unix when creating the memory-mapped shared memory fails, instead of postponing. This avoids jobs getting stuck after client restarts when mmap() cannot be created.

- **Bug Fixes**
  - Abort on mmap() failure in `ACTIVE_TASK::start()`; removed postpone checks in `resume_or_start()`.
  - Added `ERR_MMAP` and error text; return specific errors in `create_shmem_mmap()` (e.g., `ERR_OPEN`, `ERR_STAT`, `ERR_WRITE`, `ERR_NULL`) instead of generic `ERR_SHMGET`.
  - Removes outdated Mac-only postpone behavior now that we use memory-mapped files instead of `shmget`.

<sup>Written for commit a65ebb929b5a7ff4a5f0df44e9cbf11f65490734. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

