### PR TITLE
[snap] replace core22 with core24

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -54,6 +54,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install -y p7zip-full
+        sudo snap install snapcraft --classic
 
     - name: Running from origin repo
       if: ${{ success() && env.AWS_ACCESS_KEY_ID != 0 && env.AWS_SECRET_ACCESS_KEY != 0 }}
@@ -75,40 +76,11 @@ jobs:
         PKG_VERSION_FULL="${PKG_VERSION}-${{ github.run_number }}"
         sed -i -E "s/(version: \"$PKG_VERSION\")/version: \"$PKG_VERSION_FULL\"/" ${{ github.workspace }}/snap/snapcraft.yaml
 
-    - name: Configure docker qemu
-      if: success()
-      uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
-
     - name: Build boinc snap
       if: success()
       run: |
-        docker run \
-          --rm \
-          --tty \
-          --privileged \
-          --volume $PWD:/root \
-          --workdir /root \
-          --env VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES \
-          --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
-          --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
-          --env AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION \
-          diddledani/snapcraft:core22 \
-          "snap run snapcraft --verbosity verbose pack --destructive-mode --output boinc_${{ matrix.arch }}.snap --build-for=${{ matrix.arch }}"
-
+          sudo --preserve-env=VCPKG_BINARY_SOURCES,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_DEFAULT_REGION snap run snapcraft --verbosity verbose pack --destructive-mode --output boinc_${{ matrix.arch }}.snap --build-for=${{ matrix.arch }}
           sudo chown $USER boinc_${{ matrix.arch }}.snap
-
-    - name: Install and test snap boinc inside docker
-      if: success()
-      run: |
-        docker run \
-          --rm \
-          --tty \
-          --privileged \
-          --volume $PWD:/root \
-          --workdir /root \
-          --platform linux/${{ matrix.arch }} \
-          diddledani/snapcraft:core22 \
-          "snap install --dangerous boinc_${{ matrix.arch }}.snap && boinc --version && boinc.client --version"
 
     - name: Install and test snap boinc on host
       if: success()

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 name: boinc
-base: core22
+base: core24
 version: "8.3.0"
 type: app
 title: BOINC Manager
@@ -32,6 +32,14 @@ source-code: https://github.com/BOINC/boinc
 website: https://boinc.berkeley.edu/
 grade: stable
 confinement: strict
+
+platforms:
+  amd64:
+    build-on: amd64
+    build-for: amd64
+  arm64:
+    build-on: arm64
+    build-for: arm64
 
 apps:
   boinc:
@@ -101,13 +109,13 @@ parts:
     plugin: autotools
     build-environment:
     - CRYPTOGRAPHY_DONT_BUILD_RUST: "1"
-    - triplet: snap-linux-$SNAPCRAFT_TARGET_ARCH
+    - triplet: snap-linux-$CRAFT_ARCH_BUILD_FOR
     - VCPKG_DIR: "$PWD/3rdParty/linux/vcpkg/installed/$triplet"
     - _libcurl_pc: "$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
-    - VCPKG_BINARY_SOURCES: "$VCPKG_BINARY_SOURCES"
-    - AWS_ACCESS_KEY_ID: "$AWS_ACCESS_KEY_ID"
-    - AWS_SECRET_ACCESS_KEY: "$AWS_SECRET_ACCESS_KEY"
-    - AWS_DEFAULT_REGION: "$AWS_DEFAULT_REGION"
+    - VCPKG_BINARY_SOURCES: "${VCPKG_BINARY_SOURCES:+$VCPKG_BINARY_SOURCES}"
+    - AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID:+$AWS_ACCESS_KEY_ID}"
+    - AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY:+$AWS_SECRET_ACCESS_KEY}"
+    - AWS_DEFAULT_REGION: "${AWS_DEFAULT_REGION:+$AWS_DEFAULT_REGION}"
     - prefix: /usr
     - PKG_CONFIG_PATH: $VCPKG_DIR/lib/pkgconfig/
     autotools-configure-parameters:
@@ -120,7 +128,7 @@ parts:
     - --disable-server
     - GTK_LIBS="`pkg-config --libs gtk+-3.0`"
     override-build: |
-      echo ARCH=$SNAPCRAFT_TARGET_ARCH
+      echo ARCH=$CRAFT_ARCH_BUILD_FOR
 
       export PATH=/snap/cmake/current/bin/:$PATH
       cmake --version
@@ -140,4 +148,4 @@ parts:
       linux/update_vcpkg_manager.sh $triplet $triplet
 
       ./_autosetup
-      snapcraftctl build
+      craftctl default


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move the Snap build to `core24` and run builds with `snapcraft` installed via Snap. CI drops Docker/QEMU; builds target `amd64` and `arm64`.

- **Refactors**
  - Set `base: core24` and add `platforms` with per-arch `build-on`/`build-for` in `snap/snapcraft.yaml`.
  - Switch to `CRAFT_ARCH_BUILD_FOR` and `craftctl default`; guard `VCPKG_*` and AWS env vars, preserved via `sudo --preserve-env` in CI.
  - Install `snapcraft` via Snap and run `snap run snapcraft`; remove Docker/QEMU and `diddledani/snapcraft:core22`.
  - Keep `pack --destructive-mode --build-for`; remove Docker-based install/test and keep host install/test.

<sup>Written for commit 0da0f215a1d452ed1756f243707acf998d0fd07f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

