### PR TITLE
Database: use utf8mb4 for all tables

### DIFF
--- a/html/inc/util_ops.inc
+++ b/html/inc/util_ops.inc
@@ -101,17 +101,11 @@ function show_profile_link_ops($user) {
 //
 function db_init_cli() {
     $db_name = project_config_val("db_name");
-    $host = project_config_val("db_host");
-    if (is_blank($host)) {
-        $host = "localhost";
-    }
-    $in = fopen("php://stdin","r");
-    print "Database username (default: owner of mysqld process): ";
-    $user = rtrim(fgets($in, 80));
-    print "Database password (if any): ";
-    $pass = rtrim(fgets($in, 80));
-
-    $retval = _mysql_connect($host, $user, $pass, $db_name);
+    $db_host = project_config_val("db_host");
+    $db_user = project_config_val("db_user");
+    $db_pass = project_config_val("db_passwd");
+    $retval = _mysql_connect(
+    $db_host, $db_user, $db_pass, $db_name);
     if (!$retval) {
         die("Can't connect to DB\n");
     }

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1240,13 +1240,59 @@ function update_11_23_2025() {
     do_query("alter table host add column misc text not null");
 }
 
+function update_5_2_2026a() {
+    do_query("alter table platform modify name varchar(191) not null");
+    do_query("alter table app modify name varchar(191) not null");
+    do_query("alter table app_version modify plan_class varchar(128) not null default ''");
+    do_query("alter table user modify email_addr varchar(191) not null");
+    do_query("alter table user modify name varchar(191)");
+    do_query("alter table user modify authenticator varchar(191)");
+    do_query("alter table team modify name varchar(191) not null");
+    do_query("alter table workunit modify name varchar(191) not null");
+    do_query("alter table result modify name varchar(191) not null");
+    do_query("alter table job_file modify name varchar(191) not null");
+    do_query("alter table category modify name varchar(180) not null");
+    do_query("alter table forum modify title varchar(175) not null");
+    do_query("alter table token modify token varchar(64) not null");
+    do_query("alter table consent_type modify shortname varchar(191) not null");
+}
+
+function update_5_2_2026b() {
+    do_query("alter table platform CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table app CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table app_version CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table user CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table team CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table host CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table workunit CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table result CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table batch CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table job_file CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table msg_from_host CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table msg_to_host CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table profile CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table category CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table forum CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table thread CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table post CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table forum_preferences CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table private_messages CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table donation_items CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table donation_paypal CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table friend CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table badge CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table token CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table consent CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+    do_query("alter table consent_type CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+}
+
 // Updates are done automatically if you use "upgrade".
 //
 // If you need to do updates manually,
 // modify the following to call the function you want.
 // Make sure you do all needed functions, in order.
-// (Look at your DB structure using "explain" queries to see
-// which ones you need).
+// (Look at your DB using "explain" queries to see which ones you need).
+// Update 'db_revision' when done.
 
 //update_3_17_2010();
 
@@ -1302,6 +1348,8 @@ $db_updates = array (
     array(27028, "update_9_12_2018"),
     array(27029, "update_2_15_2025"),
     array(27030, "update_11_23_2025"),
+    array(27031, "update_5_2_2026a"),
+    array(27032, "update_5_2_2026b"),
 );
 
 ?>


### PR DESCRIPTION
... even tables that only need ASCII.  May as well be uniform.

This lets people e.g. put emojis in the message-board posts.

This required shrinking some varchar fields from 255 to 191, the largest that you can still index (767 byte limit)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all database tables to `utf8mb4` with `utf8mb4_unicode_ci` to support full Unicode (including emojis) and make collation consistent. Also reduced some indexed `varchar` fields to 191 and made CLI DB init use config-based credentials.

- **Refactors**
  - Added `update_5_2_2026a` (shrink indexed `varchar` columns; set `app_version.plan_class` to `varchar(128) not null default ''`) and `update_5_2_2026b` (convert all relevant tables to `utf8mb4`/`utf8mb4_unicode_ci`), with `db_revision` entries 27031 and 27032.
  - `db_init_cli` now reads `db_host`, `db_user`, and `db_passwd` from project config; removed interactive prompts.

- **Migration**
  - Run the standard upgrade to apply revisions 27031 and 27032.
  - If you maintain custom tables/indexes, ensure indexed `varchar` columns are ≤191 before converting.

<sup>Written for commit c3f55b709cde24c86edb0be1fc893c08f6ace15a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

