### PR TITLE
Add '--get_project_urls' to boinccmd's help page

### DIFF
--- a/client/boinc_cmd.cpp
+++ b/client/boinc_cmd.cpp
@@ -74,6 +74,7 @@ Commands:\n\
  --get_notices [ seqno ]            show notices > seqno\n\
  --get_project_config URL\n\
  --get_project_status               show status of all attached projects\n\
+ --get_project_urls                 show master URLs of all attached projects\n\
  --get_proxy_settings\n\
  --get_simple_gui_info              show status of projects and active tasks\n\
  --get_state                        show entire state\n\


### PR DESCRIPTION
Boinccmd knows the option `--get_project_urls` which outputs a list of master URLs like:
```
boinccmd --host hostname:port --get_project_urls
https://asteroidsathome.net/boinc/
https://einstein.phys.uwm.edu/
https://lhcathome.cern.ch/lhcathome/
http://milkyway.cs.rpi.edu/milkyway/
https://spaciousathome.eu/spaciousathome/
http://gene.disi.unitn.it/test/

```
So far `--get_project_urls` is missing at boinccmd's help page.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--get_project_urls` to `boinccmd` help so users can discover the command that prints master URLs of attached projects. This aligns the help text with existing functionality.

<sup>Written for commit f2328a34ae7d6b959c48ef2a1b96e60a6a875703. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

