### PR TITLE
[ci] fix release build of sample applications

### DIFF
--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -19,7 +19,6 @@ name: Windows cmake
 on:
   push:
     branches: [ master ]
-    tags: [ 'vboxwrapper/**', 'wrapper/**', 'dockerwrapper/**', 'wslwrapper/**', 'worker/**' ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ name: Windows
 on:
   push:
     branches: [ master, 'client_release/**' ]
-    tags: [ 'client_release/**' ]
+    tags: [ 'client_release/**', 'vboxwrapper/**', 'wrapper/**', 'dockerwrapper/**', 'wslwrapper/**', 'worker/**' ]
   pull_request:
     branches: [ master ]
   schedule:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated GitHub Actions triggers so Windows release builds for sample apps run when wrapper tags are pushed. Moved tag filters from `windows-cmake` to the main `windows` workflow.

- **Bug Fixes**
  - `windows.yml`: added tag patterns for `client_release/**`, `vboxwrapper/**`, `wrapper/**`, `dockerwrapper/**`, `wslwrapper/**`, `worker/**` to trigger builds.
  - `windows-cmake.yml`: removed tag filters to avoid redundant or misrouted builds.

<sup>Written for commit c4e3edc6e9d4b8baab9d5226eb4450bbdb4c0f31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

