### PR TITLE
remove last uses of ad-hoc XML parsing

### DIFF
--- a/html/inc/web_rpc_api.inc
+++ b/html/inc/web_rpc_api.inc
@@ -76,20 +76,8 @@ function create_account(
         return array(null, -1, "HTTP error to $url");
     }
 
-    $r = @simplexml_load_string($reply);
+    $r = simplexml_load_string($reply);
     if (!$r) {
-        // old server code returns PHP warnings, which break XML.
-        // do ad-hoc parsing instead
-        //
-        $auth = parse_element_text($reply, "<authenticator>");
-        if ($auth) {
-            return array($auth, 0, null);
-        }
-        $error_num = parse_element_text($reply, "<error_num>");
-        $error_msg = parse_element_text($reply, "<error_msg>");
-        if ($error_num) {
-            return array(null, $error_num, $error_msg);
-        }
         return array(null, -1, "Can't parse reply XML:\n$reply");
     }
     $auth = (string)$r->authenticator;

--- a/html/inc/web_rpc_api.inc
+++ b/html/inc/web_rpc_api.inc
@@ -76,7 +76,7 @@ function create_account(
         return array(null, -1, "HTTP error to $url");
     }
 
-    $r = simplexml_load_string($reply);
+    $r = @simplexml_load_string($reply);
     if (!$r) {
         return array(null, -1, "Can't parse reply XML:\n$reply");
     }

