### PR TITLE
Mac fix recovery mode 2

### DIFF
--- a/client/Run_Podman.cpp
+++ b/client/Run_Podman.cpp
@@ -105,7 +105,7 @@ int main(int argc, char *argv[])
         system(buf);
     } else {
         args[argsCount++] = "su";
-        args[argsCount++] = "-m";   // boinc_project doesn't have a shell, so use root's shell /bin/sh
+        args[argsCount++] = "-l";
         args[argsCount++] = "boinc_project";    // Create Podman VM using boinc_project so projects can access it
         args[argsCount++] = "-c";
         args[argsCount++] = buf;

--- a/clientgui/mac/SecurityUtility.cpp
+++ b/clientgui/mac/SecurityUtility.cpp
@@ -23,13 +23,18 @@
 
 //  SecurityUtility.cpp
 
+#define CREATE_LOG 1    /* for debugging */
+
 #include <sys/param.h>  // for MAXPATHLEN
 #include <unistd.h>     // for getwd
+#include <sys/stat.h>   // for chmod
 
 #include <Carbon/Carbon.h>
 
 #include "SetupSecurity.h"
 #include "mac_branding.h"
+
+void print_to_log_file(const char *format, ...);
 
 int main(int argc, char *argv[]) {
     OSStatus            err;
@@ -61,3 +66,44 @@ int main(int argc, char *argv[]) {
     return err;
 }
 
+void strip_cr(char *buf)
+{
+    char *theCR;
+
+    theCR = strrchr(buf, '\n');
+    if (theCR)
+        *theCR = '\0';
+    theCR = strrchr(buf, '\r');
+    if (theCR)
+        *theCR = '\0';
+}
+
+// For debugging
+void print_to_log_file(const char *format, ...) {
+    va_list args;
+    char buf[256];
+    time_t t;
+    sprintf(buf, "/Users/Shared/test_log_finish_install.txt");
+    FILE *f;
+    f = fopen(buf, "a");
+    if (!f) return;
+
+    // File may be owned by various users, so make it world readable & writable
+    chmod(buf, 0666);
+
+    time(&t);
+    strlcpy(buf, asctime(localtime(&t)), sizeof(buf));
+
+    strip_cr(buf);
+
+    fputs(buf, f);
+    fputs("   ", f);
+
+    va_start(args, format);
+    vfprintf(f, format, args);
+    va_end(args);
+
+    fputs("\n", f);
+    fflush(f);
+    fclose(f);
+}

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -962,7 +962,7 @@ setGroupForUser:
     if (err)
         return err;
 
-    DoSudoPosixSpawn("/bin/mkdir", "0755", buf2, NULL, NULL, NULL, NULL);
+    DoSudoPosixSpawn("/bin/mkdir", "-m", "0755", buf2, NULL, NULL, NULL);
 
     // Fix the directory's permissions if created by an earlier version of BOINC.
     DoSudoPosixSpawn(chmodPath, "-f", "0755", buf2, NULL, NULL, NULL);

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -848,6 +848,7 @@ static OSStatus CreateUserAndGroup(char * user_name, char * group_name) {
     char            buf2[80];
     char            buf3[80];
     char            buf4[80];
+    char            buf5[80];
     char            *args[5];
     extern char     **environ;
     pid_t           thePid = 0;
@@ -946,22 +947,51 @@ static OSStatus CreateUserAndGroup(char * user_name, char * group_name) {
         err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "uid", buf4, NULL);
         if (err)
             return err;
-
-        // Something like "dscl . -create /users/boinc_master home /var/empty"
-        err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "home", "/var/empty", NULL);
-        if (err)
-            return err;
     }           // if (! userExists)
 
 setGroupForUser:
-    // As part of implementing Podman support, some versions of BOINC changed the
-    // shell setting from /usr/bin/false to /bin/zsh (PR #6465, #6508, #6520), but
-    // this created a user directory (/Users/boinc_master or /Users/boinc_project)
-    // and also caused MacOS system updates to drop into Recovery Mode (Issue #6970.)
-    // To fix the Recovery Mode issue we are reverting to a shell of /usr/bin/false.
+    // Some versions of BOINC set the shell to /usr/bin/false and some to /bin/zsh.
+    // Having the user shell as /bin/zsh wthout specitying the home directory caused
+    // MacOS system updates to drop into Recovery Mode (Issue #6970.)
+    // To fix the Recovery Mode issue we are reverting to a shell of /bin/zsh and
+    // changing the home directory from /var/empty to /Users/boinc_master or
+    // /Users/boinc_master.
     // Since some versions set shell to /bin/zsh, do this even if the user exists.
     // Something like "dscl . -create /users/boinc_master shell /usr/bin/false"
-    err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "shell", "/usr/bin/false", NULL);
+    err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "shell", "/bin/zsh", NULL);
+    if (err)
+        return err;
+
+    DoSudoPosixSpawn("/bin/mkdir", "0755", buf2, NULL, NULL, NULL, NULL);
+
+    // Fix the directory's permissions if created by an earlier version of BOINC.
+    DoSudoPosixSpawn(chmodPath, "-f", "0755", buf2, NULL, NULL, NULL);
+
+    // Something like "dscl . -create /users/boinc_master home /Users/boinc_master"
+    // Since some versions set home dir to /var/empty, do this even if the user exists.
+    err = DoSudoPosixSpawn(dsclPath, ".", "-create", buf2, "home", buf2, NULL);
+    if (err)
+        return err;
+
+    // Hide the home directory and share point https://support.apple.com/en-mn/102099
+    // Something like "sudo chflags hidden /Users/boinc_master"
+    args[0] = "/usr/bin/sudo";
+    args[1] = "chflags";
+    args[2] = "hidden";
+    args[3] = buf2;
+    args[4] = NULL;
+    err = posix_spawnp(&thePid, "/usr/bin/sudo", NULL, NULL, args, environ);
+    waitpid(thePid, &status, WUNTRACED);
+    if (status != 0) {
+        err = status;
+    } else {
+        if (WIFEXITED(status)) {
+            err = WEXITSTATUS(status);
+            if (err == 1) {
+                err = errno;
+            }
+        }   // end if (WIFEXITED(status)) else
+    }       // end if waitpid returned 0 sstaus else
     if (err)
         return err;
 
