### PR TITLE
support cross-compiling for windows_arm64

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -35,11 +35,17 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.type }}-build
+    name: ${{ matrix.type }}-${{ matrix.arch }}-build
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        arch: [x86_64, aarch64]
         type: [libs-mingw, apps-mingw-vcpkg, libs-mingw-cmake]
+        exclude:
+          - arch: aarch64
+            type: apps-mingw-vcpkg
+          - arch: aarch64
+            type: libs-mingw-cmake
       fail-fast: false
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -57,11 +63,29 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y mingw-w64 mingw-w64-tools mingw-w64-x86-64-dev mingw-w64-i686-dev tar curl zip unzip p7zip-full
+          sudo apt-get install -y tar curl zip unzip p7zip-full
 
-      - name: Make libs with mingw
-        if: success() && matrix.type == 'libs-mingw'
+      - name: Install x86_64 mingw toolchain
+        if: success() && matrix.arch == 'x86_64'
+        run: |
+          sudo apt-get install -y mingw-w64 mingw-w64-tools mingw-w64-x86-64-dev mingw-w64-i686-dev
+
+      - name: Install aarch64 llvm-mingw toolchain
+        if: success() && matrix.arch == 'aarch64'
+        run: |
+          wget -q https://github.com/mstorsjo/llvm-mingw/releases/download/20260421/llvm-mingw-20260421-msvcrt-ubuntu-22.04-x86_64.tar.xz
+          echo "18488138efd8d621930fa85c86c3e3eb9967c0bfa253e1f6f73c5212f7180f31 llvm-mingw-20260421-msvcrt-ubuntu-22.04-x86_64.tar.xz" | sha256sum -c -
+          tar -Jxf llvm-mingw-20260421-msvcrt-ubuntu-22.04-x86_64.tar.xz
+          echo "$GITHUB_WORKSPACE/llvm-mingw-20260421-msvcrt-ubuntu-22.04-x86_64/bin" >> $GITHUB_PATH
+
+      - name: Build libs (x86_64)
+        if: matrix.type == 'libs-mingw' && matrix.arch == 'x86_64'
         run: cd lib && MINGW=x86_64-w64-mingw32 make -f Makefile.mingw
+
+      - name: Build libs (aarch64)
+        if: success() && matrix.type == 'libs-mingw' && matrix.arch == 'aarch64'
+        run: cd lib && MINGW=aarch64-w64-mingw32 make -f Makefile.mingw
+
       - name: Install Powershell for vcpkg
         if: success() && matrix.type == 'apps-mingw-vcpkg'
         run: |
@@ -101,7 +125,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: mingw_logs_${{ matrix.type }}_${{ github.event.pull_request.head.sha }}
+          name: mingw_logs_${{ matrix.type }}_${{ matrix.arch }}_${{ github.event.pull_request.head.sha }}
           path: deploy/logs.7z
 
       - name: Prepare artifacts for deploy
@@ -112,5 +136,5 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         if: ${{! contains(matrix.type, 'libs')}}
         with:
-          name: win_${{ matrix.type }}_${{ github.event.pull_request.head.sha }}
+          name: win_${{ matrix.type }}_${{ matrix.arch }}_${{ github.event.pull_request.head.sha }}
           path: deploy/win_${{ matrix.type }}.7z

--- a/configure.ac
+++ b/configure.ac
@@ -1215,6 +1215,7 @@ AM_CONDITIONAL(OS_LINUX, [echo $host_os | grep '^linux' > /dev/null])
 AM_CONDITIONAL(OS_FREEBSD, [echo $host_os | grep '^freebsd' > /dev/null])
 dnl In case anyone wants to try building the windows code using mingw!
 AM_CONDITIONAL(OS_WIN32, [echo $host_os | grep -E '^mingw|^winnt' > /dev/null])
+AM_CONDITIONAL(OS_WINARM64, [echo $host_os | grep -E '^mingw|^winnt' > /dev/null && echo $host_cpu | grep -E '^aarch64' > /dev/null])
 AM_CONDITIONAL(OS_WIN32_MINGW, [echo $host_os | grep '^mingw' > /dev/null])
 dnl or OS2
 AM_CONDITIONAL(OS_OS2, [echo $host_os | grep '^os2' > /dev/null])

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -80,10 +80,13 @@ win_sources = \
     idlemon_win.cpp \
     procinfo_win.cpp \
     run_app_windows.cpp \
