### PR TITLE
Fix issue with the failing linux package tests on Ubuntu resolute armhf

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -806,7 +806,26 @@ jobs:
         if: success() && matrix.arch == 'armhf'
         run: |
           dpkg --add-architecture armhf
-          apt update
+
+      - name: Fix armhf architecture for resolute distro
+        if: success() && matrix.arch == 'armhf' && matrix.os == 'resolute'
+        run: |
+          rm -f /etc/apt/sources.list
+          rm -rf /etc/apt/sources.list.d/*
+          cat <<EOF | tee /etc/apt/sources.list
+          deb [arch=arm64] http://archive.ubuntu.com/ubuntu resolute main universe multiverse restricted
+          deb [arch=arm64] http://archive.ubuntu.com/ubuntu resolute-updates main universe multiverse restricted
+          deb [arch=arm64] http://archive.ubuntu.com/ubuntu resolute-backports main universe multiverse restricted
+          deb [arch=arm64] http://security.ubuntu.com/ubuntu resolute-security main universe multiverse restricted
+          EOF
+          cat <<EOF | tee /etc/apt/sources.list.d/armhf.list
+          deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports resolute main universe multiverse restricted
+          deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports resolute-updates main universe multiverse restricted
+          deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports resolute-security main universe multiverse restricted
+          deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports resolute-backports main universe multiverse restricted
+          EOF
+          rm -rf /var/lib/apt/lists/*
+          apt clean
 
       - name: Install dependencies
         if: success()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes failing Linux package tests on Ubuntu resolute armhf by rebuilding APT sources in CI. Default repos target `arm64`; add `armhf` repos from `ports.ubuntu.com` and clean caches for correct indexes.

- **Bug Fixes**
  - Run only when `matrix.arch == 'armhf'` and `matrix.os == 'resolute'`.
  - Replace `/etc/apt/sources.list` and clear `/etc/apt/sources.list.d/*`; add `resolute*` entries on `archive.ubuntu.com`/`security.ubuntu.com` with `[arch=arm64]`.
  - Create `/etc/apt/sources.list.d/armhf.list` with `resolute*` entries on `ports.ubuntu.com` with `[arch=armhf]`.
  - Remove `apt update`; wipe `/var/lib/apt/lists/*` and run `apt clean` to avoid stale indexes.

<sup>Written for commit d62559fb8a49f30cbb2cf329ea50fa2a18e4105d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

