### PR TITLE
[snap] fix running on wayland

### DIFF
--- a/snap/local/launch-manager
+++ b/snap/local/launch-manager
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Fix XDG_RUNTIME_DIR: snap confinement redirects it to a snap-specific subdirectory,
+# but the real runtime dir is needed to find display sockets (Wayland, X11).
+REAL_RUNTIME_DIR="/run/user/$(id -u)"
+if [ -d "$REAL_RUNTIME_DIR" ]; then
+    export XDG_RUNTIME_DIR="$REAL_RUNTIME_DIR"
+fi
+
+# Auto-detect WAYLAND_DISPLAY if not set
+if [ -z "$WAYLAND_DISPLAY" ]; then
+    for socket in wayland-0 wayland-1 wayland-2; do
+        if [ -S "${XDG_RUNTIME_DIR}/${socket}" ]; then
+            export WAYLAND_DISPLAY="$socket"
+            break
+        fi
+    done
+fi
+
+if [ -n "$WAYLAND_DISPLAY" ] && [ -S "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]; then
+    if [ -n "$DISPLAY" ]; then
+        # Both Wayland and X11 available — allow GTK to fall back to X11 if Wayland fails
+        # (e.g. WSLg where the Wayland socket resolves to /mnt/wslg/ outside the snap namespace)
+        export GDK_BACKEND=wayland,x11
+    else
+        export GDK_BACKEND=wayland
+    fi
+elif [ -n "$DISPLAY" ]; then
+    export GDK_BACKEND=x11
+fi
+
+exec "$SNAP/usr/bin/boincmgr" --datadir "$HOME" "$@"

--- a/snap/local/launch-manager
+++ b/snap/local/launch-manager
@@ -28,30 +28,20 @@ log "--- wayland socket ---"
 log "XDG_RUNTIME_DIR (after fix)=$XDG_RUNTIME_DIR"
 log "socket: $(ls -la "$XDG_RUNTIME_DIR/wayland-0" 2>&1)"
 
-# Fix XAUTHORITY: on GNOME Wayland, $XAUTHORITY points to a session-specific file
-# in /run/user/ (e.g. .mutter-Xwaylandauth.XXXXX) which the snap's x11 AppArmor policy
-# may not allow reading (it only permits $HOME/.Xauthority). Try to merge the session
-# cookies into ~/.Xauthority so the snap can access them.
-log "--- xauthority fix ---"
+# TODO: XAUTHORITY fix — disabled pending investigation.
+# On GNOME Wayland, $XAUTHORITY may point to a session-specific file in /run/user/
+# (e.g. .mutter-Xwaylandauth.XXXXX) which the snap's x11 AppArmor policy doesn't allow
+# reading. When needed, the fix is to merge cookies into the real ~/.Xauthority:
+#   REAL_XAUTH="${SNAP_REAL_HOME:-$HOME}/.Xauthority"
+#   if [ -n "$XAUTHORITY" ] && [ ! -r "$XAUTHORITY" ]; then
+#       xauth merge "$XAUTHORITY" && export XAUTHORITY="$REAL_XAUTH"
+#   elif [ -z "$XAUTHORITY" ]; then
+#       export XAUTHORITY="$REAL_XAUTH"
+#   fi
+log "--- xauthority ---"
 log "XAUTHORITY=$XAUTHORITY"
 log "XAUTHORITY readable: $([ -r "$XAUTHORITY" ] && echo yes || echo no)"
-log "~/.Xauthority exists: $([ -f "$HOME/.Xauthority" ] && echo yes || echo no)"
-if [ -n "$XAUTHORITY" ] && [ "$XAUTHORITY" != "$HOME/.Xauthority" ]; then
-    if command -v xauth >/dev/null 2>&1; then
-        log "xauth=$(command -v xauth)"
-        if xauth merge "$XAUTHORITY" 2>> "$LOG"; then
-            log "xauth merge succeeded"
-        else
-            log "xauth merge failed (AppArmor may block reading $XAUTHORITY)"
-        fi
-    else
-        log "xauth not found in PATH"
-    fi
-    # Point to ~/.Xauthority regardless; if merge worked it now has the right cookies,
-    # and if not it's the only path the snap's AppArmor policy allows.
-    export XAUTHORITY="$HOME/.Xauthority"
-    log "XAUTHORITY -> $XAUTHORITY"
-fi
+log "SNAP_REAL_HOME=$SNAP_REAL_HOME"
 
 # Auto-detect WAYLAND_DISPLAY if not set
 if [ -z "$WAYLAND_DISPLAY" ]; then
@@ -64,12 +54,20 @@ if [ -z "$WAYLAND_DISPLAY" ]; then
     done
 fi
 
-if [ -n "$WAYLAND_DISPLAY" ] && [ -S "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]; then
-    if [ -n "$DISPLAY" ]; then
-        # Both Wayland and X11 available — allow GTK to fall back to X11 if Wayland fails
-        # (e.g. WSLg where the Wayland socket resolves to /mnt/wslg/ outside the snap namespace)
+# Determine GDK backend:
+#   - Native Wayland socket (real socket, not symlink): use Wayland only — it works natively
+#   - Symlinked Wayland socket (WSLg): socket may be inaccessible inside snap namespace,
+#     allow X11 fallback via XWayland
+#   - No Wayland at all: use X11
+WAYLAND_SOCKET="${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}"
+log "--- backend selection ---"
+log "socket type: $([ -L "$WAYLAND_SOCKET" ] && echo symlink || ([ -S "$WAYLAND_SOCKET" ] && echo real || echo none))"
+if [ -n "$WAYLAND_DISPLAY" ] && [ -S "$WAYLAND_SOCKET" ]; then
+    if [ -L "$WAYLAND_SOCKET" ]; then
+        # Symlinked socket (e.g. WSLg) — allow X11 fallback if Wayland is inaccessible
         export GDK_BACKEND=wayland,x11
     else
+        # Real native Wayland socket — use Wayland directly
         export GDK_BACKEND=wayland
     fi
 elif [ -n "$DISPLAY" ]; then

--- a/snap/local/launch-manager
+++ b/snap/local/launch-manager
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+LOG=/tmp/boinc-launch-debug.log
+
+log() { echo "$@" >> "$LOG"; }
+
+{
+    echo ""
+    echo "=== boinc manager launch $(date) ==="
+    echo "uid=$(id -u) user=$(id -un)"
+} >> "$LOG"
+
+log "--- env before fixes ---"
+log "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+log "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
+log "DISPLAY=$DISPLAY"
+log "GDK_BACKEND=$GDK_BACKEND"
+log "XAUTHORITY=$XAUTHORITY"
+
 # Fix XDG_RUNTIME_DIR: snap confinement redirects it to a snap-specific subdirectory,
 # but the real runtime dir is needed to find display sockets (Wayland, X11).
 REAL_RUNTIME_DIR="/run/user/$(id -u)"
@@ -7,11 +24,41 @@ if [ -d "$REAL_RUNTIME_DIR" ]; then
     export XDG_RUNTIME_DIR="$REAL_RUNTIME_DIR"
 fi
 
+log "--- wayland socket ---"
+log "XDG_RUNTIME_DIR (after fix)=$XDG_RUNTIME_DIR"
+log "socket: $(ls -la "$XDG_RUNTIME_DIR/wayland-0" 2>&1)"
+
+# Fix XAUTHORITY: on GNOME Wayland, $XAUTHORITY points to a session-specific file
+# in /run/user/ (e.g. .mutter-Xwaylandauth.XXXXX) which the snap's x11 AppArmor policy
+# may not allow reading (it only permits $HOME/.Xauthority). Try to merge the session
+# cookies into ~/.Xauthority so the snap can access them.
+log "--- xauthority fix ---"
+log "XAUTHORITY=$XAUTHORITY"
+log "XAUTHORITY readable: $([ -r "$XAUTHORITY" ] && echo yes || echo no)"
+log "~/.Xauthority exists: $([ -f "$HOME/.Xauthority" ] && echo yes || echo no)"
+if [ -n "$XAUTHORITY" ] && [ "$XAUTHORITY" != "$HOME/.Xauthority" ]; then
+    if command -v xauth >/dev/null 2>&1; then
+        log "xauth=$(command -v xauth)"
+        if xauth merge "$XAUTHORITY" 2>> "$LOG"; then
+            log "xauth merge succeeded"
+        else
+            log "xauth merge failed (AppArmor may block reading $XAUTHORITY)"
+        fi
+    else
+        log "xauth not found in PATH"
+    fi
+    # Point to ~/.Xauthority regardless; if merge worked it now has the right cookies,
+    # and if not it's the only path the snap's AppArmor policy allows.
+    export XAUTHORITY="$HOME/.Xauthority"
+    log "XAUTHORITY -> $XAUTHORITY"
+fi
+
 # Auto-detect WAYLAND_DISPLAY if not set
 if [ -z "$WAYLAND_DISPLAY" ]; then
     for socket in wayland-0 wayland-1 wayland-2; do
         if [ -S "${XDG_RUNTIME_DIR}/${socket}" ]; then
             export WAYLAND_DISPLAY="$socket"
+            log "auto-detected WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
             break
         fi
     done
@@ -28,5 +75,13 @@ if [ -n "$WAYLAND_DISPLAY" ] && [ -S "${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}" ]; 
 elif [ -n "$DISPLAY" ]; then
     export GDK_BACKEND=x11
 fi
+
+log "--- env after fixes ---"
+log "XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR"
+log "WAYLAND_DISPLAY=$WAYLAND_DISPLAY"
+log "DISPLAY=$DISPLAY"
+log "GDK_BACKEND=$GDK_BACKEND"
+log "XAUTHORITY=$XAUTHORITY"
+log "=== launching boincmgr ==="
 
 exec "$SNAP/usr/bin/boincmgr" --datadir "$HOME" "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -47,10 +47,13 @@ apps:
     - network-bind
 
   manager:
-    command: usr/bin/boincmgr --datadir $HOME
+    command: usr/bin/launch-manager
     plugs:
+    - home
     - network
     - network-bind
+    - wayland
+    - x11
     extensions:
     - gnome
     slots:
@@ -58,6 +61,7 @@ apps:
     common-id: boinc.manager
     environment:
       XAUTHORITY: $SNAP_REAL_HOME/.Xauthority
+      GDK_BACKEND: wayland,x11
 
 slots:
   dbus-daemon:
@@ -136,3 +140,11 @@ parts:
 
       ./_autosetup
       snapcraftctl build
+
+  snap-local:
+    plugin: dump
+    source: snap/local
+    organize:
+      launch-manager: usr/bin/launch-manager
+    stage:
+    - usr/bin/launch-manager


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix BOINC snap startup on Wayland and improve X11 fallback by launching the Manager through a wrapper that fixes `XDG_RUNTIME_DIR`, auto-detects Wayland, and selects the right `GDK_BACKEND`. Adds debug logging for display issues.

- **Bug Fixes**
  - Replace Manager command with `usr/bin/launch-manager`; sets `XDG_RUNTIME_DIR=/run/user/$(id -u)`, logs to `/tmp/boinc-launch-debug.log`, then execs `boincmgr`.
  - Auto-detect `WAYLAND_DISPLAY` (`wayland-0..2`); set `GDK_BACKEND` to `wayland`, `wayland,x11` for symlinked sockets (e.g., WSLg), or `x11` if only `DISPLAY` is present.
  - Simplify Xauthority handling: no `xauth merge`; keep `XAUTHORITY` from snap env and log readability.
  - Snapcraft: add `home`, `wayland`, `x11` plugs; run `usr/bin/launch-manager`; set `XAUTHORITY=$SNAP_REAL_HOME/.Xauthority` and default `GDK_BACKEND=wayland,x11`; add `snap-local` part; update copyright to 2026.

<sup>Written for commit 81034c2242f5ebe7fbc31ac08a2652c544323ad2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