@@ -989,32 +1019,10 @@ setGroupForUser:
     if (err)
         return err;
 
-    // Hide the home directory and share point https://support.apple.com/en-mn/102099
-    // Something like "sudo chflags hidden /Users/boinc_master"
-    // buf2 was overwritten to DSCL path "/users/<name>" above; rebuild filesystem path.
-    // Skip if the directory doesn't exist (fresh installs set home to /var/empty).
-    sprintf(buf2, "/Users/%s", user_name);
-    if (access(buf2, F_OK) == 0) {
-        args[0] = "/usr/bin/sudo";
-        args[1] = "chflags";
-        args[2] = "hidden";
-        args[3] = buf2;
-        args[4] = NULL;
-        err = posix_spawnp(&thePid, "/usr/bin/sudo", NULL, NULL, args, environ);
-        waitpid(thePid, &status, WUNTRACED);
-        if (status != 0) {
-            err = status;
-        } else {
-            if (WIFEXITED(status)) {
-                err = WEXITSTATUS(status);
-                if (err == 1) {
-                    err = errno;
-                }
-            }   // end if (WIFEXITED(status)) else
-        }       // end if waitpid returned 0 sstaus else
-        if (err)
-            return err;
-    }
+    sprintf(buf5, "%s:wheel", user_name);
+    err = DoSudoPosixSpawn(chownPath, buf5, buf2, NULL, NULL, NULL, NULL);
+    if (err)
+        return err;
 
     err = ResynchDSSystem();
     if (err != noErr)

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -141,7 +141,7 @@ int optionally_install_rosetta2();
 pid_t FindProcessPID(char* name, pid_t thePID, Boolean currentUserOnly);
 static OSErr QuitAppleEventHandler(const AppleEvent *appleEvt, AppleEvent* reply, UInt32 refcon);
 int callPosixSpawn(const char *cmd);
-void print_to_log(const char *format, ...);
+void print_to_log_file(const char *format, ...);
 void strip_cr(char *buf);
 void CopyPreviousErrorsToLog(void);
 
