### PR TITLE
docker_wrapper: print stats errors only once

### DIFF
--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -130,6 +130,7 @@
 #include <cstdio>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include <signal.h>
 
 #include "toml.h"
@@ -763,6 +764,16 @@ JOB_STATUS poll_app() {
     return JOB_FAIL;
 }
 
+// print the given message, but only once
+//
+void print_once(string msg) {
+    static vector<string> msgs;
+    if (std::find(msgs.begin(), msgs.end(), msg) == msgs.end()) {
+        printf("%s", msg.c_str());
+        msgs.push_back(msg);
+    }
+}
+
 // Get CPU and mem usage.
 // This is also surprisingly slow; do it every 10 sec
 //
@@ -784,8 +795,14 @@ int get_stats(RSC_USAGE &ru) {
     );
 #endif
     retval = docker_conn.command(cmd, out, verbose_all());
-    if (retval) return -1;
-    if (out.empty()) return -1;
+    if (retval) {
+        print_once(string("stats command failed\n"));
+        return -1;
+    }
+    if (out.empty()) {
+        print_once(string("stats command returned nothing\n"));
+        return -1;
+    }
 
     // output is like
     // 97.12% 420KiB / 503.8GiB
@@ -803,7 +820,7 @@ int get_stats(RSC_USAGE &ru) {
         }
     }
     if (!found) {
-        fprintf(stderr, "Can't parse stats reply\n");
+        print_once(string("stats command parse failed\n"));
         return -1;
     }
     switch (mem_unit) {
@@ -824,8 +841,12 @@ int get_stats(RSC_USAGE &ru) {
     ru.cpu_frac = cpu_pct/100.;
     ru.wss = mem;
     // sanity checks
-    if (mem == 0 || ru.cpu_frac > aid.ncpus) {
-        fprintf(stderr, "invalid usage stats; using defaults\n");
+    if (mem == 0 ) {
+        print_once(string("stats command returned zero memory\n"));
+        return -1;
+    }
+    if (ru.cpu_frac > aid.ncpus) {
+        print_once(string("stats command returned excessive CPU usage\n"));
         return -1;
     }
     return 0;

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -766,7 +766,7 @@ JOB_STATUS poll_app() {
 
 // print the given message, but only once
 //
-void print_once(string msg) {
+void print_once(const string& msg) {
     static vector<string> msgs;
     if (std::find(msgs.begin(), msgs.end(), msg) == msgs.end()) {
         fprintf(stderr, "%s", msg.c_str());

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -769,7 +769,7 @@ JOB_STATUS poll_app() {
 void print_once(string msg) {
     static vector<string> msgs;
     if (std::find(msgs.begin(), msgs.end(), msg) == msgs.end()) {
-        printf("%s", msg.c_str());
+        fprintf(stderr, "%s", msg.c_str());
         msgs.push_back(msg);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce log noise in the Docker wrapper by printing each unique stats error only once to stderr. Adds a print_once() utility and uses it in get_stats() for errors like command failed, no output, parse failed, zero memory, or excessive CPU usage.

<sup>Written for commit e5bb4291b0a721196559520b54e41391a3884318. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