-    stackwalker_win.cpp \
     win_util.cpp \
     wslinfo.cpp
-win_headers= \
+if !OS_WINARM64
+win_sources += \
+    stackwalker_win.cpp
+endif
+win_headers = \
     boinc_win.h \
     diagnostics_win.h \
     run_app_windows.h \

--- a/lib/Makefile.mingw
+++ b/lib/Makefile.mingw
@@ -32,6 +32,10 @@ ifdef MINGW
     RANLIB = $(MINGW)-ranlib
 endif
 
+ifeq ($(findstring aarch64,$(shell $(CXX) -dumpmachine)),aarch64)
+    AARCH64_BUILD = 1
+endif
+
 # headers to install
 HEADERS = $(BOINC_SRC)/version.h \
 	$(BOINC_SRC)/svn_version.h \
@@ -96,11 +100,14 @@ LIB_OBJ = app_ipc.o \
 	proxy_info.o \
 	str_util.o \
 	shmem.o \
-	stackwalker_win.o \
 	url.o \
 	util.o \
 	win_util.o \
 	wslinfo.o
+
+ifndef AARCH64_BUILD
+	LIB_OBJ += stackwalker_win.o
+endif
 
 ZIP_OBJ = zip/boinc_zip.o
 
@@ -130,9 +137,9 @@ OPTFLAGS = -O3
 # various cpp & gcc flags (for both C and C++ mode)
 # set NOCYGWIN=-mno-cygwin to build non-Cygwin Windows libs under Cygwin
 # -D_WIN32_WINDOWS=0x0410 sets to use Win98 API
-WINVERFLAGS = -D_WINDOWS -D_WIN32 -DWIN32 -DWINVER=0x0500 -D_WIN32_WINNT=0x0500 -D_MT
 HAVEFLAGS = -DHAVE_STRCASECMP
-CCXXFLAGS = $(INCS) $(DEBUG) --include $(BOINC_SRC)/version.h -DEINSTEINATHOME_CROSS_BUILD -DMINGW_WIN32 \
+WINVERFLAGS = -D_WINDOWS -D_MT -D_WIN32 -DWIN32 -DWINVER=0x0500 -D_WIN32_WINNT=0x0500
+CCXXFLAGS = $(INCS) $(DEBUG) --include $(BOINC_SRC)/version.h \
 	$(HAVEFLAGS) $(WINVERFLAGS) -DBOINC \
 	-DNODB -D_CONSOLE -fexceptions $(OPTFLAGS) $(NOCYGWIN)
 

--- a/lib/boinc_win.h
+++ b/lib/boinc_win.h
@@ -161,6 +161,7 @@
 #endif
 
 #ifndef HAVE_SOCKLEN_T
+#include <stddef.h> // for size_t
 typedef size_t socklen_t;
 #endif
 

