### PR TITLE
web: fix XML parsing issue

### DIFF
--- a/html/inc/db_ops.inc
+++ b/html/inc/db_ops.inc
@@ -396,7 +396,7 @@ function link_results($n, $mq, $query, $clauses) {
 // @param String $stderr_out the stderr_out value to parse
 //
 function stderr_error_string($stderr_out){
-    $y = parse_element_text($stderr_out, "<error_code>");
+    $y = parse_element($stderr_out, "<error_code>");
     $x = 0;
     if ($y) {
         $x = (int)$y;

--- a/html/inc/util_basic.inc
+++ b/html/inc/util_basic.inc
@@ -130,10 +130,11 @@ function project_config_bool($tag) {
     return true;
 }
 
-// parse an element from an XML string that may have errors
-// (e.g. job submission RPC replies)
+// ad-hoc XML parsing functions.
+// currently used in job RPC handling and project-specific prefs.
+// TODO: changes these to use simplexml, and get rid of these
 //
-function parse_element_text($xml, $tag) {
+function parse_element($xml, $tag) {
     $closetag = "</" . substr($tag,1);
     $x = strstr($xml, $tag);
     if ($x) {
@@ -146,6 +147,35 @@ function parse_element_text($xml, $tag) {
         }
     }
     return null;
+}
+
+function parse_next_element($xml, $tag, &$cursor) {
+    $element = null;
+    $closetag = "</" . substr($tag,1);
+    $pos = substr($xml,$cursor);
+    $x = strstr($pos, $tag);
+    if ($x) {
+        if (strstr($tag, "/>")) return $tag;
+        $y = substr($x, strlen($tag));
+        $n = strpos($y, $closetag);
+        if ($n) {
+            $element = substr($y, 0, $n);
+        }
+        $cursor = (strlen($xml) - strlen($x)) + strlen($tag) + strlen($closetag) + strlen($element);
+    }
+    if (!$element) return null;
+    return trim($element);
+}
+
+// return true if XML contains either <tag/> or <tag>1</tag>
+//
+function parse_bool($xml, $tag) {
+    $x = "<$tag/>";
+    if (strstr($xml, $x)) return true;
+    $x = "<$tag>";
+    $y = (int)parse_element($xml, $x);
+    if ($y != 0) return true;
+    return false;
 }
 
 // uniform 0..1

--- a/html/inc/web_rpc_api.inc
+++ b/html/inc/web_rpc_api.inc
@@ -81,12 +81,12 @@ function create_account(
         // old server code returns PHP warnings, which break XML.
         // do ad-hoc parsing instead
         //
-        $auth = parse_element_text($reply, "<authenticator>");
+        $auth = parse_element($reply, "<authenticator>");
         if ($auth) {
             return array($auth, 0, null);
         }
-        $error_num = parse_element_text($reply, "<error_num>");
-        $error_msg = parse_element_text($reply, "<error_msg>");
+        $error_num = parse_element($reply, "<error_num>");
+        $error_msg = parse_element($reply, "<error_msg>");
         if ($error_num) {
             return array(null, $error_num, $error_msg);
         }

--- a/tools/update_versions
+++ b/tools/update_versions
@@ -41,11 +41,11 @@ $verbose = false;
 
 $config = file_get_contents("config.xml");
 if (!$config) die("config.xml not found.  Run this in project root dir.\n");
-$download_url = parse_element_text($config, "<download_url>");
+$download_url = parse_element($config, "<download_url>");
 if (!$download_url) die("<download_url> not found in config.xml\n");
-$download_dir = parse_element_text($config, "<download_dir>");
+$download_dir = parse_element($config, "<download_dir>");
 if (!$download_dir) die("<download_dir> not found in config.xml\n");
-$key_dir = parse_element_text($config, "<key_dir>");
+$key_dir = parse_element($config, "<key_dir>");
 if (!$key_dir) die("<key_dir> not found in config.xml\n");
 
 function lookup_app($name) {


### PR DESCRIPTION
Turns out that html/project.sample/project_specific_prefs.inc was still using the old XML parsing code.
So I restored it for now.
TODO: change that file to use simplexml

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored ad‑hoc XML parsing to handle malformed replies and PHP warnings in legacy paths. This fixes project-specific prefs and makes account creation, config parsing, and stderr error parsing reliable again.

- **Bug Fixes**
  - Switched to parse_element in account creation (authenticator, error_num, error_msg), stderr parsing (error_code), and tools/update_versions (download_url, download_dir, key_dir).
  - Added lightweight XML helpers in util_basic.inc: parse_element (renamed), parse_next_element, and parse_bool with self-closing tag support.

<sup>Written for commit d77d67cf2071943443891668b93acf79cd6ab229. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