@@ -165,7 +165,7 @@ void notused() {
 static char * Catalog_Name = (char *)"BOINC-Setup";
 static char * Catalogs_Dir = (char *)"/Library/Application Support/BOINC Data/locale/";
 
-#define REPORT_ERROR(isError) if (isError) print_to_log("BOINC PostInstall error at line %d", __LINE__);
+#define REPORT_ERROR(isError) if (isError) print_to_log_file("BOINC PostInstall error at line %d", __LINE__);
 
 /* globals */
 static Boolean                  gCommandLineInstall = false;
@@ -2454,19 +2454,19 @@ int callPosixSpawn(const char *cmdline) {
     }
 
 #if VERBOSE_TEST
-    print_to_log("***********");
+    print_to_log_file("***********");
     for (int i=0; i<argc; ++i) {
-        print_to_log("argv[%d]=%s", i, argv[i]);
+        print_to_log_file("argv[%d]=%s", i, argv[i]);
     }
-    print_to_log("***********\n");
+    print_to_log_file("***********\n");
 #endif
 
     errno = 0;
 
     result = posix_spawnp(&thePid, progPath, NULL, NULL, argv, environ);
 #if VERBOSE_TEST
-    print_to_log("callPosixSpawn command: %s", cmdline);
-    print_to_log("callPosixSpawn: posix_spawnp returned %d: %s", result, strerror(result));
+    print_to_log_file("callPosixSpawn command: %s", cmdline);
+    print_to_log_file("callPosixSpawn: posix_spawnp returned %d: %s", result, strerror(result));
 #endif
     if (result) {
         return result;
@@ -2476,7 +2476,7 @@ int callPosixSpawn(const char *cmdline) {
 // CAF        if (val < 0) printf("first waitpid returned %d\n", val);
     if (status != 0) {
 #if VERBOSE_TEST
-        print_to_log("waitpid() returned status=%d", status);
+        print_to_log_file("waitpid() returned status=%d", status);
 #endif
         result = status;
     } else {
@@ -2484,13 +2484,13 @@ int callPosixSpawn(const char *cmdline) {
             result = WEXITSTATUS(status);
             if (result == 1) {
 #if VERBOSE_TEST
-                print_to_log("WEXITSTATUS(status) returned 1, errno=%d: %s", errno, strerror(errno));
+                print_to_log_file("WEXITSTATUS(status) returned 1, errno=%d: %s", errno, strerror(errno));
 #endif
                 result = errno;
             }
 #if VERBOSE_TEST
             else if (result) {
-                print_to_log("WEXITSTATUS(status) returned %d", result);
+                print_to_log_file("WEXITSTATUS(status) returned %d", result);
             }
 #endif
         }   // end if (WIFEXITED(status)) else
@@ -2513,7 +2513,7 @@ void strip_cr(char *buf)
 }
 
 // For debugging
-void print_to_log(const char *format, ...) {
+void print_to_log_file(const char *format, ...) {
     va_list args;
     char buf[256];
     time_t t;


### PR DESCRIPTION
Fixes #6970m #7007

My attempt to fix issue #6970 with PR #7007 worked in my tests but failed to fix it in testing by the originator of that issue. This implements the alternate solution I described in [this](https://github.com/BOINC/boinc/pull/7007#issuecomment-4267311551) comment, which fixed it in both my tests and testing by the originator of issue #6970.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS Recovery Mode during updates by giving `boinc_master` and `boinc_project` real, hidden home directories and using a login shell for Podman VM setup. Adds minimal logging and corrects home directory ownership/permissions handling.

- **Bug Fixes**
  - Set service user shell to `/bin/zsh` and home to `/Users/<user>`; hide the directory with `chflags hidden`.
  - Create home directory if missing (`mkdir -m 0755`); enforce `chmod 0755` and `chown <user>:wheel`; stop using `/var/empty`.
  - Update DSCL records with the new home path; resync Directory Services.
  - Use `su -l boinc_project` when creating the Podman VM to load the login environment.
  - Add `print_to_log_file` debugging in `SecurityUtility` and standardize installer logging calls to it.

<sup>Written for commit 1aa9e1070592ac5f6ee97f31e596f82fba2da867. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