--- a/html/project.sample/project_specific_prefs.inc
+++ b/html/project.sample/project_specific_prefs.inc
@@ -266,32 +266,33 @@ function project_specific_prefs_show($prefs, $columns=false) {
 }
 
 function project_specific_prefs_parse($prefs_xml) {
+    $prefs_xml = "<foo>$prefs_xml</foo>";
+    $p = simplexml_load_string($prefs_xml);
+    if (!$p) {
+        error_page("Can't parse prefs:\n$prefs_xml\n");
+    }
     $prefs = new StdClass;
     if (COLOR_PREFS) {
-        $prefs->color_scheme = parse_element($prefs_xml, "<color_scheme>");
+        $prefs->color_scheme = (string)$p->color_scheme;
     }
     if (GFX_CPU_PREFS) {
-        $prefs->max_gfx_cpu_pct = parse_element($prefs_xml, "<max_gfx_cpu_pct>");
+        $prefs->max_gfx_cpu_pct = (string)$p->max_gfx_cpu_pct;
     }
     if (APP_SELECT_PREFS) {
-        $cursor = 0;
-        while ($thisxml = parse_next_element($prefs_xml, "<app_id>", $cursor)) {
-            if (is_numeric($thisxml)) {
-                $n = (int) $thisxml;
-                $prefs->app_ids[] = $n;
-            }
+        foreach ($p->apps_selected->app_id as $item) {
+            $prefs->app_ids[] = (int)$item;
         }
-        $prefs->allow_non_preferred_apps = parse_element($prefs_xml, "<allow_non_preferred_apps>");
+        $prefs->allow_non_preferred_apps = (int)$p->allow_non_preferred_apps;
         $prefs->allow_non_preferred_apps_text = $prefs->allow_non_preferred_apps?"yes":"no";
     }
     if (NON_GRAPHICAL_PREF) {
-        $prefs->non_graphical = parse_bool($prefs_xml, "non_graphical");
+        $prefs->non_graphical = (int)$p->non_graphical;
     }
     if (MAX_JOBS_PREF) {
-        $prefs->max_jobs = parse_element($prefs_xml, "<max_jobs>");
+        $prefs->max_jobs = (string)$p->max_jobs;
     }
     if (MAX_CPUS_PREF) {
-        $prefs->max_cpus = parse_element($prefs_xml, "<max_cpus>");
+        $prefs->max_cpus = (string)$p->max_cpus;
     }
     return $prefs;
 }

--- a/html/project.sample/project_specific_prefs.inc
+++ b/html/project.sample/project_specific_prefs.inc
@@ -279,7 +279,15 @@ function project_specific_prefs_parse($prefs_xml) {
         $prefs->max_gfx_cpu_pct = (string)$p->max_gfx_cpu_pct;
     }
     if (APP_SELECT_PREFS) {
-        foreach ($p->apps_selected->app_id as $item) {
+        $prefs->app_ids = [];
+        // in older code, <app_id>s weren't enclosed in <app_selected>
+        //
+        if (empty($p->apps_selected)) {
+            $app_id_nodes = $p->app_id;
+        } else {
+            $app_id_nodes = $p->apps_selected->app_id;
+        }
+        foreach ($app_id_nodes as $item) {
             $prefs->app_ids[] = (int)$item;
         }
         $prefs->allow_non_preferred_apps = (int)$p->allow_non_preferred_apps;

--- a/tools/update_versions
+++ b/tools/update_versions
@@ -39,13 +39,13 @@ $platforms = BoincPlatform::enum("");
 $confirm = true;
 $verbose = false;
 
-$config = file_get_contents("config.xml");
-if (!$config) die("config.xml not found.  Run this in project root dir.\n");
-$download_url = parse_element_text($config, "<download_url>");
+$c = simplexml_load_file("config.xml");
+if (!$c) die("config.xml not found.  Run this in project root dir.\n");
+$download_url = $c->config->download_url;
 if (!$download_url) die("<download_url> not found in config.xml\n");
-$download_dir = parse_element_text($config, "<download_dir>");
+$download_dir = $c->config->download_dir;
 if (!$download_dir) die("<download_dir> not found in config.xml\n");
-$key_dir = parse_element_text($config, "<key_dir>");
+$key_dir = $c->config->key_dir;
 if (!$key_dir) die("<key_dir> not found in config.xml\n");
 
 function lookup_app($name) {

--- a/tools/update_versions
+++ b/tools/update_versions
@@ -40,13 +40,21 @@ $confirm = true;
 $verbose = false;
 
 $c = simplexml_load_file("config.xml");
-if (!$c) die("config.xml not found.  Run this in project root dir.\n");
-$download_url = $c->config->download_url;
-if (!$download_url) die("<download_url> not found in config.xml\n");
-$download_dir = $c->config->download_dir;
-if (!$download_dir) die("<download_dir> not found in config.xml\n");
-$key_dir = $c->config->key_dir;
-if (!$key_dir) die("<key_dir> not found in config.xml\n");
+if (!$c) {
+    die("config.xml not found.  Run this in project root dir.\n");
+}
+$download_url = (string)$c->config->download_url;
+if (!$download_url) {
+    die("<download_url> not found in config.xml\n");
+}
+$download_dir = (string)$c->config->download_dir;
+if (!$download_dir) {
+    die("<download_dir> not found in config.xml\n");
+}
+$key_dir = (string)$c->config->key_dir;
+if (!$key_dir) {
+    die("<key_dir> not found in config.xml\n");
+}
 
 function lookup_app($name) {
     global $apps;


### PR DESCRIPTION
... from RPC binding, update_versions, project-specific prefs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the last ad‑hoc XML parsing with `SimpleXML` in RPC account creation, project prefs, and `tools/update_versions`, suppressed parser warnings to fail fast on bad XML, and added support for legacy prefs where `<app_id>` entries aren’t wrapped in `<apps_selected>`.

- **Refactors**
  - `html/inc/web_rpc_api.inc`: Removed ad‑hoc fallback in `create_account()`; now only uses `@simplexml_load_string` and fails fast on bad XML.
  - `html/project.sample/project_specific_prefs.inc`: Parse prefs via `simplexml_load_string` (wraps fragment in a root). Reads values directly, supports both `<apps_selected><app_id>` and top‑level `<app_id>`, and sets types explicitly.
  - `tools/update_versions`: Load `config.xml` with `simplexml_load_file` and read `config->download_url`, `config->download_dir`, `config->key_dir`, with clearer missing‑field errors.

- **Migration**
  - RPC responses must be valid XML with no warnings; malformed replies will now error.
  - `config.xml` must contain `<config><download_url>`, `<download_dir>`, and `<key_dir>` elements.

<sup>Written for commit 5f78bf2de5da01d66073c0f00e5c40de9ebdf733. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

