### PR TITLE
Improve battery level validation logic

### DIFF
--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -311,7 +311,7 @@ int CLIENT_STATE::check_suspend_processing() {
         // If suspend, don't resume for at least 5 min
         //
         int cp = device_status.battery_charge_pct;
-        if ((cp >= 0) && (cp < global_prefs.battery_charge_min_pct)) {
+        if ((cp > 0) && (cp < global_prefs.battery_charge_min_pct)) {
             battery_charge_resume_time = now + ANDROID_BATTERY_BACKOFF;
             return SUSPEND_REASON_BATTERY_CHARGING;
         }


### PR DESCRIPTION
Fixes #6710 #5305 

**Description of the Change**
This PR fixes a bug in the Android client where computation would be incorrectly suspended when the screen turns off. The issue occurred because the client receives stale or erroneous battery data (often reported as 0%) from the GUI when the device screen is off, triggering an unnecessary low-battery suspension.


**Alternate Designs**
#6727(also submitted by me with another account), according to @davidpanderson , is "needlessly complex"

**Release Notes**
For Android Users: Fixed an issue where BOINC would incorrectly pause computation when your phone's screen was off, even if the battery was not actually low.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent false low‑battery suspends on Android by ignoring bogus 0% battery readings when the screen is off. Now requires charge > 0% before comparing against `battery_charge_min_pct`, avoiding unnecessary pauses.

<sup>Written for commit f317420db365127eaf66051effa2069fb334ca60. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

