### PR TITLE
fix AI web warnings.  No functional change

### DIFF
--- a/html/ops/batch_stats.php
+++ b/html/ops/batch_stats.php
@@ -148,8 +148,8 @@ function update_db() {
         $n = count($hlist);
         if ($n > 100) {
             $nfast = 0;
-            foreach ($hlist as $id=>$count) {
-                $x = $hosts[$id];
+            foreach ($hlist as $host_id=>$count) {
+                $x = $hosts[$host_id];
                 $avg = $x->ntt_sum / $x->ntt_n;
                 if ($avg < 1) {
                     $nfast++;

--- a/html/ops/credit.php
+++ b/html/ops/credit.php
@@ -85,7 +85,7 @@ function handle_result($resultid) {
 }
 
 function show_host_av($host_id, $av_id) {
-    $hav = BoincHostAppVersion::lookup("host_id=$host_id and app_version_id=$av_id");
+    $hav = BoincHostAppVersion::lookup($host_id, $av_id);
     page_head("Host $host_id / app_version $av_id credit");
     echo "Results";
     $rs = BoincResult::enum("hostid=$host_id and app_version_id=$av_id and validate_state=1 order by id desc limit 100");

--- a/html/ops/remote_server_status.php
+++ b/html/ops/remote_server_status.php
@@ -64,7 +64,9 @@ function is_daemon_running($host, $d) {
         $prog = $cmd[0];
         $path = "../../pid_$host/$prog".".pid";
     }
-    $pid = trim(@file_get_contents($path));
+    $x = @file_get_contents($path);
+    if ($x === false) return false;
+    $pid = trim($x);
     if ($pid === false) return false;
     $cmd = "ssh $host 'ps $pid'";
     $out = exec($cmd);

--- a/html/user/lammps.php
+++ b/html/user/lammps.php
@@ -38,9 +38,9 @@ function terminate_job($p) {
     // echo "child process is $ret\n";
     $pids=preg_split('/\s+/',$ret);
     foreach($pids as $pid){
-        if(is_numeric($pid)){
+        if (is_numeric($pid)){
             if($GLOBALS["debug"])echo "killing child process $pid\n";
-            posix_kill($pid,9);
+            posix_kill(intval($pid), 9);
         }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed PHP warnings and improved type safety across ops and user pages. No functional changes; reduces noisy logs and makes process handling safer.

- **Bug Fixes**
  - Use correct foreach key `$host_id` when indexing `$hosts` in `batch_stats.php`.
  - Call `BoincHostAppVersion::lookup` with explicit params instead of a query string in `credit.php`.
  - Safely handle missing PID files before trimming in `remote_server_status.php`.
  - Cast PIDs to int before `posix_kill` and minor style cleanup in `lammps.php`.

<sup>Written for commit f753dbc8b9835a2b8107058a4c3e6b6ae709daeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

