### PR TITLE
Fix MinGW and Windows build after zlib rename

### DIFF
--- a/mingw/ci_make_apps.sh
+++ b/mingw/ci_make_apps.sh
@@ -33,13 +33,13 @@ export CXX="x86_64-w64-mingw32-g++"
 export CC="x86_64-w64-mingw32-gcc"
 # condor
 export MINGW_FLAGS="-Dflockfile=_lock_file -Dfunlockfile=_unlock_file"
-export CURL_EXTRA_LDFLAGS="-lcurl -lwinmm -lpthread -lssl -lcrypto -lws2_32 -lzlib -ladvapi32 -lcrypt32 -lbcrypt"
+export CURL_EXTRA_LDFLAGS="-lcurl -lwinmm -lpthread -lssl -lcrypto -lws2_32 -lzs -ladvapi32 -lcrypt32 -lbcrypt"
 # wrapper
 export MINGW_WRAPPER_FLAGS="-DEINSTEINATHOME_CROSS_BUILD -DMINGW_WIN32 -DHAVE_STRCASECMP -D_WINDOWS -D_WIN32 -DWIN32 -DWINVER=0x0500 -D_WIN32_WINNT=0x0500 -D_MT -DBOINC -DNODB -D_CONSOLE -fexceptions"
 export MINGW_LIBS="-lpsapi -lzip"
 # wrappture
 if [ ! -f $VCPKG_DIR/lib/libz.a ]; then
-    ln -s $VCPKG_DIR/lib/libzlib.a $VCPKG_DIR/lib/libz.a
+    ln -s $VCPKG_DIR/lib/libzs.a $VCPKG_DIR/lib/libz.a
 fi
 # uc2_graphics & slideshow
 if [ ! -f $VCPKG_DIR/lib/libfreeglut_static.a ]; then

--- a/win_build/boinc_cli.vcxproj
+++ b/win_build/boinc_cli.vcxproj
@@ -19,8 +19,8 @@
     <Link>
       <AdditionalDependencies>libcrypto.lib;libssl.lib;wsock32.lib;winhttp.lib;winmm.lib;sensapi.lib;userenv.lib;shell32.lib;secur32.lib;wtsapi32.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib;Iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)'=='x64'">nvapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zlibd.lib;libcurl-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zlib.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zsd.lib;libcurl-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zs.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>../coprocs/NVIDIA/mswin/$(Platform)/$(Configuration)/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ProgramDatabaseFile>$(OutDir)$(ProjectName)_exe.pdb</ProgramDatabaseFile>
       <SubSystem>Console</SubSystem>

--- a/win_build/boinc_ss.vcxproj
+++ b/win_build/boinc_ss.vcxproj
@@ -21,8 +21,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;glu32.lib;psapi.lib;wsock32.lib;brotlicommon.lib;brotlidec.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;freetyped.lib;ftgld.lib;libpng16d.lib;zlibd.lib;bz2d.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;zlib.lib;bz2.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;freetyped.lib;ftgld.lib;libpng16d.lib;zsd.lib;bz2d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;zs.lib;bz2.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>GDI32.DLL;OPENGL32.DLL;GLU32.DLL;%(DelayLoadDLLs)</DelayLoadDLLs>
       <SubSystem>Windows</SubSystem>
     </Link>

