### PR TITLE
Mac improve pr7022

### DIFF
--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -1019,7 +1019,7 @@ setGroupForUser:
     if (err)
         return err;
 
-    sprintf(buf5, "%s:wheel", user_name);
+    sprintf(buf5, "%s:staff", user_name);
     err = DoSudoPosixSpawn(chownPath, buf5, buf2, NULL, NULL, NULL, NULL);
     if (err)
         return err;

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/mac_build/Mac_SA_Insecure.sh
+++ b/mac_build/Mac_SA_Insecure.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # http://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -55,6 +55,7 @@
 #
 # Updated 1/27/11 for BOINC versions 6.8.19, 6.10.30 and 6.11.1
 # Updated 8/25/25 to add Run_Podman and BOINC podman directory
+# Updated 5/2/26 to delete directories /Users/boinc_master & /Users/boinc_project
 #
 
 function remove_boinc_users() {
@@ -62,6 +63,8 @@ function remove_boinc_users() {
     if [ "$name" = "boinc_master" ] ; then
         sudo dscl . -delete /users/boinc_master
     fi
+
+    rm -fR /Users/boinc_master
 
     name=$(dscl . search /groups RecordName boinc_master | cut -f1 -s)
     if [ "$name" = "boinc_master" ] ; then
@@ -72,6 +75,8 @@ function remove_boinc_users() {
     if [ "$name" = "boinc_project" ] ; then
         sudo dscl . -delete /users/boinc_project
     fi
+
+    rm -fR /Users/boinc_project
 
     name=$(dscl . search /groups RecordName boinc_project | cut -f1 -s)
     if [ "$name" = "boinc_project" ] ; then

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # http://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -74,6 +74,7 @@
 # Updated 8/24/25 to add Run_Podman and BOINC podman directory
 # Updated 8/27/25 to allow podman to stat items under BOINC Data directory
 # Updated 11/9/25 to create "BOINC podman" directory if not present (for bare client)
+# Updated 5/7/26 to set home directories for users boinc_master & boinc_project
 #
 # WARNING: do not use this script with versions of BOINC older
 # than 7.20.4
@@ -121,7 +122,13 @@ function make_boinc_user() {
         dscl . -create /users/$1
         dscl . -create /users/$1 uid $uid
         dscl . -create /users/$1 shell /bin/zsh
-        dscl . -create /users/$1 home /var/empty
+        mkdir -m 0755 /Users/$1
+        chmod -f 0755 /Users/$1
+        dscl . -create /users/$1 IsHidden 1
+        dscl . -create /users/$1 home /Users/$1
+        chflags hidden /Users/$1
+        ## For some reason, "chown $1:staff" fails here but "chown $uid:staff" works.
+        chown $uid:staff /Users/$1
     else
         uid=$(dscl . read /users/$1 UniqueID | cut -d" " -f2 -s)
     fi

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -2149,37 +2149,41 @@ void FindAllVisibleUsers() {
     for (userIndex=human_user_names.size(); userIndex>0; --userIndex) {
         flag = 0;
         strlcpy(human_user_name, human_user_names[userIndex-1].c_str(), sizeof(human_user_name));
-        sprintf(cmd, "dscl . -read \"/Users/%s\" NFSHomeDirectory", human_user_name);
-        f = popen(cmd, "r");
-        REPORT_ERROR(!f);
-        if (f) {
-            while (PersistentFGets(buf, sizeof(buf), f)) {
-                p = strrchr(buf, ' ');
-                if (p) {
-                    if (strstr(p, "/var/empty") != NULL) {
-                        flag = 1;
-                        break;
-                    }
-                }
-            }
-            pclose(f);
-        }
-
-        if (flag) {
-            sprintf(cmd, "dscl . -read \"/Users/%s\" UserShell", human_user_name);
+        if (strcmp(human_user_name, boinc_master_user_name) == 0) flag = 3;
+        if (strcmp(human_user_name, boinc_project_user_name) == 0) flag = 3;
+        if (flag != 3) {
+            sprintf(cmd, "dscl . -read \"/Users/%s\" NFSHomeDirectory", human_user_name);
             f = popen(cmd, "r");
             REPORT_ERROR(!f);
             if (f) {
                 while (PersistentFGets(buf, sizeof(buf), f)) {
                     p = strrchr(buf, ' ');
                     if (p) {
-                        if (strstr(p, "/usr/bin/false") != NULL) {
-                            flag |= 2;
+                        if (strstr(p, "/var/empty") != NULL) {
+                            flag = 1;
                             break;
                         }
-                   }
+                    }
                 }
                 pclose(f);
+            }
+
+            if (flag) {
+                sprintf(cmd, "dscl . -read \"/Users/%s\" UserShell", human_user_name);
+                f = popen(cmd, "r");
+                REPORT_ERROR(!f);
+                if (f) {
+                    while (PersistentFGets(buf, sizeof(buf), f)) {
+                        p = strrchr(buf, ' ');
+                        if (p) {
+                            if (strstr(p, "/usr/bin/false") != NULL) {
+                                flag |= 2;
+                                break;
+                            }
+                       }
+                    }
+                    pclose(f);
+                }
             }
         }
 

--- a/mac_installer/PostInstall.cpp
+++ b/mac_installer/PostInstall.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -578,6 +578,8 @@ fprintf(stdout, "Starting privileged tool (stdout)\n");
     callPosixSpawn ("sudo dscl . -delete /groups/boinc_master");
     callPosixSpawn ("sudo dscl . -delete /users/boinc_project");
     callPosixSpawn ("sudo dscl . -delete /groups/boinc_project");
+    callPosixSpawn ("sudo rm -fR /Users/boinc_master");
+    callPosixSpawn ("sudo rm -fR /Users/boinc_project");
 
     return 0;
 }


### PR DESCRIPTION
Extends / improves the changes made in PR #7022:
* Sets the group of the home directories for users boinc_master and boinc_project to _staff_ instead of _wheel_.
* Updates the Mac_SA_Secure.sh script to create home directories for users boinc_master and boinc_project.
* Updates the uninstaller and the Mac_SA_Insecure.sh script to remove the home directories for users boinc_master and boinc_project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creates hidden home directories for `boinc_master` and `boinc_project` on macOS, sets their group to `staff`, and ensures the uninstaller removes them. Also updates the installer to never treat these accounts as human users, even with non-empty homes. This aligns and extends the installer changes from PR #7022.

- **Bug Fixes**
  - `SetupSecurity.cpp`: set home dir ownership to `user:staff` (was `user:wheel`).
  - `Mac_SA_Secure.sh`: create `/Users/boinc_master` and `/Users/boinc_project` with 0755 perms, `IsHidden=1`, `chflags hidden`, and `chown uid:staff`; set these as user homes.
  - `Mac_SA_Insecure.sh` and uninstaller: remove `/Users/boinc_master` and `/Users/boinc_project` on uninstall.
  - `PostInstall.cpp`: never treat `boinc_master` and `boinc_project` as human users.
  - Update copyright years to 2026.

<sup>Written for commit ec57928420e4b2c6f95cee0fecf4737ee618c9eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

