### PR TITLE
Mac: update to  use wxWidgets 3.3.2

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -191,11 +191,8 @@ bool CBOINCGUIApp::OnInit() {
 
 #ifdef __WXMAC__
     // Don't open main window if we were started automatically at login
-    if (compareOSVersionTo(13, 0) >= 0) {
         m_bGUIVisible = !m_bBOINCMGRAutoStarted;
-    } else {
-        m_bGUIVisible = IsApplicationVisible();
-    }
+
     if (getTimeSinceBoot() < 30.) {
         // If the system was just started, we usually get a "Connection
         // failed" error if we try to connect too soon, so delay a bit.

--- a/clientgui/BOINCGUIApp.h
+++ b/clientgui/BOINCGUIApp.h
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -282,10 +282,6 @@ public:
     void                SetActivationPolicyAccessory(bool hideDock);
     void                CheckPartialActivation();
     long                GetBrandID();
-
-    // Override standard wxCocoa wxApp::CallOnInit() to allow Manager
-    // to run properly when launched hidden on login via Login Item.
-    bool                CallOnInit();
 #endif
 
 DECLARE_EVENT_TABLE()

--- a/clientgui/mac/BOINCGUIApp.mm
+++ b/clientgui/mac/BOINCGUIApp.mm
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // https://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -25,28 +25,6 @@
 #ifndef NSEventTypeApplicationDefined
 #define NSEventTypeApplicationDefined NSApplicationDefined
 #endif
-
-// Cocoa routines which are part of CBOINCGUIApp
-// Override standard wxCocoa wxApp::CallOnInit() to allow Manager
-// to run properly when launched hidden on login via Login Item.
-bool CBOINCGUIApp::CallOnInit() {
-        NSAutoreleasePool *mypool = [[NSAutoreleasePool alloc] init];
-
-        NSEvent *event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
-                                        location:NSMakePoint(0.0, 0.0)
-                                   modifierFlags:0
-                                       timestamp:0
-                                    windowNumber:0
-                                         context:nil
-                                         subtype:0 data1:0 data2:0];
-        [NSApp postEvent:event atStart:FALSE];
-
-   bool retVal = wxApp::CallOnInit();
-
-    [mypool release];
-    return retVal;
-}
-
 
 // Our application can get into a strange state
 // if our login item launched it hidden and the
@@ -236,8 +214,8 @@ OSErr QuitAppleEventHandler( const AppleEvent *appleEvt, AppleEvent* reply, UInt
                 // treat this as an autostart and launch hidden.
                     wxGetApp().SetBOINCMGRWasShutDownBySystemWhileHidden(1);
                 }
-                // The following may no longer be needed under wxCocoa-3.0.0
-                wxGetApp().ExitMainLoop();  // Prevents wxMac from issuing events to closed frames
+                // The following causes a crash when logging out under wxWidgets 3.3.2
+//                wxGetApp().ExitMainLoop();  // Prevents wxMac from issuing events to closed frames
             }
         }
     }

--- a/mac_build/dependencyNames.sh
+++ b/mac_build/dependencyNames.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -52,11 +52,10 @@ curlBaseName="curl"
 curlFileName="curl-8.16.0.tar.gz"
 curlURL="https://curl.se/download/curl-8.16.0.tar.gz"
 
-wxWidgetsDirName="wxWidgets-3.3.1"
+wxWidgetsDirName="wxWidgets-3.3.2"
 wxWidgetsBaseName="wxWidgets"
-wxWidgetsFileName="wxWidgets-3.3.1.tar.bz2"
-wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.3.1/wxWidgets-3.3.1.tar.bz2"
-
+wxWidgetsFileName="wxWidgets-3.3.2.tar.bz2"
+wxWidgetsURL="https://github.com/wxWidgets/wxWidgets/releases/download/v3.3.2/wxWidgets-3.3.2.tar.bz2"
 freetypeDirName="freetype-2.11.0"
 freetypeBaseName="freetype"
 freetypeFileName="freetype-2.11.0.tar.gz"


### PR DESCRIPTION
This PR upgrades BOINC for the Mac to use wxWidgets 3.3.2.

Under MacOS 26, BOINC Manager startup stalled until there was user input (mouse move, keystroke, etc.) This was an issue under wxWidgets 3.3.1 and has been fixed in wxWidgets 3.3.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Mac build to `wxWidgets` 3.3.2 to fix BOINC Manager startup delays on macOS 26 when launched without user input. Also removes obsolete Mac init code and avoids a logout crash with 3.3.2.

- **Dependencies**
  - Bump `wxWidgets` from 3.3.1 to 3.3.2 in `mac_build/dependencyNames.sh` (dir, file, URL).

- **Bug Fixes**
  - Remove custom `CBOINCGUIApp::CallOnInit()` override no longer needed with 3.3.2.
  - Stop calling `ExitMainLoop()` on logout (crashed under 3.3.2).
  - Always set `m_bGUIVisible` from the autostart flag on macOS; drop legacy OS check.

<sup>Written for commit becb060407ef4120c8292f97288b78588d4cb89c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