--- a/win_build/boincmgr.vcxproj
+++ b/win_build/boincmgr.vcxproj
@@ -23,8 +23,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>ole32.lib;oleaut32.lib;oleacc.lib;shell32.lib;comdlg32.lib;oldnames.lib;uuid.lib;rpcrt4.lib;comctl32.lib;wsock32.lib;wininet.lib;userenv.lib;winspool.lib;lzma.lib;nanosvg.lib;nanosvgrast.lib;Ws2_32.Lib;libwebp.lib;libwebpdemux.lib;libsharpyuv.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">wxbase33ud.lib;wxbase33ud_net.lib;wxbase33ud_xml.lib;wxmsw33ud_adv.lib;wxmsw33ud_core.lib;wxmsw33ud_html.lib;wxmsw33ud_qa.lib;wxmsw33ud_webview.lib;pcre2-8d.lib;pcre2-16d.lib;pcre2-32d.lib;pcre2-posixd.lib;libpng16d.lib;jpeg.lib;tiffd.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">wxbase33u.lib;wxbase33u_net.lib;wxbase33u_xml.lib;wxmsw33u_adv.lib;wxmsw33u_core.lib;wxmsw33u_html.lib;wxmsw33u_qa.lib;wxmsw33u_webview.lib;pcre2-8.lib;pcre2-16.lib;pcre2-32.lib;pcre2-posix.lib;libpng16.lib;jpeg.lib;tiff.lib;zlib.lib;lzma.lib;nanosvg.lib;nanosvgrast.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">wxbase33ud.lib;wxbase33ud_net.lib;wxbase33ud_xml.lib;wxmsw33ud_adv.lib;wxmsw33ud_core.lib;wxmsw33ud_html.lib;wxmsw33ud_qa.lib;wxmsw33ud_webview.lib;pcre2-8d.lib;pcre2-16d.lib;pcre2-32d.lib;pcre2-posixd.lib;libpng16d.lib;jpeg.lib;tiffd.lib;zsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">wxbase33u.lib;wxbase33u_net.lib;wxbase33u_xml.lib;wxmsw33u_adv.lib;wxmsw33u_core.lib;wxmsw33u_html.lib;wxmsw33u_qa.lib;wxmsw33u_webview.lib;pcre2-8.lib;pcre2-16.lib;pcre2-32.lib;pcre2-posix.lib;libpng16.lib;jpeg.lib;tiff.lib;zs.lib;lzma.lib;nanosvg.lib;nanosvgrast.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/win_build/sim.vcxproj
+++ b/win_build/sim.vcxproj
@@ -18,8 +18,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>wsock32.lib;wininet.lib;winmm.lib;oldnames.lib;libcrypto.lib;libssl.lib;Ws2_32.Lib;Crypt32.Lib;Wldap32.Lib;Iphlpapi.lib;Secur32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zlibd.lib;libcurl-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zlib.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zsd.lib;libcurl-d.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zs.lib;libcurl.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/win_build/slide_show.vcxproj
+++ b/win_build/slide_show.vcxproj
@@ -16,8 +16,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;glu32.lib;psapi.lib;oldnames.lib;brotlicommon.lib;brotlidec.lib;zip.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>GDI32.DLL;OPENGL32.DLL;GLU32.DLL;%(DelayLoadDLLs)</DelayLoadDLLs>
       <SubSystem>Windows</SubSystem>
     </Link>

--- a/win_build/uc2_graphics.vcxproj
+++ b/win_build/uc2_graphics.vcxproj
@@ -16,8 +16,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>opengl32.lib;glu32.lib;psapi.lib;brotlicommon.lib;brotlidec.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;freetyped.lib;ftgld.lib;libpng16d.lib;bz2d.lib;zsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;freetype.lib;ftgl.lib;libpng16.lib;bz2.lib;zs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>GDI32.DLL;OPENGL32.DLL;GLU32.DLL;%(DelayLoadDLLs)</DelayLoadDLLs>
       <SubSystem>Windows</SubSystem>
     </Link>

--- a/win_build/unittests.vcxproj
+++ b/win_build/unittests.vcxproj
@@ -22,8 +22,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>gtest_main.lib;gmock_main.lib;zip.lib;atls.lib;ole32.lib;wsock32.lib;psapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zlibd.lib;libcmtd.lib;libcpmtd.lib;comsuppwd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zlib.lib;libcmt.lib;libcpmt.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zsd.lib;libcmtd.lib;libcpmtd.lib;comsuppwd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zs.lib;libcmt.lib;libcpmt.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(Configuration)'=='Debug'">$(VcpkgInstalledDir)/debug/lib/manual-link;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Configuration)'=='Release'">$(VcpkgInstalledDir)/lib/manual-link;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>

--- a/win_build/wrapper.vcxproj
+++ b/win_build/wrapper.vcxproj
@@ -24,8 +24,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>ole32.lib;psapi.lib;oldnames.lib;zip.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;zsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;zs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(TargetDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <SubSystem>Console</SubSystem>
     </Link>

--- a/win_build/wrappture_example.vcxproj
+++ b/win_build/wrappture_example.vcxproj
@@ -20,8 +20,8 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>rappture.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libexpatdMT.lib;libcmtd.lib;libcpmtd.lib;zlibd.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libexpatMT.lib;libcmt.lib;libcpmt.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libexpatdMT.lib;libcmtd.lib;libcpmtd.lib;zsd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libexpatMT.lib;libcmt.lib;libcpmt.lib;zs.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes MinGW and Windows builds by replacing `zlib` with `zs`/`zsd`. CI and Visual Studio projects link cleanly again.

- **Bug Fixes**
  - Windows .vcxproj: swap `zlib` to `zs`/`zsd` across client, manager, screensaver, tests, and samples.
  - MinGW CI: set `CURL_EXTRA_LDFLAGS` to `-lzs`; add `libz.a` -> `libzs.a` symlink.

<sup>Written for commit e6638b4f9f6099a99ffc8a5b099156a1744ab4f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

