### PR TITLE
[snap] fix gpu detection

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,12 +47,14 @@ apps:
     plugs:
     - network
     - network-bind
+    - opengl
 
   client:
     command: usr/bin/boinc --dir $HOME
     plugs:
     - network
     - network-bind
+    - opengl
 
   manager:
     command: usr/bin/boincmgr --datadir $HOME


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable GPU detection in the snap by adding the `opengl` plug to the BOINC daemon and client apps. This lets the sandbox access host GPU drivers so projects can use GPU compute.

<sup>Written for commit fdad28e0bfeea7c624288f923fea5fefa1c40f1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

