### PR TITLE
fix ardeno flops estimate

### DIFF
--- a/client/gpu_opencl.cpp
+++ b/client/gpu_opencl.cpp
@@ -109,6 +109,11 @@ static bool is_intel(char* vendor) {
     return false;
 }
 
+static bool is_ardeno(char* vendor) {
+    if (strcasestr(vendor, "QUALCOMM")) return true;
+    return false;
+}
+
 #ifdef __APPLE__
 static bool is_apple(char* vendor) {
     if (strcasestr(vendor, "apple")) return true;
@@ -742,8 +747,17 @@ void COPROCS::get_opencl(
                 //
                 prop.peak_flops = 0;
                 if (prop.max_compute_units) {
-                    double freq = ((double)prop.max_clock_frequency) * MEGA;
-                    prop.peak_flops = ((double)prop.max_compute_units) * freq;
+                    double freq = ((double)prop.max_clock_frequency);
+                    if (is_ardeno(prop.vendor)) {
+                        if (freq == 1.0) {
+                            freq = 1000.0; // Estimate 1 GHz if driver returns 1 Mhz
+                        }
+                    }
+                    // may be inaccurate
+                    int simd_width = 128; // 128-bit vector unit
+                    int simd_per_compute_unit = 4; // 4 × FP32 ops per cycle
+
+                    prop.peak_flops = ((double)prop.max_compute_units) * freq * simd_width * simd_per_compute_unit * 1e6;
                 }
                 if (prop.peak_flops <= 0 || prop.peak_flops > GPU_MAX_PEAK_FLOPS) {
                     char buf2[256];


### PR DESCRIPTION
Fixes #6989

**Description of the Change**
before
OpenCL: QUALCOMM Adreno(TM) 750 0: QUALCOMM Adreno(TM) 750 (driver version OpenCL 3.0 QUALCOMM build: 0762.39 Compiler E031.45.02.26, device version OpenCL 3.0 Adreno(TM) 750, 5.41GB, 5.41GB available, 0 GFLOPS peak)

after
OpenCL: QUALCOMM Adreno(TM) 750 0: QUALCOMM Adreno(TM) 750 (driver version OpenCL 3.0 QUALCOMM build: 0762.39 Compiler E031.45.02.26, device version OpenCL 3.0 Adreno(TM) 750, 5.41GB, 5.41GB available, 3072 GFLOPS peak)

**Alternate Designs**
From the details exposed through OpenCL, there doesn’t seem to be a 100% reliable method for calculating FLOPs without relying on a predefined mapping of known hardware specifications.
https://en.wikipedia.org/wiki/Adreno
or actually benchmarking the GPU

**Release Notes**
"N/A"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes peak FLOPS reporting for Qualcomm Adreno GPUs in OpenCL, so devices like the Adreno 750 now show a realistic value (~3072 GFLOPS instead of 0).

- **Bug Fixes**
  - Detect `QUALCOMM` vendor and apply Adreno-specific logic: treat a 1 MHz clock as 1000 MHz and compute peak FLOPS from compute units, clock, and SIMD width (128 × 4 FP32 ops).
  - OpenCL device info now reports the corrected estimate (e.g., Adreno 750: 0 → ~3072 GFLOPS).

<sup>Written for commit adaeafed2270bcd92df8a8625ac421cccd470b7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

