### PR TITLE
macOS: fix chflags failure on fresh installs breaking permission setup

### DIFF
--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -986,25 +986,30 @@ setGroupForUser:
 
     // Hide the home directory and share point https://support.apple.com/en-mn/102099
     // Something like "sudo chflags hidden /Users/boinc_master"
-    args[0] = "/usr/bin/sudo";
-    args[1] = "chflags";
-    args[2] = "hidden";
-    args[3] = buf2;
-    args[4] = NULL;
-    err = posix_spawnp(&thePid, "/usr/bin/sudo", NULL, NULL, args, environ);
-    waitpid(thePid, &status, WUNTRACED);
-    if (status != 0) {
-        err = status;
-    } else {
-        if (WIFEXITED(status)) {
-            err = WEXITSTATUS(status);
-            if (err == 1) {
-                err = errno;
-            }
-        }   // end if (WIFEXITED(status)) else
-    }       // end if waitpid returned 0 sstaus else
-if (err)
-    return err;
+    // buf2 was overwritten to DSCL path "/users/<name>" above; rebuild filesystem path.
+    // Skip if the directory doesn't exist (fresh installs set home to /var/empty).
+    sprintf(buf2, "/Users/%s", user_name);
+    if (access(buf2, F_OK) == 0) {
+        args[0] = "/usr/bin/sudo";
+        args[1] = "chflags";
+        args[2] = "hidden";
+        args[3] = buf2;
+        args[4] = NULL;
+        err = posix_spawnp(&thePid, "/usr/bin/sudo", NULL, NULL, args, environ);
+        waitpid(thePid, &status, WUNTRACED);
+        if (status != 0) {
+            err = status;
+        } else {
+            if (WIFEXITED(status)) {
+                err = WEXITSTATUS(status);
+                if (err == 1) {
+                    err = errno;
+                }
+            }   // end if (WIFEXITED(status)) else
+        }       // end if waitpid returned 0 sstaus else
+        if (err)
+            return err;
+    }
 
     err = ResynchDSSystem();
     if (err != noErr)

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -384,9 +384,9 @@ int main(int argc, char *argv[])
     for (i=0; i<RETRY_LIMIT; ++i) {
         err = CreateBOINCUsersAndGroups();
         if (err != noErr) {
-            printf("CreateBOINCUsersAndGroups returned %d (repetition=%d)", err, i);
+            printf("CreateBOINCUsersAndGroups returned %d (repetition=%d)\n", err, i);
             fflush(stdout);
-            REPORT_ERROR(i >= RETRY_LIMIT);
+            REPORT_ERROR(i >= RETRY_LIMIT - 1);
             continue;
         }
 
@@ -394,17 +394,17 @@ int main(int argc, char *argv[])
         err = SetBOINCAppOwnersGroupsAndPermissions(appPath[brandID]);
 
         if (err != noErr) {
-            printf("SetBOINCAppOwnersGroupsAndPermissions returned %d (repetition=%d)", err, i);
+            printf("SetBOINCAppOwnersGroupsAndPermissions returned %d (repetition=%d)\n", err, i);
             fflush(stdout);
-            REPORT_ERROR(i >= RETRY_LIMIT);
+            REPORT_ERROR(i >= RETRY_LIMIT - 1);
             continue;
         }
 
         err = SetBOINCDataOwnersGroupsAndPermissions();
         if (err != noErr) {
-            printf("SetBOINCDataOwnersGroupsAndPermissions returned %d (repetition=%d)", err, i);
+            printf("SetBOINCDataOwnersGroupsAndPermissions returned %d (repetition=%d)\n", err, i);
             fflush(stdout);
-            REPORT_ERROR(i >= RETRY_LIMIT);
+            REPORT_ERROR(i >= RETRY_LIMIT - 1);
             continue;
         }
 
@@ -414,12 +414,21 @@ int main(int argc, char *argv[])
             true, false, NULL, 0
         );
         if (err != noErr) {
-            printf("check_security returned %d (repetition=%d)", err, i);
+            printf("check_security returned %d (repetition=%d)\n", err, i);
             fflush(stdout);
-            REPORT_ERROR(i >= RETRY_LIMIT);
+            REPORT_ERROR(i >= RETRY_LIMIT - 1);
         } else {
             break;
         }
+    }
+
+    // If security setup failed after all retries, report failure to the
+    // macOS Installer so it does not show "Installation Successful" when
+    // permissions were never set correctly.
+    if (err != noErr) {
+        printf("BOINC security setup failed after %d attempts (last error=%d)\n", RETRY_LIMIT, err);
+        fflush(stdout);
+        return err;
     }
 
 #else   // ! defined(SANDBOX)


### PR DESCRIPTION
Fixes #6963

## Problem

`CreateUserAndGroup()` runs `chflags hidden` on `/Users/<name>`, but on fresh installs the home directory is `/var/empty`. `chflags` fails with "No such file or directory", `CreateBOINCUsersAndGroups()` returns 256 on all 5 retries, and the permission-setting functions never execute.

Also: `buf2` was overwritten from the filesystem path (`/Users/`) to the DSCL path (`/users/`) at line 967, so the wrong path was being passed.

## Changes

**`clientgui/mac/SetupSecurity.cpp`:**
- Check `access(path, F_OK)` before calling `chflags`
- Rebuild `buf2` to correct filesystem path

**`mac_installer/PostInstall.cpp`:**
- Fix off-by-one in `REPORT_ERROR(i >= RETRY_LIMIT)` (never true inside the loop)
- Return non-zero when security setup fails after all retries
- Add missing newlines to printf calls