### PR TITLE
Client: avoid XScreenSaver probing on Wayland

### DIFF
--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -2488,7 +2488,10 @@ https://github.com/jamescowens/idle_detect");
 
 #if HAVE_XSS
 #ifndef ANDROID
-    if (!detect_wayland()) {
+    // Detect Wayland once. The display server type is not expected to
+    // change while this client process is running.
+    static bool wayland_detected = detect_wayland();
+    if (!wayland_detected) {
         //printf("Using XScreenSaver API for idle detection\n");
         idle_time = min(idle_time, xss_idle());
     }

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -40,9 +40,12 @@
 // prevents naming collision between X.h define of Always and boinc's
 // lib/prefs.h definition in an enum.
 #undef Always
-#include <dirent.h> //for opening /tmp/.X11-unix/
-  // (There is a DirScanner class in BOINC, but it doesn't do what we want)
 #include "log_flags.h" // idle_detection_debug flag for verbose output
+#endif
+
+#if LINUX_LIKE_SYSTEM
+#include <dirent.h> //for opening /tmp/.X11-unix/ and /run/user/
+  // (There is a DirScanner class in BOINC, but it doesn't do what we want)
 #endif
 
 #include <cstdio>
@@ -2341,6 +2344,94 @@ bool get_idle_time_from_daemon(long &idle_time) {
     return true;
 }
 
+#if LINUX_LIKE_SYSTEM
+static bool is_wayland_socket(const string& path) {
+    struct stat st;
+    return stat(path.c_str(), &st) == 0 && S_ISSOCK(st.st_mode);
+}
+
+static bool detect_wayland_socket_in_dir(const string& dir) {
+    DIR* dp = opendir(dir.c_str());
+    if (!dp) {
+        return false;
+    }
+
+    struct dirent* dirp;
+    while ((dirp = readdir(dp)) != NULL) {
+        if (strncmp(dirp->d_name, "wayland-", 8) != 0) {
+            continue;
+        }
+        if (is_wayland_socket(dir + "/" + dirp->d_name)) {
+            closedir(dp);
+            return true;
+        }
+    }
+
+    closedir(dp);
+    return false;
+}
+
+static bool detect_wayland_socket() {
+    const char* xdg_runtime_dir = getenv("XDG_RUNTIME_DIR");
+    if (xdg_runtime_dir && strlen(xdg_runtime_dir)) {
+        if (detect_wayland_socket_in_dir(xdg_runtime_dir)) {
+            return true;
+        }
+    }
+
+    DIR* dp = opendir("/run/user");
+    if (!dp) {
+        return false;
+    }
+
+    struct dirent* dirp;
+    while ((dirp = readdir(dp)) != NULL) {
+        if (!strcmp(dirp->d_name, ".")) continue;
+        if (!strcmp(dirp->d_name, "..")) continue;
+        if (detect_wayland_socket_in_dir(string("/run/user/") + dirp->d_name)) {
+            closedir(dp);
+            return true;
+        }
+    }
+
+    closedir(dp);
+    return false;
+}
+
+static bool detect_xwayland_process() {
+    DIR* dp = opendir("/proc");
+    if (!dp) {
+        return false;
+    }
+
+    struct dirent* dirp;
+    while ((dirp = readdir(dp)) != NULL) {
+        if (dirp->d_name[0] < '0' || dirp->d_name[0] > '9') {
+            continue;
+        }
+
+        string comm_path = string("/proc/") + dirp->d_name + "/comm";
+        FILE* f = fopen(comm_path.c_str(), "r");
+        if (!f) {
+            continue;
+        }
+
+        char comm[32];
+        bool is_xwayland = fgets(comm, sizeof(comm), f)
+            && strncmp(comm, "Xwayland", 8) == 0;
+        fclose(f);
+
+        if (is_xwayland) {
+            closedir(dp);
+            return true;
+        }
+    }
+
+    closedir(dp);
+    return false;
+}
+#endif
+
 bool detect_wayland() {
     const char* wayland_display = getenv("WAYLAND_DISPLAY");
     if (wayland_display && strlen(wayland_display)) {
@@ -2350,7 +2441,15 @@ bool detect_wayland() {
     if (xdg_session_type && strcmp(xdg_session_type, "wayland") == 0) {
         return true;
     }
+    // boinc-client often runs as a daemon without the user's session
+    // environment.  Detect compositor sockets and Xwayland directly so we do
+    // not probe Xwayland displays with XOpenDisplay(), which can block
+    // indefinitely.
+#if LINUX_LIKE_SYSTEM
+    return detect_wayland_socket() || detect_xwayland_process();
+#else
     return false;
+#endif
 }
 
 #endif      // !ANDROID
@@ -2389,8 +2488,7 @@ https://github.com/jamescowens/idle_detect");
 
 #if HAVE_XSS
 #ifndef ANDROID
-    static bool wayland_detected = detect_wayland();
-    if (!wayland_detected) {
+    if (!detect_wayland()) {
         //printf("Using XScreenSaver API for idle detection\n");
         idle_time = min(idle_time, xss_idle());
     }


### PR DESCRIPTION
## Summary
- Detect Wayland in daemon/non-session contexts by checking active Wayland sockets and Xwayland processes in addition to session environment variables.
- Re-evaluate Wayland detection before legacy XScreenSaver idle probing instead of caching the initial result, so clients started before a desktop session do not later probe Xwayland displays.
- Skip `XOpenDisplay()` XScreenSaver probing on Wayland/Xwayland to avoid blocking the client main thread and starving GUI RPC handling.

## Root Cause
On Ubuntu 26.04 Wayland systems, `boinc-client` can run without `WAYLAND_DISPLAY` or `XDG_SESSION_TYPE` in its environment. The existing `detect_wayland()` then returns false, and the legacy idle path enumerates `/tmp/.X11-unix/*` and calls `XOpenDisplay()` for those displays. On the reproduced system, opening the Xwayland display blocks in `unix_wait_for_peer`, leaving local GUI RPC requests unanswered; `boinccmd` then reports authorization failures and raw `<auth1/>` requests time out.

## Repro
- Start an isolated client with `--allow_multiple_clients --skip_cpu_benchmarks --gui_rpc_port 31427 --no_gpus`.
- Run `boinccmd --host localhost:31427 --passwd boinc123 --get_state`.
- Observe `Authorization failure: -102`; raw `<auth1/>` to `127.0.0.1:31427` times out.
- `strace`/`wchan` show the client stuck while connecting to `/tmp/.X11-unix/X1`.

## Verification
- `git diff --check`
- `g++ -std=c++17 -fsyntax-only ... -DHAVE_XSS=0 client/hostinfo_unix.cpp` using a temporary generated `config.h` and curl stub
- `g++ -std=c++17 -fsyntax-only ... -DHAVE_XSS=1 client/hostinfo_unix.cpp` using a temporary generated `config.h` and curl stub

`./_autosetup` could not run in this environment because `m4`/`gm4` is not installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent GUI RPC deadlocks on Wayland by skipping XScreenSaver probing and improving Wayland detection. Detection now scans sockets/processes and caches the result for idle probing.

- **Bug Fixes**
  - Detect Wayland by scanning `XDG_RUNTIME_DIR` and `/run/user/*` for `wayland-*` sockets and by checking `/proc/*/comm` for `Xwayland`.
  - Cache Wayland detection for XScreenSaver idle probing.
  - Skip `XOpenDisplay()` probing on Wayland/Xwayland to prevent main-thread blocking and stalled GUI RPC.

<sup>Written for commit a1c9bbcd79f484047890dbc47fef4059c6d4dbf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

