### PR TITLE
client: show GPU flops as TFLOPS/GFLOPS/MFLOPS depending on value

### DIFF
--- a/client/gpu_opencl.cpp
+++ b/client/gpu_opencl.cpp
@@ -741,15 +741,37 @@ void COPROCS::get_opencl(
                 // TODO: is there a better way to estimate peak_flops?
                 //
                 prop.peak_flops = 0;
-                if (prop.max_compute_units) {
-                    double freq = ((double)prop.max_clock_frequency) * MEGA;
-                    prop.peak_flops = ((double)prop.max_compute_units) * freq;
+
+                double freq;
+                if (prop.max_clock_frequency == 1) {
+                    // Adreno reports 1MHz, which is not correct.
+                    // Actual rate could be 155 MHz to 1.5 GHz;
+                    // split the difference.
+                    freq = 1e9;
+                } else {
+                    freq = ((double)prop.max_clock_frequency) * 1e6;
                 }
+
+                // OpenCL doesn't tell us this critical parameter;
+                // it varies between manufacturer and model.
+                // For recent Intel GPUs it's 8; we'll use this as a default
+                //
+                int alus_per_compute_unit = 8;
+
+                // other manufacturers
+                //
+                if (strcasestr(prop.vendor, "QUALCOMM")) {
+                    // can be 32 to 256; most are 128
+                    alus_per_compute_unit = 128;
+                }
+
+                prop.peak_flops = freq * prop.max_compute_units * alus_per_compute_unit;
                 if (prop.peak_flops <= 0 || prop.peak_flops > GPU_MAX_PEAK_FLOPS) {
                     char buf2[256];
                     snprintf(buf2, sizeof(buf2),
-                        "OpenCL generic: bad peak FLOPS; Max units %u, max freq %u MHz",
-                        prop.max_compute_units, prop.max_clock_frequency
+                        "OpenCL generic: bad peak FLOPS; Max units %u, max freq %u MHz ALUs per CU %d",
+                        prop.max_compute_units, prop.max_clock_frequency,
+                        alus_per_compute_unit
                     );
                     gpu_warning(warnings, buf2);
                     prop.peak_flops = GPU_DEFAULT_PEAK_FLOPS;

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -2312,7 +2312,7 @@ bool get_idle_time_from_daemon(long &idle_time) {
             close(fd);
             return false;
         }
-        if (st.st_size < 2*sizeof(int64_t)) {
+        if ((size_t)st.st_size < 2*sizeof(int64_t)) {
             close(fd);
             return false;
         }

--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -363,9 +363,10 @@ void COPROC_NVIDIA::description(char* buf, int buflen) {
         safe_strcpy(cuda_vers, "unknown");
     }
     snprintf(buf, buflen,
-        "%s (driver version %s, CUDA version %s, compute capability %d.%d, %.2fGB, %.2fGB available, %.0f GFLOPS peak)",
+        "%s (driver version %s, CUDA version %s, compute capability %d.%d, %.2fGB, %.2fGB available, %s peak)",
         prop.name, vers, cuda_vers, prop.major, prop.minor,
-        prop.totalGlobalMem/GIGA, available_ram/GIGA, peak_flops/1e9
+        prop.totalGlobalMem/GIGA, available_ram/GIGA,
+        flops_to_string(peak_flops).c_str()
     );
 }
 
@@ -879,9 +880,9 @@ int COPROC_ATI::parse(XML_PARSER& xp) {
 
 void COPROC_ATI::description(char* buf, int buflen) {
     snprintf(buf, buflen,
-        "%s (CAL version %s, %.2fGB, %.2fGB available, %.0f GFLOPS peak)",
+        "%s (CAL version %s, %.2fGB, %.2fGB available, %s peak)",
         name, version, attribs.localRAM/1024.,
-        available_ram/GIGA, peak_flops/1.e9
+        available_ram/GIGA, flops_to_string(peak_flops).c_str()
     );
 }
 

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -126,7 +126,7 @@ void APP_VERSION::print() {
         printf("   coprocessor type: %s\n", proc_type_name(gpu_type));
         printf("   coprocessor usage: %.3f\n", gpu_usage);
     }
-    printf("   estimated GFLOPS: %.2f\n", flops/1e9);
+    printf("   estimated speed: %s\n", flops_to_string(flops).c_str());
     printf("   filename: %s\n", exec_filename);
 }
 

--- a/lib/opencl_boinc.cpp
+++ b/lib/opencl_boinc.cpp
@@ -263,10 +263,11 @@ void OPENCL_DEVICE_PROP::description(char* buf, int buflen, const char* type) {
     n = (int)strlen(s1) - 1;
     if ((n > 0) && (s1[n] == ' ')) s1[n] = '\0';
     snprintf(s2, sizeof(s2),
-        "%.64s (driver version %.64s, device version %.64s, %.2fGB, %.2fGB available, %.0f GFLOPS peak)",
+        "%.64s (driver version %.64s, device version %.64s, %.2fGB, %.2fGB available, %s peak)",
         name, opencl_driver_version,
         s1, (double)global_mem_size/GIGA,
-        opencl_available_ram/GIGA, peak_flops/1.e9
+        opencl_available_ram/GIGA,
+        flops_to_string(peak_flops).c_str()
     );
 
     switch(is_used) {

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -196,9 +196,9 @@ void secs_to_hmsf(double secs, char* buf) {
 //
 string flops_to_string(double flops) {
     char buf[256];
-    if (flops > 1e12) {
+    if (flops >= 1e12) {
         snprintf(buf, 256, "%0.2f TFLOPS", flops/1e12);
-    } else if (flops > 1e9) {
+    } else if (flops >= 1e9) {
         snprintf(buf, 256, "%0.2f GFLOPS", flops/1e9);
     } else {
         snprintf(buf, 256, "%0.2f MFLOPS", flops/1e6);

--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -192,6 +192,20 @@ void secs_to_hmsf(double secs, char* buf) {
     sprintf(buf, "%uh%02um%02us%02u", h, m, s, f);
 }
 
+// return e.g. '12.23 GFLOPS'
+//
+string flops_to_string(double flops) {
+    char buf[256];
+    if (flops > 1e12) {
+        snprintf(buf, 256, "%0.2f TFLOPS", flops/1e12);
+    } else if (flops > 1e9) {
+        snprintf(buf, 256, "%0.2f GFLOPS", flops/1e9);
+    } else {
+        snprintf(buf, 256, "%0.2f MFLOPS", flops/1e6);
+    }
+    return string(buf);
+}
+
 // Convert nbytes into a string.  If total_bytes is non-zero,
 // convert the two into a fractional display (i.e. 4/16 KB)
 //

--- a/lib/str_util.h
+++ b/lib/str_util.h
@@ -28,6 +28,7 @@
 extern void strcpy_overlap(char*, const char*);
 extern int ndays_to_string(double x, int smallest_timescale, char *buf);
 extern void nbytes_to_string(double nbytes, double total_bytes, char* str, int len);
+extern std::string flops_to_string(double flops);
 extern int parse_command_line(char*, char**);
 extern void strip_whitespace(char *str);
 extern void strip_whitespace(std::string&);


### PR DESCRIPTION
Fixes #6989

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show GPU performance using scaled units (MFLOPS/GFLOPS/TFLOPS) and improve OpenCL peak FLOPS estimation for more accurate values. Applies across device descriptions and CLI output.

- **New Features**
  - Added flops_to_string(double) to format FLOPS as MFLOPS/GFLOPS/TFLOPS (2 decimals).
  - Applied to NVIDIA, AMD/ATI, and OpenCL device descriptions and CLI "estimated speed".

- **Bug Fixes**
  - Fixed generic OpenCL peak_flops calculation: handle 1 MHz Adreno reports by using 1 GHz, and compute clock * CUs * ALUs/CU (default 8; QUALCOMM/Adreno 128) to avoid bogus values; also show 1.00 TFLOPS instead of 1000.00 GFLOPS.
  - Cast file size to size_t in idle-time check to avoid incorrect comparisons on some platforms.

<sup>Written for commit 7ce1f5e796904ed3a5e6264b58d9bd38a1c57dcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

