### PR TITLE
Mac: in command-line installs don't ask about setting screensaver

### DIFF
--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -24,7 +24,8 @@
 //  [1] allow non-administrative users to run the BOINC Manager
 //      (asked only if this Mac has any non-administrative users)
 //  [2] set BOINC as the screensaver for all users who can run BOINC
-//      (asked only if BOINC screensaver is not already set for them)
+//      (only for MacOS < 14.0 Sonoma and only if BOINC screensaver is
+//      not already set for them.)
 //
 // The installer can also be run from the command line.  This is useful
 //  for installation on remote Macs.  However, there is no way to respond
@@ -32,15 +33,15 @@
 //
 // Apple's command-line installer sets the following environment variable:
 //     COMMAND_LINE_INSTALL=1
-// The postinstall script, postupgrade script, and this Postinstall.app
-//   detect this environment variable and do the following:
-//  * Redirect the Postinstall.app log output to a file
-//      /tmp/BOINCInstallLog.txt
+// The postinstall script, postupgrade script, this Postinstall.app and
+// BOINC_Finish_Install.app detect this environment variable and do the
+// following:
 //  * Suppress the 2 dialogs
 //  * test for the existence of a file /tmp/nonadminusersok.txt; if the
 //     file exists, allow non-administrative users to run BOINC Manager
 //  * test for the existence of a file /tmp/setboincsaver.txt; if the
 //     file exists, set BOINC as the screensaver for all BOINC users.
+//     (available only for MacOS < 14.0 Sonoma.)
 //
 // The BOINC installer package to be used for command line installs can
 // be found embedded inside the GUI BOINC Installer application at:
@@ -219,6 +220,8 @@ int main(int argc, char *argv[])
     }
 
     // getlogin() gives unreliable results under OS 10.6.2, so use environment
