### PR TITLE
[ci] Fix linux package build

### DIFF
--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -42,11 +42,88 @@ env:
   BASEREPO: https://boinc.berkeley.edu/dl/linux # no trailing slash
   AUTOCONF_WITH_VERSION: autoconf-2.73
   BISON_WITH_VERSION: bison-3.8.2
+  PYTHON_VERSION: 3.9.0
 
 jobs:
+  prepare-build-dependencies:
+    name: Prepare build dependencies
+    runs-on: ubuntu-latest
+    container:
+      image: debian:buster
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 2
+
+      - name: Cache dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+        with:
+          path: |
+            ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
+            ${{ env.BISON_WITH_VERSION }}.tar.gz
+            Python-${{ env.PYTHON_VERSION }}.tar.xz
+          key: ${{ env.AUTOCONF_WITH_VERSION }}_${{ env.BISON_WITH_VERSION }}_Python-${{ env.PYTHON_VERSION }}
+
+      - name: Fix debian sources
+        run: |
+          sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+          sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool curl tar xz-utils make gcc libssl-dev lzma-dev liblzma-dev libreadline-dev libbz2-dev libsqlite3-dev libgdbm-dev libgdbm-compat-dev uuid-dev libffi-dev tk-dev
+
+      - name: Build updated version of autoconf
+        run: |
+          if [ ! -f ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz ]; then
+            curl https://ftp.gnu.org/gnu/autoconf/${{ env.AUTOCONF_WITH_VERSION }}.tar.gz -o ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
+          fi
+          tar -xzf ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
+          cd ${{ env.AUTOCONF_WITH_VERSION }}
+          ./configure --prefix=/usr
+          make -j $(nproc --all)
+          cd ..
+
+      - name: Build updated version of bison
+        run: |
+          if [ ! -f ${{ env.BISON_WITH_VERSION }}.tar.gz ]; then
+            curl https://ftp.gnu.org/gnu/bison/${{ env.BISON_WITH_VERSION }}.tar.gz -o ${{ env.BISON_WITH_VERSION }}.tar.gz
+          fi
+          tar -xzf ${{ env.BISON_WITH_VERSION }}.tar.gz
+          cd ${{ env.BISON_WITH_VERSION }}
+          ./configure --prefix=/usr
+          make -j $(nproc --all)
+          cd ..
+
+      - name: Build updated version of python
+        run: |
+          if [ ! -f Python-${{ env.PYTHON_VERSION }}.tar.xz ]; then
+            curl https://www.python.org/ftp/python/${{ env.PYTHON_VERSION }}/Python-${{ env.PYTHON_VERSION }}.tar.xz -o Python-${{ env.PYTHON_VERSION }}.tar.xz
+          fi
+          tar -xf Python-${{ env.PYTHON_VERSION }}.tar.xz
+          cd Python-${{ env.PYTHON_VERSION }}
+          ./configure --prefix=/usr/local --with-ensurepip=install
+          make -j $(nproc --all)
+          cd ..
+
+      - name: Add prepared dependencies to archive
+        run: |
+           tar -cvzpf build-deps_${{ github.event.pull_request.head.sha }}.tar.gz \
+            ${{ env.AUTOCONF_WITH_VERSION }}/ \
+            ${{ env.BISON_WITH_VERSION }}/ \
+            Python-${{ env.PYTHON_VERSION }}/
+
+      - name: Upload prepared dependencies
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: build-deps_${{ github.event.pull_request.head.sha }}
+          path: build-deps_${{ github.event.pull_request.head.sha }}.tar.gz
+
   prepare-binaries:
     name: Prepare Binaries
     runs-on: ubuntu-latest
+    needs: prepare-build-dependencies
     container:
       image: debian:buster
       env:
@@ -62,14 +139,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 2
-
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
-        with:
-          path: |
-            ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
-            ${{ env.BISON_WITH_VERSION }}.tar.gz
-          key: ${{ env.AUTOCONF_WITH_VERSION }}_${{ env.BISON_WITH_VERSION }}
 
       - name: Check if build is running from origin repo
         if: ${{ success() && env.AWS_ACCESS_KEY_ID != 0 && env.AWS_SECRET_ACCESS_KEY != 0 }}
@@ -89,7 +158,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git python3 python3-distutils python3-jinja2 python3-venv curl zip unzip tar bison p7zip-full dbus flex
+          apt-get install -y autopoint make build-essential m4 pkg-config autoconf autoconf-archive libtool git curl zip unzip tar p7zip-full dbus flex
 
       - name: Install dependencies for arm64
         if: matrix.arch == 'arm64'
@@ -101,31 +170,42 @@ jobs:
         run: |
           apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
 
