### PR TITLE
web: fix wiki URLs in PHP code.

### DIFF
--- a/html/ops/badge_admin.php
+++ b/html/ops/badge_admin.php
@@ -143,8 +143,8 @@ echo "
     <p>
     Badges are assigned using a PHP script;
     see
-    <a href=https://github.com/BOINC/boinc/wiki/BadgeDoc>
-    https://github.com/BOINC/boinc/wiki/BadgeDoc
+    <a href=https://github.com/BOINC/boinc/wiki/Badges>
+    https://github.com/BOINC/boinc/wiki/Badges
     </a>
     <p>
     Fields marked 'optional' are not used by the default script.

--- a/html/ops/index.php
+++ b/html/ops/index.php
@@ -199,19 +199,23 @@ if ($show_deprecated) {
 }
 
 echo "<h3>Periodic tasks</h3>
-The following scripts should be run as periodic tasks, not via this web page
-(see <a href=\"https://github.com/BOINC/boinc/wiki/ProjectTasks\">https://github.com/BOINC/boinc/wiki/ProjectTasks</a>):
+<p>
+The following scripts should be run as
+<a href=https://github.com/BOINC/boinc/wiki/Periodic-tasks>periodic tasks</a>,
+not via this web page.
 <pre>
     update_forum_activities.php, update_profile_pages.php, update_uotd.php, delete_expired_tokens.php, delete_expired_users_and_hosts.php
 </pre>
 
 <h3>Repair tasks</h3>
+<p>
 The following scripts do one-time repair operations.
 Run them manually on the command line as needed
 (i.e. <tt>php scriptname.php</tt>):
 <pre>forum_repair.php, team_repair.php, repair_validator_problem.php</pre>
 
 <h3>Cleanup tasks</h3>
+<p>
 You can run the following as a periodic task, on the command line,
 or by clicking here:
     <ul>

--- a/html/ops/manage_apps.php
+++ b/html/ops/manage_apps.php
@@ -96,7 +96,7 @@ function show_form($all) {
         "ID",
         "Name and description<br><small>Click for details</small>",
         "Created",
-        "weight<br><a href=https://github.com/BOINC/boinc/wiki/BackendPrograms#feeder><small>details</small></a>",
+        "weight<br><a href=https://github.com/BOINC/boinc/wiki/Daemons#feeder><small>details</small></a>",
         "shmem items",
         "HR type<br><a href=https://github.com/BOINC/boinc/wiki/Homogeneous-Redundancy><small>details</small></a>",
         "Adaptive replication<br><a href=https://github.com/BOINC/boinc/wiki/Adaptive-Replication><small>details</small></a>",

--- a/html/ops/manage_user.php
+++ b/html/ops/manage_user.php
@@ -22,8 +22,7 @@
 // and forum suspension (banishment).   Put this in html/ops,
 // (or could be used by moderators for bans < 24 hrs).
 
-
-// TODO: use DB abstraction layer
+// TODO: use DB abstraction layer, get_str() functions etc.
 
 require_once("../inc/util.inc");
 require_once("../inc/user.inc");
@@ -97,12 +96,6 @@ function handle_suspend($user) {
             $t = $dt>0 ? time()+$dt : 0;
             $q = "UPDATE forum_preferences SET banished_until=$t WHERE userid=$user->id";
             _mysql_query($q);
-
-            // put a timestamp in wiki to trigger re-validation of credentials
-
-            if (function_exists('touch_wiki_user')){
-                touch_wiki_user($user);
-            }
 
             // Send suspension e-mail to user and administrators
 
@@ -204,7 +197,6 @@ function show_manage_user_form($user) {
     echo "</form>\n";
 
     echo "\n\n</td><td valign='TOP'>\n\n";
-
 
     // Suspended posting privileges
 

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -206,7 +206,7 @@ function variant_form($user) {
     ";
     $sb = '<br><small>From your <a href=sandbox.php>file sandbox</a></small>';
     $pc = '<br><small>Specify
-    <a href=https://github.com/BOINC/boinc/wiki/AppPlan>GPU and other host requirements</a>.<br>Leave blank if none.</small>';
+    <a href=https://github.com/BOINC/boinc/wiki/Plan-classes>GPU and other host requirements</a>.<br>Leave blank if none.</small>';
     form_start('buda.php');
     form_input_hidden('app', $app);
     form_input_hidden('action', 'variant_action');

--- a/html/user/cert1.php
+++ b/html/user/cert1.php
@@ -18,7 +18,7 @@
 
 // show certificate for user: signup date, credit, FLOPs
 // Projects can customize this:
-// https://github.com/BOINC/boinc/wiki/WebConfig#certificate-related-constants
+// https://github.com/BOINC/boinc/wiki/Web-configuration-file#certificate-related-constants
 
 require_once("../inc/util.inc");
 require_once("../inc/cert.inc");

--- a/html/user/cert_all.php
+++ b/html/user/cert_all.php
@@ -18,7 +18,7 @@
 
 // show certificate listing join time and credit across all projects
 // Projects can customize this:
-// https://github.com/BOINC/boinc/wiki/WebConfig#certificate-related-constants
+// https://github.com/BOINC/boinc/wiki/Web-configuration-file#certificate-related-constants
 
 require_once("../inc/util.inc");
 require_once("../inc/cert.inc");

--- a/html/user/cert_team.php
+++ b/html/user/cert_team.php
@@ -19,7 +19,7 @@
 // show a web-based certificate for a team,
 // showing the team's creation date and total credit in this project.
 // Projects can customize this:
-// https://github.com/BOINC/boinc/wiki/WebConfig#certificate-related-constants
+// https://github.com/BOINC/boinc/wiki/Web-configuration-file#certificate-related-constants
 
 require_once("../inc/util.inc");
 require_once("../inc/cert.inc");

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -16,8 +16,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// Handler for remote job submission.
-// See https://github.com/BOINC/boinc/wiki/RemoteJobs
+// Handler for remote job submission RPCs.
+// See https://github.com/BOINC/boinc/wiki/Remote-job-submission-RPCs
 
 require_once("../inc/boinc_db.inc");
 require_once("../inc/submit_db.inc");


### PR DESCRIPTION
We've been fixing the filenames of lots of wiki files recently. Need to change them in PDP code too.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken BOINC wiki links across admin and user PHP pages to point to the new page names. Also remove an obsolete wiki sync call and tidy copy in the ops index.

- **Bug Fixes**
  - Updated outdated wiki URLs (Badges, Periodic tasks, Daemons#feeder, Plan classes, Web configuration file, Remote job submission RPCs).
  - Removed obsolete touch_wiki_user call in manage_user.php when suspending users.
  - Minor HTML/copy tweaks in ops/index to clarify periodic and repair tasks.

<sup>Written for commit 150d48557089981bcc97529d79a6a760e2d55048. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

