### PR TITLE
web: fix outdated wiki links

### DIFF
--- a/html/user/download_software.php
+++ b/html/user/download_software.php
@@ -169,7 +169,7 @@ function direct_to_boinc() {
                 to connect BOINC to your %1 account.
                 See <a href=%2>detailed instructions</a>.",
                 PROJECT,
-                'https://boinc.berkeley.edu/wiki/Account_managers'
+                'https://github.com/BOINC/boinc/wiki/Account_managers'
             )
         );
     } else {

--- a/html/user/welcome.php
+++ b/html/user/welcome.php
@@ -25,7 +25,7 @@ echo tra("
     If not, %2get help here%3.
     ",
     "<img src=https://boinc.berkeley.edu/logo/boinc32.bmp>",
-    "<a href=https://boinc.berkeley.edu/wiki/BOINC_Help>",
+    '<a href=https://github.com/BOINC/boinc/wiki/BOINC-Help>',
     "</a>"
 );
 
@@ -50,7 +50,7 @@ echo sprintf('
     tra("You can monitor what BOINC is doing, and control it, using the BOINC Manager.
         Open this by double-clicking on the BOINC icon.
         Details are %1here%2.",
-        "<a href=https://boinc.berkeley.edu/wiki/BOINC_Manager>",
+        '<a href=https://github.com/BOINC/boinc/wiki/BOINC_Manager>',
         "</a>"
     )
 );
@@ -94,7 +94,7 @@ echo sprintf('
         It will process jobs for all attached projects.
         %2Learn about how to do this%3.",
         PROJECT,
-        "<a href=https://boinc.berkeley.edu/wiki/Choosing_and_joining_projects>",
+        '<a href=https://github.com/BOINC/boinc/wiki/Choosing-and-joining-projects>',
         "</a>"
     )
 );


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated user-facing help links to the BOINC GitHub Wiki to replace outdated `boinc.berkeley.edu/wiki` URLs. This fixes broken links on the download and welcome pages.

- **Bug Fixes**
  - Replaced `boinc.berkeley.edu/wiki` with `github.com/BOINC/boinc/wiki` in `download_software.php` and `welcome.php`.
  - Updated pages: Account managers, BOINC Help, BOINC Manager, Choosing and joining projects.

<sup>Written for commit 563234bdf03f52f8e5a62ca219846534b9ae8450. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

