### PR TITLE
Various AI fixes

### DIFF
--- a/client/net_stats.cpp
+++ b/client/net_stats.cpp
@@ -168,7 +168,7 @@ void NET_STATUS::network_available() {
         p->download_backoff.clear_temporary();
     }
 
-    // tell active tasks that network is available (for Folding@home)
+    // tell active tasks that network is available
     //
     gstate.active_tasks.network_available();
 }

--- a/html/inc/prefs.inc
+++ b/html/inc/prefs.inc
@@ -53,8 +53,7 @@ $in_use_prefs = [
         tra("'In use' means mouse/keyboard input in last"),
         tra("This determines when the computer is considered 'in use'."),
         "idle_time_to_run",
-        new NUM_SPEC(tra("minutes"), 1, 9999, 3),
-        true
+        new NUM_SPEC(tra("minutes"), 1, 9999, 3)
     ),
     new PREF_BOOL(
         tra("Suspend all computing"),

--- a/html/inc/user.inc
+++ b/html/inc/user.inc
@@ -674,7 +674,7 @@ function show_account_private($user) {
             );
             panel(
                 tra("Preferences"),
-                function() use($user) {
+                function() {
                     start_table();
                     show_preference_links();
                     end_table();

--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -1051,6 +1051,8 @@ function credit_to_gflop_hours($c) {
     return $c/(200/24);
 }
 
+// $name is the name of the downloaded file
+//
 function download_header($name, $nbytes) {
     header('Content-Description: File Transfer');
     header('Content-Type: application/octet-stream');
@@ -1063,8 +1065,11 @@ function download_header($name, $nbytes) {
     flush();
 }
 
-function do_download($path) {
-    download_header(basename($path), filesize($path));
+function do_download($path, $name=null) {
+    if (!$name) {
+        $name = basename($path);
+    }
+    download_header($name, filesize($path));
     readfile($path);
 }
 

--- a/html/ops/block_host.php
+++ b/html/ops/block_host.php
@@ -34,7 +34,7 @@ if (get_int('hostid')) {
     error_page("no hostid");
 }
 
-$timestr = time_str(time(0));
+$timestr = time_str(time());
 $title = "host ".$hostid." max_results_day set to 1 at ".$timestr;
 
 admin_page_head($title);

--- a/html/ops/eah_server_status.php
+++ b/html/ops/eah_server_status.php
@@ -152,7 +152,7 @@ echo "
 if ($dbrc) {
     echo "The database server is not accessable";
 } else {
-    $now=time(0);
+    $now=time();
     $s_day=24*3600;
     $d_ago=$now-$s_day;
     $s_week=7*$s_day;
@@ -276,7 +276,7 @@ if ($dbrc) {
         <tr><td>invalid</td><td>".number_format($n)."</td></tr>
     ";
 
-    $n = time(0)-find_oldest();
+    $n = time()-find_oldest();
     $days = (int)($n/86400);
     $hours=(int)($n/3600);
     $hours=$hours % 24;

--- a/html/ops/hrclass_summary.php
+++ b/html/ops/hrclass_summary.php
@@ -71,7 +71,7 @@ function make_reset_url($hr_class) {
 
 db_init();
 
-$timestr = time_str(time(0));
+$timestr = time_str(time());
 $title = "hr_class summary list at ".$timestr;
 
 admin_page_head($title);

--- a/html/ops/job_times.php
+++ b/html/ops/job_times.php
@@ -169,7 +169,7 @@ function analyze($appid, $app_version_id, $nresults) {
     }
 
     ksort($hist);
-    show_stats($hist);
+    show_stats();
     echo "<hr>\n";
     show_as_table();
     echo "<hr>\n";

--- a/html/ops/mass_email.php
+++ b/html/ops/mass_email.php
@@ -58,7 +58,7 @@ if ($receiver > 0) {
         break;
     case 2:
         // unsuccessful users
-        $week_ago = time(0) - 7*86400;
+        $week_ago = time() - 7*86400;
         $query = "select user.id,user.name,user.email_addr from user left join result on user.id=result.userid where send_email>0 and total_credit=0 and user.create_time<$week_ago and isnull(result.id)";
         break;
     case 3:

--- a/html/ops/reset_hrclass.php
+++ b/html/ops/reset_hrclass.php
@@ -35,7 +35,7 @@ if (get_int('hr_class')) {
     $hr_class = 0;
 }
 
-$timestr = time_str(time(0));
+$timestr = time_str(time());
 $title = "hr_class ".$hr_class." reset at ".$timestr;
 
 admin_page_head($title);

--- a/html/ops/submit_init_priority.php
+++ b/html/ops/submit_init_priority.php
@@ -69,7 +69,7 @@ function process_batch($b) {
 }
 
 function scan_batches() {
-    $batches = BoincBatch::enum("", "order by id");
+    $batches = BoincBatch::enum('');
     foreach ($batches as $b) {
         process_batch($b);
     }

--- a/html/user/sandbox.php
+++ b/html/user/sandbox.php
@@ -134,7 +134,6 @@ function list_files($user, $notice=null) {
                 'sandbox.php?',
                 $sort_field, $sort_rev
             ),
-            "MD5",
             "Delete",
             "Download"
         );
@@ -144,7 +143,6 @@ function list_files($user, $notice=null) {
                 "<a href=sandbox.php?action=view_file&name=$f->name>$f->name</a>",
                 $ct,
                 $f->size,
-                $f->md5,
                 button_text_small(
                     "sandbox.php?action=delete_file&name=$f->name",
                     "Delete"
@@ -284,7 +282,7 @@ case 'get_file': get_file($user); break;
 case 'delete_file': delete_file($user); break;
 case 'download_file': download_file($user); break;
 case 'view_file': view_file($user); break;
-case 'add_form': add_form($user); break;
+case 'add_form': add_form(); break;
 default: error_page("no such action: ".htmlspecialchars($action));
 }
 

--- a/html/user/submit_example.php
+++ b/html/user/submit_example.php
@@ -272,7 +272,7 @@ function handle_create_action() {
 
     $get_estimate = get_str('get_estimate', true);
     if ($get_estimate) {
-        $req = form_to_request($project, $auth);
+        $req = form_to_request();
         list($e, $errmsg) = boinc_estimate_batch($req);
         if ($errmsg) error_page(htmlentities($errmsg));
         page_head("Batch estimate");
@@ -280,7 +280,7 @@ function handle_create_action() {
         echo "<p><a href=submit_example.php>Return to job control page</a>\n";
         page_tail();
     } else {
-        $req = form_to_request($project, $auth);
+        $req = form_to_request();
         list($id, $errmsg) = boinc_submit_batch($req);
         if ($errmsg) error_page(htmlentities($errmsg));
         page_head("Batch submitted");

--- a/html/user/submit_rpc_handler.php
+++ b/html/user/submit_rpc_handler.php
@@ -207,7 +207,7 @@ function stage_file($file, $user) {
         }
         return $name;
     }
-    log_write(-1, "unsupported file mode: $file->mode");
+    log_write("unsupported file mode: $file->mode");
     xml_error(-1, "unsupported file mode: $file->mode");
 }
 


### PR DESCRIPTION
- when downloading output files (pre-BUDA scheme) give them the right names.
- don't show MD5 in sandbox file list

The other fixes should have no visible effect

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes output file downloads to use the correct filenames for pre-BUDA jobs and removes MD5 hashes from the sandbox file list. Includes small internal cleanups with no user-visible impact.

- **Bug Fixes**
  - Output files now download with their original names for pre-BUDA jobs (via optional name support in `do_download()`).
  - Removed the MD5 column from the sandbox file list.

- **Refactors**
  - Minor internal tidy-ups: use `time()` consistently, simplify callbacks and function params (`form_to_request()`, `add_form()`), adjust logging in `submit_rpc_handler`, and small admin/UI tweaks; no behavior changes.

<sup>Written for commit 2959289a3d3ed253c8c9efe19cfc73b38861af1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