+      - name: Download prepared dependencies
+        if: success()
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: build-deps_${{ github.event.pull_request.head.sha }}
+
+      - name: Extract prepared dependencies
+        if: success()
+        run: |
+          tar -xvzpf build-deps_${{ github.event.pull_request.head.sha }}.tar.gz
+
       - name: Install updated version of autoconf
         run: |
-          if [ ! -f ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz ]; then
-            curl https://ftp.gnu.org/gnu/autoconf/${{ env.AUTOCONF_WITH_VERSION }}.tar.gz -o ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
-          fi
-          tar -xzf ${{ env.AUTOCONF_WITH_VERSION }}.tar.gz
           cd ${{ env.AUTOCONF_WITH_VERSION }}
-          ./configure --prefix=/usr
-          make -j $(nproc --all)
           make install
           cd ..
           autoconf --version
 
       - name: Install updated version of bison
         run: |
-          if [ ! -f ${{ env.BISON_WITH_VERSION }}.tar.gz ]; then
-            curl https://ftp.gnu.org/gnu/bison/${{ env.BISON_WITH_VERSION }}.tar.gz -o ${{ env.BISON_WITH_VERSION }}.tar.gz
-          fi
-          tar -xzf ${{ env.BISON_WITH_VERSION }}.tar.gz
           cd ${{ env.BISON_WITH_VERSION }}
-          ./configure --prefix=/usr
-          make -j $(nproc --all)
           make install
           cd ..
           bison --version
+
+      - name: Install updated version of python
+        run: |
+          cd Python-${{ env.PYTHON_VERSION }}
+          make install
+          cd ..
+          python3 --version
+
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install jinja2
 
       - name: Install aws cli tool
         run: |

--- a/3rdParty/vcpkg_ports/ports/libsystemd/disable-warning-nonnull.patch
+++ b/3rdParty/vcpkg_ports/ports/libsystemd/disable-warning-nonnull.patch
@@ -1,0 +1,14 @@
+diff --git a/src/basic/memory-util.h b/src/basic/memory-util.h
+index 1179513..fc39e06 100644
+--- a/src/basic/memory-util.h
++++ b/src/basic/memory-util.h
+@@ -41,7 +41,9 @@ static inline int memcmp_safe(const void *s1, const void *s2, size_t n) {
+                 return 0;
+         assert(s1);
+         assert(s2);
++DISABLE_WARNING_NONNULL
+         return memcmp(s1, s2, n);
++REENABLE_WARNING
+ }
+ 
+ /* Compare s1 (length n1) with s2 (length n2) in lexicographic order. */

