### PR TITLE
[mac] provide a path to the system root certificates file

### DIFF
--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -490,6 +490,13 @@ int HTTP_OP::libcurl_exec(
         curl_easy_setopt(curlEasy, CURLOPT_CAINFO, CA_BUNDLE_FILENAME);
     }
 #endif
+#ifdef __APPLE__
+    // It looks like for the Mac we need to specify the path
+    // to the system certificates file if it exists
+    if (boinc_file_exists("/etc/ssl/cert.pem")) {
+        curl_easy_setopt(curlEasy, CURLOPT_CAINFO, "/etc/ssl/cert.pem");
+    }
+#endif
 
     // set the user agent as this boinc client & version
     //


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
On macOS, set cURL’s CA bundle to `/etc/ssl/cert.pem` when it exists to prevent HTTPS certificate verification errors. Adds a file-existence check and sets `CURLOPT_CAINFO` during request setup in `client/http_curl.cpp`.

<sup>Written for commit cf15a9f0a90a25ff23be541133decd11aa04515d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

