### PR TITLE
web: give page_head_select2() same options as page_head()

### DIFF
--- a/html/inc/profile.inc
+++ b/html/inc/profile.inc
@@ -222,7 +222,7 @@ function show_profile($user, $logged_in_user, $screen_mode = false) {
 
     // If screening is enabled, only show picture in certain situations
     //
-    $show_picture = $profile->has_picture;
+    $show_picture = file_exists(profile_image_path($user->id));
     if (profile_screening()) {
         if (!$screen_mode && !$can_edit && $profile->verification!=1) {
             $show_picture = false;

--- a/html/inc/uotd.inc
+++ b/html/inc/uotd.inc
@@ -26,7 +26,7 @@ if (!defined('UOTD_THRESHOLD')) {
 }
 
 function uotd_thumbnail($profile, $user) {
-    if ($profile->has_picture) {
+    if (file_exists(profile_thumb_path($user->id))) {
         return "<a href=\"".url_base()."view_profile.php?userid=$user->id\"><img border=0 vspace=4 hspace=8 align=left src=\"".profile_thumb_url($user->id)."\" alt=\"".tra("User profile")."\"></a>";
     } else {
         return "";

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -240,8 +240,8 @@ $is_login_page = false;
 // then calls project_banner() (in html/project/project.inc)
 // to output whatever you want at the top of your web pages.
 //
-// Page_head() is overridable so that projects that want to integrate BOINC
-// with an existing web framework can more easily do so.
+// page_head() is overridable so that you can integrate BOINC
+// with an existing web framework.
 // To do so, define page_head() in html/project/project.inc
 //
 if (!function_exists("page_head")){
@@ -257,7 +257,7 @@ function page_head(
         // if set, include schedulers.txt.
         // also pass to project_banner() in case you want a different
         // header for your main page.
-    $url_prefix="",
+    $url_prefix='',
         // prepend this to links.
         // Use for web pages not in the top directory
     $head_extra=null


### PR DESCRIPTION
Also: make sure profile pictures exist; avoid broken images

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned `page_head_select2()` options with `page_head()` for consistent header rendering and overrides. Added file checks for profile photos and thumbnails to prevent broken images.

- **Bug Fixes**
  - Only show profile images if the files exist (`profile_image_path()`, `profile_thumb_path()`), avoiding broken `<img>` tags.

- **Refactors**
  - Matched `page_head_select2()` options to `page_head()`; clarified comments and standardized the `$url_prefix` default.

<sup>Written for commit 9baec8718fdbe746dcf31510f497583187ac1a99. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

