### PR TITLE
client: if allow_multiple_clients is set, don't do Docker cleanup

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -747,7 +747,13 @@ int CLIENT_STATE::init() {
 
     process_gpu_exclusions();
 
-    docker_cleanup();
+    // delete Docker images and containers not used by current jobs.
+    // Skip this if multiple clients are allowed;
+    // otherwise we'd delete other clients' containers
+    //
+    if (!cc_config.allow_multiple_clients) {
+        docker_cleanup();
+    }
 
     check_clock_reset();
 

--- a/html/ops/delete_spammers.php
+++ b/html/ops/delete_spammers.php
@@ -471,8 +471,6 @@ for ($i=1; $i<$argc; $i++) {
         $max_days = $argv[++$i];
     } else if ($argv[$i] == "--days") {     // deprecated
         $max_days = $argv[++$i];
-    } else {
-        echo "unrecognized arg: ".$argv[$i];
     }
 }
 

--- a/html/ops/delete_spammers.php
+++ b/html/ops/delete_spammers.php
@@ -2,8 +2,8 @@
 
 <?php
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2024 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -138,10 +138,10 @@ $test = false;
 
 // delete a spammer account, and everything associated with it
 //
-function do_delete_user($user) {
+function do_delete_user($user, $reason) {
     global $test;
     $age = (time() - $user->create_time) / 86400;
-    echo "deleting user\n";
+    echo "deleting user: $reason\n";
     echo "   ID: $user->id\n";
     echo "   email: $user->email_addr\n";
     echo "   name: $user->name\n";
@@ -166,7 +166,7 @@ function delete_list($fname) {
         if (!is_numeric($s)) die("bad ID $s\n");
         $user = BoincUser::lookup_id((int)$s);
         if ($user) {
-            do_delete_user($user);
+            do_delete_user($user, 'list');
         } else {
             echo "no user ID $s\n";
         }
@@ -216,7 +216,7 @@ function delete_forums() {
         // posts with at least 2 URLs
         $n = BoincPost::count("user=$user->id and (content like '%http%http%')");
         if (!$n) continue;
-        do_delete_user($user);
+        do_delete_user($user, 'forums');
         $count++;
     }
     echo "delete_forums(): deleted $count users\n";
@@ -246,7 +246,7 @@ function delete_profiles() {
             $m = BoincPost::count("user=$p->userid");
             if ($m) continue;
 
-            do_delete_user($user);
+            do_delete_user($user, 'profiles');
             if ($test) {
                 echo "\n$p->userid\n$p->response1\n$p->response2\n";
             }
@@ -267,7 +267,7 @@ function delete_profiles_strict() {
         }
         $n = BoincPost::count("user=$p->userid");
         if ($n) continue;
-        do_delete_user($user);
+        do_delete_user($user, 'profiles_strict');
         if ($test) {
             echo "\n$p->userid\n$p->response1\n$p->response2\n";
         }
@@ -316,7 +316,7 @@ function delete_users($no_hosts, $no_posts, $no_teams, $have_url) {
         if ($have_url) {
             if (!strlen($user->url)) continue;
         }
-        do_delete_user($user);
+        do_delete_user($user, 'users');
         $n++;
     }
     echo "deleted $n users\n";
@@ -330,7 +330,7 @@ function delete_banished() {
         if (!$user) continue;
         if ($user->create_time > time() - $min_days*86400) continue;
         if ($user->create_time < time() - $max_days*86400) continue;
-        do_delete_user($user);
+        do_delete_user($user, 'banished');
     }
 }
 
@@ -419,7 +419,7 @@ function delete_team($team, $users) {
         $team->delete();
         echo "deleted team ID $team->id name $team->name\n";
         foreach ($users as $user) {
-            do_delete_user($user);
+            do_delete_user($user, 'team');
         }
     }
 }
@@ -428,7 +428,7 @@ function delete_user_id($id) {
     $user = BoincUser::lookup_id($id);
     if ($user) {
         echo "deleting user $id\n";
-        do_delete_user($user);
+        do_delete_user($user, 'id');
     } else {
         echo "no such user\n";
     }
@@ -439,7 +439,7 @@ function delete_user_id_range($id1, $id2) {
         $user = BoincUser::lookup_id($i);
         if ($user) {
             echo "deleting user $i\n";
-            do_delete_user($user);
+            do_delete_user($user, 'id range');
         }
     }
 }
@@ -471,6 +471,8 @@ for ($i=1; $i<$argc; $i++) {
         $max_days = $argv[++$i];
     } else if ($argv[$i] == "--days") {     // deprecated
         $max_days = $argv[++$i];
+    } else {
+        echo "unrecognized arg: ".$argv[$i];
     }
 }
 


### PR DESCRIPTION
... otherwise we'd delete other instances' containers.

Also: in delete spammer script, show reason for each deletion

Fixes #7020

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Docker cleanup when `allow_multiple_clients` is enabled to avoid removing other clients’ containers. Improve spammer cleanup logs by tagging each deletion with a reason.

- **Bug Fixes**
  - Client: only call `docker_cleanup()` when `allow_multiple_clients` is false.
  - Ops: `delete_spammers.php` now prints a reason label in all deletion paths.

<sup>Written for commit 24b981665f6530af8f95a658b1cc7f188a0b97e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

