### PR TITLE
docker_wrapper: run Docker commands with 2>&1 so we get stderr

### DIFF
--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -799,7 +799,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
 //
 int DOCKER_CONN::parse_image_name(string line, string &name) {
     char buf[1024];
-    strcpy(buf, line.c_str());
+    safe_strcpy(buf, line.c_str());
     if (strstr(buf, "REPOSITORY")) return -1;
     if (strstr(buf, "localhost/") != buf) return -1;
     char *p = buf + strlen("localhost/");
@@ -822,7 +822,7 @@ int DOCKER_CONN::parse_image_name(string line, string &name) {
 
 int DOCKER_CONN::parse_container_name(string line, string &name) {
     char buf[1024];
-    strcpy(buf, line.c_str());
+    safe_strcpy(buf, line.c_str());
     if (strstr(buf, "CONTAINER")) return -1;
     char *p = strrchr(buf, ' ');
     if (!p) return -1;

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -742,7 +742,7 @@ int DOCKER_CONN::init(DOCKER_TYPE docker_type, bool _verbose) {
 }
 #endif
 
-// issue a Docker command and return its output
+// issue a Docker command and return its output (stdout + stderr)
 // as a vector of lines (\n-terminated)
 //
 int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
@@ -758,7 +758,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     // In the Win case we read the output from a pipe.
     // Append 'EOM' to the output so we know when we've reached the end
 
-    snprintf(buf, sizeof(buf), "%s %s; echo EOM\n", cli_prog, cmd);
+    snprintf(buf, sizeof(buf), "%s %s 2>&1; echo EOM\n", cli_prog, cmd);
     write_to_pipe(ctl_wc.in_write, buf);
     retval = read_from_pipe(
         ctl_wc.out_read, ctl_wc.proc_handle, output, CMD_TIMEOUT, "EOM"
@@ -770,7 +770,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     out = split(output, '\n');
 #else
     snprintf(buf, sizeof(buf),
-        "%s %s",
+        "%s %s 2>&1",
         cli_prog, cmd
     );
     retval = run_command(buf, out);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Capture stderr from Docker commands so callers receive both stdout and stderr in the returned output. Also switch to safe_strcpy() in Docker image/container name parsing to prevent buffer overflows during cleanup.

<sup>Written for commit 261d1b6e84d95bcf14dd80bbec11c08615a401d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

