### PR TITLE
[gdk-pibxuf] update custom vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/add_optional_svg_support.patch
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/add_optional_svg_support.patch
@@ -1,8 +1,8 @@
 diff --git a/gdk-pixbuf/gdk-pixbuf-io.c b/gdk-pixbuf/gdk-pixbuf-io.c
-index e1df5900f..d7018da6e 100644
+index ba6747e11..2c7fa8bce 100644
 --- a/gdk-pixbuf/gdk-pixbuf-io.c
 +++ b/gdk-pixbuf/gdk-pixbuf-io.c
-@@ -592,7 +592,10 @@ gdk_pixbuf_init_modules (const char  *path,
+@@ -594,7 +594,10 @@ gdk_pixbuf_init_modules (const char  *path,
  	g_free (filename);
  	return ret;
  }
@@ -14,7 +14,7 @@ index e1df5900f..d7018da6e 100644
  static void
  gdk_pixbuf_io_init_builtin (void)
  {
-@@ -659,6 +662,10 @@ gdk_pixbuf_io_init_builtin (void)
+@@ -661,6 +664,10 @@ gdk_pixbuf_io_init_builtin (void)
          /* Except the gdip-png loader which normally isn't built at all even */
          load_one_builtin_module (png);
  #endif
@@ -22,13 +22,14 @@ index e1df5900f..d7018da6e 100644
 +        if (_gdk_pixbuf__svg_fill_info && _gdk_pixbuf__svg_fill_vtable)
 +                load_one_builtin_module (svg);
 +#endif
- 
- #undef load_one_builtin_module
- }
-@@ -777,6 +784,15 @@ gdk_pixbuf_load_module_unlocked (GdkPixbufModule *image_module,
+ #ifdef INCLUDE_glycin
+         load_one_builtin_module (avif);
+         load_one_builtin_module (bmp);
+@@ -871,7 +878,15 @@ gdk_pixbuf_load_module_unlocked (GdkPixbufModule *image_module,
  #ifdef INCLUDE_qtif
          try_module (qtif,qtif);
  #endif
+-
 +#ifdef INCLUDE_svg
 +if (fill_info == NULL &&
 +           strcmp (image_module->module_name, "svg") == 0) {
@@ -38,9 +39,9 @@ index e1df5900f..d7018da6e 100644
 +               }
 +       }
 +#endif
- 
  #undef try_module
          
+         if (fill_vtable) {
 diff --git a/meson.build b/meson.build
 index 3eb3fcc15..b11331239 100644
 --- a/meson.build

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 ae9fcc9b4e8fd10a4c9bf34c3a755205dae7bbfe13fbc93ec4e63323dad10cc862df6a9e2e2e63c84ffa01c5e120a3be06ac9fad2a7c5e58d3dc6ba14d1766e8
+    SHA512 45ad815dda5d7b86fafe4a14300a676130f1c404299989616e41fa84e872516304bc6c3ebee9e1153bce01245333b1f8dfedee4bcde27a323e27d7e70fcb597f
 )
 
 vcpkg_extract_source_archive(
@@ -61,6 +61,10 @@ if(VCPKG_TARGET_IS_LINUX OR VCPKG_TARGET_IS_OSX OR VCPKG_TARGET_IS_WINDOWS)
     list(APPEND OPTIONS -Drelocatable=true)
 endif()
 
+if(VCPKG_TARGET_IS_ANDROID AND VCPKG_DETECTED_CMAKE_SYSTEM_VERSION VERSION_LESS "31")
+    list(APPEND OPTIONS -Dandroid=disabled)
+endif()
+
 if(VCPKG_TARGET_IS_WINDOWS)
     #list(APPEND OPTIONS -Dnative_windows_loaders=true) # Use Windows system components to handle BMP, EMF, GIF, ICO, JPEG, TIFF and WMF images, overriding jpeg and tiff.  To build this into gdk-pixbuf, pass in windows" with the other loaders to build in or use "all" with the builtin_loaders option
 endif()
@@ -68,10 +72,10 @@ vcpkg_configure_meson(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         -Dman=false                 # Whether to generate man pages (requires xlstproc)
-        -Dgtk_doc=false             # Whether to generate the API reference (requires GTK-Doc)
-        -Ddocs=false
+        -Ddocumentation=false       # Whether to generate the API reference (requires GTK-Doc)
         -Dtests=false
         -Dinstalled_tests=false
+        -Dglycin=disabled
         -Dgio_sniffing=false        # Perform file type detection using GIO (Unused on MacOS and Windows)
         -Dbuiltin_loaders=all       # since it is unclear where loadable plugins should be located;
                                     # Comma-separated list of loaders to build into gdk-pixbuf, or "none", or "all" to build all buildable loaders into gdk-pixbuf

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdk-pixbuf",
-  "version": "2.42.12",
-  "port-version": 6,
+  "version": "2.44.6",
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the custom `gdk-pixbuf` `vcpkg` port to 2.44.6 with updated Meson flags and improved Android compatibility on API < 31. Keeps optional SVG loader working with 2.44.x.

- **Dependencies**
  - Bumped `gdk-pixbuf` from 2.42.12 to 2.44.6 and updated SHA512; refreshed `add_optional_svg_support.patch` to align with 2.44.6 and load built-in SVG when enabled.
  - Replaced `-Dgtk_doc=false`/`-Ddocs=false` with `-Ddocumentation=false`; added `-Dglycin=disabled`.
  - For Android API < 31, pass `-Dandroid=disabled` to avoid incompatible builds.

<sup>Written for commit 3f145fdb0725122a32834db6023230b48247ac66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

