### PR TITLE
docker_wrapper: don't log ps and stats commands by default

### DIFF
--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -407,7 +407,7 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
 
     // first containers
     //
-    retval = dc.command("ps --all", out);
+    retval = dc.command("ps --all", out, true);
     if (retval) {
         fprintf(stderr, "Docker command failed: ps --all\n");
     } else {
@@ -417,7 +417,7 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
             if (!docker_is_boinc_name(name.c_str())) continue;
             if (info.container_present(name)) continue;
             sprintf(cmd, "rm -f %s", name.c_str());
-            retval = dc.command(cmd, out2);
+            retval = dc.command(cmd, out2, true);
             if (retval) {
                 fprintf(stderr, "Docker command failed: %s\n", cmd);
                 continue;
@@ -430,7 +430,7 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
 
     // then images
     //
-    retval = dc.command("images", out);
+    retval = dc.command("images", out, true);
     if (retval) {
         fprintf(stderr, "Docker command failed: images\n");
     } else {
@@ -440,7 +440,7 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
             if (!docker_is_boinc_name(name.c_str())) continue;
             if (info.image_present(name)) continue;
             sprintf(cmd, "image rm %s", name.c_str());
-            retval = dc.command(cmd, out2);
+            retval = dc.command(cmd, out2, true);
             if (retval) {
                 fprintf(stderr, "Docker command failed: %s\n", cmd);
                 continue;

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -710,9 +710,7 @@ string parse_ldd_libc(const char* input) {
 // On Win this requires connecting to a shell in the WSL distro
 //
 #ifdef _WIN32
-int DOCKER_CONN::init(
-    WSL_DISTRO &wd, bool _verbose
-) {
+int DOCKER_CONN::init(WSL_DISTRO &wd) {
     string err_msg;
     type = wd.docker_type;
     cli_prog = docker_cli_prog(wd.docker_type);
@@ -730,14 +728,12 @@ int DOCKER_CONN::init(
         );
         return -1;
     }
-    verbose = _verbose;
     return 0;
 }
 #else
-int DOCKER_CONN::init(DOCKER_TYPE docker_type, bool _verbose) {
+int DOCKER_CONN::init(DOCKER_TYPE docker_type) {
     type = docker_type;
     cli_prog = docker_cli_prog(docker_type);
-    verbose = _verbose;
     return 0;
 }
 #endif
@@ -745,7 +741,9 @@ int DOCKER_CONN::init(DOCKER_TYPE docker_type, bool _verbose) {
 // issue a Docker command and return its output (stdout + stderr)
 // as a vector of lines (\n-terminated)
 //
-int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
+int DOCKER_CONN::command(
+    const char* cmd, vector<string> &out, bool verbose
+) {
     char buf[1024];
     int retval;
     if (verbose) {
@@ -775,9 +773,7 @@ int DOCKER_CONN::command(const char* cmd, vector<string> &out) {
     );
     retval = run_command(buf, out);
     if (retval) {
-        if (verbose) {
-            fprintf(stderr, "command failed: %s\n", boincerror(retval));
-        }
+        fprintf(stderr, "command failed: %s\n", boincerror(retval));
         return retval;
     }
 #endif  // _WIN32

--- a/lib/util.h
+++ b/lib/util.h
@@ -152,14 +152,13 @@ extern double simtime;
 struct DOCKER_CONN {
     DOCKER_TYPE type;
     const char* cli_prog;
-    bool verbose;
 #ifdef _WIN32
     WSL_CMD ctl_wc;
-    int init(WSL_DISTRO&, bool verbose=false);
+    int init(WSL_DISTRO&);
 #else
-    int init(DOCKER_TYPE, bool verbose=false);
+    int init(DOCKER_TYPE);
 #endif
-    int command(const char* cmd, std::vector<std::string> &out);
+    int command(const char* cmd, std::vector<std::string> &out, bool verbose);
 
     static const int CMD_TIMEOUT = 600;
         // timeout for docker commands.

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -167,6 +167,7 @@ struct RSC_USAGE {
 };
 
 // verbosity levels
+#define VERBOSE_NONE    0
 #define VERBOSE_STD     1
     // include only start/pause/end commands
 #define VERBOSE_ALL     2
@@ -188,7 +189,7 @@ struct CONFIG {
         // additional args for docker build command
     string create_args;
         // additional args for docker create command
-    int verbose;
+    int verbose;    // see above
     bool use_gpu;
         // tell Docker to enable GPU access
     int web_graphics_guest_port;
@@ -242,12 +243,21 @@ DOCKER_TYPE docker_type;
 string wsl_distro_name;
 double cpu_time = 0;
 
+inline bool verbose_std() {
+    return config.verbose >= VERBOSE_STD;
+}
+
+inline bool verbose_all() {
+    return config.verbose >= VERBOSE_ALL;
+}
+
 // parse job config file (job.toml)
 //
 int parse_config_file() {
     // defaults
     config.workdir = "/app";
     config.use_gpu = false;
+    config.verbose = VERBOSE_STD;
 
     std::ifstream ifs(config_file);
     if (ifs.fail()) {
@@ -401,7 +411,7 @@ void get_image_name() {
 int image_exists(bool &exists) {
     vector<string> out;
 
-    int retval = docker_conn.command("images", out);
+    int retval = docker_conn.command("images", out, verbose_std());
     if (retval) return retval;
     string image_name_space = image_name + string(" ");
     for (string line: out) {
@@ -420,7 +430,7 @@ int build_image() {
     snprintf(cmd, sizeof(cmd), "build \"%s\" -t %s -f %s %s",
         escaped_cwd, image_name, dockerfile, config.build_args.c_str()
     );
-    int retval = docker_conn.command(cmd, out);
+    int retval = docker_conn.command(cmd, out, verbose_std());
     if (retval) return retval;
     return 0;
 }
@@ -473,7 +483,7 @@ int get_container_state(int &state) {
 
         container_name
     );
-    retval = docker_conn.command(cmd, out);
+    retval = docker_conn.command(cmd, out, verbose_all());
     if (retval) return retval;
     for (string line: out) {
         char buf[256];
@@ -606,7 +616,7 @@ int create_container() {
 
     strcat(cmd, " ");
     strcat(cmd, image_name);
-    retval = docker_conn.command(cmd, out);
+    retval = docker_conn.command(cmd, out, verbose_std());
     if (retval) {
         fprintf(stderr, "create command failed: %d\n", retval);
         return retval;
@@ -627,7 +637,7 @@ int container_op(const char *op) {
     char cmd[1024];
     vector<string> out;
     snprintf(cmd, sizeof(cmd), "%s %s", op, container_name);
-    int retval = docker_conn.command(cmd, out);
+    int retval = docker_conn.command(cmd, out, verbose_std());
     if (retval) {
         fprintf(stderr, "%s command failed: %d\n", op, retval);
         return retval;
@@ -648,7 +658,7 @@ void cleanup() {
     vector<string> out;
 
     snprintf(cmd, sizeof(cmd), "logs %s", container_name);
-    docker_conn.command(cmd, out);
+    docker_conn.command(cmd, out, verbose_std());
     fprintf(stderr, "stderr from container:\n");
     for (string line: out) {
         fprintf(stderr, "%s", line.c_str());
@@ -656,13 +666,13 @@ void cleanup() {
     fprintf(stderr, "stderr end\n");
 
     snprintf(cmd, sizeof(cmd), "container rm %s", container_name);
-    docker_conn.command(cmd, out);
+    docker_conn.command(cmd, out, verbose_std());
 
     // don't remove image if it was specified in config
     //
     if (config.image_name.empty()) {
         snprintf(cmd, sizeof(cmd), "image rm %s", image_name);
-        docker_conn.command(cmd, out);
+        docker_conn.command(cmd, out, verbose_std());
     }
 }
 
@@ -732,7 +742,7 @@ JOB_STATUS poll_app() {
     int retval;
 
     snprintf(cmd, sizeof(cmd), "ps --all -f \"name=%s\"", container_name);
-    retval = docker_conn.command(cmd, out);
+    retval = docker_conn.command(cmd, out, verbose_all());
     if (retval) return JOB_FAIL;
     for (string line: out) {
         if (strstr(line.c_str(), container_name)) {
@@ -773,7 +783,7 @@ int get_stats(RSC_USAGE &ru) {
         container_name
     );
 #endif
-    retval = docker_conn.command(cmd, out);
+    retval = docker_conn.command(cmd, out, verbose_all());
     if (retval) return -1;
     if (out.empty()) return -1;
 
@@ -857,7 +867,7 @@ int wsl_init() {
     fprintf(stderr, "Using WSL distro %s\n", dp->distro_name.c_str());
     wsl_distro_name = dp->distro_name;
     docker_type = dp->docker_type;
-    return docker_conn.init(*dp, config.verbose>0);
+    return docker_conn.init(*dp);
 }
 #endif
 
@@ -894,7 +904,7 @@ int main(int argc, char** argv) {
         if (!strcmp(argv[j], "--sporadic")) {
             sporadic = true;
         } else if (!strcmp(argv[j], "--verbose")) {
-            config.verbose = VERBOSE_STD;
+            config.verbose = VERBOSE_ALL;
         } else if (!strcmp(argv[j], "--config")) {
             config_file = argv[++j];
         } else if (!strcmp(argv[j], "--dockerfile")) {
@@ -977,7 +987,7 @@ int main(int argc, char** argv) {
         }
         docker_type = aid.host_info.docker_type;
     }
-    retval = docker_conn.init(docker_type, config.verbose>0);
+    retval = docker_conn.init(docker_type);
     if (retval) {
         fprintf(stderr, "docker_conn.init() failed: %d\n", retval);
         boinc_finish(1);


### PR DESCRIPTION
These are periodic (10 sec) and flood stderr.
By default log only one-time commands (start/stop). To log nothing, put 'verbose = 0' in job.toml.
To log all commands, use 'verbose = 2'.

Fixes #7001

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce stderr noise by not logging periodic docker ps/stats by default; only one-off commands (create/start/stop) are logged unless verbosity is raised. Fixes #7001.

- **New Features**
  - Added verbosity levels: 0 (none), 1 (default), 2 (all).
  - Default is 1; set `verbose = 0` in job.toml to silence or `verbose = 2` to log all. `--verbose` now sets level 2.

- **Refactors**
  - Removed persistent verbosity from `DOCKER_CONN`; `init()` no longer takes a verbose flag.
  - `DOCKER_CONN::command()` now takes a `bool verbose`; call sites pass `verbose_std()` or `verbose_all()`.
  - Updated client to pass `true` for one-off maintenance commands and match the new signature, fixing the client build.
  - Always print command failures to stderr.

<sup>Written for commit 5b258c9e7ba5feb537413419d81621801788dc7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

