### PR TITLE
web: code cleanup; no functional changes

### DIFF
--- a/html/inc/akismet.inc
+++ b/html/inc/akismet.inc
@@ -16,6 +16,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// Akismet is an anti-spam system: https://akismet.com/
+// BOINC lets you use it to prevent spam in forums and profiles.
+// You need to create an Akismet account (there's a free option),
+// and put the key in config.xml:
+// https://github.com/BOINC/boinc/wiki/ProtectionFromSpam#akismet
+//
 function akismet_check($user, $post) {
     $master_url = master_url();
     $config = get_config();

--- a/html/inc/cache.inc
+++ b/html/inc/cache.inc
@@ -32,7 +32,7 @@ function make_cache_dirs() {
         mkdir("../cache", 0770);
         chmod("../cache", 0770);
     }
-    for ($i=0;$i<256;$i++) {
+    for ($i=0; $i<256; $i++) {
         $j=sprintf("%02x",$i);
         if (!@filemtime("../cache/$j")) {
             mkdir("../cache/$j", 0770);
@@ -42,7 +42,9 @@ function make_cache_dirs() {
 }
 
 function get_path($params, $phpfile=null) {
-    if (!@filemtime("../cache/00")) make_cache_dirs();
+    if (!@filemtime("../cache/00")) {
+        make_cache_dirs();
+    }
     if ($phpfile) {
         $z = $phpfile;
     } else {
@@ -51,7 +53,7 @@ function get_path($params, $phpfile=null) {
     }
 
     // add a layer of subdirectories for reducing file lookup time
-    $sz = substr(md5($z."_".urlencode($params)),1,2);
+    $sz = substr(md5($z."_".urlencode($params)), 1, 2);
     $path = "../cache/".$sz."/".$z;
     if ($params) {
         $path = $path."_".urlencode($params);
@@ -60,19 +62,21 @@ function get_path($params, $phpfile=null) {
 }
 
 function disk_usage($dir) {
+    $handle = @opendir($dir);
+    if (!$handle) {
+        return 0;
+    }
     $usage=0;
-    if ($handle=@opendir($dir)) {
-        while ($file=readdir($handle)) {
-            if (($file != ".") && ($file != "..")) {
-                if (@is_dir($dir."/".$file)) {
-                    $usage+=disk_usage($dir."/".$file);
-                } else {
-                    $usage+=@filesize($dir."/".$file);
-                }
+    while ($file = readdir($handle)) {
+        if (($file != ".") && ($file != "..")) {
+            if (@is_dir($dir."/".$file)) {
+                $usage += disk_usage($dir."/".$file);
+            } else {
+                $usage += @filesize($dir."/".$file);
             }
         }
-        @closedir($handle);
     }
+    @closedir($handle);
     return $usage;
 }
 
@@ -81,8 +85,9 @@ function clean_cache($max_age, $dir) {
     if (!chdir($dir)) {
         return;
     }
-    if ($handle=@opendir(".")) {
-        while ($file=readdir($handle)) {
+    $handle = @opendir(".");
+    if ($handle) {
+        while ($file = readdir($handle)) {
             if ($file == ".") continue;
             if ($file == "..") continue;
 
@@ -108,8 +113,12 @@ function clean_cache($max_age, $dir) {
 // check cache size every once in a while, purge if too big
 //
 function cache_check_diskspace(){
-    if ((rand() % CACHE_SIZE_CHECK_FREQ)) return;
-    if (disk_usage("../cache") < MAX_CACHE_USAGE) return;
+    if ((rand() % CACHE_SIZE_CHECK_FREQ)) {
+        return;
+    }
+    if (disk_usage("../cache") < MAX_CACHE_USAGE) {
+        return;
+    }
     $x = max(TEAM_PAGE_TTL, USER_PAGE_TTL, USER_HOST_TTL,
         USER_PROFILE_TTL, TOP_PAGES_TTL, INDEX_PAGE_TTL
     );
@@ -138,11 +147,14 @@ function cache_need_to_regenerate($path, $max_age){
     return $regenerate;
 }
 
-// Returns cached data or false if nothing was found
+// Returns cached data or null if nothing was found
+//
 function get_cached_data($max_age, $params=""){
     global $no_cache;
 
-    if ($no_cache) return false;
+    if ($no_cache) {
+        return null;
+    }
 
     $path = get_path($params);
     if ($max_age) {
@@ -161,14 +173,16 @@ function get_cached_data($max_age, $params=""){
             }
         }
     }
-    return false; //No data was cached, just return
+    return null;
 }
 
 // DEPRECATED
 function start_cache($max_age, $params=""){
     global $no_cache, $caching, $memcache;
 
-    if ($no_cache) return;
+    if ($no_cache) {
+        return;
+    }
     $caching = true;
 
     if ($max_age) {
@@ -184,10 +198,12 @@ function start_cache($max_age, $params=""){
             }
         } else {
             $lastmodified = @filemtime($path);
-            cache_check_diskspace(); //Check free disk space once in a while
+            // Check free disk space once in a while
+            //
+            cache_check_diskspace();
             $regenerate = cache_need_to_regenerate($path, $max_age);
         }
-        //Is the stored version too old, do we need to regenerate it?
+        // Is the stored version too old, do we need to regenerate it?
         if ($regenerate){
             // If cached version is too old (or non-existent)
             // generate the page and write to cache
@@ -230,7 +246,9 @@ function start_cache($max_age, $params=""){
 // DEPRECATED
 function end_cache($max_age,$params=""){
     global $no_cache;
-    if ($no_cache) return;
+    if ($no_cache) {
+        return;
+    }
 
     // for the benefit of hackers
     if (strstr($params, "..")) {

--- a/html/inc/db_conn.inc
+++ b/html/inc/db_conn.inc
@@ -27,7 +27,7 @@ class DbConn {
 
     function init_conn($user, $passwd, $host, $name) {
         $x = explode(":", $host);
-        if (sizeof($x)>1) {
+        if (sizeof($x) > 1) {
             $host = $x[0];
             $port = $x[1];
         } else {
@@ -138,7 +138,7 @@ class DbConn {
     }
 
     function enum($table, $classname, $where_clause=null, $order_clause=null) {
-        return self::enum_fields(
+        return $this->enum_fields(
             $table, $classname, '*', $where_clause, $order_clause
         );
     }

--- a/html/inc/email.inc
+++ b/html/inc/email.inc
@@ -169,7 +169,7 @@ function is_valid_email_sfs($addr) {
     // could also look at 'frequency' and 'lastseen'
     // see https://www.stopforumspam.com/usage
     //
-    if (substr_count($x, '<appears>yes</appears>')) {
+    if ($x && substr_count($x, '<appears>yes</appears>')) {
         error_log("stopforumspam.com rejected email $addr, IP $ip");
         return false;
     }

--- a/html/inc/forum_email.inc
+++ b/html/inc/forum_email.inc
@@ -65,7 +65,7 @@ function mail_report_list($forum, $subject, $body, $must_send=false) {
 function send_moderation_email($forum, $post, $thread, $explanation, $action) {
     $master_url = master_url();
 
-    $moderator=get_logged_in_user();
+    $moderator = get_logged_in_user();
     $body = "";
     $user = BoincUser::lookup_id($post->user);
 

--- a/html/inc/submit.inc
+++ b/html/inc/submit.inc
@@ -152,27 +152,29 @@ function do_http_op($req, $xml, $op) {
         curl_setopt($ch, CURLOPT_TIMEOUT, $rpc_timeout);
     }
 
-// see if we need to send any files
-//
-$nfiles = 0;
-$post = array();
-$post["request"] = $xml;
-$cwd = getcwd();
-if ($op == "submit_batch") {
-    foreach ($req->jobs as $job) {
-        foreach ($job->input_files as $file) {
-            if ($file->mode == "inline") {
-                $path = realpath("$cwd/$file->path");
-                $post["file$nfiles"] = $path;
-                $nfiles++;
+    // see if we need to send any files
+    //
+    $nfiles = 0;
+    $post = array();
+    $post["request"] = $xml;
+    $cwd = getcwd();
+    if ($op == "submit_batch") {
+        foreach ($req->jobs as $job) {
+            foreach ($job->input_files as $file) {
+                if ($file->mode == "inline") {
+                    $path = realpath("$cwd/$file->path");
+                    $post["file$nfiles"] = $path;
+                    $nfiles++;
+                }
             }
         }
     }
-}
-curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
     $reply = curl_exec($ch);
     curl_close($ch);
-    if (!$reply) return array(null, "HTTP error");
+    if (!$reply) {
+        return array(null, "HTTP error");
+    }
     $r = @simplexml_load_string($reply);
     if (!$r) {
         return array(null, "Can't parse reply XML:\n$reply");

--- a/html/inc/team.inc
+++ b/html/inc/team.inc
@@ -213,10 +213,10 @@ function display_team_members($team, $offset, $sort_by) {
     $admins = BoincTeamAdmin::enum("teamid=$team->id");
 
     // there aren't indices to support sorting by credit.
-    // set the following variable to disable sorted output.
+    // set the following variable to 1 to disable sorted output.
     // (though since caching is generally used this shouldn't be needed)
     //
-    $nosort = false;
+    $nosort = 0;
 
     if ($sort_by == "total_credit") {
         $sort_clause = "total_credit desc";
@@ -253,8 +253,11 @@ function display_team_members($team, $offset, $sort_by) {
     $a[] = "";
     row_heading_array($x, $a);
 
-    $cache_args = "teamid=".$team->id."&mosort=".$nosort."&order=".$sort_clause."&limit=".$offset."_".$n;
-    $users = unserialize(get_cached_data(TEAM_PAGE_TTL, $cache_args));
+    $cache_args = "teamid=".$team->id."&nosort=".$nosort."&order=".$sort_clause."&limit=".$offset."_".$n;
+    $users = get_cached_data(TEAM_PAGE_TTL, $cache_args);
+    if ($users) {
+        $users = unserialize($users);
+    }
     if (!$users) {
         if ($nosort) {
             $users = BoincUser::enum("teamid=$team->id limit $offset,$n");

--- a/html/inc/util_basic.inc
+++ b/html/inc/util_basic.inc
@@ -101,6 +101,8 @@ function get_config() {
     return $config;
 }
 
+// TODO: GET RID OF THE FOLLOWING.  Use simplexml
+
 // Look for an element in a line of XML text
 // If it's a single-tag element, and it's present, just return the tag
 //
@@ -117,24 +119,6 @@ function parse_element($xml, $tag) {
         }
     }
     return null;
-}
-
-function parse_next_element($xml, $tag, &$cursor) {
-    $element = null;
-    $closetag = "</" . substr($tag,1);
-    $pos = substr($xml,$cursor);
-    $x = strstr($pos, $tag);
-    if ($x) {
-        if (strstr($tag, "/>")) return $tag;
-        $y = substr($x, strlen($tag));
-        $n = strpos($y, $closetag);
-        if ($n) {
-            $element = substr($y, 0, $n);
-        }
-        $cursor = (strlen($xml) - strlen($x)) + strlen($tag) + strlen($closetag) + strlen($element);
-    }
-    if (!$element) return null;
-    return trim($element);
 }
 
 // return true if XML contains either <tag/> or <tag>1</tag>

--- a/html/inc/web_rpc_api.inc
+++ b/html/inc/web_rpc_api.inc
@@ -72,7 +72,9 @@ function create_account(
     $url = $project_url."/create_account.php?email_addr=".urlencode($email_addr)."&passwd_hash=$passwd_hash&user_name=".urlencode($user_name);
 
     $reply = fetch_url($url);
-    if (!$reply) return array(null, -1, "HTTP error to $url");
+    if (!$reply) {
+        return array(null, -1, "HTTP error to $url");
+    }
 
     $r = @simplexml_load_string($reply);
     if (!$r) {


### PR DESCRIPTION
avoid 1-line if()
avoid assignment in if() clause

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Code cleanup across web PHP files to expand one-line conditionals, remove assignments in if clauses, and improve readability and safety. No behavior change intended.

- **Refactors**
  - Expanded single-line ifs, added braces, removed assignments inside conditions.
  - Clarified comments and formatting; fixed small naming issues (e.g., cache arg `nosort`).
  - Added guards and early returns in cache, HTTP, and email paths to avoid warnings.
  - get_cached_data now returns null instead of false; updated team page caller.
  - Replaced a static call with an instance call in `DbConn::enum` for consistency.

<sup>Written for commit 56e76dd702a71859c32bdddcb9f7bcc0476dc0fa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

