### PR TITLE
Mac: Fix installer failure when it is run from a short path

### DIFF
--- a/mac_installer/Installer.cpp
+++ b/mac_installer/Installer.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2022 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -159,8 +159,8 @@ int main(int argc, char *argv[])
 
     // Write a temp file to tell our PostInstall.app the previous branding, if any
     oldBrandID = GetOldBrandID();
-    snprintf(temp, sizeof(temp), "/tmp/%s/OldBranding", tempDirName);
-    f = fopen(temp, "w");
+    snprintf(temp2, sizeof(temp2), "/tmp/%s/OldBranding", tempDirName);
+    f = fopen(temp2, "w");
     if (!f) {
         REPORT_ERROR(true);
     } else {


### PR DESCRIPTION
Fix installer failure when it is run from a short path like "/Applications/BOINC Installer.app"

Fixes issue raised [here](https://github.com/BOINC/boinc/pull/7007#issuecomment-4301122962)

**Description of the Change**
The code was modifying a char array while the previous contents were still needed. The fix was to use 2 different char arrays.
This PR is ready to be merged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS installer failure when run from a short path like "/Applications/BOINC Installer.app". Uses a second char buffer for the temp file path to avoid overwriting the original, ensuring the OldBranding file is written and PostInstall runs correctly.

<sup>Written for commit 0a0a85eadae8572fc48f807a7dd46b30f89268a8. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7048?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

