### PR TITLE
scheduler: add <gpu_type_regex> plan class option.

### DIFF
--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -239,8 +239,8 @@ void COPROCS::summary_string_json(string &out) {
         if (!strlen(cp.opencl_prop.name)) continue;
         if (!out.empty()) out += ",\n";
         summary_json(buf2,
-            "opencl",
-            cp.type,
+            cp.opencl_prop.vendor,
+            cp.opencl_prop.name,
             cp.count,
             (int)((double)cp.opencl_prop.global_mem_size/MEGA),
             cp.opencl_prop.opencl_device_version,

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -870,8 +870,23 @@ bool PLAN_CLASS_SPEC::check(
             }
         }
 
-    // custom GPU type
+    // other (OpenCL) GPU type
     //
+    } else if (have_gpu_type_regex) {
+        for (int i=1; i<sreq.coprocs.n_rsc; i++) {
+            if (!regexec(&(gpu_type_regex), sreq.coprocs.coprocs[i].type, 0, NULL, 0)) {
+                cpp = &sreq.coprocs.coprocs[i];
+                break;
+            }
+        }
+        if (!cpp) {
+            if (config.debug_version_select) {
+                log_messages.printf(MSG_NORMAL,
+                    "[version] plan_class_spec: No gpu_type match found\n"
+                );
+            }
+            return false;
+        }
     } else if (strlen(gpu_type)) {
         cpp = sreq.coprocs.lookup_type(gpu_type);
         if (!cpp) {
@@ -882,12 +897,14 @@ bool PLAN_CLASS_SPEC::check(
             }
             return false;
         }
+    }
+    if (cpp) {
         if (config.debug_version_select) {
             log_messages.printf(MSG_NORMAL,
-                "[version] plan_class_spec: Custom coproc %s found\n", gpu_type
+                "[version] plan_class_spec: OpenCL coproc %s found\n", gpu_type
             );
         }
-        if (cpp->bad_gpu_peak_flops("Custom GPU", msg)) {
+        if (cpp->bad_gpu_peak_flops("OpenCL coproc", msg)) {
             log_messages.printf(MSG_NORMAL, "%s\n", msg.c_str());
         }
     }
@@ -1221,6 +1238,8 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
         if (xp.parse_bool("project_prefs_default_true", project_prefs_default_true)) continue;
         if (xp.parse_double("avg_ncpus", avg_ncpus)) continue;
 
+        // GPU info
+        //
         if (xp.parse_double("cpu_frac", cpu_frac)) continue;
         if (xp.parse_double("min_gpu_ram_mb", min_gpu_ram_mb)) continue;
         if (xp.parse_double("gpu_ram_used_mb", gpu_ram_used_mb)) continue;
@@ -1231,10 +1250,6 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
         if (xp.parse_int("min_driver_version", min_driver_version)) continue;
         if (xp.parse_int("max_driver_version", max_driver_version)) continue;
         if (xp.parse_str("gpu_utilization_tag", gpu_utilization_tag, sizeof(gpu_utilization_tag))) continue;
-        if (xp.parse_long("min_wu_id", min_wu_id)) {wu_restricted_plan_class = true; continue;}
-        if (xp.parse_long("max_wu_id", max_wu_id)) {wu_restricted_plan_class = true; continue;}
-        if (xp.parse_long("min_batch", min_batch)) {wu_restricted_plan_class = true; continue;}
-        if (xp.parse_long("max_batch", max_batch)) {wu_restricted_plan_class = true; continue;}
 
         if (xp.parse_bool("need_ati_libs", need_ati_libs)) continue;
         if (xp.parse_bool("need_amd_libs", need_amd_libs)) continue;
@@ -1256,7 +1271,19 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
         if (xp.parse_bool("double_precision_fp", double_precision_fp)) continue;
 
         if (xp.parse_int("min_metal_support", min_metal_support)) continue;
+        if (xp.parse_str("gpu_type_regex", buf, sizeof(buf))) {
+            if (regcomp(&(gpu_type_regex), buf, REG_EXTENDED|REG_NOSUB) ) {
+                log_messages.printf(MSG_CRITICAL,
+                    "BAD GPU TYPE REGEXP: %s\n", buf
+                );
+                return ERR_XML_PARSE;
+            }
+            have_gpu_type_regex = true;
+            continue;
+        }
 
+        // Virtualbox
+        //
         if (xp.parse_int("min_vbox_version", min_vbox_version)) continue;
         if (xp.parse_int("max_vbox_version", max_vbox_version)) continue;
         if (xp.parse_int("exclude_vbox_version", i)) {
@@ -1264,6 +1291,11 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
             continue;
         }
         if (xp.parse_bool("vm_accel_required", vm_accel_required)) continue;
+
+        if (xp.parse_long("min_wu_id", min_wu_id)) {wu_restricted_plan_class = true; continue;}
+        if (xp.parse_long("max_wu_id", max_wu_id)) {wu_restricted_plan_class = true; continue;}
+        if (xp.parse_long("min_batch", min_batch)) {wu_restricted_plan_class = true; continue;}
+        if (xp.parse_long("max_batch", max_batch)) {wu_restricted_plan_class = true; continue;}
     }
     return ERR_XML_PARSE;
 }
