### PR TITLE
[ci] update actions

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 2
 
       - name: Cache dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
           key: ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -220,7 +220,7 @@ jobs:
           ./tests/integration_test/installTestSuite.sh
 
       - name: Cache dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             3rdParty/buildCache
@@ -478,7 +478,7 @@ jobs:
 
       - name: Upload integration-test docker logs
         if: ${{ always() && matrix.type == 'integration-test' }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: linux_integration_test_docker_logs_${{ github.sha }}
           path: ${{ runner.temp }}/integration-test-logs

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Cache dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: 3rdParty/buildCache
           key: osx-${{ hashFiles('.github/workflows/osx.yml', '3rdParty/buildMacDependencies.sh', 'mac_build/dependencyNames.sh', 'mac_build/buildc-ares.sh', 'mac_build/buildcurl.sh', 'mac_build/buildfreetype.sh', 'mac_build/buildFTGL.sh', 'mac_build/buildopenssl.sh', 'mac_build/buildWxMac.sh') }}
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Cache dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: 3rdParty/buildCache
           key: osx-${{ hashFiles('.github/workflows/osx.yml', '3rdParty/buildMacDependencies.sh', 'mac_build/dependencyNames.sh', 'mac_build/buildc-ares.sh', 'mac_build/buildcurl.sh', 'mac_build/buildfreetype.sh', 'mac_build/buildFTGL.sh', 'mac_build/buildopenssl.sh', 'mac_build/buildWxMac.sh') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,7 +89,7 @@ jobs:
         run: vcpkg.exe integrate remove
 
       - name: Cache dependencies
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ${{github.workspace}}\3rdParty\Windows\cuda\


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update CI workflows to use newer pinned versions of `actions/cache` and `actions/upload-artifact` for stability and security. Applied across Linux, macOS, Windows, and linux-package workflows, including artifact upload for Linux integration-test logs.

<sup>Written for commit 201d87a6afb712e71b7bba67a3268bd840b6cc8c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

