### PR TITLE
Use 'Type=exec' in boinc-client.service.in

### DIFF
--- a/client/scripts/boinc-client.service.in
+++ b/client/scripts/boinc-client.service.in
@@ -5,7 +5,7 @@ Wants=vboxdrv.service
 After=vboxdrv.service network-online.target
 
 [Service]
-Type=simple
+Type=exec
 ProtectHome=true
 ProtectSystem=strict
 ProtectControlGroups=true


### PR DESCRIPTION
**Description of the Change**
Below please find an excerpt from the systemd manpage.
According to the suggestions there `Type=exec` appears to be the preferred option instead of `Type=simple`.

man systemd.service:

```
Type=
Configures the mechanism via which the service notifies the manager that the service start-up has finished.
One of simple, exec, forking, oneshot, dbus, notify, notify-reload, or idle:

- If set to simple (the default if ExecStart= is specified but neither Type= nor BusName= are,
and credentials are not used), the service manager will consider the unit started immediately
after the main service process has been forked off (i.e. immediately after fork(), and before
various process attributes have been configured and in particular before the new process has
called execve() to invoke the actual service binary).
Typically, Type=exec is the better choice, see below.

It is expected that the process configured with ExecStart= is the main process of the service.
In this mode, if the process offers functionality to other processes on the system, its communication
channels should be installed before the service is started up (e.g. sockets set up by systemd,
via socket activation), as the service manager will immediately proceed starting follow-up units,
right after creating the main service process, and before executing the service's binary.
Note that this means systemctl start command lines for simple services will report success
even if the service's binary cannot be invoked successfully (for example because the selected
User= does not exist, or the service binary is missing).

- The exec type is similar to simple, but the service manager will consider the unit started immediately
after the main service binary has been executed. The service manager will delay starting of follow-up
units until that point. (Or in other words: simple proceeds with further jobs right after fork() returns,
while exec will not proceed before both fork() and execve() in the service process succeeded.)
Note that this means systemctl start command lines for exec services will report failure when the
service's binary cannot be invoked successfully (for example because the selected User= does not exist,
or the service binary is missing).
This type is implied if credentials are used (refer to LoadCredential= in systemd.exec(5) for details).
```


**Alternate Designs**
Leave it as is.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `client/scripts/boinc-client.service.in` from Type=simple to Type=exec so systemd only marks the service started after the BOINC client binary executes. This avoids false-positive start successes and ensures follow-up units wait until exec succeeds, per systemd guidance.

<sup>Written for commit 8e83665fd23239e28eadb9a83076f72cd72f1af7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

