### PR TITLE
Mac: Update PR #6088 for MacOS 26.5

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -555,6 +555,8 @@ static int check_boinc_users_primarygroupIds(int useFakeProjectUserAndGroup, int
     passwd              *pw;
     group               *grp;
 
+    callPosixSpawn("/usr/bin/dscacheutil -flushcache");
+
     if ((!useFakeProjectUserAndGroup) || isMacInstaller) {
        // Require absolute owner and group boinc_master:boinc_master
         strlcpy(boinc_master_user_name, REAL_BOINC_MASTER_NAME, sizeof(boinc_master_user_name));

--- a/clientgui/mac/MacFixUserGroups.cpp
+++ b/clientgui/mac/MacFixUserGroups.cpp
@@ -43,5 +43,7 @@ int main(int argc, char *argv[])
         callPosixSpawn (cmd);
     }
 
+    callPosixSpawn("/usr/bin/dscacheutil -flushcache");
+
     return 0;
 }


### PR DESCRIPTION
Under MacOS 26.5, getpwnam() returns the old primary group ID unless we first flush the Directory Services cache, even if the value was changed by a MacOS system updated. This PR adds the code to flush the cache before checking the primary group of boinc_master & boinc_project. It also flushes the cache after repairing them.

**Alternate Designs**
We could instead use `FILE *f = popen "dscl . -read /Users/boinc_master PrimaryGroupID" ` to check the primary group of boinc_master & boinc_project, but that would require parsing the response, which is of the form `PrimaryGroupID: 505`. This method is simpler and more robust.

**Release Notes**
Updates fixing directory permissions on MacOS updates for MacOS 26.5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flush the macOS Directory Services cache on macOS 26.5 to avoid stale primary group data when verifying and repairing BOINC users. Ensures correct groups for `boinc_master` and `boinc_project` after system updates.

- **Bug Fixes**
  - Run `/usr/bin/dscacheutil -flushcache` before `getpwnam()` checks in `client/check_security.cpp`.
  - Run the same cache flush after updating primary groups in `clientgui/mac/MacFixUserGroups.cpp`.

<sup>Written for commit d0e9a178f228cae7433387b17933d7bd3e6842fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

