### PR TITLE
Update the type of the rss field to be long for Linux

### DIFF
--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -89,7 +89,7 @@ struct PROC_STAT {
     int itrealvalue;
     unsigned long starttime;
     unsigned long vsize;
-    int rss;
+    long rss;
     unsigned long rlim;
     unsigned long startcode;
     unsigned long endcode;
@@ -118,7 +118,7 @@ int PROC_STAT::parse(char* buf) {
         "%lu %lu %lu %lu %lu %lu %lu "
         "%d %d %d %d %d %d "
         "%lu %lu "
-        "%d "
+        "%ld "
         "%lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu %lu "
         "%d %d",
         &pid,


### PR DESCRIPTION


Fixes #

**Description of the Change**
<!-- We must be able to understand the design of your change from this description. -->

The `proc_pid_stat` manpage on my system (Ubuntu 25.10) has the type of this field as `%ld`. Update the type used here to match that printf formatting.

This also fixes a bug where applications using more than 4GB of RSS memory were shown and handled incorrectly due to integer overflow that happened during multiplication.

**Alternate Designs**
<!-- Explain what other alternates were considered and why the proposed version was selected -->

**Release Notes**
<!--
Please describe the changes in a single line that explains this improvement in terms that a user can understand.
This text will be used in BOINC's release notes.
If this change is not user-facing or notable enough to be included in release notes you may use the string "N/A" here. -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `rss` in `PROC_STAT` from int to long and parse with `%ld` to match `proc_pid_stat`, fixing overflow and incorrect RSS reporting for processes over 4 GB.

- **Bug Fixes**
  - Changed struct field and format spec in `lib/procinfo_unix.cpp`.
  - Aligns with the manpage and prevents integer overflow when converting pages to bytes.

<sup>Written for commit 60a556ce6bce01e3bba724794f2cfd51b6b3813e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

