### PR TITLE
Mac fix recovery mode

### DIFF
--- a/client/Run_Podman.cpp
+++ b/client/Run_Podman.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     // Podman always writes its files owned by the logged in user and
     // mostly in that user's home directory. To get around this, we
     // simulate a login by user boinc_project and set environment
-    // variables for Podman to use our BOINC podman" directory instead
+    // variables for Podman to use our "BOINC podman" directory instead
     strlcpy(buf, "env XDG_CONFIG_HOME=\"/Library/Application Support/BOINC podman\" XDG_DATA_HOME=\"/Library/Application Support/BOINC podman\" HOME=\"/Library/Application Support/BOINC podman\" ", sizeof(buf));
 
     argvCount = 1;   // arguments to be passed to Podman
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
         system(buf);
     } else {
         args[argsCount++] = "su";
-        args[argsCount++] = "-l";
+        args[argsCount++] = "-m";   // boinc_project doesn't have a shell, so use root's shell /bin/sh
         args[argsCount++] = "boinc_project";    // Create Podman VM using boinc_project so projects can access it
         args[argsCount++] = "-c";
         args[argsCount++] = buf;

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -954,9 +954,14 @@ static OSStatus CreateUserAndGroup(char * user_name, char * group_name) {
     }           // if (! userExists)
 
 setGroupForUser:
-    // Older versions set shell to /usr/bin/false so do this even if the user exists
-    // Something like "dscl . -create /users/boinc_master shell /bin/zsh"
-    err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "shell", "/bin/zsh", NULL);
+    // As part of implementing Podman support, some versions of BOINC changed the
+    // shell setting from /usr/bin/false to /bin/zsh (PR #6465, #6508, #6520), but
+    // this created a user directory (/Users/boinc_master or /Users/boinc_project)
+    // and also caused MacOS system updates to drop into Recovery Mode (Issue #6970.)
+    // To fix the Recovery Mode issue we are reverting to a shell of /usr/bin/false.
+    // Since some versions set shell to /bin/zsh, do this even if the user exists.
+    // Something like "dscl . -create /users/boinc_master shell /usr/bin/false"
+    err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "shell", "/usr/bin/false", NULL);
     if (err)
         return err;
 


### PR DESCRIPTION
Fixes #6970

As part of implementing Podman support, some versions of BOINC changed the user shell setting for users _boinc_master_ and _boinc_project_ from _/usr/bin/false_ to _/bin/zsh_ (PR #6465, #6508, #6520), but this created a user directory for each user (_/Users/boinc_master_ and /_Users/boinc_project_)  and also caused MacOS system updates to drop into Recovery Mode (Issue #6970.) To fix the Recovery Mode issue we are reverting to a shell of _/usr/bin/false_ (which tells the system that this user has no shell.)

The _Run_Podman_ utility runs Podman commands as user _boinc_project_ to allow projects to access it. It had been relying on _boinc_project_'s user shell. Since this PR eliminates user _boinc_project_'s shell, this PR modifies _Run_Podman_ to instead use _root_'s user shell.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore “no shell” for macOS BOINC service users to prevent system updates entering Recovery Mode, and adjust Podman runner to work without a user shell. Fixes #6970 while keeping project access to Podman.

- **Bug Fixes**
  - Set shells for `boinc_master` and `boinc_project` back to `/usr/bin/false` (was `/bin/zsh`) to avoid creating home dirs and triggering Recovery Mode.
  - Update `Run_Podman` to use `su -m boinc_project -c ...` so it runs with root’s shell (`/bin/sh`), since `boinc_project` has no shell.

<sup>Written for commit 62bea248c1d1ea564d735bc095cfe66d642406cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