+    // Note: command-line installer must be run as root, so loginName will
+    // always be root for command-line installs
     strncpy(loginName, getenv("USER"), sizeof(loginName)-1);
     if (loginName[0] == '\0') {
         ShowMessage(false, (char *)_("Could not get user login name"));
@@ -786,6 +789,10 @@ Boolean IsRestartNeeded() {
     FILE *restartNeededFile;
     int value;
 
+    if (compareOSVersionTo(10, 9) >= 0) {
+        return false;
+    }
+
     snprintf(s, sizeof(s), "/tmp/%s/BOINC_restart_flag", tempDirName);
     restartNeededFile = fopen(s, "r");
     if (restartNeededFile) {
@@ -1020,12 +1027,15 @@ Boolean SetLoginItemLaunchAgent(long brandID, long oldBrandID, Boolean deleteLog
 #if COPY_FINISH_INSTALL_TO_USER_DIRECTORY
     fprintf(f, "\t\t<string>/Users/%s/Library/Application Support/BOINC/%s_Finish_Install.app/Contents/MacOS/%s_Finish_Install</string>\n", pw->pw_name, brandName[brandID], brandName[brandID]);
 #else
-    // For a reason I do't understand, setting the screensaver under MacOS 26
+    // For a reason I don't understand, setting the screensaver under MacOS 26
     // works if we use the BOINC_Finish_Install in the BOINC Data directory
     // but not one at /Users/%s/Library/Application Support/BOINC/ so we no
     // longer put one in the usr's directory tree.
     fprintf(f, "\t\t<string>/Library/Application Support/BOINC Data/%s_Finish_Install.app/Contents/MacOS/%s_Finish_Install</string>\n", brandName[brandID], brandName[brandID]);
 #endif
+    if (gCommandLineInstall) {
+        fprintf(f, "\t\t<string>-c</string>\n");
+    }
     if (deleteLogInItem) {
         fprintf(f, "\t\t<string>-d</string>\n");
         fprintf(f, "\t\t<string>%d</string>\n", (int)oldBrandID);
@@ -1558,17 +1568,20 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
                 currentUserCanRunBOINC = true;
             }
 
-            err = GetCurrentScreenSaverSelection(pw, s, sizeof(s) -1);
-            if (err == noErr) {
-                if (strcmp(s, saverName[brandID])) {
-                    saverAlreadySetForAll = false;
+            if (compareOSVersionTo(14, 0) < 0) {
+                // As of MacOS 14.0 Sonoma, this code no longer
+                // will detect the current screensaver,
+                err = GetCurrentScreenSaverSelection(pw, s, sizeof(s) -1);
+                if (err == noErr) {
+                    if (strcmp(s, saverName[brandID])) {
+                        saverAlreadySetForAll = false;
+                    }
                 }
+                printf("[1] Current Screensaver Selection for user %s is: \"%s\"\n", pw->pw_name, s);
+                fflush(stdout);
             }
-            printf("[1] Current Screensaver Selection for user %s is: \"%s\"\n", pw->pw_name, s);
-            fflush(stdout);
         }       // End if (isGroupMember)
     }           // End for (userIndex=0; userIndex< human_user_names.size(); ++userIndex)
-
     ResynchDSSystem();
 
     if (allNonAdminUsersAreSet) {
@@ -1726,6 +1739,8 @@ OSErr UpdateAllVisibleUsers(long brandID, long oldBrandID)
         // Set login item for this user
         bool useOSASript = false;
 
+        // Note: command-line installer must be run as root, so
+        // loginName will be root if this is a commmand-line install
         if ((compareOSVersionTo(10, 13) < 0)
             || (strcmp(loginName, human_user_name) == 0)
                 || (strcmp(loginName, pw->pw_name) == 0)

--- a/mac_installer/finish_install.cpp
+++ b/mac_installer/finish_install.cpp
@@ -88,6 +88,7 @@ int main(int argc, const char * argv[]) {
     bool                    calledFromInstaller = false;
     bool                    createdByUninstaller = false;
     bool                    calledFromManager = false;
+    bool                    commandLineInstall = false;
 
     // Wait until we are the active login (in case of fast user switching)
     userName = getenv("USER");
@@ -114,7 +115,9 @@ int main(int argc, const char * argv[]) {
         } else if (strcmp(argv[i], "-u") == 0) {
             isUninstall = true;
             createdByUninstaller = true;
-        }
+        } else if (strcmp(argv[i], "-c") == 0) {
+            commandLineInstall = true;
+       }
     }   // end for (i=i; i<argc; i+=2)
 
     if (isUninstall) {
@@ -143,8 +146,10 @@ int main(int argc, const char * argv[]) {
         if (!success) {
         }
         if (compareOSVersionTo(26, 0) >= 0) {
-            GetAndLoadPreferredLanguages();
-            MaybeSetScreenSaver(iBrandId);
+            if (! commandLineInstall){
+                GetAndLoadPreferredLanguages();
+                MaybeSetScreenSaver(iBrandId);
+            }
         }
 
         if (compareOSVersionTo(10, 13) >= 0) {
@@ -362,8 +367,8 @@ static Boolean IsUserActive(const char *userName){
 
 
 // It would be nice to check whether our screen saver is already set for
-// this user so we can ask wethr to set it only if necessary, but that
-// triggrs a scary warning asking for permission to let System Events
+// this user so we can ask whether to set it only if necessary, but that
+// triggers a scary warning asking for permission to let System Events
 // administer the Mac, so we don't. (If the user answers yes to setting
 // the screensaver, then the code which sets the screensaver will show
 // that warning, but this seems less scary than having it pop up for no
@@ -372,6 +377,22 @@ void MaybeSetScreenSaver(int brandId){
     char                buf[MAXPATHLEN];
     char                mySaverName[1024];
 
+// The installer can also be run from the command line.  This is useful
+//  for installation on remote Macs.  However, there is no way to respond
+//  to dialogs during a command-line install.
+//
+// Apple's command-line installer sets the following environment variable:
+//     COMMAND_LINE_INSTALL=1
+// The postinstall script, postupgrade script, Postinstall.app and
+// this BOINC_Finish_Install.app detect this environment variable and do
+// the following:
+//  * Suppress the 2 dialogs
+//  * test for the existence of a file /tmp/nonadminusersok.txt; if the
+//     file exists, allow non-administrative users to run BOINC Manager
+//  * test for the existence of a file /tmp/setboincsaver.txt; if the
+//     file exists, set BOINC as the screensaver for all BOINC users.
+//     (available only for MacOS < 14.0 Sonoma.)
+//
     if ((ShowMessage(true,
         (char *)_("Do you want to set %s as your screensaver?"),
                     brandName[brandId], brandName[brandId])) == false) {


### PR DESCRIPTION
The BOINC installer for the Mac is normally interactive, asking the user about options including whether to allow non-administrative users to manage BOINC and whether to set BOINC as the user's screensaver.

Command-line installs are intended primarily for situations where the operator is not sitting at the target computer, such as deploying BOINC on multiple computers in a school computer lab. It might also be used for alternate installation methods, such as homebrew. In these cases, interactive  operation is not desirable.

PR #6460 added a dialog "Do you wish to set BOINC as your screensaver?" to the BOINC installer for Macintosh but did not include code to suppress that dialog for command-line installs. This PR fixes that.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Mac command-line installs fully non‑interactive by suppressing the screensaver prompt and signaling finish-install with `-c`. Screensaver detection/setting now only runs on macOS < 14 (Sonoma); GUI installs are unchanged.

- **Bug Fixes**
  - Detect `COMMAND_LINE_INSTALL=1` in Postinstall and `BOINC_Finish_Install` to skip the "Set BOINC as your screensaver?" dialog.
  - Pass `-c` to the finish-install LaunchAgent during command-line installs to ensure no prompts.
  - Restrict screensaver checks and setting to macOS versions earlier than 14.

<sup>Written for commit 6f4229bfbe35b3bdf3e3e4f690af76279aca4dea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