@@ -1338,6 +1370,7 @@ PLAN_CLASS_SPEC::PLAN_CLASS_SPEC() {
     min_driver_version = 0;
     max_driver_version = 0;
     strcpy(gpu_utilization_tag, "");
+    have_gpu_type_regex = false;
 
     need_ati_libs = false;
     need_amd_libs = false;

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -901,7 +901,7 @@ bool PLAN_CLASS_SPEC::check(
     if (cpp) {
         if (config.debug_version_select) {
             log_messages.printf(MSG_NORMAL,
-                "[version] plan_class_spec: OpenCL coproc %s found\n", gpu_type
+                "[version] plan_class_spec: OpenCL coproc %s found\n", cpp->type
             );
         }
         if (cpp->bad_gpu_peak_flops("OpenCL coproc", msg)) {
@@ -951,7 +951,7 @@ bool PLAN_CLASS_SPEC::check(
 
     // general GPU
     //
-    if (strlen(gpu_type)) {
+    if (cpp) {
 
         // GPU RAM
         //
@@ -1045,10 +1045,10 @@ bool PLAN_CLASS_SPEC::check(
         } else if (!strcmp(gpu_type, "nvidia")) {
             hu.proc_type = PROC_TYPE_NVIDIA_GPU;
             hu.gpu_usage = gpu_usage;
-        } else if (strstr(gpu_type, "intel")==gpu_type) {
+        } else if (strstr(gpu_type, "intel") == gpu_type) {
             hu.proc_type = PROC_TYPE_INTEL_GPU;
             hu.gpu_usage = gpu_usage;
-        } else if (strstr(gpu_type, "apple_gpu")==gpu_type) {
+        } else if (strstr(gpu_type, "apple_gpu") == gpu_type) {
             hu.proc_type = PROC_TYPE_APPLE_GPU;
             hu.gpu_usage = gpu_usage;
         } else {

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -84,6 +84,8 @@ struct PLAN_CLASS_SPEC {
         // the project prefs tag for user-supplied gpu_utilization factor
     double min_gpu_peak_flops;
     double max_gpu_peak_flops;
+    bool have_gpu_type_regex;
+    regex_t gpu_type_regex;
 
     // AMD/ATI apps
     //


### PR DESCRIPTION
If the client detects (via OpenCL) a GPU that's not one of the original 4 (NVIDIA, AMD, Intel, Apple)
it reports it to the scheduler with its model name as its 'type'.

A GPU plan class can now specify its GPU type with a regular expression that's matched against this.

This allows BOINC to use new GPU types -
such as integrated GPUs on ARM chips -
with no changes to client or server software.
All that's needed is for projects to develop applications, and to create plan classes with appropriate <gpu_type_regex>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `gpu_type_regex` to GPU plan classes so the scheduler can match OpenCL device model names and schedule apps on new GPU types (e.g., ARM iGPUs) without client updates. Also update the OpenCL summary JSON to report `vendor` and `name` (model).

- **New Features**
  - Parse and compile `gpu_type_regex`; version selection tries it first, then `gpu_type`, with clearer debug logs.
  - Regex-matched devices now run the same GPU RAM and FLOPS checks as typed matches.
  - OpenCL summary JSON now emits `vendor` and `name` instead of a generic type.

- **Migration**
  - Add `gpu_type_regex` (e.g., `Mali|Adreno`) to plan classes to enable new GPU families.
  - No client changes needed.

<sup>Written for commit 41785ecd3e2f3c0616440065b8c8ab2b08e2e6d0. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7047?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

