### PR TITLE
client: don't fetch too much work for  projects with zero resource share

### DIFF
--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -254,8 +254,17 @@ void RSC_WORK_FETCH::set_request(PROJECT* p) {
     // if backup project, fetch 1 job per idle instance
     //
     if (p->resource_share == 0) {
-        req_instances = nidle_now;
-        req_secs = 1;
+        if (nidle_now) {
+            // unless we're at the max concurrent limit
+            if (p->app_configs.project_has_mc
+                && p->app_configs.project_max_concurrent
+                && p->proj_n_concurrent >= p->app_configs.project_max_concurrent
+            ) {
+                return;
+            }
+            req_instances = 1;
+            req_secs = 1;
+        }
         return;
     }
     if (cc_config.fetch_minimal_work) {

--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -250,6 +250,8 @@ static bool wacky_dcf(PROJECT* p) {
 // don't request anything if project is backed off.
 //
 void RSC_WORK_FETCH::set_request(PROJECT* p) {
+    req_instances = 0;
+    req_secs = 0;
 
     // if backup project, fetch 1 job per idle instance
     //


### PR DESCRIPTION
If there's an idle instance, and the project is not at a max concurrent limit, request 1 instance and 1 second

Fixes #7010

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce work fetch for backup projects (resource_share = 0): set `req_instances` and `req_secs` to 0, then request only 1 instance for 1 second when there’s an idle instance, skipping fetch if at the project’s max concurrent limit. Prevents over-fetching and avoids stale request values.

<sup>Written for commit ee2405a3191d48ccdf28aaac3513e9895df2a211. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

