### PR TITLE
Build gtk3 with wayland

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git python3 python3-distutils python3-jinja2 python3-venv curl zip unzip tar bison p7zip-full dbus
+          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git python3 python3-distutils python3-jinja2 python3-venv curl zip unzip tar bison p7zip-full dbus flex
 
       - name: Install dependencies for arm64
         if: matrix.arch == 'arm64'

--- a/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/manager/linux/vcpkg.json
@@ -29,6 +29,21 @@
         },
         "libnotify",
         "xcb-util",
-        "pixbufloader-svg"
+        "pixbufloader-svg",
+        {
+            "name": "gtk3",
+            "features": ["wayland"],
+            "default-features": false
+        },
+        {
+            "name": "wayland",
+            "features": ["force-build"],
+            "default-features": false
+        },
+        {
+            "name": "wayland-protocols",
+            "features": ["force-build"],
+            "default-features": false
+        }
     ]
 }

--- a/3rdParty/vcpkg_ports/ports/gtk3/0001-build.patch
+++ b/3rdParty/vcpkg_ports/ports/gtk3/0001-build.patch
@@ -1,0 +1,13 @@
+diff --git a/meson.build b/meson.build
+index 397ea07..dd6b888 100644
+--- a/meson.build
++++ b/meson.build
+@@ -997,7 +997,7 @@ subdir('docs/reference')
+ 
+ install_data('m4macros/gtk-3.0.m4', install_dir: join_paths(get_option('datadir'), 'aclocal'))
+ 
+-if not meson.is_cross_build()
++if false
+   gnome.post_install(
+     glib_compile_schemas: true,
+     gio_querymodules: gio_module_dirs,

--- a/3rdParty/vcpkg_ports/ports/gtk3/avoid-multiple-definition.diff
+++ b/3rdParty/vcpkg_ports/ports/gtk3/avoid-multiple-definition.diff
@@ -1,0 +1,13 @@
+diff --git a/gtk/inspector/size-groups.c b/gtk/inspector/size-groups.c
+index eb185ed..f7c604d 100644
+--- a/gtk/inspector/size-groups.c
++++ b/gtk/inspector/size-groups.c
+@@ -44,7 +44,7 @@ enum {
+   LAST_PROPERTY
+ };
+ 
+-GParamSpec *properties[LAST_PROPERTY] = { NULL };
++static GParamSpec *properties[LAST_PROPERTY] = { NULL };
+ 
+ GType size_group_row_get_type (void);
+ 

--- a/3rdParty/vcpkg_ports/ports/gtk3/cairo-cpp-linkage.patch
+++ b/3rdParty/vcpkg_ports/ports/gtk3/cairo-cpp-linkage.patch
@@ -1,0 +1,62 @@
+diff --git a/gtk/meson.build b/gtk/meson.build
+index ea866d8..0d312f3 100644
+--- a/gtk/meson.build
++++ b/gtk/meson.build
+@@ -1102,6 +1102,7 @@ gtk_query_settings = executable(
+   'gtk-query-settings.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_query_settings
+@@ -1111,6 +1112,7 @@ gtk_builder_tool = executable(
+   'gtk-builder-tool.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_builder_tool
+@@ -1143,6 +1145,7 @@ gtk_update_icon_cache = executable(
+   extra_update_icon_cache_objs,
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_update_icon_cache
+@@ -1153,6 +1156,7 @@ gtk_query_immodules = executable(
+   'gtkutils.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_query_immodules
+@@ -1162,6 +1166,7 @@ gtk_encode_symbolic_svg = executable(
+   'encodesymbolic.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_encode_symbolic_svg
+@@ -1171,6 +1176,7 @@ gtk_launch = executable(
+   'gtk-launch.c',
+   c_args: gtk_cargs,
+   dependencies: libgtk_dep,
++  link_language: 'cpp',
+   install: true
+ )
+ gtk_tools += gtk_launch
+diff --git a/meson.build b/meson.build
+index dd6b888..e60ad30 100644
+--- a/meson.build
++++ b/meson.build
+@@ -1,4 +1,4 @@
+-project('gtk', 'c',
++project('gtk', 'c', 'cpp',
+   version: '3.24.52',
+   default_options: [
+     'buildtype=debugoptimized',

--- a/3rdParty/vcpkg_ports/ports/gtk3/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/gtk3/portfile.cmake
@@ -1,0 +1,106 @@
+set(warning_length 24)
+string(LENGTH "${CURRENT_BUILDTREES_DIR}" buildtrees_path_length)
+if(buildtrees_path_length GREATER warning_length AND CMAKE_HOST_WIN32)
+    message(WARNING "${PORT}'s buildsystem uses very long paths and may fail on your system.\n"
+        "We recommend moving vcpkg to a short path such as 'C:\\vcpkg' or using the subst command."
+    )
+endif()
+
+string(REGEX MATCH [[^[0-9][0-9]*\.[1-9][0-9]*]] VERSION_MAJOR_MINOR ${VERSION})
+vcpkg_download_distfile(ARCHIVE
+    URLS
+        "https://download.gnome.org/sources/gtk/${VERSION_MAJOR_MINOR}/gtk-${VERSION}.tar.xz"
+        "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/gtk/${VERSION_MAJOR_MINOR}/gtk-${VERSION}.tar.xz"
+    FILENAME "GNOME-gtk-${VERSION}.tar.xz"
+    SHA512 20c119cf1a8c390c9d572729f36215fe034731d9e741a0a30c96671f4606ef8b7cdbe5d5ebe986f6f6c9ac03b3ba5cddd8d63da0ebfc5341d179ec9dea5e82eb
+)
+
+vcpkg_extract_source_archive(SOURCE_PATH
+    ARCHIVE "${ARCHIVE}"
+    PATCHES
+        0001-build.patch
+        cairo-cpp-linkage.patch
+        avoid-multiple-definition.diff
+)
+
+vcpkg_find_acquire_program(PKGCONFIG)
+get_filename_component(PKGCONFIG_DIR "${PKGCONFIG}" DIRECTORY )
+vcpkg_add_to_path("${PKGCONFIG_DIR}") # Post install script runs pkg-config so it needs to be on PATH
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/glib/")
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gdk-pixbuf")
+vcpkg_add_to_path("${CURRENT_HOST_INSTALLED_DIR}/tools/gettext/bin")
+
+
+if("introspection" IN_LIST FEATURES)
+    list(APPEND OPTIONS_RELEASE -Dintrospection=true)
+    vcpkg_get_gobject_introspection_programs(PYTHON3 GIR_COMPILER GIR_SCANNER)
+else()
+    list(APPEND OPTIONS_RELEASE -Dintrospection=false)
+endif()
+
+set(BINARIES "")
+
+if("wayland" IN_LIST FEATURES)
+    list(APPEND OPTIONS -Dwayland_backend=true)
+    if(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES)
+        list(APPEND BINARIES "wayland-scanner = '${CURRENT_HOST_INSTALLED_DIR}/tools/wayland/wayland-scanner${VCPKG_HOST_EXECUTABLE_SUFFIX}'")
+    endif()
+else()
+    list(APPEND OPTIONS -Dwayland_backend=false)
+endif()
+
+vcpkg_configure_meson(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${OPTIONS}
+        -Ddemos=false
+        -Dexamples=false
+        -Dtests=false
+        -Dgtk_doc=false
+        -Dman=false
+        -Dxinerama=no               # Enable support for the X11 Xinerama extension
+        -Dcloudproviders=false      # Enable the cloudproviders support
+        -Dprofiler=false            # include tracing support for sysprof
+        -Dtracker3=false            # Enable Tracker3 filechooser search
+        -Dcolord=no                 # Build colord support for the CUPS printing backend
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    OPTIONS_DEBUG
+        -Dintrospection=false
+    ADDITIONAL_BINARIES
+        "glib-genmarshal='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-genmarshal'"
+        "glib-mkenums='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-mkenums'"
+        "glib-compile-resources='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-resources${VCPKG_HOST_EXECUTABLE_SUFFIX}'"
+        "gdbus-codegen='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/gdbus-codegen'"
+        "glib-compile-schemas='${CURRENT_HOST_INSTALLED_DIR}/tools/glib/glib-compile-schemas${VCPKG_HOST_EXECUTABLE_SUFFIX}'"
+        "g-ir-compiler='${GIR_COMPILER}'"
+        "g-ir-scanner='${GIR_SCANNER}'"
+        ${BINARIES}
+)
+
+# Reduce command line lengths, in particular for static windows builds.
+foreach(dir IN ITEMS "${TARGET_TRIPLET}-dbg" "${TARGET_TRIPLET}-rel")
+    if(EXISTS "${CURRENT_BUILDTREES_DIR}/${dir}/build.ninja")
+        vcpkg_replace_string("${CURRENT_BUILDTREES_DIR}/${dir}/build.ninja" "/${dir}/../src/" "/src/")
+    endif()
+endforeach()
+vcpkg_install_meson(ADD_BIN_TO_PATH)
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+set(GTK_TOOLS
+    gtk-builder-tool
+    gtk-encode-symbolic-svg
+    gtk-launch
+    gtk-query-immodules-3.0
+    gtk-query-settings
+    gtk-update-icon-cache
+)
+vcpkg_copy_tools(TOOL_NAMES ${GTK_TOOLS} AUTO_CLEAN)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/etc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/gtk3/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/gtk3/vcpkg.json
@@ -1,0 +1,103 @@
+{
+  "name": "gtk3",
+  "version": "3.24.52",
+  "port-version": 1,
+  "description": "Portable library for creating graphical user interfaces.",
+  "homepage": "https://www.gtk.org/",
+  "license": null,
+  "supports": "!android",
+  "dependencies": [
+    {
+      "name": "at-spi2-atk",
+      "platform": "linux"
+    },
+    "atk",
+    {
+      "name": "cairo",
+      "default-features": false,
+      "features": [
+        "gobject"
+      ]
+    },
+    {
+      "name": "cairo",
+      "default-features": false,
+      "features": [
+        "x11"
+      ],
+      "platform": "linux | freebsd | openbsd"
+    },
+    {
+      "name": "gdk-pixbuf",
+      "host": true
+    },
+    "gdk-pixbuf",
+    {
+      "name": "gettext",
+      "host": true,
+      "default-features": false,
+      "features": [
+        "tools"
+      ]
+    },
+    "gettext-libintl",
+    "glib",
+    {
+      "name": "glib",
+      "host": true
+    },
+    "libepoxy",
+    {
+      "name": "libxi",
+      "platform": "!windows & !osx"
+    },
+    {
+      "name": "libxrandr",
+      "platform": "!windows & !osx"
+    },
+    "pango",
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    }
+  ],
+  "features": {
+    "introspection": {
+      "description": "Build with introspection",
+      "supports": "!static",
+      "dependencies": [
+        {
+          "name": "atk",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        },
+        {
+          "name": "gdk-pixbuf",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        },
+        "gobject-introspection",
+        {
+          "name": "pango",
+          "default-features": false,
+          "features": [
+            "introspection"
+          ]
+        }
+      ]
+    },
+    "wayland": {
+      "description": "Build with Wayland support",
+      "supports": "linux | freebsd | openbsd",
+      "dependencies": [
+        "libxkbcommon",
+        "wayland",
+        "wayland-protocols"
+      ]
+    }
+  }
+}

--- a/3rdParty/vcpkg_ports/triplets/ci/arm-linux-release.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/arm-linux-release.cmake
@@ -19,6 +19,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/arm-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 
 if(PORT STREQUAL "dbus")
     if(NOT $ENV{TMPDIR} STREQUAL "")

--- a/3rdParty/vcpkg_ports/triplets/ci/arm64-linux-release.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/arm64-linux-release.cmake
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -19,6 +19,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/arm64-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 
 if(PORT STREQUAL "dbus")
     if(NOT $ENV{TMPDIR} STREQUAL "")

--- a/3rdParty/vcpkg_ports/triplets/ci/snap-linux-amd64.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/snap-linux-amd64.cmake
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -19,3 +19,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/x64-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)

--- a/3rdParty/vcpkg_ports/triplets/ci/snap-linux-arm64.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/snap-linux-arm64.cmake
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -19,6 +19,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/community/arm64-linux-release.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 
 if(PORT STREQUAL "dbus")
     if(NOT $ENV{TMPDIR} STREQUAL "")

--- a/3rdParty/vcpkg_ports/triplets/ci/x64-linux.cmake
+++ b/3rdParty/vcpkg_ports/triplets/ci/x64-linux.cmake
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -19,4 +19,5 @@ include(${CMAKE_CURRENT_LIST_DIR}/../../vcpkg_root_find.cmake)
 include(${VCPKG_ROOT}/triplets/x64-linux.cmake)
 
 set(X_VCPKG_FORCE_VCPKG_X_LIBRARIES ON)
+set(X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON)
 set(VCPKG_BUILD_TYPE release)

--- a/linux/update_vcpkg_manager.sh
+++ b/linux/update_vcpkg_manager.sh
@@ -1,4 +1,22 @@
 #!/bin/sh
+
+# This file is part of BOINC.
+# https://boinc.berkeley.edu
+# Copyright (C) 2026 University of California
+#
+# BOINC is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License
+# as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# BOINC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
 set -e
 
 if [ ! -d "linux" ]; then
@@ -13,6 +31,12 @@ fi
 
 echo TRIPLET=$TRIPLET
 
+HOST_TRIPLET=""
+if [ ! -z "$2" ]; then
+    HOST_TRIPLET="--host-triplet=$2"
+    echo HOST_TRIPLET=$2
+fi
+
 . $PWD/3rdParty/vcpkg_ports/vcpkg_link.sh
 BUILD_DIR="$PWD/3rdParty/linux"
 VCPKG_PORTS="$PWD/3rdParty/vcpkg_ports"
@@ -25,4 +49,4 @@ fi
 
 git -C $VCPKG_ROOT pull
 $VCPKG_ROOT/bootstrap-vcpkg.sh
-$VCPKG_ROOT/vcpkg install  --x-manifest-root=3rdParty/vcpkg_ports/configs/manager/linux --x-install-root=$VCPKG_ROOT/installed/ --overlay-ports=$VCPKG_PORTS/ports --overlay-triplets=$VCPKG_PORTS/triplets/ci --triplet=$TRIPLET --clean-after-build
+$VCPKG_ROOT/vcpkg install  --x-manifest-root=3rdParty/vcpkg_ports/configs/manager/linux --x-install-root=$VCPKG_ROOT/installed/ --overlay-ports=$VCPKG_PORTS/ports --overlay-triplets=$VCPKG_PORTS/triplets/ci --triplet=$TRIPLET --clean-after-build $HOST_TRIPLET

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -96,6 +96,7 @@ parts:
     - cmake
     - dbus
     - python3-venv
+    - flex
     source: .
     plugin: autotools
     build-environment:
@@ -132,7 +133,11 @@ parts:
       pip install -U --user pip
       pip install --user jinja2
 
-      linux/update_vcpkg_manager.sh $triplet
+      # first parameter is the target triplet
+      # second parameter is the host triplet
+      # this needs to be changed is ever this will support a cross-compilation scenario
+      # but for now we only support building on the same architecture as the target
+      linux/update_vcpkg_manager.sh $triplet $triplet
 
       ./_autosetup
       snapcraftctl build


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable native Wayland support on Linux by adding `gtk3[wayland]` and force-building Wayland libraries. Improve CI/Snap builds by installing `flex` and passing the host triplet to vcpkg.

- **Dependencies**
  - Added `gtk3` with `features: ["wayland"]` and a custom port with patches to disable Meson post-install schema steps for cross builds, link GTK tools as C++ to fix Cairo linkage, and avoid a multiple-definition in the inspector; `libxkbcommon` is pulled via `gtk3[wayland]`.
  - Force-built `wayland` and `wayland-protocols`; set `X_VCPKG_FORCE_VCPKG_WAYLAND_LIBRARIES ON` across Linux triplets; used the vcpkg `wayland-scanner` path; passed `--host-triplet` from `snapcraft.yaml` to `linux/update_vcpkg_manager.sh`.

<sup>Written for commit 30b53e1f0fd15df1202faa8710a5e0332b2f8e3c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

