### PR TITLE
client (Win): if dont_use_wsl is set in cc_config.xml, don't query for WSL

### DIFF
--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -1670,6 +1670,7 @@ int HOST_INFO::get_host_info(bool init) {
     // apparently if WSL is not present, querying for it pops up an alert.
     // Avoid this if WSL disabled in config
     //
+    wsl_distros.clear();
     if (!cc_config.dont_use_wsl) {
         OSVERSIONINFOEX osvi;
         if (get_OSVERSIONINFO(osvi) && osvi.dwMajorVersion >= 10) {

--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -1665,14 +1665,20 @@ int HOST_INFO::get_host_info(bool init) {
     get_os_information(
         os_name, sizeof(os_name), os_version, sizeof(os_version)
     );
+
 #ifdef _WIN64
-    OSVERSIONINFOEX osvi;
-    if (get_OSVERSIONINFO(osvi) && osvi.dwMajorVersion >= 10) {
-        retval = get_wsl_information(wsl_distros);
-        if (retval) {
-            msg_printf(0, MSG_INTERNAL_ERROR,
-                "get_wsl_information(): %s", boincerror(retval)
-            );
+    // apparently if WSL is not present, querying for it pops up an alert.
+    // Avoid this if WSL disabled in config
+    //
+    if (!cc_config.dont_use_wsl) {
+        OSVERSIONINFOEX osvi;
+        if (get_OSVERSIONINFO(osvi) && osvi.dwMajorVersion >= 10) {
+            retval = get_wsl_information(wsl_distros);
+            if (retval) {
+                msg_printf(0, MSG_INTERNAL_ERROR,
+                    "get_wsl_information(): %s", boincerror(retval)
+                );
+            }
         }
     }
 #endif


### PR DESCRIPTION
Apparently doing so can pop up an annoying alert

Fixes #7039

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Windows client: Skip WSL detection when `dont_use_wsl` is set in `cc_config.xml` and clear `wsl_distros` before querying to avoid the alert on systems without WSL. Fixes #7039.

<sup>Written for commit 78c21606f9d5a179bb175a2cf3c77728a6c6be0e. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7049?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