--- a/lib/diagnostics.cpp
+++ b/lib/diagnostics.cpp
@@ -386,7 +386,9 @@ int diagnostics_init(
     //_set_abort_behavior(NULL, _WRITE_ABORT_MSG);
 #ifdef __MINGW32__
     std::set_terminate(boinc_term_func);
-    std::set_unexpected(boinc_term_func);
+    #ifndef __aarch64__
+      std::set_unexpected(boinc_term_func);
+    #endif
 #else
     set_terminate(boinc_term_func);
     set_unexpected(boinc_term_func);

--- a/lib/diagnostics_win.cpp
+++ b/lib/diagnostics_win.cpp
@@ -1614,7 +1614,7 @@ UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID /* lpParameter */) {
                 // Dump some basic stuff about runtime debugger version and date
                 diagnostics_unhandled_exception_dump_banner();
 
-#if !defined(__CYGWIN__) && !defined(_M_ARM) && !defined(_M_ARM64)
+#if !defined(__CYGWIN__) && !defined(_M_ARM) && !defined(_M_ARM64) && !defined(__aarch64__)
                 // Kickstart the debugger extensions, look for the debugger files
                 //   in the install directory if it is defined, otherwise look
                 //   in the data directory.
@@ -1655,7 +1655,7 @@ UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID /* lpParameter */) {
                         }
 
                         if (diagnostics_is_flag_set(BOINC_DIAG_DUMPCALLSTACKENABLED)) {
-#if !defined(__CYGWIN__) && !defined(_M_ARM) && !defined(_M_ARM64)
+#if !defined(__CYGWIN__) && !defined(_M_ARM) && !defined(_M_ARM64) && !defined(__aarch64__)
                             if (bDebuggerInitialized) {
                                 if (pThreadEntry->crash_exception_record ) {
                                     StackwalkFilter(
@@ -1679,7 +1679,7 @@ UINT WINAPI diagnostics_unhandled_exception_monitor(LPVOID /* lpParameter */) {
                                 }
                             }
 #else
-                            fprintf(stderr, "Warning: Callstack dumps are not supported on CYGWIN\n");
+                            fprintf(stderr, "Warning: Callstack dumps are not supported\n");
 #endif
                         }
                         fprintf(stderr, "\n");

--- a/mingw/ci_make_apps.sh
+++ b/mingw/ci_make_apps.sh
@@ -35,7 +35,7 @@ export CC="x86_64-w64-mingw32-gcc"
 export MINGW_FLAGS="-Dflockfile=_lock_file -Dfunlockfile=_unlock_file"
 export CURL_EXTRA_LDFLAGS="-lcurl -lwinmm -lpthread -lssl -lcrypto -lws2_32 -lzs -ladvapi32 -lcrypt32 -lbcrypt"
 # wrapper
-export MINGW_WRAPPER_FLAGS="-DEINSTEINATHOME_CROSS_BUILD -DMINGW_WIN32 -DHAVE_STRCASECMP -D_WINDOWS -D_WIN32 -DWIN32 -DWINVER=0x0500 -D_WIN32_WINNT=0x0500 -D_MT -DBOINC -DNODB -D_CONSOLE -fexceptions"
+export MINGW_WRAPPER_FLAGS="-DHAVE_STRCASECMP -D_WINDOWS -D_WIN32 -DWIN32 -DWINVER=0x0500 -D_WIN32_WINNT=0x0500 -D_MT -DBOINC -DNODB -D_CONSOLE -fexceptions"
 export MINGW_LIBS="-lpsapi -lzip"
 # wrappture
 if [ ! -f $VCPKG_DIR/lib/libz.a ]; then


### PR DESCRIPTION
**Description of the Change**
fixes a few issues to allow cross-compiling libraries for --host=aarch64-w64-mingw32 --with-boinc-platform="windows_arm64"

https://github.com/mstorsjo/llvm-mingw/releases 

**Alternate Designs**
Visual Studio works well, but many existing projects rely on GCC / Clang, and porting them to Visual Studio isn’t always straightforward.

**Release Notes**
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable cross-compiling BOINC libraries for Windows ARM64 with MinGW/Clang (`--host=aarch64-w64-mingw32`, `--with-boinc-platform=windows_arm64`). CI builds x86_64 and ARM64 libs on Ubuntu using `mingw-w64`/`llvm-mingw`, verifies the `llvm-mingw` checksum, and tags artifacts/logs by arch.

- **New Features**
  - Add `OS_WINARM64` and detect `AARCH64_BUILD` in `lib/Makefile.mingw`.
  - Exclude `stackwalker_win.cpp` on ARM64 (Autotools and Makefile guards).
  - Keep `WINVER`/`_WIN32_WINNT` defines; drop legacy cross-build defines.
  - Guard `std::set_unexpected` and callstack dumps on `__aarch64__`.
  - Include `<stddef.h>` for `socklen_t`.

- **CI**
  - Matrix by `arch` (`x86_64`, `aarch64`) with per-arch toolchains (`mingw-w64`, `llvm-mingw`).
  - Download `llvm-mingw` 20260421, verify SHA-256, add to `PATH` for ARM64.
  - Separate build steps for libs by arch; skip `apps-mingw-vcpkg` and `libs-mingw-cmake` on ARM64.
  - Name jobs, artifacts, and logs with `arch`.

<sup>Written for commit 91ccb8d3631ae7bedab543c08d9aa1d0571b5122. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