--- a/3rdParty/vcpkg_ports/ports/libsystemd/fix-2604-build.patch
+++ b/3rdParty/vcpkg_ports/ports/libsystemd/fix-2604-build.patch
@@ -1,0 +1,42 @@
+diff --git a/meson.build b/meson.build
+index 3d50c83..802de14 100644
+--- a/meson.build
++++ b/meson.build
+@@ -371,6 +371,8 @@ possible_common_cc_flags = [
+         '-Warray-bounds=2',
+         '-Wdate-time',
+         '-Wendif-labels',
++]
++vcpkg_omit_werror = [
+         '-Werror=bool-compare',
+         '-Werror=discarded-qualifiers',
+         '-Werror=flex-array-member-not-at-end',
+@@ -392,6 +394,8 @@ possible_common_cc_flags = [
+         '-Werror=shift-overflow=2',
+         '-Werror=strict-flex-arrays',
+         '-Werror=undef',
++]
++possible_common_cc_flags += [
+         '-Wfloat-equal',
+         # gperf prevents us from enabling this because it does not emit fallthrough
+         # attribute with clang.
+@@ -511,19 +515,6 @@ add_project_link_arguments(
+ userspace_c_args += cc.get_supported_arguments(possible_cc_flags)
+ userspace_c_ld_args += cc.get_supported_link_arguments(possible_link_flags)
+ 
+-if cc.compiles('''
+-   #include <time.h>
+-   #include <inttypes.h>
+-   typedef uint64_t usec_t;
+-   usec_t now(clockid_t clock);
+-   int main(void) {
+-           struct timespec now;
+-           return 0;
+-   }
+-''', args: '-Werror=shadow', name : '-Werror=shadow with local shadowing')
+-        add_project_arguments('-Werror=shadow', language : 'c')
+-endif
+-
+ if cxx_cmd != ''
+         add_project_arguments(cxx.get_supported_arguments(basic_disabled_warnings), language : 'cpp')
+ endif

--- a/3rdParty/vcpkg_ports/ports/libsystemd/fix-buster-build.patch
+++ b/3rdParty/vcpkg_ports/ports/libsystemd/fix-buster-build.patch
@@ -1,0 +1,499 @@
+diff --git a/src/basic/errno-list.c b/src/basic/errno-list.c
+index b6662bf05a..f60de6c673 100644
+--- a/src/basic/errno-list.c
++++ b/src/basic/errno-list.c
+@@ -24,7 +24,7 @@ int errno_from_name(const char *name) {
+         return sc->id;
+ }
+ 
+-#ifdef __GLIBC__
++#ifdef __GLIBC__ &&  __GLIBC_PREREQ(2, 32)
+ const char* errno_name_no_fallback(int id) {
+         if (id == 0) /* To stay in line with our implementation below.  */
+                 return NULL;
+diff --git a/src/basic/fd-util.c b/src/basic/fd-util.c
+index 6fb4e78c2f..8050cbcd7f 100644
+--- a/src/basic/fd-util.c
++++ b/src/basic/fd-util.c
+@@ -1072,6 +1072,9 @@ int path_is_root_at(int dir_fd, const char *path) {
+         return fds_inode_and_mount_same(dir_fd, XAT_FDROOT);
+ }
+ 
++#ifndef STATX_MNT_ID
++#define STATX_MNT_ID            0x00001000U
++#endif
+ int fds_inode_and_mount_same(int fd1, int fd2) {
+         struct statx sx1, sx2;
+         int r;
+diff --git a/src/basic/missing.h b/src/basic/missing.h
+new file mode 100644
+index 0000000000..36180c5b39
+--- /dev/null
++++ b/src/basic/missing.h
+@@ -0,0 +1,59 @@
++#pragma once
++
++#include <errno.h>
++#include <fcntl.h>
++#if HAVE_LINUX_TIME_TYPES_H
++/* This header defines __kernel_timespec for us, but is only available since Linux 5.1, hence conditionally
++ * include this. */
++#include <linux/time_types.h>
++#endif
++#include <signal.h>
++#include <sys/syscall.h>
++#include <sys/types.h>
++#include <sys/wait.h>
++#include <unistd.h>
++
++#ifdef ARCH_MIPS
++#include <asm/sgidefs.h>
++#endif
++
++//#include "macro.h"
++//#include "missing_keyctl.h"
++//#include "missing_sched.h"
++//#include "missing_stat.h"
++//#include "missing_syscall_def.h"
++
++/* linux/kcmp.h */
++#ifndef KCMP_FILE /* 3f4994cfc15f38a3159c6e3a4b3ab2e1481a6b02 (3.19) */
++#define KCMP_FILE 0
++#endif
++
++
++#if !HAVE_GETTID
++static inline pid_t missing_gettid(void) {
++#  if defined __NR_gettid && __NR_gettid >= 0
++        return (pid_t) syscall(__NR_gettid);
++#  else
++#    error "__NR_gettid not defined"
++#  endif
++}
++
++#  define gettid missing_gettid
++#endif
++
++#if !HAVE_CLOSE_RANGE
++static inline int missing_close_range(unsigned first_fd, unsigned end_fd, unsigned flags) {
++#  ifdef __NR_close_range
++        return syscall(__NR_close_range,
++                       first_fd,
++                       end_fd,
++                       flags);
++#  else
++        errno = ENOSYS;
++        return -1;
++#  endif
++}
++
++#  define close_range missing_close_range
++#endif
++
+diff --git a/src/basic/mountpoint-util.c b/src/basic/mountpoint-util.c
+index 79b51cb099..c0c9c8ee0a 100644
+--- a/src/basic/mountpoint-util.c
++++ b/src/basic/mountpoint-util.c
+@@ -44,6 +44,47 @@ bool is_name_to_handle_at_fatal_error(int err) {
+ 
+         return !IN_SET(err, -EOVERFLOW, -EINVAL);
+ }
++#ifndef STATX_MNT_ID
++#define STATX_MNT_ID            0x00001000U
++#endif
++struct new_statx {
++        __u32 stx_mask;
++        __u32 stx_blksize;
++        __u64 stx_attributes;
++        __u32 stx_nlink;
++        __u32 stx_uid;
++        __u32 stx_gid;
++        __u16 stx_mode;
++        __u16 __spare0[1];
++        __u64 stx_ino;
++        __u64 stx_size;
++        __u64 stx_blocks;
++        __u64 stx_attributes_mask;
++        struct statx_timestamp stx_atime;
++        struct statx_timestamp stx_btime;
++        struct statx_timestamp stx_ctime;
++        struct statx_timestamp stx_mtime;
++        __u32 stx_rdev_major;
++        __u32 stx_rdev_minor;
++        __u32 stx_dev_major;
++        __u32 stx_dev_minor;
++        __u64 stx_mnt_id;
++        __u64 __spare2;
++        __u64 __spare3[12];
++};
++#  define STRUCT_NEW_STATX_DEFINE(var)          \
++        union {                                 \
++                struct statx sx;                \
++                struct new_statx nsx;           \
++        } var
++#ifndef STATX_MNT_ID_UNIQUE
++#define STATX_MNT_ID_UNIQUE     0x00004000U
++#endif
++#ifndef STATX_ATTR_MOUNT_ROOT
++#define STATX_ATTR_MOUNT_ROOT   0x00002000
++#endif
++
++
+ 
+ int name_to_handle_at_loop(
+                 int fd,
+@@ -112,17 +153,16 @@ int name_to_handle_at_loop(
+                                 /* Hmm, AT_HANDLE_MNT_ID_UNIQUE is not supported? Let's try to acquire
+                                  * the unique mount id from statx() then, which has a slightly lower
+                                  * kernel version requirement (6.8 vs 6.12). */
+-
+-                                struct statx sx;
++                                STRUCT_NEW_STATX_DEFINE(buf);
+                                 r = xstatx(fd, path,
+                                            at_flags_normalize_nofollow(flags & (AT_SYMLINK_FOLLOW|AT_EMPTY_PATH))|AT_STATX_DONT_SYNC,
+                                            STATX_MNT_ID_UNIQUE,
+-                                           &sx);
++                                           &(buf.sx));
+                                 if (r >= 0) {
+                                         if (ret_handle)
+                                                 *ret_handle = TAKE_PTR(h);
+ 
+-                                        *ret_unique_mnt_id = sx.stx_mnt_id;
++                                        *ret_unique_mnt_id = buf.nsx.stx_mnt_id;
+ 
+                                         if (ret_mnt_id)
+                                                 *ret_mnt_id = -1;
+@@ -297,7 +337,7 @@ int path_is_mount_point_full(const char *path, const char *root, int flags) {
+ }
+ 
+ static int path_get_mnt_id_at_internal(int dir_fd, const char *path, bool unique, uint64_t *ret) {
+-        struct statx sx;
++        STRUCT_NEW_STATX_DEFINE(buf);
+         int r;
+ 
+         assert(dir_fd >= 0 || IN_SET(dir_fd, AT_FDCWD, XAT_FDROOT));
+@@ -308,11 +348,11 @@ static int path_get_mnt_id_at_internal(int dir_fd, const char *path, bool unique
+                    AT_NO_AUTOMOUNT |    /* don't trigger automounts, mnt_id is a local concept */
+                    AT_STATX_DONT_SYNC,  /* don't go to the network, mnt_id is a local concept */
+                    unique ? STATX_MNT_ID_UNIQUE : STATX_MNT_ID,
+-                   &sx);
++                   &(buf.sx));
+         if (r < 0)
+                 return r;
+ 
+-        *ret = sx.stx_mnt_id;
++        *ret = buf.nsx.stx_mnt_id;
+         return 0;
+ }
+ 
+diff --git a/src/basic/raw-clone.c b/src/basic/raw-clone.c
+index 5f560178c8..0c90d716a9 100644
+--- a/src/basic/raw-clone.c
++++ b/src/basic/raw-clone.c
+@@ -34,6 +34,9 @@
+  *
+  * Returns: 0 in the child process and the child process id in the parent.
+  */
++#ifndef CLONE_PIDFD
++#  define CLONE_PIDFD 0x00001000
++#endif
+ pid_t raw_clone(unsigned long flags) {
+         pid_t ret;
+ 
+diff --git a/src/basic/recurse-dir.c b/src/basic/recurse-dir.c
+index 0efa731868..cfe3021653 100644
+--- a/src/basic/recurse-dir.c
++++ b/src/basic/recurse-dir.c
+@@ -142,7 +142,9 @@ int readdir_all_at(int fd, const char *path, RecurseDirFlags flags, DirectoryEnt
+ 
+         return readdir_all(dir_fd, flags, ret);
+ }
+-
++#ifndef STATX_ATTR_MOUNT_ROOT
++#define STATX_ATTR_MOUNT_ROOT 0x00002000 /* Root of a mount */
++#endif
+ int recurse_dir(
+                 int dir_fd,
+                 const char *path,
+diff --git a/src/basic/socket-util.c b/src/basic/socket-util.c
+index eab09786b6..547247d4d6 100644
+--- a/src/basic/socket-util.c
++++ b/src/basic/socket-util.c
+@@ -1406,7 +1406,9 @@ int socket_bind_to_ifname(int fd, const char *ifname) {
+ 
+         return RET_NERRNO(setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, ifname, strlen_ptr(ifname)));
+ }
+-
++#ifndef SO_BINDTOIFINDEX
++#define SO_BINDTOIFINDEX 62
++#endif
+ int socket_bind_to_ifindex(int fd, int ifindex) {
+         assert(fd >= 0);
+ 
+diff --git a/src/basic/stat-util.c b/src/basic/stat-util.c
+index ef39562992..a35d78dc73 100644
+--- a/src/basic/stat-util.c
++++ b/src/basic/stat-util.c
+@@ -4,6 +4,7 @@
+ #include <linux/magic.h>
+ #include <sys/statvfs.h>
+ #include <unistd.h>
++#include <linux/types.h>
+ 
+ #include "alloc-util.h"
+ #include "bitfield.h"
+@@ -294,7 +295,37 @@ int null_or_empty_path_with_root(const char *fn, const char *root) {
+ 
+ static const char* statx_mask_one_to_name(unsigned mask);
+ static const char* statx_attribute_to_name(uint64_t attr);
+-
++#ifndef STATX_ATTR_VERITY
++#define STATX_ATTR_VERITY 0x00100000
++#endif
++#ifndef STATX_ATTR_WRITE_ATOMIC
++#define STATX_ATTR_WRITE_ATOMIC 0x00400000
++#endif
++#ifndef STATX_ATTR_MOUNT_ROOT
++#define STATX_ATTR_MOUNT_ROOT 0x00002000
++#endif
++#ifndef STATX_ATTR_DAX
++#define STATX_ATTR_DAX 0x00200000
++#endif
++#ifndef STATX_SUBVOL
++#define STATX_SUBVOL 0x00008000U
++#endif
++#ifndef STATX_DIOALIGN
++#define STATX_DIOALIGN 0x00002000U
++#endif
++#ifndef STATX_MNT_ID_UNIQUE
++#define STATX_MNT_ID_UNIQUE 0x00004000U
++#endif
++#ifndef STATX_WRITE_ATOMIC
++#define STATX_WRITE_ATOMIC 0x00010000U
++#endif
++#ifndef STATX_MNT_ID
++#define STATX_MNT_ID 0x00001000U
++#define NEW_STATX
++#endif
++#ifndef STATX_DIO_READ_ALIGN
++#define STATX_DIO_READ_ALIGN 0x00020000U
++#endif
+ #include "statx-attribute-to-name.inc"
+ #include "statx-mask-to-name.inc"
+ 
+@@ -687,14 +718,42 @@ bool statx_inode_same(const struct statx *a, const struct statx *b) {
+                 a->stx_dev_minor == b->stx_dev_minor &&
+                 a->stx_ino == b->stx_ino;
+ }
+-
++struct new_statx {
++        __u32 stx_mask;
++        __u32 stx_blksize;
++        __u64 stx_attributes;
++        __u32 stx_nlink;
++        __u32 stx_uid;
++        __u32 stx_gid;
++        __u16 stx_mode;
++        __u16 __spare0[1];
++        __u64 stx_ino;
++        __u64 stx_size;
++        __u64 stx_blocks;
++        __u64 stx_attributes_mask;
++        struct statx_timestamp stx_atime;
++        struct statx_timestamp stx_btime;
++        struct statx_timestamp stx_ctime;
++        struct statx_timestamp stx_mtime;
++        __u32 stx_rdev_major;
++        __u32 stx_rdev_minor;
++        __u32 stx_dev_major;
++        __u32 stx_dev_minor;
++        __u64 stx_mnt_id;
++        __u64 __spare2;
++        __u64 __spare3[12];
++};
+ int statx_mount_same(const struct statx *a, const struct statx *b) {
+         if (!statx_is_set(a) || !statx_is_set(b))
+                 return false;
+ 
+         if ((FLAGS_SET(a->stx_mask, STATX_MNT_ID) && FLAGS_SET(b->stx_mask, STATX_MNT_ID)) ||
+             (FLAGS_SET(a->stx_mask, STATX_MNT_ID_UNIQUE) && FLAGS_SET(b->stx_mask, STATX_MNT_ID_UNIQUE)))
++#ifndef NEW_STATX
+                 return a->stx_mnt_id == b->stx_mnt_id;
++#else
++                return ((const struct new_statx*)a)->stx_mnt_id == ((const struct new_statx*)b)->stx_mnt_id;
++#endif
+ 
+         return -ENODATA;
+ }
+diff --git a/src/libc/mount.c b/src/libc/mount.c
+index 1d324ef386..2d9a28ab73 100644
+--- a/src/libc/mount.c
++++ b/src/libc/mount.c
+@@ -3,45 +3,81 @@
+ #include <sys/mount.h>
+ #include <sys/syscall.h>
+ #include <unistd.h>
++#include <errno.h>
+ 
+ #if !HAVE_FSOPEN
+ int missing_fsopen(const char *fsname, unsigned flags) {
++#ifdef __NR_fsopen
+         return syscall(__NR_fsopen, fsname, flags);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+ 
+ #if !HAVE_FSMOUNT
+ int missing_fsmount(int fd, unsigned flags, unsigned ms_flags) {
++#ifdef __NR_fsmount
+         return syscall(__NR_fsmount, fd, flags, ms_flags);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+ 
+ #if !HAVE_MOVE_MOUNT
+ int missing_move_mount(int from_dfd, const char *from_pathname, int to_dfd, const char *to_pathname, unsigned flags) {
++#ifdef __NR_move_mount
+         return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd, to_pathname, flags);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+ 
+ #if !HAVE_FSCONFIG
+ int missing_fsconfig(int fd, unsigned cmd, const char *key, const void *value, int aux) {
++#ifdef __NR_fsconfig
+         return syscall(__NR_fsconfig, fd, cmd, key, value, aux);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+ 
+ #if !HAVE_OPEN_TREE
+ int missing_open_tree(int dfd, const char *filename, unsigned flags) {
++#ifdef __NR_open_tree
+         return syscall(__NR_open_tree, dfd, filename, flags);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+ 
+ #if !HAVE_MOUNT_SETATTR
+ int missing_mount_setattr(int dfd, const char *path, unsigned flags, struct mount_attr *attr, size_t size) {
++#ifdef __NR_mount_setattr
+         return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+ 
+ #if !HAVE_OPEN_TREE_ATTR
+ int missing_open_tree_attr(int dfd, const char *filename, unsigned int flags, struct mount_attr *attr, size_t size) {
++#ifdef __NR_open_tree_attr
+         return syscall(__NR_open_tree_attr, dfd, filename, flags, attr, size);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+diff --git a/src/libc/pidfd.c b/src/libc/pidfd.c
+index a779e3459c..f2c084bac2 100644
+--- a/src/libc/pidfd.c
++++ b/src/libc/pidfd.c
+@@ -3,15 +3,26 @@
+ #include <sys/pidfd.h>
+ #include <sys/syscall.h>
+ #include <unistd.h>
++#include <errno.h>
+ 
+ #if !HAVE_PIDFD_OPEN
+ int missing_pidfd_open(pid_t pid, unsigned flags) {
++#ifdef __NR_pidfd_open
+         return syscall(__NR_pidfd_open, pid, flags);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+ 
+ #if !HAVE_PIDFD_SEND_SIGNAL
+ int missing_pidfd_send_signal(int fd, int sig, siginfo_t *info, unsigned flags) {
++#ifdef __NR_pidfd_send_signal
+         return syscall(__NR_pidfd_send_signal, fd, sig, info, flags);
++#else
++        errno = ENOSYS;
++        return -1;
++#endif
+ }
+ #endif
+diff --git a/src/libsystemd/sd-event/sd-event.c b/src/libsystemd/sd-event/sd-event.c
+index b78cfe86fa..e169c6b306 100644
+--- a/src/libsystemd/sd-event/sd-event.c
++++ b/src/libsystemd/sd-event/sd-event.c
+@@ -41,7 +41,7 @@
+ #include "strv.h"
+ #include "strxcpyx.h"
+ #include "time-util.h"
+-
++#include "missing.h"
+ #define DEFAULT_ACCURACY_USEC (250 * USEC_PER_MSEC)
+ 
+ static bool EVENT_SOURCE_WATCH_PIDFD(const sd_event_source *s) {
+@@ -1881,9 +1881,9 @@ _public_ int sd_event_trim_memory(void) {
+          * NULL callback parameter. */
+ 
+         log_debug("Memory pressure event, trimming malloc() memory.");
+-
++#if __GLIBC_PREREQ(2, 33) && HAVE_MALLINFO2
+         struct mallinfo2 before_mallinfo = mallinfo2();
+-
++#endif
+         usec_t before_timestamp = now(CLOCK_MONOTONIC);
+         hashmap_trim_pools();
+         r = malloc_trim(0);
+@@ -1894,6 +1894,7 @@ _public_ int sd_event_trim_memory(void) {
+         else
+                 log_debug("Couldn't trim any memory.");
+ 
++#if __GLIBC_PREREQ(2, 33) && HAVE_MALLINFO2
+         usec_t period = after_timestamp - before_timestamp;
+ 
+         struct mallinfo2 after_mallinfo = mallinfo2();
+@@ -1906,7 +1907,7 @@ _public_ int sd_event_trim_memory(void) {
+                    LOG_MESSAGE_ID(SD_MESSAGE_MEMORY_TRIM_STR),
+                    LOG_ITEM("TRIMMED_BYTES=%zu", l),
+                    LOG_ITEM("TRIMMED_USEC=" USEC_FMT, period));
+-
++#endif
+         return 0;
+ }
+ 
+diff --git a/src/libsystemd/sd-resolve/sd-resolve.c b/src/libsystemd/sd-resolve/sd-resolve.c
+index 0f189a5044..10f25ce73e 100644
+--- a/src/libsystemd/sd-resolve/sd-resolve.c
++++ b/src/libsystemd/sd-resolve/sd-resolve.c
+@@ -23,7 +23,7 @@
+ #include "process-util.h"
+ #include "resolve-private.h"
+ #include "socket-util.h"
+-
++#include "missing.h"
+ #define WORKERS_MIN 1U
+ #define WORKERS_MAX 16U
+ #define QUERIES_MAX 256U

--- a/3rdParty/vcpkg_ports/ports/libsystemd/only-libsystemd.patch
+++ b/3rdParty/vcpkg_ports/ports/libsystemd/only-libsystemd.patch
@@ -1,0 +1,58 @@
+diff --git a/meson.build b/meson.build
+index 3672005..a39e0df 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2090,14 +2090,13 @@ libsystemd_includes = [basic_includes, include_directories(
+ includes = [libsystemd_includes, include_directories('src/shared')]
+ 
+ subdir('po')
+-subdir('catalog')
++support_url='https://github.com/microsoft/vcpkg/issues'
+ subdir('src/include')
+ subdir('src/libc')
+ subdir('src/fundamental')
+ subdir('src/basic')
+ subdir('src/libsystemd')
+-subdir('src/shared')
+-subdir('src/libudev')
++static_libudev='unused'
+ 
+ libsystemd = shared_library(
+         'systemd',
+@@ -2115,7 +2114,8 @@ libsystemd = shared_library(
+                         threads,
+                         userspace],
+         link_depends : libsystemd_sym,
+-        install : true,
++        build_by_default : static_libsystemd == 'false',
++        install : static_libsystemd == 'false',
+         install_tag: 'libsystemd',
+         install_dir : libdir)
+ 
+@@ -2148,6 +2148,8 @@ else
+         alias_target('libsystemd', libsystemd)
+ endif
+ 
++if false
++
+ libudev = shared_library(
+         'udev',
+         version : libudev_version,
+@@ -3006,6 +3008,17 @@ if conf.get('ENABLE_HWDB') == 1
+         alias_target('hwdb', auto_suspend_rules, executables_by_name.get('systemd-hwdb'), hwdb_units)
+ endif
+ 
++else
++  # headers
++  subdir('src/systemd')
++  # subdir man
++  want_html=false
++  want_man=false
++  # subdir shell-completion/*
++  bashcompletiondir='no'
++  zshcompletiondir='no'
++endif
++
+ alt_time_epoch = run_command('date', '-Is', '-u', '-d', f'@@time_epoch@', check : false)
+ if alt_time_epoch.returncode() != 0
+         # If the above fails, maybe the date(1) uses BSD-style syntax

--- a/3rdParty/vcpkg_ports/ports/libsystemd/pkgconfig.patch
+++ b/3rdParty/vcpkg_ports/ports/libsystemd/pkgconfig.patch
@@ -1,0 +1,25 @@
+diff --git a/meson.build b/meson.build
+index 22b3c96..3d50c83 100644
+--- a/meson.build
++++ b/meson.build
+@@ -996,6 +996,9 @@ threads = dependency('threads')
+ librt = cc.find_library('rt')
+ libm = cc.find_library('m')
+ libdl = cc.find_library('dl')
++conf.set_quoted('PC_RT', librt.found() ? '-lrt' : '')
++conf.set_quoted('PC_M',  libm.found()  ? '-lm'  : '')
++conf.set_quoted('PC_DL', libdl.found() ? '-ldl' : '')
+ 
+ # On some distributions that use musl (e.g. Alpine), libintl.h may be provided by gettext rather than musl.
+ # In that case, we need to explicitly link with libintl.so.
+diff --git a/src/libsystemd/libsystemd.pc.in b/src/libsystemd/libsystemd.pc.in
+index 3a43ef6..930f16a 100644
+--- a/src/libsystemd/libsystemd.pc.in
++++ b/src/libsystemd/libsystemd.pc.in
+@@ -17,4 +17,6 @@ Description: systemd Library
+ URL: {{PROJECT_URL}}
+ Version: {{PROJECT_VERSION}}
+ Libs: -L${libdir} -lsystemd
++Libs.private: {{PC_DL}} {{PC_M}} {{PC_RT}}
++Requires.private: libcap libcrypt liblz4 liblzma libzstd mount
+ Cflags: -I${includedir}

--- a/3rdParty/vcpkg_ports/ports/libsystemd/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libsystemd/portfile.cmake
@@ -1,0 +1,87 @@
+vcpkg_from_github(
+  OUT_SOURCE_PATH SOURCE_PATH
+  REPO systemd/systemd
+  REF "v${VERSION}"
+  SHA512 9f975dce6861853a817a7ceab18a24449a85d1bda6939b3a5173430c02a4d8a9a2b34ebb8cce1c51db9b0ff9078fcc65da7b0f44e3bdcbbe013b9e04bb6f0ff9
+  PATCHES
+    disable-warning-nonnull.patch
+    only-libsystemd.patch
+    pkgconfig.patch
+    fix-2604-build.patch
+    fix-buster-build.patch # vko custom patch
+)
+
+set(static false)
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+  set(static pic)
+endif()
+
+vcpkg_find_acquire_program(PYTHON3)
+x_vcpkg_get_python_packages(
+    PYTHON_VERSION 3
+    PYTHON_EXECUTABLE "${PYTHON3}"
+    PACKAGES "jinja2"
+)
+
+vcpkg_configure_meson(
+  SOURCE_PATH "${SOURCE_PATH}"
+  OPTIONS
+    -Dmode=release
+    -Dstatic-libsystemd=${static}
+    -Dtests=false
+    # disabled capabilites
+    -Ddns-over-tls=false
+    -Dtranslations=false
+    # disabled dependencies
+    -Dacl=disabled
+    -Dapparmor=disabled
+    -Daudit=disabled
+    -Dblkid=disabled
+    -Dbpf-framework=disabled
+    -Dbzip2=disabled
+    -Ddbus=disabled # tests only
+    -Delfutils=disabled
+    -Dfdisk=disabled
+    -Dgcrypt=disabled
+    -Dglib=disabled # tests only
+    -Dgnutls=disabled
+    -Dkmod=disabled
+    -Dlibcurl=disabled
+    -Dlibcryptsetup=disabled
+    -Dlibfido2=disabled
+    -Dlibidn=disabled
+    -Dlibidn2=disabled
+    -Dlibiptc=disabled
+    -Dmicrohttpd=disabled
+    -Dopenssl=disabled
+    -Dp11kit=disabled
+    -Dpam=disabled
+    -Dpcre2=disabled
+    -Dpolkit=disabled
+    -Dpwquality=disabled
+    -Dpasswdqc=disabled
+    -Dseccomp=disabled
+    -Dselinux=disabled
+    -Dtpm2=disabled
+    -Dxenctrl=disabled
+    -Dxkbcommon=disabled
+    -Dzlib=disabled
+    # enabled dependencies
+    -Dlz4=enabled
+    -Dxz=enabled
+    -Dzstd=enabled
+  ADDITIONAL_BINARIES
+    "gperf = ['${CURRENT_HOST_INSTALLED_DIR}/tools/gperf/gperf${HOST_EXECUTABLE_SUFFIX}']"
+)
+
+vcpkg_install_meson()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_fixup_pkgconfig()
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSES/README.md" "${SOURCE_PATH}/LICENSE.LGPL2.1"
+  COMMENT [[
+This port provides libsystemd.so/.a, which is based on sources in
+src/basic, src/fundamental, src/systemd and src/libsystemd.
+]])

--- a/3rdParty/vcpkg_ports/ports/libsystemd/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libsystemd/vcpkg.json
@@ -1,0 +1,28 @@
+{
+  "name": "libsystemd",
+  "version": "260.1",
+  "description": "Libsystemd",
+  "homepage": "https://github.com/systemd/systemd",
+  "license": null,
+  "supports": "linux",
+  "dependencies": [
+    {
+      "name": "gperf",
+      "host": true
+    },
+    "libcap",
+    "liblzma",
+    "libmount",
+    "libxcrypt",
+    "lz4",
+    {
+      "name": "vcpkg-get-python-packages",
+      "host": true
+    },
+    {
+      "name": "vcpkg-tool-meson",
+      "host": true
+    },
+    "zstd"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Linux package builds on `debian:buster` by prebuilding and caching `autoconf-2.73`, `bison-3.8.2`, and `Python-3.9.0`, and by adding a local `vcpkg` port for `libsystemd` 260.1 tuned for Buster. This stabilizes CI despite EOL mirrors and newer upstream APIs.

- **Bug Fixes**
  - New prepare-build-dependencies job on `debian:buster`: rewrites APT sources, installs build deps, builds `autoconf`/`bison`/`Python-3.9.0` (with ensurepip) from source, caches tarballs, archives build dirs, uploads an artifact keyed by PR SHA.
  - prepare-binaries now depends on that job, downloads and installs the artifact, drops APT installs for `python3*`/`bison`, upgrades `pip`, and installs `jinja2`.
  - Local `vcpkg` port for `libsystemd` 260.1: builds only `libsystemd`; fixes `pkg-config` (adds `-ldl`/`-lm`/`-lrt` and `libcap`/`libcrypt`/`liblz4`/`liblzma`/`libzstd`/`mount`), disables `-Werror=shadow` and nonnull warnings, and adds GLIBC guards/ENOSYS fallbacks plus missing constants/syscalls for Buster (e.g., `gettid`, `close_range`, `pidfd*`, `fsopen`/`fsmount`/`open_tree`/`open_tree_attr`/`mount_setattr`, `STATX_*`, `CLONE_PIDFD`, guarded `mallinfo2`, `SO_BINDTOIFINDEX`), including a `statx`-based fallback for unique mount IDs.

<sup>Written for commit 9d1daaf4063bf6012daced7daf92d7f2829d2f88. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7077?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

