### PR TITLE
web: require credit to post outside Help categories

### DIFF
--- a/html/inc/delete_account.inc
+++ b/html/inc/delete_account.inc
@@ -16,6 +16,14 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <https://www.gnu.org/licenses/>.
 
+// functions to remove accounts
+// wipe_account(): delete account and all related DB records
+// obfuscate_account(): change name and email of account; delete forum items
+// delete_account(): call one of these (or project-supplied func)
+//  based on config setting
+//
+// NOTE: this is way too complex.  Just use the wipe option.
+
 require_once("../inc/common_defs.inc");
 require_once("../inc/util.inc");
 require_once("../inc/user.inc");
@@ -27,8 +35,7 @@ require_once("../inc/submit_util.inc");
 require_once("../project/project.inc");
 
 // Constants for different methods of deleting accounts
-// These correspond to the value used in the config.xml
-// field of <enable_delete_account/>
+// Selected in the <enable_delete_account/> element in config.xml
 //
 define("DELETE_ACCOUNT_METHOD_OBFUSCATE", 1);
 define("DELETE_ACCOUNT_METHOD_WIPE", 2);

--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -62,7 +62,11 @@ define('ST_NEW', 'New member');
 
 if (!defined('MAXIMUM_EDIT_TIME')) {
     define('MAXIMUM_EDIT_TIME', 3600);
-        // allow edits of forums posts up till one hour after posting.
+        // allow edits of forums posts up to one hour after posting.
+}
+
+if (!defined('NEED_CREDIT_TO_POST_EXCEPT_HELP')) {
+    define('NEED_CREDIT_TO_POST_EXCEPT_HELP', true);
 }
 
 define('MAX_FORUM_LOGGING_TIME', 2419200); //3600*24*28 - 28 days
@@ -1275,20 +1279,24 @@ function is_admin($user) {
     return false;
 }
 
-// return
-// 'yes' if logged in and can post (show New thread button)
-// 'login' if could post if logged in (show login to post msg)
-// 'no' if can't post (don't show anythin)
+// should we show a 'new thread' button in a forum page?
+// Note: we show the button even if in some cases
+// an attempt to post will fail (see below)
 //
