### PR TITLE
client: fix bug: no work fetch if reset project with max_concurrent

### DIFF
--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -74,7 +74,7 @@ void RSC_PROJECT_WORK_FETCH::rr_init(PROJECT *p) {
     last_mc_limit_reltime = 0;
     if (p->app_configs.project_has_mc) {
         // compute x = max usage over this resource over P's app versions
-        double x = 0;
+        double x = 1;   // in case there are no app versions
         for (APP_VERSION* avp: gstate.app_versions) {
             if (avp->project != p) continue;
             if (rsc_type && (avp->resource_usage.rsc_type == rsc_type)) {


### PR DESCRIPTION
There was (perhaps unnecessary) logic for finding the max # of instances of a given resource that job of a given project could use. It did this by looking at the project's app versions. But if there are no app versions this gave zero.
Fix: if no app versions, use one.

Fixes #6976

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a client bug where no work is fetched after resetting a project with `max_concurrent`. If a project has no app versions, we now default the max resource instances to 1 instead of 0 so work fetch continues.

<sup>Written for commit c8d20aecdf8cb8a33e83f641e65bf52b879502ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

