### PR TITLE
Client, Manager, API, docker_wrapper: support network access from apps

### DIFF
--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -478,7 +478,7 @@ static void handle_heartbeat_msg() {
     if (parse_double(buf, "<max_wss>", dtemp)) {
         boinc_status.max_working_set_size = dtemp;
     }
-    if (parse_bool(buf, "suspend_network", btemp)) {
+    if (parse_bool(buf, "network_suspended", btemp)) {
         boinc_status.network_suspended = btemp;
     }
     if (parse_int(buf, "<sporadic_ca>", i)) {

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -424,12 +424,11 @@ static bool update_app_progress(double cpu_t, double cp_cpu_t) {
 
     snprintf(msg_buf, sizeof(msg_buf),
         "<current_cpu_time>%e</current_cpu_time>\n"
-        "<checkpoint_cpu_time>%e</checkpoint_cpu_time>\n",
-        cpu_t, cp_cpu_t
+        "<checkpoint_cpu_time>%e</checkpoint_cpu_time>\n"
+        "<want_network>%d</want_network>\n",
+        cpu_t, cp_cpu_t,
+        want_network?1:0
     );
-    if (want_network) {
-        strlcat(msg_buf, "<want_network>1</want_network>\n", sizeof(msg_buf));
-    }
     if (fraction_done >= 0) {
         double range = aid.fraction_done_end - aid.fraction_done_start;
         double fdone = aid.fraction_done_start + fraction_done*range;

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -1116,6 +1116,9 @@ int boinc_report_app_status_aux(
         sprintf(buf, "<wss>%f</wss>\n", wss);
         strlcat(msg_buf, buf, sizeof(msg_buf));
     }
+    if (want_network) {
+        strlcat(msg_buf, "<want_network>1</want_network>\n", sizeof(msg_buf));
+    }
 #ifdef MSGS_FROM_FILE
     if (fout) {
         fputs(msg_buf, fout);

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -204,7 +204,7 @@ int app_min_checkpoint_period = 0;
 static volatile SPORADIC_AC_STATE ac_state;
 static volatile int ac_fd, ca_fd;
 static volatile bool do_sporadic_files;
-bool got_heartbeat_message = false;
+volatile bool got_heartbeat_message = false;
 
 #define TIMER_PERIOD 0.1
     // Sleep interval for timer thread;
@@ -485,8 +485,6 @@ static void handle_heartbeat_msg() {
     if (parse_int(buf, "<sporadic_ca>", i)) {
         boinc_status.ca_state = (SPORADIC_CA_STATE)i;
     }
-    fprintf(stderr, "got heartbeat; net susp %d\n", boinc_status.network_suspended);
-    fprintf(stderr, "%s\n", buf);
     got_heartbeat_message = true;
 }
 

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -485,6 +485,8 @@ static void handle_heartbeat_msg() {
     if (parse_int(buf, "<sporadic_ca>", i)) {
         boinc_status.ca_state = (SPORADIC_CA_STATE)i;
     }
+    fprintf(stderr, "got heartbeat; net susp %d\n", boinc_status.network_suspended);
+    fprintf(stderr, "%s\n", buf);
     got_heartbeat_message = true;
 }
 

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -190,7 +190,6 @@ static volatile int running_interrupt_count = 0;
 static volatile bool finishing;
     // used for worker/timer synch during boinc_finish();
 static int want_network = 0;
-static int have_network = 1;
 static double bytes_sent = 0;
 static double bytes_received = 0;
 bool boinc_disable_timer_thread = false;
@@ -970,11 +969,6 @@ void boinc_exit(int status) {
 #endif
 }
 
-void boinc_network_usage(double sent, double received) {
-    bytes_sent = sent;
-    bytes_received = received;
-}
-
 int boinc_is_standalone() {
     if (standalone) return 1;
     return 0;
@@ -1370,9 +1364,6 @@ static void handle_process_control_msg() {
     }
     if (match_tag(buf, "<reread_app_info/>")) {
         boinc_status.reread_init_data_file = true;
-    }
-    if (match_tag(buf, "<network_available/>")) {
-        have_network = 1;
     }
 #ifdef ANDROID
     // Trigger call to worker_signal_handler() in the worker thread
@@ -1794,17 +1785,8 @@ int boinc_upload_status(std::string& name) {
     return ERR_NOT_FOUND;
 }
 
-void boinc_need_network() {
-    want_network = 1;
-    have_network = 0;
-}
-
-int boinc_network_poll() {
-    return have_network?0:1;
-}
-
-void boinc_network_done() {
-    want_network = 0;
+void boinc_waiting_for_network(bool x) {
+    want_network = x;
 }
 
 #ifndef _WIN32

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -204,6 +204,7 @@ int app_min_checkpoint_period = 0;
 static volatile SPORADIC_AC_STATE ac_state;
 static volatile int ac_fd, ca_fd;
 static volatile bool do_sporadic_files;
+bool got_heartbeat_message = false;
 
 #define TIMER_PERIOD 0.1
     // Sleep interval for timer thread;
@@ -484,6 +485,7 @@ static void handle_heartbeat_msg() {
     if (parse_int(buf, "<sporadic_ca>", i)) {
         boinc_status.ca_state = (SPORADIC_CA_STATE)i;
     }
+    got_heartbeat_message = true;
 }
 
 // called in timer thread

--- a/api/boinc_api.cpp
+++ b/api/boinc_api.cpp
@@ -190,8 +190,6 @@ static volatile int running_interrupt_count = 0;
 static volatile bool finishing;
     // used for worker/timer synch during boinc_finish();
 static int want_network = 0;
-static double bytes_sent = 0;
-static double bytes_received = 0;
 bool boinc_disable_timer_thread = false;
     // simulate unresponsive app by setting to true (debugging)
 static FUNC_PTR timer_callback = 0;
@@ -434,14 +432,6 @@ static bool update_app_progress(double cpu_t, double cp_cpu_t) {
         double range = aid.fraction_done_end - aid.fraction_done_start;
         double fdone = aid.fraction_done_start + fraction_done*range;
         snprintf(buf, sizeof(buf), "<fraction_done>%e</fraction_done>\n", fdone);
-        strlcat(msg_buf, buf, sizeof(msg_buf));
-    }
-    if (bytes_sent) {
-        snprintf(buf, sizeof(buf), "<bytes_sent>%f</bytes_sent>\n", bytes_sent);
-        strlcat(msg_buf, buf, sizeof(msg_buf));
-    }
-    if (bytes_received) {
-        snprintf(buf, sizeof(buf), "<bytes_received>%f</bytes_received>\n", bytes_received);
         strlcat(msg_buf, buf, sizeof(msg_buf));
     }
     if (ac_state) {
@@ -1082,8 +1072,8 @@ int boinc_report_app_status_aux(
     double checkpoint_cpu_time,
     double _fraction_done,
     int other_pid,
-    double _bytes_sent,
-    double _bytes_received,
+    double /* _bytes_sent*/,
+    double /* _bytes_received*/,
     double wss
 ) {
     char msg_buf[MSG_CHANNEL_SIZE], buf[1024];
@@ -1099,14 +1089,6 @@ int boinc_report_app_status_aux(
     );
     if (other_pid) {
         snprintf(buf, sizeof(buf), "<other_pid>%d</other_pid>\n", other_pid);
-        safe_strcat(msg_buf, buf);
-    }
-    if (_bytes_sent) {
-        snprintf(buf, sizeof(buf), "<bytes_sent>%f</bytes_sent>\n", _bytes_sent);
-        safe_strcat(msg_buf, buf);
-    }
-    if (_bytes_received) {
-        snprintf(buf, sizeof(buf), "<bytes_received>%f</bytes_received>\n", _bytes_received);
         safe_strcat(msg_buf, buf);
     }
     if (ac_state) {

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -163,7 +163,7 @@ extern HANDLE worker_thread_handle;
 extern int boinc_init_options_general(BOINC_OPTIONS& opt);
 extern int start_timer_thread(void);
 extern bool boinc_disable_timer_thread;
-extern bool got_heartbeat_message;
+extern volatile bool got_heartbeat_message;
 
 inline void boinc_options_defaults(BOINC_OPTIONS& b) {
     b.main_program = 1;

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -100,10 +100,7 @@ extern int boinc_report_app_status(
 extern int boinc_time_to_checkpoint(void);
 extern void boinc_begin_critical_section(void);
 extern void boinc_end_critical_section(void);
-extern void boinc_need_network(void);
-extern int boinc_network_poll(void);
-extern void boinc_network_done(void);
-extern void boinc_network_usage(double sent, double received);
+extern void boinc_waiting_for_network(bool);
 extern int boinc_is_standalone(void);
 extern void boinc_ops_per_cpu_sec(double fp, double integer);
 extern void boinc_ops_cumulative(double fp, double integer);

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -100,7 +100,6 @@ extern int boinc_report_app_status(
 extern int boinc_time_to_checkpoint(void);
 extern void boinc_begin_critical_section(void);
 extern void boinc_end_critical_section(void);
-extern void boinc_waiting_for_network(bool);
 extern int boinc_is_standalone(void);
 extern void boinc_ops_per_cpu_sec(double fp, double integer);
 extern void boinc_ops_cumulative(double fp, double integer);
@@ -129,6 +128,7 @@ extern int setMacIcon(char *filename, char *iconData, long iconSize);
 #include <string>
 #include "app_ipc.h"
 
+extern void boinc_waiting_for_network(bool);
 extern int boinc_resolve_filename_s(const char*, std::string&);
 extern int boinc_get_init_data(APP_INIT_DATA&);
 extern int boinc_wu_cpu_time(double&);

--- a/api/boinc_api.h
+++ b/api/boinc_api.h
@@ -63,7 +63,7 @@ typedef struct BOINC_OPTIONS {
         // set this if application creates subprocesses.
 } BOINC_OPTIONS;
 
-// info passed from client to app in heartbeat message
+// info passed from client to app in heartbeat and process control messages
 //
 typedef struct BOINC_STATUS {
     int no_heartbeat;
@@ -163,6 +163,7 @@ extern HANDLE worker_thread_handle;
 extern int boinc_init_options_general(BOINC_OPTIONS& opt);
 extern int start_timer_thread(void);
 extern bool boinc_disable_timer_thread;
+extern bool got_heartbeat_message;
 
 inline void boinc_options_defaults(BOINC_OPTIONS& b) {
     b.main_program = 1;
@@ -174,7 +175,6 @@ inline void boinc_options_defaults(BOINC_OPTIONS& b) {
     b.multi_thread = 0;
     b.multi_process = 0;
 }
-
 
 /////////// IMPLEMENTATION STUFF ENDS HERE
 

--- a/client/app.cpp
+++ b/client/app.cpp
@@ -121,10 +121,6 @@ ACTIVE_TASK::ACTIVE_TASK() {
     run_interval_start_wall_time = gstate.now;
     checkpoint_wall_time = 0;
     elapsed_time = 0;
-    bytes_sent_episode = 0;
-    bytes_received_episode = 0;
-    bytes_sent = 0;
-    bytes_received = 0;
     safe_strcpy(slot_dir, "");
     safe_strcpy(slot_path, "");
     max_elapsed_time = 0;
@@ -795,9 +791,7 @@ int ACTIVE_TASK::write(MIOFILE& fout) {
         "    <swap_size>%f</swap_size>\n"
         "    <working_set_size>%f</working_set_size>\n"
         "    <working_set_size_smoothed>%f</working_set_size_smoothed>\n"
-        "    <page_fault_rate>%f</page_fault_rate>\n"
-        "    <bytes_sent>%f</bytes_sent>\n"
-        "    <bytes_received>%f</bytes_received>\n",
+        "    <page_fault_rate>%f</page_fault_rate>\n",
         result->project->master_url,
         result->name,
         task_state(),
@@ -812,9 +806,7 @@ int ACTIVE_TASK::write(MIOFILE& fout) {
         procinfo.swap_size,
         procinfo.working_set_size,
         procinfo.working_set_size_smoothed,
-        procinfo.page_fault_rate,
-        bytes_sent,
-        bytes_received
+        procinfo.page_fault_rate
     );
     fout.printf("</active_task>\n");
     return 0;
@@ -848,10 +840,7 @@ int ACTIVE_TASK::write_gui(MIOFILE& fout) {
         "    <working_set_size>%f</working_set_size>\n"
         "    <working_set_size_smoothed>%f</working_set_size_smoothed>\n"
         "    <page_fault_rate>%f</page_fault_rate>\n"
-        "    <bytes_sent>%f</bytes_sent>\n"
-        "    <bytes_received>%f</bytes_received>\n"
-        "%s"
-        "%s",
+        "%s%s%s",
         task_state(),
         app_version->version_num,
         slot,
@@ -865,10 +854,9 @@ int ACTIVE_TASK::write_gui(MIOFILE& fout) {
         procinfo.working_set_size,
         procinfo.working_set_size_smoothed,
         procinfo.page_fault_rate,
-        bytes_sent,
-        bytes_received,
         too_large?"   <too_large/>\n":"",
-        needs_shmem?"   <needs_shmem/>\n":""
+        needs_shmem?"   <needs_shmem/>\n":"",
+        want_network?"   <want_network/>\n":""
     );
     if (elapsed_time > first_fraction_done_elapsed_time) {
         fout.printf(
@@ -1008,8 +996,6 @@ int ACTIVE_TASK::parse(XML_PARSER& xp) {
         else if (xp.parse_double("working_set_size_smoothed", procinfo.working_set_size_smoothed)) continue;
         else if (xp.parse_double("page_fault_rate", procinfo.page_fault_rate)) continue;
         else if (xp.parse_double("current_cpu_time", x)) continue;
-        else if (xp.parse_double("bytes_sent", bytes_sent)) continue;
-        else if (xp.parse_double("bytes_received", bytes_received)) continue;
         else {
             if (log_flags.unparsed_xml) {
                 msg_printf(project, MSG_INFO,
@@ -1220,21 +1206,11 @@ void ACTIVE_TASK_SET::handle_upload_files() {
     }
 }
 
-bool ACTIVE_TASK_SET::want_network() {
+bool ACTIVE_TASK_SET::some_task_wants_network() {
     for (ACTIVE_TASK* atp: active_tasks) {
         if (atp->want_network) return true;
     }
     return false;
-}
-
-void ACTIVE_TASK_SET::network_available() {
-#ifndef SIM
-    for (ACTIVE_TASK* atp: active_tasks) {
-        if (atp->want_network) {
-            atp->send_network_available();
-        }
-    }
-#endif
 }
 
 void ACTIVE_TASK::upload_notify_app(const FILE_INFO* fip, const FILE_REF* frp) {

--- a/client/app.h
+++ b/client/app.h
@@ -127,13 +127,6 @@ struct ACTIVE_TASK {
         // wall time at the last checkpoint
     double elapsed_time;
         // current total running time, adjusted for CPU throttling
-    double bytes_sent_episode;
-        // bytes sent in current episode of job,
-        // as (optionally) reported by boinc_network_usage()
-    double bytes_received_episode;
-    double bytes_sent;
-        // bytes in all episodes
-    double bytes_received;
     char slot_dir[256];
         // directory where process runs (relative)
     char slot_path[MAXPATHLEN];
@@ -159,8 +152,9 @@ struct ACTIVE_TASK {
     bool needs_shmem;
         // waiting for a free shared memory segment
     int want_network;
-        // This task wants to do network comm (for F@h)
-        // this is passed via share-memory message (app_status channel)
+        // This task is waiting for the network
+        // (physical connection or no suspension)
+        // This is passed via share-memory message (app_status channel)
     double abort_time;
         // when we sent an abort message to this app
         // kill it 5 seconds later if it doesn't exit
@@ -300,7 +294,6 @@ struct ACTIVE_TASK {
     int preempt(PREEMPT_TYPE preempt_type, int reason=0);
         // preempt (via suspend or quit) a running task
     int resume_or_start(bool);
-    void send_network_available();
 #ifdef _WIN32
     void handle_exited_app(unsigned long);
 #else
@@ -363,8 +356,7 @@ public:
     void report_overdue();
     void handle_upload_files();
     void upload_notify_app(FILE_INFO*);
-    bool want_network();    // does any task want network?
-    void network_available();   // notify tasks that network is available
+    bool some_task_wants_network();
     void free_mem();
     bool slot_taken(int);
     void get_memory_usage();

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -1363,7 +1363,7 @@ bool ACTIVE_TASK::get_app_status_msg() {
             "[app_msg_receive] got msg from slot %d: %s", slot, msg_buf
         );
     }
-    int new_want_network = -1;
+    int new_want_network = 0;
     current_cpu_time = checkpoint_cpu_time = 0.0;
     if (parse_double(msg_buf, "<fraction_done>", fd)) {
         // fraction_done will be reported as zero

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -1418,6 +1418,9 @@ bool ACTIVE_TASK::get_app_status_msg() {
         sporadic_ac_state = (SPORADIC_AC_STATE)i;
     }
 
+    // if want_network goes from false to true, show notice
+    // if it goes true to false, remove notice
+    //
     switch (new_want_network) {
     case 0:
         if (want_network) {

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -415,8 +415,6 @@ void ACTIVE_TASK::copy_final_info() {
     result->final_peak_working_set_size = peak_working_set_size;
     result->final_peak_swap_size = peak_swap_size;
     result->final_peak_disk_usage = peak_disk_usage;
-    result->final_bytes_sent = bytes_sent;
-    result->final_bytes_received = bytes_received;
 }
 
 // deal with a process that has exited, for whatever reason:
@@ -1341,15 +1339,6 @@ int ACTIVE_TASK::unsuspend(int reason) {
     return 0;
 }
 
-void ACTIVE_TASK::send_network_available() {
-    if (!app_client_shm.shm) return;
-    process_control_queue.msg_queue_send(
-        "<network_available/>",
-        app_client_shm.shm->process_control_request
-    );
-    return;
-}
-
 // See if the app has placed a new message in shared mem
 // (with CPU done, frac done etc.)
 // If so parse it and return true.
@@ -1358,7 +1347,6 @@ bool ACTIVE_TASK::get_app_status_msg() {
     char msg_buf[MSG_CHANNEL_SIZE];
     double fd;
     int other_pid, i;
-    double dtemp;
     static double last_msg_time=0;
 
     if (!app_client_shm.shm) {
@@ -1375,7 +1363,7 @@ bool ACTIVE_TASK::get_app_status_msg() {
             "[app_msg_receive] got msg from slot %d: %s", slot, msg_buf
         );
     }
-    want_network = 0;
+    int new_want_network = -1;
     current_cpu_time = checkpoint_cpu_time = 0.0;
     if (parse_double(msg_buf, "<fraction_done>", fd)) {
         // fraction_done will be reported as zero
@@ -1420,23 +1408,7 @@ bool ACTIVE_TASK::get_app_status_msg() {
     parse_double(msg_buf, "<fpops_cumulative>", result->fpops_cumulative);
     parse_double(msg_buf, "<intops_per_cpu_sec>", result->intops_per_cpu_sec);
     parse_double(msg_buf, "<intops_cumulative>", result->intops_cumulative);
-    if (parse_double(msg_buf, "<bytes_sent>", dtemp)) {
-        if (dtemp > bytes_sent_episode) {
-            double nbytes = dtemp - bytes_sent_episode;
-            daily_xfer_history.add(nbytes, true);
-            bytes_sent += nbytes;
-        }
-        bytes_sent_episode = dtemp;
-    }
-    if (parse_double(msg_buf, "<bytes_received>", dtemp)) {
-        if (dtemp > bytes_received_episode) {
-            double nbytes = dtemp - bytes_received_episode;
-            daily_xfer_history.add(nbytes, false);
-            bytes_received += nbytes;
-        }
-        bytes_received_episode = dtemp;
-    }
-    parse_int(msg_buf, "<want_network>", want_network);
+    parse_int(msg_buf, "<want_network>", new_want_network);
     if (parse_int(msg_buf, "<other_pid>", other_pid)) {
         // for now, we handle only one of these
         other_pids.clear();
@@ -1444,6 +1416,32 @@ bool ACTIVE_TASK::get_app_status_msg() {
     }
     if (parse_int(msg_buf, "<sporadic_ac>", i)) {
         sporadic_ac_state = (SPORADIC_AC_STATE)i;
+    }
+
+    switch (new_want_network) {
+    case 0:
+        if (want_network) {
+            // app was waiting for network, now isn't.
+            if (net_status.network_notice_active) {
+                notices.remove_notices(NULL, REMOVE_NETWORK_MSG);
+                net_status.network_notice_active = false;
+            }
+            want_network = 0;
+        }
+        break;
+    case 1:
+        if (!want_network) {
+            if (!net_status.network_notice_active) {
+                if (gstate.network_suspended) {
+                    msg_printf(0, MSG_USER_ALERT, APP_NETWORK_SUSPENDED_MSG);
+                } else {
+                    msg_printf(0, MSG_USER_ALERT, APP_NEED_NETWORK_MSG);
+                }
+                net_status.network_notice_active = true;
+            }
+            want_network = 1;
+        }
+        break;
     }
     return true;
 }

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -1420,15 +1420,18 @@ bool ACTIVE_TASK::get_app_status_msg() {
 
     switch (new_want_network) {
     case 0:
-        // if want_network goes true to false,
+        // if this task's want_network goes from true to false,
         // and no tasks now want network, remove notice
         //
         if (want_network) {
             want_network = 0;
-            if (net_status.network_notice_active) {
+            if (net_status.app_connection_notice_active
+                || net_status.app_suspend_notice_active
+            ) {
                 if (!gstate.active_tasks.some_task_wants_network()) {
                     notices.remove_notices(NULL, REMOVE_NETWORK_MSG);
-                    net_status.network_notice_active = false;
+                    net_status.app_suspend_notice_active = false;
+                    net_status.app_connection_notice_active = false;
                 }
             }
         }
@@ -1437,13 +1440,16 @@ bool ACTIVE_TASK::get_app_status_msg() {
         // if want_network goes from false to true, show notice
         //
         if (!want_network) {
-            if (!net_status.network_notice_active) {
-                if (gstate.network_suspended) {
+            if (gstate.network_suspended) {
+                if (!net_status.app_suspend_notice_active) {
                     msg_printf(0, MSG_USER_ALERT, APP_NETWORK_SUSPENDED_MSG);
-                } else {
-                    msg_printf(0, MSG_USER_ALERT, APP_NEED_NETWORK_MSG);
+                    net_status.app_suspend_notice_active = true;
                 }
-                net_status.network_notice_active = true;
+            } else {
+                if (!net_status.app_connection_notice_active) {
+                    msg_printf(0, MSG_USER_ALERT, APP_NEED_NETWORK_MSG);
+                    net_status.app_connection_notice_active = true;
+                }
             }
             want_network = 1;
         }

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -1418,21 +1418,24 @@ bool ACTIVE_TASK::get_app_status_msg() {
         sporadic_ac_state = (SPORADIC_AC_STATE)i;
     }
 
-    // if want_network goes from false to true, show notice
-    // if it goes true to false, remove notice
-    //
     switch (new_want_network) {
     case 0:
+        // if want_network goes true to false,
+        // and no tasks now want network, remove notice
+        //
         if (want_network) {
-            // app was waiting for network, now isn't.
-            if (net_status.network_notice_active) {
-                notices.remove_notices(NULL, REMOVE_NETWORK_MSG);
-                net_status.network_notice_active = false;
-            }
             want_network = 0;
+            if (net_status.network_notice_active) {
+                if (!gstate.active_tasks.some_task_wants_network()) {
+                    notices.remove_notices(NULL, REMOVE_NETWORK_MSG);
+                    net_status.network_notice_active = false;
+                }
+            }
         }
         break;
     case 1:
+        // if want_network goes from false to true, show notice
+        //
         if (!want_network) {
             if (!net_status.network_notice_active) {
                 if (gstate.network_suspended) {

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -265,6 +265,9 @@ void ACTIVE_TASK::init_app_init_data(APP_INIT_DATA& aid) {
         aid.gpu_usage = 0;
     }
     aid.ncpus = result->resource_usage.avg_ncpus;
+    if (strcmp(nvc_config.network_test_url.c_str(), DEFAULT_NETWORK_TEST_URL)) {
+        safe_strcpy(aid.network_test_url, nvc_config.network_test_url.c_str());
+    }
     aid.vbox_window = cc_config.vbox_window;
     aid.checkpoint_period = gstate.global_prefs.disk_interval;
     aid.fraction_done_start = 0;

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -674,9 +674,6 @@ int ACTIVE_TASK::start() {
     graphics_request_queue.init(result->name);        // reset message queues
     process_control_queue.init(result->name);
 
-    bytes_sent_episode = 0;
-    bytes_received_episode = 0;
-
     if (!app_client_shm.shm) {
         retval = get_shmem_seg_name();
         if (retval) {

--- a/client/app_start.cpp
+++ b/client/app_start.cpp
@@ -265,9 +265,6 @@ void ACTIVE_TASK::init_app_init_data(APP_INIT_DATA& aid) {
         aid.gpu_usage = 0;
     }
     aid.ncpus = result->resource_usage.avg_ncpus;
-    if (strcmp(nvc_config.network_test_url.c_str(), DEFAULT_NETWORK_TEST_URL)) {
-        safe_strcpy(aid.network_test_url, nvc_config.network_test_url.c_str());
-    }
     aid.vbox_window = cc_config.vbox_window;
     aid.checkpoint_period = gstate.global_prefs.disk_interval;
     aid.fraction_done_start = 0;

--- a/client/client_msgs.cpp
+++ b/client/client_msgs.cpp
@@ -162,7 +162,7 @@ void msg_printf(PROJ_AM *p, int priority, const char *fmt, ...) {
     buf[sizeof(buf)-1] = 0;
     va_end(ap);
 
-    show_message(p, buf, priority, true, 0);
+    show_message(p, buf, priority, false, 0);
 }
 
 void msg_printf_notice(

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -717,6 +717,8 @@ extern void show_docker_messages();
     // Don't do this on Android
 #endif
 
-#define NEED_NETWORK_MSG _("BOINC can't access Internet - check network connection or proxy configuration.")
+#define NEED_NETWORK_MSG _("BOINC can't access Internet - check network connection")
+#define APP_NEED_NETWORK_MSG _("Tasks can't access Internet - check network connection")
+#define APP_NETWORK_SUSPENDED_MSG _("Tasks need Internet access - consider unsuspending network")
 
 #endif

--- a/client/cs_notice.cpp
+++ b/client/cs_notice.cpp
@@ -538,7 +538,10 @@ void NOTICES::remove_notices(PROJECT* p, int which) {
         bool remove = false;
         switch (which) {
         case REMOVE_NETWORK_MSG:
-            remove = !strcmp(n.description.c_str(), NEED_NETWORK_MSG);
+            remove = !strcmp(n.description.c_str(), NEED_NETWORK_MSG)
+                || !strcmp(n.description.c_str(), APP_NEED_NETWORK_MSG)
+                || !strcmp(n.description.c_str(), APP_NETWORK_SUSPENDED_MSG)
+            ;
             break;
         case REMOVE_SCHEDULER_MSG:
             remove = !strcmp(n.category, "scheduler");
@@ -574,11 +577,9 @@ void NOTICES::write(int seqno, GUI_RPC_CONN& grc, bool public_only) {
     size_t i;
     MIOFILE mf;
 
-    if (!net_status.need_physical_connection) {
-        remove_notices(NULL, REMOVE_NETWORK_MSG);
-    }
     if (log_flags.notice_debug) {
-        msg_printf(0, MSG_INFO, "NOTICES::write: seqno %d, refresh %s, %d notices",
+        msg_printf(0, MSG_INFO,
+            "NOTICES::write: seqno %d, refresh %s, %d notices",
             seqno, grc.get_notice_refresh()?"true":"false", (int)notices.size()
         );
     }

--- a/client/current_version.cpp
+++ b/client/current_version.cpp
@@ -45,13 +45,14 @@ NVC_CONFIG::NVC_CONFIG() {
     defaults();
 }
 
-// this is called first thing by client right after CC_CONFIG::defaults()
+// this is called in main.cpp:init_core_client(),
+// right after CC_CONFIG::defaults()
 //
 void NVC_CONFIG::defaults() {
-    client_download_url = "https://boinc.berkeley.edu/download.php";
+    client_download_url = DEFAULT_DOWNLOAD_URL;
     client_new_version_name.clear();
     client_version_check_url = DEFAULT_VERSION_CHECK_URL;
-    network_test_url = "https://www.google.com/";
+    network_test_url = DEFAULT_NETWORK_TEST_URL;
 };
 
 int NVC_CONFIG::parse(FILE* f) {

--- a/client/current_version.h
+++ b/client/current_version.h
@@ -22,7 +22,7 @@
 
 #define DEFAULT_VERSION_CHECK_URL "https://boinc.berkeley.edu/download.php?xml=1"
 #define DEFAULT_DOWNLOAD_URL "https://boinc.berkeley.edu/download.php"
-#define DEFAULT_NETWORK_TEST_URL "https://www.google.com/"
+#define DEFAULT_NETWORK_TEST_URL "https://berkeley.edu/"
 
 struct GET_CURRENT_VERSION_OP: public GUI_HTTP_OP {
     int error_num;

--- a/client/current_version.h
+++ b/client/current_version.h
@@ -21,6 +21,8 @@
 #include "gui_http.h"
 
 #define DEFAULT_VERSION_CHECK_URL "https://boinc.berkeley.edu/download.php?xml=1"
+#define DEFAULT_DOWNLOAD_URL "https://boinc.berkeley.edu/download.php"
+#define DEFAULT_NETWORK_TEST_URL "https://www.google.com/"
 
 struct GET_CURRENT_VERSION_OP: public GUI_HTTP_OP {
     int error_num;

--- a/client/gui_http.h
+++ b/client/gui_http.h
@@ -18,7 +18,10 @@
 #ifndef BOINC_GUI_HTTP_H
 #define BOINC_GUI_HTTP_H
 
-// A high-level interface for client-initiated HTTP requests.
+// A high-level interface for
+// 1) Manager-initiated HTTP requests.
+// 2) client-initiated requests like doing acct mgr ops
+//   (hence 'GUI' is a misnomer)
 
 // GUI_HTTP represents a "channel" for doing a sequence of HTTP ops,
 // possibly to different servers.

--- a/client/net_stats.cpp
+++ b/client/net_stats.cpp
@@ -122,6 +122,8 @@ int NET_STATS::parse(XML_PARSER& xp) {
 // WANT_DISCONNECT if we don't have any connections, and don't need any
 // LOOKUP_PENDING if a website lookup is pending (try again later)
 //
+// This is used for the get_cc_status() GUI RPC.
+//
 // There's a 10-second slop factor;
 // if we've done network comm in the last 10 seconds,
 // we act as if we're doing it now.
@@ -142,7 +144,7 @@ int NET_STATUS::network_status() {
         retval = NETWORK_STATUS_ONLINE;
     } else if (need_physical_connection) {
         retval = NETWORK_STATUS_WANT_CONNECTION;
-    } else if (gstate.active_tasks.want_network()) {
+    } else if (gstate.active_tasks.some_task_wants_network()) {
         retval = NETWORK_STATUS_WANT_CONNECTION;
     } else {
         have_sporadic_connection = false;
@@ -154,8 +156,9 @@ int NET_STATUS::network_status() {
     return retval;
 }
 
-// There's now a network connection, after some period of disconnection.
-// Do all communication that we can.
+// the user has requested file xfer retry;
+// presumably there's a network connection after a period of disconnection.
+// Clear backoffs.
 //
 void NET_STATUS::network_available() {
     have_sporadic_connection = true;
@@ -167,10 +170,6 @@ void NET_STATUS::network_available() {
         p->upload_backoff.clear_temporary();
         p->download_backoff.clear_temporary();
     }
-
-    // tell active tasks that network is available
-    //
-    gstate.active_tasks.network_available();
 }
 
 // An HTTP operation failed;
@@ -197,11 +196,12 @@ void NET_STATUS::got_http_error() {
         );
     }
     need_to_contact_reference_site = true;
-    show_ref_message = true;
 }
 
 void NET_STATUS::http_op_succeeded() {
     need_physical_connection = false;
+    notices.remove_notices(NULL, REMOVE_NETWORK_MSG);
+    network_notice_active = false;
 }
 
 void NET_STATUS::contact_reference_site() {
@@ -222,11 +222,9 @@ static void show_fail_msg() {
 int LOOKUP_WEBSITE_OP::do_rpc(string& url) {
     int retval;
 
-    if (net_status.show_ref_message) {
-        msg_printf(0, MSG_INFO,
-            "Project communication failed: attempting access to reference site"
-        );
-    }
+    msg_printf(0, MSG_INFO,
+        "Project communication failed: attempting access to reference site"
+    );
     retval = gui_http->do_rpc(this, url.c_str(), LOOKUP_WEBSITE_FILENAME, true);
     if (retval) {
         error_num = retval;
@@ -253,11 +251,9 @@ void LOOKUP_WEBSITE_OP::handle_reply(int http_op_retval) {
         net_status.last_comm_time = 0;
         show_fail_msg();
     } else {
-        if (net_status.show_ref_message) {
-            msg_printf(0, MSG_INFO,
-                "Internet access OK - project servers may be temporarily down."
-            );
-        }
+        msg_printf(0, MSG_INFO,
+            "Internet access OK - project servers may be temporarily down."
+        );
     }
 }
 
@@ -266,15 +262,22 @@ void NET_STATUS::poll() {
     // may still be coming up, so defer the reference site check;
     // otherwise might show spurious "need connection" message
     //
-    if (gstate.now < gstate.last_wakeup_time + 30) return;
+    if (gstate.now < gstate.last_wakeup_time + 30) {
+        return;
+    }
     // wait until after a round of automatic proxy detection
     // before attempting to contact the reference site
     //
-    if (working_proxy_info.autodetect_proxy_supported &&
-        working_proxy_info.need_autodetect_proxy_settings &&
-        !working_proxy_info.have_autodetect_proxy_settings) return;
+    if (working_proxy_info.autodetect_proxy_supported
+        && working_proxy_info.need_autodetect_proxy_settings
+        && !working_proxy_info.have_autodetect_proxy_settings
+    ) {
+        return;
+    }
 
-    if (net_status.need_to_contact_reference_site && !gstate.gui_http.is_busy()) {
+    if (net_status.need_to_contact_reference_site
+        && !gstate.gui_http.is_busy()
+    ) {
         net_status.contact_reference_site();
     }
 }

--- a/client/net_stats.cpp
+++ b/client/net_stats.cpp
@@ -201,7 +201,8 @@ void NET_STATUS::got_http_error() {
 void NET_STATUS::http_op_succeeded() {
     need_physical_connection = false;
     notices.remove_notices(NULL, REMOVE_NETWORK_MSG);
-    network_notice_active = false;
+    app_connection_notice_active = false;
+    app_suspend_notice_active = false;
 }
 
 void NET_STATUS::contact_reference_site() {

--- a/client/net_stats.h
+++ b/client/net_stats.h
@@ -88,7 +88,8 @@ public:
         // (e.g. report completed results)
     double last_comm_time;
         // last time there were HTTP ops in progress
-    bool network_notice_active;
+    bool app_connection_notice_active;
+    bool app_suspend_notice_active;
         // we posted a network-related notice,
         // and there hasn't been evidence of a reconnection,
         // so don't post another one.
@@ -102,7 +103,8 @@ public:
         have_sporadic_connection = false;
         need_to_contact_reference_site = false;
         last_comm_time = 0;
-        network_notice_active = false;
+        app_connection_notice_active = false;
+        app_suspend_notice_active = false;
     }
     void poll();
 };

--- a/client/net_stats.h
+++ b/client/net_stats.h
@@ -87,7 +87,7 @@ public:
         // so do as much network comm as possible
         // (e.g. report completed results)
     double last_comm_time;
-        // unclear what this means
+        // last time there were HTTP ops in progress
     bool network_notice_active;
         // we posted a network-related notice,
         // and there hasn't been evidence of a reconnection,

--- a/client/net_stats.h
+++ b/client/net_stats.h
@@ -74,7 +74,6 @@ public:
         // contact the reference site as soon as GUI_HTTP is idle
         // polled from NET_STATS::poll(), for want of a better place
     void contact_reference_site();
-    bool show_ref_message;
     bool need_physical_connection;
         // client wants to do network comm and no physical connection exists.
         // Initially false; set whenever a Curl operation
@@ -88,6 +87,11 @@ public:
         // so do as much network comm as possible
         // (e.g. report completed results)
     double last_comm_time;
+        // unclear what this means
+    bool network_notice_active;
+        // we posted a network-related notice,
+        // and there hasn't been evidence of a reconnection,
+        // so don't post another one.
 
     int network_status();
     void network_available();
@@ -97,8 +101,8 @@ public:
         need_physical_connection = false;
         have_sporadic_connection = false;
         need_to_contact_reference_site = false;
-        show_ref_message = false;
         last_comm_time = 0;
+        network_notice_active = false;
     }
     void poll();
 };
@@ -106,7 +110,7 @@ public:
 // This is used to access a reference website (like yahoo or google)
 // that is assumed to be 100% available.
 // It is used ONLY from the HTTP code, when a transaction fails
-
+//
 struct LOOKUP_WEBSITE_OP: public GUI_HTTP_OP {
     int error_num;
 

--- a/client/result.cpp
+++ b/client/result.cpp
@@ -65,8 +65,6 @@ void RESULT::clear() {
     final_peak_working_set_size = 0;
     final_peak_swap_size = 0;
     final_peak_disk_usage = 0;
-    final_bytes_sent = 0;
-    final_bytes_received = 0;
 #ifdef SIM
     peak_flop_count = 0;
 #endif
@@ -186,8 +184,6 @@ int RESULT::parse_state(XML_PARSER& xp) {
         if (xp.parse_double("final_peak_working_set_size", final_peak_working_set_size)) continue;
         if (xp.parse_double("final_peak_swap_size", final_peak_swap_size)) continue;
         if (xp.parse_double("final_peak_disk_usage", final_peak_disk_usage)) continue;
-        if (xp.parse_double("final_bytes_sent", final_bytes_sent)) continue;
-        if (xp.parse_double("final_bytes_received", final_bytes_received)) continue;
         if (xp.parse_int("exit_status", exit_status)) continue;
         if (xp.parse_bool("got_server_ack", got_server_ack)) continue;
         if (xp.parse_bool("ready_to_report", ready_to_report)) continue;
@@ -267,18 +263,6 @@ int RESULT::write(MIOFILE& out, bool to_server) {
         out.printf(
             "    <final_peak_disk_usage>%.0f</final_peak_disk_usage>\n",
             final_peak_disk_usage
-        );
-    }
-    if (final_bytes_sent) {
-        out.printf(
-            "    <final_bytes_sent>%.0f</final_bytes_sent>\n",
-            final_bytes_sent
-        );
-    }
-    if (final_bytes_received) {
-        out.printf(
-            "    <final_bytes_received>%.0f</final_bytes_received>\n",
-            final_bytes_received
         );
     }
     if (to_server) {

--- a/client/result.h
+++ b/client/result.h
@@ -44,8 +44,6 @@ struct RESULT {
     double final_peak_working_set_size;
     double final_peak_swap_size;
     double final_peak_disk_usage;
-    double final_bytes_sent;
-    double final_bytes_received;
 #ifdef SIM
     double peak_flop_count;
     double sim_flops_left;

--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -597,12 +597,24 @@ void WORK_FETCH::piggyback_work_request(PROJECT* p) {
             rwf.dont_fetch_reason = RSC_REASON_BUFFER_FULL;
             continue;
         }
+
+        // don't request this resource if there's a strictly higher priority
+        // project that we could get it from
+        //
         if (check_higher_priority_projects) {
             PROJECT* p2 = NULL;
             for (unsigned int j=0; j<projects_sorted.size(); j++) {
                 p2 = projects_sorted[j];
                 if (p2 == p) break;
                 if (p2->sched_priority == p->sched_priority) continue;
+                if (p2->sched_req_no_work[i]) {
+                    if (log_flags.work_fetch_debug) {
+                        msg_printf(p, MSG_INFO,
+                            "piggyback: %s doesn't have jobs", p2->project_name
+                        );
+                    }
+                    continue;
+                }
                 if (p2->pwf.project_reason) {
                     if (log_flags.work_fetch_debug) {
                         msg_printf(p, MSG_INFO,
@@ -702,7 +714,7 @@ static PROJECT_REASON compute_project_reason(PROJECT* p) {
 // setup for choose_project() and piggyback():
 // - do RR simulation
 // - set request fields for each resource
-// - compute "projects_sorted": priority-sorted list of projects
+// - compute "projects_sorted": list of projects sorted by decr priority
 //
 void WORK_FETCH::setup() {
     gstate.compute_nuploading_results();

--- a/client/work_fetch.cpp
+++ b/client/work_fetch.cpp
@@ -561,7 +561,7 @@ void WORK_FETCH::piggyback_work_request(PROJECT* p) {
     //
     for (int i=0; i<coprocs.n_rsc; i++) {
         if (log_flags.work_fetch_debug) {
-            msg_printf(p, MSG_INFO, "piggyback: resource %s", rsc_name_long(i));
+            msg_printf(NULL, MSG_INFO, "piggyback: resource %s", rsc_name_long(i));
         }
         RSC_WORK_FETCH& rwf = rsc_work_fetch[i];
         if (i && !gpus_usable) {
@@ -575,7 +575,7 @@ void WORK_FETCH::piggyback_work_request(PROJECT* p) {
             break;
         default:
             if (log_flags.work_fetch_debug) {
-                msg_printf(p, MSG_INFO,
+                msg_printf(NULL, MSG_INFO,
                     "piggyback: can't fetch %s: %s",
                     rsc_name_long(i),
                     rsc_reason_string(rpwf.rsc_project_reason)
@@ -590,7 +590,7 @@ void WORK_FETCH::piggyback_work_request(PROJECT* p) {
         }
         if (!need_work) {
             if (log_flags.work_fetch_debug) {
-                msg_printf(p, MSG_INFO, "piggyback: don't need %s",
+                msg_printf(NULL, MSG_INFO, "piggyback: don't need %s",
                     rsc_name_long(i)
                 );
             }
@@ -609,7 +609,7 @@ void WORK_FETCH::piggyback_work_request(PROJECT* p) {
                 if (p2->sched_priority == p->sched_priority) continue;
                 if (p2->sched_req_no_work[i]) {
                     if (log_flags.work_fetch_debug) {
-                        msg_printf(p, MSG_INFO,
+                        msg_printf(NULL, MSG_INFO,
                             "piggyback: %s doesn't have jobs", p2->project_name
                         );
                     }
@@ -617,7 +617,7 @@ void WORK_FETCH::piggyback_work_request(PROJECT* p) {
                 }
                 if (p2->pwf.project_reason) {
                     if (log_flags.work_fetch_debug) {
-                        msg_printf(p, MSG_INFO,
+                        msg_printf(NULL, MSG_INFO,
                             "piggyback: %s can't fetch work", p2->project_name
                         );
                     }
@@ -626,7 +626,7 @@ void WORK_FETCH::piggyback_work_request(PROJECT* p) {
                 RSC_PROJECT_WORK_FETCH& rpwf2 = rwf.project_state(p2);
                 if (!rpwf2.rsc_project_reason) {
                     if (log_flags.work_fetch_debug) {
-                        msg_printf(p, MSG_INFO,
+                        msg_printf(NULL, MSG_INFO,
                             "piggyback: better proj %s", p2->project_name
                         );
                     }

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -2650,6 +2650,8 @@ wxString result_description(RESULT* result, bool show_resources) {
                 strBuffer += _("Waiting for memory");
             } else if (result->needs_shmem) {
                 strBuffer += _("Waiting for shared memory");
+            } else if (result->want_network) {
+                strBuffer += _("Waiting for network");
             } else if (result->scheduler_state == CPU_SCHED_SCHEDULED) {
                 strBuffer += _("Running");
                 if (project && project->non_cpu_intensive) {

--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -72,7 +72,6 @@ void APP_INIT_DATA::copy(const APP_INIT_DATA& a) {
     safe_strcpy(authenticator, a.authenticator);
     memcpy(&shmem_seg_name, &a.shmem_seg_name, sizeof(SHMEM_SEG_NAME));
     safe_strcpy(gpu_type, a.gpu_type);
-    safe_strcpy(network_test_url, a.network_test_url);
 
     // use assignment for the rest, especially the classes
     // (so that the overloaded operators are called!)
@@ -163,10 +162,6 @@ int write_init_data_file(FILE* f, APP_INIT_DATA& ai) {
     if (strlen(ai.user_name)) {
         xml_escape(ai.user_name, buf, sizeof(buf));
         fprintf(f, "<user_name>%s</user_name>\n", buf);
-    }
-    if (strlen(ai.network_test_url)) {
-        xml_escape(ai.network_test_url, buf, sizeof(buf));
-        fprintf(f, "<network_test_url>%s</network_test_url>\n", buf);
     }
     fprintf(f, "<project_dir>%s</project_dir>\n", ai.project_dir);
     fprintf(f, "<boinc_dir>%s</boinc_dir>\n", ai.boinc_dir);
@@ -304,7 +299,6 @@ void APP_INIT_DATA::clear() {
     gpu_opencl_dev_index = -1;
     gpu_usage = 0;
     ncpus = 0;
-    network_test_url[0] = 0;
     memset(&shmem_seg_name, 0, sizeof(shmem_seg_name));
     wu_cpu_time = 0;
     vbox_window = false;
@@ -415,7 +409,6 @@ int parse_init_data_file(FILE* f, APP_INIT_DATA& ai) {
         if (xp.parse_int("gpu_opencl_dev_index", ai.gpu_opencl_dev_index)) continue;
         if (xp.parse_double("gpu_usage", ai.gpu_usage)) continue;
         if (xp.parse_double("ncpus", ai.ncpus)) continue;
-        if (xp.parse_str("network_test_url", ai.network_test_url, sizeof(ai.network_test_url))) continue;
         if (xp.parse_double("fraction_done_start", ai.fraction_done_start)) continue;
         if (xp.parse_double("fraction_done_end", ai.fraction_done_end)) continue;
         if (xp.parse_bool("vbox_window", ai.vbox_window)) continue;

--- a/lib/app_ipc.cpp
+++ b/lib/app_ipc.cpp
@@ -72,6 +72,7 @@ void APP_INIT_DATA::copy(const APP_INIT_DATA& a) {
     safe_strcpy(authenticator, a.authenticator);
     memcpy(&shmem_seg_name, &a.shmem_seg_name, sizeof(SHMEM_SEG_NAME));
     safe_strcpy(gpu_type, a.gpu_type);
+    safe_strcpy(network_test_url, a.network_test_url);
 
     // use assignment for the rest, especially the classes
     // (so that the overloaded operators are called!)
@@ -162,6 +163,10 @@ int write_init_data_file(FILE* f, APP_INIT_DATA& ai) {
     if (strlen(ai.user_name)) {
         xml_escape(ai.user_name, buf, sizeof(buf));
         fprintf(f, "<user_name>%s</user_name>\n", buf);
+    }
+    if (strlen(ai.network_test_url)) {
+        xml_escape(ai.network_test_url, buf, sizeof(buf));
+        fprintf(f, "<network_test_url>%s</network_test_url>\n", buf);
     }
     fprintf(f, "<project_dir>%s</project_dir>\n", ai.project_dir);
     fprintf(f, "<boinc_dir>%s</boinc_dir>\n", ai.boinc_dir);
@@ -299,6 +304,7 @@ void APP_INIT_DATA::clear() {
     gpu_opencl_dev_index = -1;
     gpu_usage = 0;
     ncpus = 0;
+    network_test_url[0] = 0;
     memset(&shmem_seg_name, 0, sizeof(shmem_seg_name));
     wu_cpu_time = 0;
     vbox_window = false;
@@ -409,6 +415,7 @@ int parse_init_data_file(FILE* f, APP_INIT_DATA& ai) {
         if (xp.parse_int("gpu_opencl_dev_index", ai.gpu_opencl_dev_index)) continue;
         if (xp.parse_double("gpu_usage", ai.gpu_usage)) continue;
         if (xp.parse_double("ncpus", ai.ncpus)) continue;
+        if (xp.parse_str("network_test_url", ai.network_test_url, sizeof(ai.network_test_url))) continue;
         if (xp.parse_double("fraction_done_start", ai.fraction_done_start)) continue;
         if (xp.parse_double("fraction_done_end", ai.fraction_done_end)) continue;
         if (xp.parse_bool("vbox_window", ai.vbox_window)) continue;

--- a/lib/app_ipc.h
+++ b/lib/app_ipc.h
@@ -195,10 +195,6 @@ struct APP_INIT_DATA {
     //
     double ncpus;
 
-    // for apps that use network
-    //
-    char network_test_url[256];
-
     // client configuration info, from cc_config.h
     //
     bool vbox_window;       // whether to open a console window for VM apps

--- a/lib/app_ipc.h
+++ b/lib/app_ipc.h
@@ -126,9 +126,11 @@ public:
 
 // parsed version of main init file
 // If you add anything here, update
-// APP_INIT_DATA::clear(), copy(),
-// write_init_data_file(), parse_init_data_file()
-// ACTIVE_TASK::init_app_init_data()
+// in app_ipc.cpp:
+//      APP_INIT_DATA::clear(), copy(),
+//      write_init_data_file(), parse_init_data_file()
+// in client/app_start.cpp:
+//      ACTIVE_TASK::init_app_init_data()
 //
 struct APP_INIT_DATA {
     int major_version;          // BOINC client version info
@@ -192,6 +194,10 @@ struct APP_INIT_DATA {
     // info for multicore apps: how many cores to use
     //
     double ncpus;
+
+    // for apps that use network
+    //
+    char network_test_url[256];
 
     // client configuration info, from cc_config.h
     //

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -65,19 +65,6 @@ RPC_CLIENT::~RPC_CLIENT() {
     close();
 }
 
-#ifdef _WIN32
-static int addr_len(sockaddr_storage&) {
-    return (int) sizeof(sockaddr_in);
-}
-#else
-static int addr_len(sockaddr_storage& s) {
-    if (s.ss_family == AF_INET6) {
-        return (int) sizeof(sockaddr_in6);
-    }
-    return (int) sizeof(sockaddr_in);
-}
-#endif
-
 // if any RPC returns ERR_READ or ERR_WRITE,
 // call this and then call init() again.
 //

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -295,6 +295,7 @@ struct RESULT {
     double bytes_received;
     bool too_large;
     bool needs_shmem;
+    bool want_network;
     bool edf_scheduled;
     char graphics_exec_path[MAXPATHLEN];
     char web_graphics_url[256];

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -706,6 +706,7 @@ int RESULT::parse(XML_PARSER& xp) {
         if (xp.parse_double("bytes_received", bytes_received)) continue;
         if (xp.parse_bool("too_large", too_large)) continue;
         if (xp.parse_bool("needs_shmem", needs_shmem)) continue;
+        if (xp.parse_bool("want_network", want_network)) continue;
         if (xp.parse_bool("edf_scheduled", edf_scheduled)) continue;
         if (xp.parse_str("graphics_exec_path", graphics_exec_path, sizeof(graphics_exec_path))) continue;
         if (xp.parse_str("web_graphics_url", web_graphics_url, sizeof(web_graphics_url))) continue;
@@ -763,6 +764,7 @@ void RESULT::clear() {
     bytes_received = 0;
     too_large = false;
     needs_shmem = false;
+    want_network = false;
     edf_scheduled = false;
 
     app = NULL;

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -368,12 +368,16 @@ int boinc_get_port(bool is_remote, int& port) {
 // So use ping instead.
 // But guess what?  The Win version is different from Unix
 //
-bool network_connected() {
+bool network_connected(const char *hostname) {
+    char cmd[256];
+    snprintf(cmd, sizeof(cmd), "ping %s %s",
+        hostname,
 #ifdef _WIN32
-    const char* cmd = "ping google.com -n 1";
+        "-n 1"
 #else
-    const char* cmd = "ping google.com -c 1";
+        "-c 1"
 #endif
+    );
     vector<string> out;
     int retval = run_command(cmd, out);
     // ping exits nonzero on failure

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -360,8 +360,15 @@ int boinc_get_port(bool is_remote, int& port) {
 // is the given host reachable?
 // (used w/ google.com to check for network connection)
 //
+// We used to do this directly, by gethostbyname() and connect().
+// But on Windows, gethostbyname() caches negative results,
+// so once 'google.com' fails (due to network disconnection)
+// it keeps failing after reconnection!  WTF??
+//
+// So use ping instead.
+// But guess what?  The Win version is different from Unix
+//
 int network_connected() {
-#if 1
 #ifdef _WIN32
     const char* cmd = "ping google.com -n 1";
 #else
@@ -372,28 +379,6 @@ int network_connected() {
     if (retval) {
         fprintf(stderr, "%s failed: %d\n", cmd, retval);
     }
-    for (string line: out) {
-        if (strstr(line.c_str(), "bytes from")) {   // Unix
-            return 0;
-        }
-        if (strstr(line.c_str(), "Reply from")) {   // Win
-            return 0;
-        }
-    }
-    return -1;
-#else
-    sockaddr_storage ip_addr;
-    int sock;
-    int retval = resolve_hostname("google.com", ip_addr);
-    if (retval) {
-        return ERR_GETHOSTBYNAME;
-    }
-    boinc_socket(sock, AF_INET);
-    retval = connect(sock, (const sockaddr*)(&ip_addr), addr_len(ip_addr));
-    close(sock);
-    if (retval) {
-        return ERR_CONNECT;
-    }
+    // ping exits nonzero on failure
     return 0;
-#endif
 }

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -35,6 +35,11 @@
 #include <errno.h>
 #endif
 
+#include <vector>
+#include <string>
+using std::vector;
+using std::string;
+
 #include "error_numbers.h"
 #include "str_util.h"
 #include "util.h"
@@ -355,10 +360,24 @@ int boinc_get_port(bool is_remote, int& port) {
 // is the given host reachable?
 // (used w/ google.com to check for network connection)
 //
-int test_connect(const char* hostname) {
+int network_connected() {
+#if 1
+    const char* cmd = "ping google.com -c 1";
+    vector<string> out;
+    int retval = run_command(cmd, out);
+    if (retval) {
+        fprintf(stderr, "%s failed: %d\n", cmd, retval);
+    }
+    for (string line: out) {
+        if (strstr(line.c_str(), "bytes from")) {
+            return 0;
+        }
+    }
+    return -1;
+#else
     sockaddr_storage ip_addr;
     int sock;
-    int retval = resolve_hostname(hostname, ip_addr);
+    int retval = resolve_hostname("google.com", ip_addr);
     if (retval) {
         return ERR_GETHOSTBYNAME;
     }
@@ -369,4 +388,5 @@ int test_connect(const char* hostname) {
         return ERR_CONNECT;
     }
     return 0;
+#endif
 }

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -358,20 +358,21 @@ int boinc_get_port(bool is_remote, int& port) {
     return 0;
 }
 
-// is the given host reachable?
-// (used w/ google.com to check for network connection)
+// is a high-availability server reachable?
+// (we use berkeley.edu for this purpose)
 //
 // We used to do this directly, by gethostbyname() and connect().
 // But on Windows, gethostbyname() caches negative results,
-// so once 'google.com' fails (due to network disconnection)
+// so once a DNS resolution fails (due to network disconnection)
 // it keeps failing after reconnection!  WTF??
 //
 // So use ping instead.
-// But guess what?  The Win version is different from Unix
+// The Win version is different from Unix, both the args and the output.
+// But both exit nonzero on failure.
 //
 bool network_connected() {
     char cmd[256];
-    snprintf(cmd, sizeof(cmd), "ping berkeley.edu %s",
+    snprintf(cmd, sizeof(cmd), "ping %s berkeley.edu",
 #ifdef _WIN32
         "-n 1"
 #else

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -362,14 +362,21 @@ int boinc_get_port(bool is_remote, int& port) {
 //
 int network_connected() {
 #if 1
+#ifdef _WIN32
+    const char* cmd = "ping google.com -n 1";
+#else
     const char* cmd = "ping google.com -c 1";
+#endif
     vector<string> out;
     int retval = run_command(cmd, out);
     if (retval) {
         fprintf(stderr, "%s failed: %d\n", cmd, retval);
     }
     for (string line: out) {
-        if (strstr(line.c_str(), "bytes from")) {
+        if (strstr(line.c_str(), "bytes from")) {   // Unix
+            return 0;
+        }
+        if (strstr(line.c_str(), "Reply from")) {   // Win
             return 0;
         }
     }

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -368,7 +368,7 @@ int boinc_get_port(bool is_remote, int& port) {
 // So use ping instead.
 // But guess what?  The Win version is different from Unix
 //
-int network_connected() {
+bool network_connected() {
 #ifdef _WIN32
     const char* cmd = "ping google.com -n 1";
 #else
@@ -376,9 +376,9 @@ int network_connected() {
 #endif
     vector<string> out;
     int retval = run_command(cmd, out);
-    if (retval) {
-        fprintf(stderr, "%s failed: %d\n", cmd, retval);
-    }
     // ping exits nonzero on failure
-    return 0;
+    if (retval) {
+        return false;
+    }
+    return true;
 }

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -353,17 +353,20 @@ int boinc_get_port(bool is_remote, int& port) {
 }
 
 // is the given host reachable?
+// (used w/ google.com to check for network connection)
 //
-bool is_reachable(const char* hostname) {
+int test_connect(const char* hostname) {
     sockaddr_storage ip_addr;
     int sock;
     int retval = resolve_hostname(hostname, ip_addr);
-    if (retval) return false;
+    if (retval) {
+        return ERR_GETHOSTBYNAME;
+    }
     boinc_socket(sock, AF_INET);
     retval = connect(sock, (const sockaddr*)(&ip_addr), addr_len(ip_addr));
-    if (retval) {
-        return false;
-    }
     close(sock);
-    return true;
+    if (retval) {
+        return ERR_CONNECT;
+    }
+    return 0;
 }

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -37,6 +37,7 @@
 
 #include <vector>
 #include <string>
+#include <cctype>
 using std::vector;
 using std::string;
 
@@ -369,6 +370,17 @@ int boinc_get_port(bool is_remote, int& port) {
 // But guess what?  The Win version is different from Unix
 //
 bool network_connected(const char *hostname) {
+    // make sure it's a valid hostname
+    //
+    for (unsigned int i=0; i<strlen(hostname); i++) {
+        char c = hostname[i];
+        if (std::isalpha(c)) continue;
+        if (std::isdigit(c)) continue;
+        if (c == '.') continue;
+        if (c == '-') continue;
+        fprintf(stderr, "network_connected: invalid hostname %s\n", hostname);
+        return true;
+    }
     char cmd[256];
     snprintf(cmd, sizeof(cmd), "ping %s %s",
         hostname,

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -351,3 +351,19 @@ int boinc_get_port(bool is_remote, int& port) {
     boinc_close_socket(sock);
     return 0;
 }
+
+// is the given host reachable?
+//
+bool is_reachable(const char* hostname) {
+    sockaddr_storage ip_addr;
+    int sock;
+    int retval = resolve_hostname(hostname, ip_addr);
+    if (retval) return false;
+    boinc_socket(sock, AF_INET);
+    retval = connect(sock, (const sockaddr*)(&ip_addr), addr_len(ip_addr));
+    if (retval) {
+        return false;
+    }
+    close(sock);
+    return true;
+}

--- a/lib/network.cpp
+++ b/lib/network.cpp
@@ -369,21 +369,9 @@ int boinc_get_port(bool is_remote, int& port) {
 // So use ping instead.
 // But guess what?  The Win version is different from Unix
 //
-bool network_connected(const char *hostname) {
-    // make sure it's a valid hostname
-    //
-    for (unsigned int i=0; i<strlen(hostname); i++) {
-        char c = hostname[i];
-        if (std::isalpha(c)) continue;
-        if (std::isdigit(c)) continue;
-        if (c == '.') continue;
-        if (c == '-') continue;
-        fprintf(stderr, "network_connected: invalid hostname %s\n", hostname);
-        return true;
-    }
+bool network_connected() {
     char cmd[256];
-    snprintf(cmd, sizeof(cmd), "ping %s %s",
-        hostname,
+    snprintf(cmd, sizeof(cmd), "ping berkeley.edu %s",
 #ifdef _WIN32
         "-n 1"
 #else

--- a/lib/network.h
+++ b/lib/network.h
@@ -58,7 +58,7 @@ extern int get_socket_error(int fd);
 extern const char* socket_error_str();
 extern void reset_dns();
 extern int boinc_get_port(bool is_remote, int& port);
-extern bool network_connected(const char* hostname);
+extern bool network_connected();
 
 #ifdef _WIN32
 inline int addr_len(sockaddr_storage&) {

--- a/lib/network.h
+++ b/lib/network.h
@@ -58,7 +58,7 @@ extern int get_socket_error(int fd);
 extern const char* socket_error_str();
 extern void reset_dns();
 extern int boinc_get_port(bool is_remote, int& port);
-extern bool network_connected();
+extern bool network_connected(const char* hostname);
 
 #ifdef _WIN32
 inline int addr_len(sockaddr_storage&) {

--- a/lib/network.h
+++ b/lib/network.h
@@ -58,7 +58,7 @@ extern int get_socket_error(int fd);
 extern const char* socket_error_str();
 extern void reset_dns();
 extern int boinc_get_port(bool is_remote, int& port);
-extern int network_connected();
+extern bool network_connected();
 
 #ifdef _WIN32
 inline int addr_len(sockaddr_storage&) {

--- a/lib/network.h
+++ b/lib/network.h
@@ -58,7 +58,7 @@ extern int get_socket_error(int fd);
 extern const char* socket_error_str();
 extern void reset_dns();
 extern int boinc_get_port(bool is_remote, int& port);
-extern int test_connect(const char* hostname);
+extern int network_connected();
 
 #ifdef _WIN32
 inline int addr_len(sockaddr_storage&) {

--- a/lib/network.h
+++ b/lib/network.h
@@ -27,6 +27,7 @@
 #else
 #include <sys/select.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <unistd.h>
 #endif
 
@@ -57,6 +58,20 @@ extern int get_socket_error(int fd);
 extern const char* socket_error_str();
 extern void reset_dns();
 extern int boinc_get_port(bool is_remote, int& port);
+extern bool is_reachable(const char* hostname);
+
+#ifdef _WIN32
+inline int addr_len(sockaddr_storage&) {
+    return (int) sizeof(sockaddr_in);
+}
+#else
+inline int addr_len(sockaddr_storage& s) {
+    if (s.ss_family == AF_INET6) {
+        return (int) sizeof(sockaddr_in6);
+    }
+    return (int) sizeof(sockaddr_in);
+}
+#endif
 
 #if defined(_WIN32) && !defined(__CYGWIN32__)
 typedef int BOINC_SOCKLEN_T;

--- a/lib/network.h
+++ b/lib/network.h
@@ -58,7 +58,7 @@ extern int get_socket_error(int fd);
 extern const char* socket_error_str();
 extern void reset_dns();
 extern int boinc_get_port(bool is_remote, int& port);
-extern bool is_reachable(const char* hostname);
+extern int test_connect(const char* hostname);
 
 #ifdef _WIN32
 inline int addr_len(sockaddr_storage&) {

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -286,7 +286,7 @@ int run_program(
 // Unix: if you want stderr too, add 2>&1 to command
 // Return error if command failed
 //
-int run_command(char *cmd, vector<string> &out) {
+int run_command(const char *cmd, vector<string> &out) {
     out.clear();
 #ifdef _WIN32
     HANDLE pipe_read, pipe_write;

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -293,6 +293,11 @@ int run_command(const char *cmd, vector<string> &out) {
     SECURITY_ATTRIBUTES sa;
     STARTUPINFO si;
     PROCESS_INFORMATION pi;
+    char cmd2[1024];
+
+    // CreateProcess() can modify its cmd arg (WTF???)
+    // So copy it to a temp buffer
+    safe_strcpy(cmd2, cmd);
 
     memset(&si, 0, sizeof(si));
     memset(&pi, 0, sizeof(pi));
@@ -314,7 +319,7 @@ int run_command(const char *cmd, vector<string> &out) {
 
     if (!CreateProcess(
         NULL,
-        (LPTSTR)cmd,
+        (LPTSTR)cmd2,
         NULL,
         NULL,
         TRUE,   // inherit handles

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -339,7 +339,6 @@ int run_command(const char *cmd, vector<string> &out) {
 
     unsigned long exit_code;
     GetExitCodeProcess(pi.hProcess, &exit_code);
-    if (exit_code) return -1;
 
     DWORD count, nread;
     PeekNamedPipe(pipe_read, NULL, NULL, NULL, &count, NULL);
@@ -360,6 +359,7 @@ int run_command(const char *cmd, vector<string> &out) {
         p = q + 1;
     }
     free(buf);
+    if (exit_code) return -1;
 #else
 #ifndef _USING_FCGI_
     char buf[256];

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -281,6 +281,7 @@ int run_program(
 #endif
 
 // Run command, wait for exit.
+// If command exits nonzero, return value is -1.
 // Return its output as vector of lines (\n-terminated).
 // Win: output includes stdout and stderr
 // Unix: if you want stderr too, add 2>&1 to command
@@ -371,9 +372,8 @@ int run_command(const char *cmd, vector<string> &out) {
     while (fgets(buf, 256, fp)) {
         out.push_back(buf);
     }
-    pclose(fp);
-    if (errno) {
-        fprintf(stderr, "popen() failed errno %d: %s\n", errno, cmd);
+    int exit_status = pclose(fp);
+    if (exit_status) {
         return -1;
     }
 #endif

--- a/lib/util.h
+++ b/lib/util.h
@@ -128,7 +128,7 @@ extern int get_exit_status(PROCESS_REF, int& status, double dt);
 // Wait for exit, and return output as vector of lines.
 // Return error if command failed
 //
-extern int run_command(char *cmd, std::vector<std::string> &out);
+extern int run_command(const char *cmd, std::vector<std::string> &out);
 
 // get the path of the calling process's executable
 //

--- a/samples/docker_wrapper/checkpoint_notes
+++ b/samples/docker_wrapper/checkpoint_notes
@@ -1,0 +1,37 @@
+// ************** Checkpoint/restart ***************
+//
+// This would limit lost work if the host is rebooted
+// while a BUDA job is running.
+// In other cases (e.g. the user exits the client)
+// we pause the container and no work is lost.
+//
+// Podman and Docker have different interfaces:
+// podman: https://podman.io/docs/checkpoint
+//      podman container checkpoint <name>
+//      podman container restore <name>
+// docker: https://docs.docker.com/reference/cli/docker/checkpoint/
+//      docker checkpoint create <cont_name> <checkpoint_name>
+//      docker checkpoint ls   (lists checkpoints)
+//      docker checkpoint rm   (delete checkpoint)
+//      docker start --checkpoint <checkpoint_name> <cont_name>
+//      (use <cont_name>_checkpoint as the checkpoint name)
+//      need --security-opt=seccomp:unconfined in initial run command?
+//
+// In both cases the CRIU library is required.
+//
+// Note: I spent several days trying to get it to work on Podman
+// with all sorts of variants like --pre-checkpoint, --keep etc.
+// Whenever I did
+// - create a checkpoint
+// - compute some more
+// - stop or kill the container
+// - restore
+// I always get
+// Error: OCI runtime error: runc: criu failed: type RESTORE errno 0
+//
+// So I gave up; checkpoint/restart is only relevant to the reboot scenario,
+// this is rare.
+//
+// I took out the checkpoint-related code 1/30/2026.
+// If you want to see it, look at an older version
+

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -424,6 +424,7 @@ int build_image() {
         check_exit_request();        // should we exit?
         if (!got_heartbeat_message) {
             // need a heartbeat msg to know network suspended status
+            fprintf(stderr, "waiting for heartbeat\n");
             boinc_sleep(1);
             continue;
         }

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -363,6 +363,21 @@ void get_app_args(char* buf) {
 
 //////////  IMAGE  ////////////
 
+// used during build sleeps
+//
+void poll_client_msgs_init() {
+    BOINC_STATUS status;
+    boinc_get_status(&status);
+    if (status.no_heartbeat
+        || status.quit_request
+        || status.abort_request
+    ) {
+        fprintf(stderr, "client exit request during init\n");
+        exit(0);
+    }
+}
+
+// check whether job:
 void get_image_name() {
     if (config.image_name.empty()) {
         string s = docker_image_name(project_dir, aid.wu_name);
@@ -402,6 +417,7 @@ int build_image() {
         // google was unreachable last time we checked
     BOINC_STATUS status;
     while (1) {
+        poll_client_msgs_init();        // should we exit?
         boinc_get_status(&status);
         if (status.network_suspended) {
             fprintf(stderr, "network suspended; sleeping 10\n");
@@ -743,7 +759,6 @@ int poll_client_msgs() {
     return 0;
 }
 
-// check whether job:
 // - has exited success (JOB_SUCCESS)
 // - has exited failure (JOB_FAIL)
 // - is in progress (JOB_IN_PROGRESS)

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -413,6 +413,8 @@ int build_image() {
         char *p = strstr(aid.network_test_url, "//");
         if (p) {
             strcpy(test_host, p+2);
+        } else {
+            strcpy(test_host, aid.network_test_url);
         }
         p = strstr(test_host, "/");
         if (p) {
@@ -448,11 +450,10 @@ int build_image() {
         }
         // if google was previously unreachable, see if that's changed
         if (google_unreachable) {
-            retval = network_connected(test_host);
-            if (retval) {
+            if (!network_connected(test_host)) {
                 if (verbose_all()) {
                     fprintf(stderr,
-                        "google still unreachable (%d); sleeping 10\n", retval
+                        "test server still unreachable; sleeping 10\n"
                     );
                 }
                 boinc_sleep(10);
@@ -468,17 +469,16 @@ int build_image() {
             if (verbose_std()) {
                 fprintf(stderr, "build cmd output has 'retrying'\n");
             }
-            retval = network_connected(test_host);
-            if (retval == 0) {
+            if (network_connected(test_host)) {
                 // network connection exists but the create operation
                 // couldn't reach a needed server; error out
                 if (verbose_std()) {
-                    fprintf(stderr, "... but google is reachable; quitting\n");
+                    fprintf(stderr, "... but test server is reachable; quitting\n");
                 }
                 return -1;
             }
             if (verbose_std()) {
-                fprintf(stderr, "google is unreachable (%d); sleeping\n", retval);
+                fprintf(stderr, "test server is unreachable; sleeping\n");
             }
             google_unreachable = true;
             boinc_waiting_for_network(true);

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -422,6 +422,7 @@ int build_image() {
         if (status.network_suspended) {
             fprintf(stderr, "network suspended; sleeping 10\n");
             boinc_waiting_for_network(true);
+            boinc_report_app_status(0, 0, 0);
             boinc_sleep(10);
             continue;
         }
@@ -453,6 +454,7 @@ int build_image() {
             fprintf(stderr, "google is unreachable (%d); sleeping\n", retval);
             google_unreachable = true;
             boinc_waiting_for_network(true);
+            boinc_report_app_status(0, 0, 0);
             boinc_sleep(10);
             continue;
         }
@@ -463,6 +465,7 @@ int build_image() {
         // here if build succeeded
         fprintf(stderr, "build succeeded\n");
         boinc_waiting_for_network(false);
+        boinc_report_app_status(0, 0, 0);
         break;
     }
     return 0;

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -407,22 +407,6 @@ int build_image() {
     vector<string> out;
     int retval;
 
-    char test_host[256];
-    if (strlen(aid.network_test_url)) {
-        // make URL into a hostname if it's not already
-        char *p = strstr(aid.network_test_url, "//");
-        if (p) {
-            strcpy(test_host, p+2);
-        } else {
-            strcpy(test_host, aid.network_test_url);
-        }
-        p = strstr(test_host, "/");
-        if (p) {
-            *p = 0;
-        }
-    } else {
-        strcpy(test_host, "www.google.com");
-    }
     snprintf(cmd, sizeof(cmd),
         "build \"%s\" %s -t %s -f %s %s",
         escaped_cwd,
@@ -433,8 +417,8 @@ int build_image() {
     // build command might fail because network is disconnected
     // (this is the only command that uses network)
     //
-    bool google_unreachable = false;
-        // google was unreachable last time we checked
+    bool test_host_unreachable = false;
+        // test host was unreachable last time we checked
     BOINC_STATUS status;
     while (1) {
         poll_client_msgs_init();        // should we exit?
@@ -448,9 +432,9 @@ int build_image() {
             boinc_sleep(10);
             continue;
         }
-        // if google was previously unreachable, see if that's changed
-        if (google_unreachable) {
-            if (!network_connected(test_host)) {
+        // if test host was previously unreachable, see if that's changed
+        if (test_host_unreachable) {
+            if (!network_connected()) {
                 if (verbose_all()) {
                     fprintf(stderr,
                         "test server still unreachable; sleeping 10\n"
@@ -469,7 +453,7 @@ int build_image() {
             if (verbose_std()) {
                 fprintf(stderr, "build cmd output has 'retrying'\n");
             }
-            if (network_connected(test_host)) {
+            if (network_connected()) {
                 // network connection exists but the create operation
                 // couldn't reach a needed server; error out
                 if (verbose_std()) {
@@ -480,7 +464,7 @@ int build_image() {
             if (verbose_std()) {
                 fprintf(stderr, "test server is unreachable; sleeping\n");
             }
-            google_unreachable = true;
+            test_host_unreachable = true;
             boinc_waiting_for_network(true);
             boinc_report_app_status(0, 0, 0);
             boinc_sleep(10);

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -449,9 +449,12 @@ int build_image() {
             fprintf(stderr, "build command failed: %d\n", retval);
             return retval;
         }
-        if (output_has_str(out, "retrying")) {
+        if (
+            output_has_str(out, "unable to copy")   // podman
+            || output_has_str(out, "unreachable")   // docker?
+        ) {
             if (verbose_std()) {
-                fprintf(stderr, "build cmd output has 'retrying'\n");
+                fprintf(stderr, "build cmd output indicates disconnection\n");
             }
             if (network_connected()) {
                 // network connection exists but the create operation

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -405,6 +405,7 @@ int image_exists(bool &exists) {
 int build_image() {
     char cmd[256];
     vector<string> out;
+    int retval;
     snprintf(cmd, sizeof(cmd), "build \"%s\" -t %s -f %s %s",
         escaped_cwd, image_name, dockerfile, config.build_args.c_str()
     );
@@ -435,7 +436,7 @@ int build_image() {
                 continue;
             }
         }
-        int retval = docker_conn.command(cmd, out, verbose_std());
+        retval = docker_conn.command(cmd, out, verbose_std());
         if (retval) {
             fprintf(stderr, "build command failed: %d\n", retval);
             return retval;

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -406,7 +406,7 @@ int build_image() {
     char cmd[256];
     vector<string> out;
     int retval;
-    snprintf(cmd, sizeof(cmd), "build \"%s\" -t %s -f %s %s",
+    snprintf(cmd, sizeof(cmd), "build \"%s\" --retry 0 -t %s -f %s %s",
         escaped_cwd, image_name, dockerfile, config.build_args.c_str()
     );
 

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -406,6 +406,21 @@ int build_image() {
     char cmd[256];
     vector<string> out;
     int retval;
+
+    char test_host[256];
+    if (strlen(aid.network_test_url)) {
+        // make URL into a hostname if it's not already
+        char *p = strstr(aid.network_test_url, "//");
+        if (p) {
+            strcpy(test_host, p+2);
+        }
+        p = strstr(test_host, "/");
+        if (p) {
+            *p = 0;
+        }
+    } else {
+        strcpy(test_host, "www.google.com");
+    }
     snprintf(cmd, sizeof(cmd),
         "build \"%s\" %s -t %s -f %s %s",
         escaped_cwd,
@@ -433,7 +448,7 @@ int build_image() {
         }
         // if google was previously unreachable, see if that's changed
         if (google_unreachable) {
-            retval = network_connected();
+            retval = network_connected(test_host);
             if (retval) {
                 if (verbose_all()) {
                     fprintf(stderr,
@@ -453,7 +468,7 @@ int build_image() {
             if (verbose_std()) {
                 fprintf(stderr, "build cmd output has 'retrying'\n");
             }
-            retval = network_connected();
+            retval = network_connected(test_host);
             if (retval == 0) {
                 // network connection exists but the create operation
                 // couldn't reach a needed server; error out

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -420,7 +420,9 @@ int build_image() {
         poll_client_msgs_init();        // should we exit?
         boinc_get_status(&status);
         if (status.network_suspended) {
-            fprintf(stderr, "network suspended; sleeping 10\n");
+            if (verbose_all()) {
+                fprintf(stderr, "network suspended; sleeping 10\n");
+            }
             boinc_waiting_for_network(true);
             boinc_report_app_status(0, 0, 0);
             boinc_sleep(10);
@@ -430,9 +432,11 @@ int build_image() {
         if (google_unreachable) {
             retval = network_connected();
             if (retval) {
-                fprintf(stderr,
-                    "google still unreachable (%d); sleeping 10\n", retval
-                );
+                if (verbose_all()) {
+                    fprintf(stderr,
+                        "google still unreachable (%d); sleeping 10\n", retval
+                    );
+                }
                 boinc_sleep(10);
                 continue;
             }
@@ -443,15 +447,21 @@ int build_image() {
             return retval;
         }
         if (output_has_str(out, "retrying")) {
-            fprintf(stderr, "build cmd output has 'retrying'\n");
+            if (verbose_std()) {
+                fprintf(stderr, "build cmd output has 'retrying'\n");
+            }
             retval = network_connected();
             if (retval == 0) {
                 // network connection exists but the create operation
                 // couldn't reach a needed server; error out
-                fprintf(stderr, "... but google is reachable; quitting\n");
+                if (verbose_std()) {
+                    fprintf(stderr, "... but google is reachable; quitting\n");
+                }
                 return -1;
             }
-            fprintf(stderr, "google is unreachable (%d); sleeping\n", retval);
+            if (verbose_std()) {
+                fprintf(stderr, "google is unreachable (%d); sleeping\n", retval);
+            }
             google_unreachable = true;
             boinc_waiting_for_network(true);
             boinc_report_app_status(0, 0, 0);
@@ -463,7 +473,9 @@ int build_image() {
             return -1;
         }
         // here if build succeeded
-        fprintf(stderr, "build succeeded\n");
+        if (verbose_std()) {
+            fprintf(stderr, "build succeeded\n");
+        }
         boinc_waiting_for_network(false);
         boinc_report_app_status(0, 0, 0);
         break;

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -394,8 +394,57 @@ int build_image() {
     snprintf(cmd, sizeof(cmd), "build \"%s\" -t %s -f %s %s",
         escaped_cwd, image_name, dockerfile, config.build_args.c_str()
     );
-    int retval = docker_conn.command(cmd, out, verbose_std());
-    if (retval) return retval;
+
+    // build command might fail because network is disconnected
+    // (this is the only command that uses network)
+    //
+    bool google_unreachable = false;
+        // google was unreachable last time we checked
+    BOINC_STATUS status;
+    while (1) {
+        boinc_get_status(&status);
+        if (status.network_suspended) {
+            fprintf(stderr, "network suspended; sleeping 10\n");
+            boinc_waiting_for_network(true);
+            boinc_sleep(10);
+            continue;
+        }
+        // if google was previously unreachable, see if that's changed
+        if (google_unreachable) {
+            if (!is_reachable("google.com")) {
+                fprintf(stderr, "google still unreachable; sleeping 10\n");
+                boinc_sleep(10);
+                continue;
+            }
+        }
+        int retval = docker_conn.command(cmd, out, verbose_std());
+        if (retval) {
+            fprintf(stderr, "build command failed: %d\n", retval);
+            return retval;
+        }
+        if (output_has_str(out, "retrying")) {
+            fprintf(stderr, "build cmd output has 'retrying'\n");
+            if (is_reachable("google.com")) {
+                // network connection exists but the create operation
+                // couldn't reach a needed server; error out
+                fprintf(stderr, "... but google is reachable; quitting\n");
+                return -1;
+            }
+            fprintf(stderr, "google is unreachable; sleeping\n");
+            google_unreachable = true;
+            boinc_waiting_for_network(true);
+            boinc_sleep(10);
+            continue;
+        }
+        if (output_has_str(out, "Error")) {
+            show_output(out, "build");
+            return -1;
+        }
+        // here if build succeeded
+        fprintf(stderr, "build succeeded\n");
+        boinc_waiting_for_network(false);
+        break;
+    }
     return 0;
 }
 
@@ -580,55 +629,14 @@ int create_container() {
 
     strcat(cmd, " ");
     strcat(cmd, image_name);
-
-    // create command might fail because network is disconnected
-    //
-    bool google_unreachable = false;
-        // google was unreachable last time we checked
-    BOINC_STATUS status;
-    while (1) {
-        boinc_get_status(&status);
-        if (status.network_suspended) {
-            fprintf(stderr, "network suspended; sleeping 10\n");
-            boinc_waiting_for_network(true);
-            boinc_sleep(10);
-            continue;
-        }
-        // if google was previously unreachable, see if that's changed
-        if (google_unreachable) {
-            if (!is_reachable("google.com")) {
-                fprintf(stderr, "google still unreachable; sleeping 10\n");
-                boinc_sleep(10);
-                continue;
-            }
-        }
-        retval = docker_conn.command(cmd, out, verbose_std());
-        if (retval) {
-            fprintf(stderr, "create command failed: %d\n", retval);
-            return retval;
-        }
-        if (output_has_str(out, "retrying")) {
-            fprintf(stderr, "create cmd has 'retrying'\n");
-            if (is_reachable("google.com")) {
-                // network connection exists but the create operation
-                // couldn't reach a needed server; error out
-                fprintf(stderr, "... but google is reachable; quitting\n");
-                return -1;
-            }
-            fprintf(stderr, "google is unreachable; sleeping\n");
-            google_unreachable = true;
-            boinc_waiting_for_network(true);
-            boinc_sleep(10);
-            continue;
-        }
-        if (output_has_str(out, "Error")) {
-            show_output(out, "create");
-            return -1;
-        }
-        // here if create succeeded
-        fprintf(stderr, "create succeeded\n");
-        boinc_waiting_for_network(false);
-        break;
+    retval = docker_conn.command(cmd, out, verbose_std());
+    if (retval) {
+        fprintf(stderr, "create command failed: %d\n", retval);
+        return retval;
+    }
+    if (output_has_str(out, "Error")) {
+        show_output(out, "create");
+        return -1;
     }
     return 0;
 }

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -445,10 +445,6 @@ int build_image() {
             }
         }
         retval = docker_conn.command(cmd, out, verbose_std());
-        if (retval) {
-            fprintf(stderr, "build command failed: %d\n", retval);
-            return retval;
-        }
         if (
             output_has_str(out, "unable to copy")   // podman
             || output_has_str(out, "unreachable")   // docker?
@@ -472,6 +468,12 @@ int build_image() {
             boinc_report_app_status(0, 0, 0);
             boinc_sleep(10);
             continue;
+        }
+        // see if the build command failed for a reason other than network
+        //
+        if (retval) {
+            fprintf(stderr, "build command failed: %d\n", retval);
+            return -1;
         }
         if (output_has_str(out, "Error")) {
             show_output(out, "build");

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -406,8 +406,11 @@ int build_image() {
     char cmd[256];
     vector<string> out;
     int retval;
-    snprintf(cmd, sizeof(cmd), "build \"%s\" --retry 0 -t %s -f %s %s",
-        escaped_cwd, image_name, dockerfile, config.build_args.c_str()
+    snprintf(cmd, sizeof(cmd),
+        "build \"%s\" %s -t %s -f %s %s",
+        escaped_cwd,
+        docker_type == PODMAN?"--retry 0":"",
+        image_name, dockerfile, config.build_args.c_str()
     );
 
     // build command might fail because network is disconnected

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -427,7 +427,7 @@ int build_image() {
         }
         // if google was previously unreachable, see if that's changed
         if (google_unreachable) {
-            retval = test_connect("google.com");
+            retval = network_connected();
             if (retval) {
                 fprintf(stderr,
                     "google still unreachable (%d); sleeping 10\n", retval
@@ -443,7 +443,7 @@ int build_image() {
         }
         if (output_has_str(out, "retrying")) {
             fprintf(stderr, "build cmd output has 'retrying'\n");
-            retval = test_connect("google.com");
+            retval = network_connected();
             if (retval == 0) {
                 // network connection exists but the create operation
                 // couldn't reach a needed server; error out

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -377,7 +377,6 @@ void poll_client_msgs_init() {
     }
 }
 
-// check whether job:
 void get_image_name() {
     if (config.image_name.empty()) {
         string s = docker_image_name(project_dir, aid.wu_name);
@@ -427,8 +426,11 @@ int build_image() {
         }
         // if google was previously unreachable, see if that's changed
         if (google_unreachable) {
-            if (!is_reachable("google.com")) {
-                fprintf(stderr, "google still unreachable; sleeping 10\n");
+            retval = test_connect("google.com");
+            if (retval) {
+                fprintf(stderr,
+                    "google still unreachable (%d); sleeping 10\n", retval
+                );
                 boinc_sleep(10);
                 continue;
             }
@@ -440,13 +442,14 @@ int build_image() {
         }
         if (output_has_str(out, "retrying")) {
             fprintf(stderr, "build cmd output has 'retrying'\n");
-            if (is_reachable("google.com")) {
+            retval = test_connect("google.com");
+            if (retval == 0) {
                 // network connection exists but the create operation
                 // couldn't reach a needed server; error out
                 fprintf(stderr, "... but google is reachable; quitting\n");
                 return -1;
             }
-            fprintf(stderr, "google is unreachable; sleeping\n");
+            fprintf(stderr, "google is unreachable (%d); sleeping\n", retval);
             google_unreachable = true;
             boinc_waiting_for_network(true);
             boinc_sleep(10);

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -365,7 +365,7 @@ void get_app_args(char* buf) {
 
 // used during build sleeps
 //
-void poll_client_msgs_init() {
+void check_exit_request() {
     BOINC_STATUS status;
     boinc_get_status(&status);
     if (status.no_heartbeat
@@ -421,7 +421,12 @@ int build_image() {
         // test host was unreachable last time we checked
     BOINC_STATUS status;
     while (1) {
-        poll_client_msgs_init();        // should we exit?
+        check_exit_request();        // should we exit?
+        if (!got_heartbeat_message) {
+            // need a heartbeat msg to know network suspended status
+            boinc_sleep(1);
+            continue;
+        }
         boinc_get_status(&status);
         if (status.network_suspended) {
             if (verbose_all()) {

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -90,43 +90,6 @@
 // https://docs.docker.com/reference/cli/docker/container/run/
 // https://docs.docker.com/engine/containers/resource_constraints/
 
-// ************** Checkpoint/restart ***************
-//
-// This would limit lost work if the host is rebooted
-// while a BUDA job is running.
-// In other cases (e.g. the user exits the client)
-// we pause the container and no work is lost.
-//
-// Podman and Docker have different interfaces:
-// podman: https://podman.io/docs/checkpoint
-//      podman container checkpoint <name>
-//      podman container restore <name>
-// docker: https://docs.docker.com/reference/cli/docker/checkpoint/
-//      docker checkpoint create <cont_name> <checkpoint_name>
-//      docker checkpoint ls   (lists checkpoints)
-//      docker checkpoint rm   (delete checkpoint)
-//      docker start --checkpoint <checkpoint_name> <cont_name>
-//      (use <cont_name>_checkpoint as the checkpoint name)
-//      need --security-opt=seccomp:unconfined in initial run command?
-//
-// In both cases the CRIU library is required.
-//
-// Note: I spent several days trying to get it to work on Podman
-// with all sorts of variants like --pre-checkpoint, --keep etc.
-// Whenever I did
-// - create a checkpoint
-// - compute some more
-// - stop or kill the container
-// - restore
-// I always get
-// Error: OCI runtime error: runc: criu failed: type RESTORE errno 0
-//
-// So I gave up; checkpoint/restart is only relevant to the reboot scenario,
-// this is rare.
-//
-// I took out the checkpoint-related code 1/30/2026.
-// If you want to see it, look at an older version
-
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -331,20 +294,20 @@ int parse_config_file() {
 
 // If command output includes "Error", show the output and return true
 //
-bool output_has_error(vector<string> &out, const char* cmd_name) {
-    bool found = false;
+bool output_has_str(vector<string> &out, const char* s) {
     for (string line: out) {
-        if (strstr(line.c_str(), "Error")) {
-            found = true;
-            break;
+        if (strstr(line.c_str(), s)) {
+            return true;
         }
     }
-    if (!found) return false;
+    return false;
+}
+
+void show_output(vector<string> &out, const char* cmd_name) {
     fprintf(stderr, "Error output from '%s' command:\n", cmd_name);
     for (const string &line: out) {
         fprintf(stderr, "   %s", line.c_str());
     }
-    return true;
 }
 
 //////////  PODMAN ARGS  ////////////
@@ -617,15 +580,56 @@ int create_container() {
 
     strcat(cmd, " ");
     strcat(cmd, image_name);
-    retval = docker_conn.command(cmd, out, verbose_std());
-    if (retval) {
-        fprintf(stderr, "create command failed: %d\n", retval);
-        return retval;
-    }
-    if (output_has_error(out, "create")) {
-        return -1;
-    }
 
+    // create command might fail because network is disconnected
+    //
+    bool google_unreachable = false;
+        // google was unreachable last time we checked
+    BOINC_STATUS status;
+    while (1) {
+        boinc_get_status(&status);
+        if (status.network_suspended) {
+            fprintf(stderr, "network suspended; sleeping 10\n");
+            boinc_waiting_for_network(true);
+            boinc_sleep(10);
+            continue;
+        }
+        // if google was previously unreachable, see if that's changed
+        if (google_unreachable) {
+            if (!is_reachable("google.com")) {
+                fprintf(stderr, "google still unreachable; sleeping 10\n");
+                boinc_sleep(10);
+                continue;
+            }
+        }
+        retval = docker_conn.command(cmd, out, verbose_std());
+        if (retval) {
+            fprintf(stderr, "create command failed: %d\n", retval);
+            return retval;
+        }
+        if (output_has_str(out, "retrying")) {
+            fprintf(stderr, "create cmd has 'retrying'\n");
+            if (is_reachable("google.com")) {
+                // network connection exists but the create operation
+                // couldn't reach a needed server; error out
+                fprintf(stderr, "... but google is reachable; quitting\n");
+                return -1;
+            }
+            fprintf(stderr, "google is unreachable; sleeping\n");
+            google_unreachable = true;
+            boinc_waiting_for_network(true);
+            boinc_sleep(10);
+            continue;
+        }
+        if (output_has_str(out, "Error")) {
+            show_output(out, "create");
+            return -1;
+        }
+        // here if create succeeded
+        fprintf(stderr, "create succeeded\n");
+        boinc_waiting_for_network(false);
+        break;
+    }
     return 0;
 }
 
@@ -643,7 +647,8 @@ int container_op(const char *op) {
         fprintf(stderr, "%s command failed: %d\n", op, retval);
         return retval;
     }
-    if (output_has_error(out, op)) {
+    if (output_has_str(out, "Error")) {
+        show_output(out, op);
         return -1;
     }
     return 0;

--- a/samples/example_app/uc2.cpp
+++ b/samples/example_app/uc2.cpp
@@ -36,7 +36,6 @@
 // --run_slow: sleep 1 second after each character
 // --trickle_up: sent a trickle-up message
 // --trickle_down: receive a trickle-up message
-// --network_usage: tell the client we used some network
 //
 
 #ifdef _WIN32
@@ -78,7 +77,6 @@ bool trickle_up = false;
 bool trickle_down = false;
 bool critical_section = false;    // run most of the time in a critical section
 bool report_fraction_done = true;
-bool network_usage = false;
 double cpu_time = 20, comp_result;
 
 // do about .5 seconds of computing
@@ -153,7 +151,6 @@ int main(int argc, char **argv) {
         if (strstr(argv[i], "early_sleep")) early_sleep = true;
         if (strstr(argv[i], "run_slow")) run_slow = true;
         if (strstr(argv[i], "critical_section")) critical_section = true;
-        if (strstr(argv[i], "network_usage")) network_usage = true;
         if (strstr(argv[i], "cpu_time")) {
             cpu_time = atof(argv[++i]);
         }
@@ -237,10 +234,6 @@ int main(int argc, char **argv) {
     update_shmem();
     boinc_register_timer_callback(update_shmem);
 #endif
-
-    if (network_usage) {
-        boinc_network_usage(5., 17.);
-    }
 
     // main loop - read characters, convert to UC, write
     //


### PR DESCRIPTION
The goal of this PR is to allow apps that do network communication
to work properly in the presence of network outages and suspension.
With these changes:

- If a job that needs network (such as a docker job) runs while
the network is disconnected, it figures this out, tells the client,
and the user is shown a notice suggesting that they reconnect.

- If such a job needs network and network access is suspended by the user
(via time-of-day prefs or the 'suspend network' command)
it sees this, tells the client that it needs to communicate,
and the user is shown a notice suggesting that they unsuspend.

This requires some logic in apps; this PR adds this to docker_wrapper.

This is described here:
https://github.com/BOINC/boinc/wiki/Apps-that-do-network-communication

Note: in ~2004 there was an unsuccessful effort to run Folding@home
as a BOINC app, and we added logic where the client is responsible
for knowing whether a connection exists, and it notifies the app.
This PR removes this logic; in the new design it's up to the app
to detect the absence of a connection.

Remove an API where the app tells the client how much data it transferred.
This info isn't used, and in the case of Docker the app doesn't know
how much data was transferred.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apps can now tell the client when they’re waiting for Internet, and the UI shows clear notices and a “Waiting for network” task state. `docker_wrapper` detects outages, retries image builds until connectivity returns, and surfaces better errors.

- **New Features**
  - API: added `boinc_waiting_for_network(bool)`; app status always includes `<want_network>`; removed `boinc_need_network()`, `boinc_network_poll()`, `boinc_network_done()`, `boinc_network_usage()`.
  - Client/Manager: shows notices when tasks need Internet or network is suspended; tracks connection vs. suspension notices separately and clears them on reconnection or when no tasks want network; GUI shows “Waiting for network”; GUI RPC exposes `want_network`; don’t strip tags in notices; removed unused bytes sent/received tracking.
  - `docker_wrapper`: waits for a heartbeat before checking suspend state; detects disconnect/suspension, sets `want_network`, and retries image builds until network returns; checks connectivity via ping to `berkeley.edu`; honors exit/abort while waiting; prints network-related logs only with verbose flags; shows command output on errors; uses `--retry 0` for Podman builds; on Windows, copies the command string before `CreateProcess`.
  - Work fetch: piggyback requests no longer skip higher‑priority projects that previously returned no jobs.
  - Lib: `run_command()` returns non‑zero on command failures and (on Windows) still returns command output; added `network_connected()`.

- **Migration**
  - Replace removed APIs with `boinc_waiting_for_network(bool)`.
  - Apps should detect connectivity and call `boinc_waiting_for_network(true/false)`; include `<want_network>` in status updates.

<sup>Written for commit cbe058ee89fdbbeae0608461447ceb00d4399e1a. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7084?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