-function user_can_create_thread($user, $forum) {
+function show_post_button($user, $forum) {
     if ($forum->is_dev_blog) {
-        return is_admin($user)?'yes':'no';
+        return is_admin($user);
     }
-    return $user ?'yes':'login';
+    return true;
 }
 
+// If the user is not allowed to post to the forum, show an error page.
+//
 function check_post_access($user, $forum) {
     if (is_admin($user)) return;
+    if ($forum->is_dev_blog) {
+        error_page("Can't post to News");
+    }
 
     switch ($forum->parent_type) {
     case 0:
@@ -1306,34 +1314,49 @@ function check_post_access($user, $forum) {
         break;
     }
 
-    // If user haven't got enough credit (according to forum regulations)
-    // We do not tell the (ab)user how much this is -
+    // check if user has enough credit according to forum settings.
+    // We don't tell the user how much this is -
     // no need to make it easy for them to break the system.
     //
-    if ($user->total_credit<$forum->post_min_total_credit || $user->expavg_credit<$forum->post_min_expavg_credit) {
-        error_page(tra("To create a new thread in %1 you must have a certain level of average credit. This is to protect against abuse of the system.", $forum->title));
+    if ($user->total_credit<$forum->post_min_total_credit
+        || $user->expavg_credit<$forum->post_min_expavg_credit
+    ) {
+        error_page(tra("To create a thread you must have computing credit."));
+    }
+
+    if (NEED_CREDIT_TO_POST_EXCEPT_HELP) {
+        if ($user->total_credit == 0) {
+            $category = BoincCategory::lookup_id($forum->category);
+            if (!$category->is_helpdesk) {
+                error_page(
+                    tra("To create a thread you must have computing credit.")
+                );
+            }
+        }
     }
 
     // If the user is posting faster than forum regulations allow
     // Tell the user to wait a while before creating any more posts
     //
-    if (time()-$user->prefs->last_post <$forum->post_min_interval) {
-        error_page(tra("You cannot create threads right now. Please wait before trying again. This is to protect against abuse of the system."));
+    if (time() - $user->prefs->last_post < $forum->post_min_interval) {
+        error_page(
+            tra(
+                "You can't create a thread right now. Please try again later."
+            )
+        );
     }
 }
 
+// if the user is not allowed to reply to threads in the forum,
+// show an error page
+//
 function check_reply_access($user, $forum, $thread) {
     if ($thread->locked && !is_moderator($user, $forum)) {
-        error_page(
-            tra("This thread is locked. Only forum moderators and administrators are allowed to post there.")
-        );
+        error_page(tra("This thread is locked."));
     }
     if ($thread->hidden) {
-        error_page(
-           tra("Can't post to a hidden thread.")
-        );
+        error_page(tra("Can't post to a hidden thread."));
     }
-
     check_post_access($user, $forum);
 }
 

--- a/html/ops/delete_user.php
+++ b/html/ops/delete_user.php
@@ -30,7 +30,7 @@ die("Delete this line first\n");
 if (is_numeric($argv[1])) {
     $user = BoincUser::lookup_id((int) $argv[1]);
     if (!$user) die("no such user\n");
-    $retval = delete_account($user);
+    $retval = wipe_account($user);
     if ($retval) {
         echo "Failed to delete user: $retval\n";
     } else {
@@ -39,7 +39,7 @@ if (is_numeric($argv[1])) {
 } else {
     $users = BoincUser::enum(sprintf("name='%s'", $argv[1]));
     foreach ($users as $user) {
-        $retval = delete_account($user);
+        $retval = wipe_account($user);
         if ($retval) {
             echo "Failed to delete user: $retval\n";
         } else {

--- a/html/user/forum_forum.php
+++ b/html/user/forum_forum.php
@@ -97,16 +97,15 @@ function forum_page($forum, $user, $msg=null) {
         <td colspan=2>
     ';
 
-    switch (user_can_create_thread($user, $forum)) {
-    case 'yes':
-        show_button(
-            "forum_post.php?id=$forum->id", tra("New thread"),
-            tra("Add a new thread to this forum")
-        );
-        break;
-    case 'login':
+    if ($user) {
+        if (show_post_button($user, $forum)) {
+            show_button(
+                "forum_post.php?id=$forum->id", tra("New thread"),
+                tra("Add a new thread to this forum")
+            );
+        }
+    } else {
         echo "To add a thread, you must <a href=login_form.php>log in</a>.";
-        break;
     }
 
     if ($user) {

--- a/html/user/forum_post.php
+++ b/html/user/forum_post.php
@@ -44,9 +44,6 @@ if (DISABLE_FORUMS && !is_admin($logged_in_user)) {
     error_page("Forums are disabled");
 }
 
-if (user_can_create_thread($logged_in_user, $forum)=='no') {
-    error_page(tra("Only project admins may create a thread here. However, you may reply to existing threads."));
-}
 check_post_access($logged_in_user, $forum);
 
 $title = post_str("title", true);


### PR DESCRIPTION
Configurable by NEED_CREDIT_TO_POST_EXCEPT_HELP in project.inc (default true)

Also minor code cleanup

Also change ops/delete_account.php to use wipe_account()

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require computing credit to post outside Help categories, controlled by `NEED_CREDIT_TO_POST_EXCEPT_HELP` (default true). Also update the delete-user CLI to use `wipe_account()`.

- **New Features**
  - Block creating threads and replies if the user has zero credit, except in Help categories.
  - Prevent posting in News (dev blog) for non-admins with a clear error message.
  - Keep the “New thread” button visible to logged-in users; server-side checks enforce access.

- **Refactors**
  - Replace `user_can_create_thread()` with `show_post_button()` and centralize rules in `check_post_access()`.
  - Define `NEED_CREDIT_TO_POST_EXCEPT_HELP` in `forum.inc` (default true).
  - Switch `html/ops/delete_user.php` to call `wipe_account()`.
  - Add clarifying comments in `delete_account.inc` and minor copy cleanups.

<sup>Written for commit 673b3e7f2a8da5674c61ffab8a3d2440544d42dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

