### PR TITLE
[ci] Remove unnecessary ci workflow runs.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -18,7 +18,6 @@
 name: Android
 on:
   push:
-    branches: [ master, 'client_release/**' ]
     tags: [ 'client_release/**' ]
   pull_request:
     branches: [ master ]

--- a/.github/workflows/guix_get_release_hash.yml
+++ b/.github/workflows/guix_get_release_hash.yml
@@ -19,8 +19,6 @@ name: Get Guix Release Hash
 on:
   push:
     tags: [ 'client_release/**' ]
-  pull_request:
-    branches: [ master ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/linux-package.yml
+++ b/.github/workflows/linux-package.yml
@@ -18,7 +18,6 @@
 name: Linux Package
 on:
   push:
-    branches: [ 'master' ]
     tags: [ 'client_release/**' ]
   pull_request:
       branches: [ master ]

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -18,7 +18,6 @@
 name: Linux release
 on:
   push:
-    branches: [ master ]
     tags: [ 'vboxwrapper/**', 'wrapper/**', 'dockerwrapper/**', 'worker/**' ]
   pull_request:
     branches: [ master ]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,6 @@
 name: Linux
 on:
   push:
-    branches: [ master, 'client_release/**' ]
     tags: [ 'client_release/**' ]
   pull_request:
     branches: [ master ]

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -17,8 +17,6 @@
 
 name: Linux-MinGW
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/osx-cmake.yml
+++ b/.github/workflows/osx-cmake.yml
@@ -17,8 +17,6 @@
 
 name: OSX cmake
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -18,7 +18,6 @@
 name: OSX
 on:
   push:
-    branches: [ master, 'client_release/**' ]
     tags: [ 'client_release/**', 'vboxwrapper/**', 'wrapper/**', 'dockerwrapper/**', 'worker/**' ]
   pull_request:
     branches: [ master ]

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -18,7 +18,6 @@
 name: Snap
 on:
   push:
-    branches: [ master ]
     tags: [ 'client_release/**' ]
   pull_request:
     branches: [ master ]

--- a/.github/workflows/source-code-check.yml
+++ b/.github/workflows/source-code-check.yml
@@ -17,12 +17,8 @@
 
 name: Source Code Check
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
-  schedule:
-    - cron:  '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/vcpkg_test.yml
+++ b/.github/workflows/vcpkg_test.yml
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -17,8 +17,6 @@
 
 name: vcpkg test
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/windows-cmake.yml
+++ b/.github/workflows/windows-cmake.yml
@@ -17,8 +17,6 @@
 
 name: Windows cmake
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
   schedule:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,6 @@
 name: Windows
 on:
   push:
-    branches: [ master, 'client_release/**' ]
     tags: [ 'client_release/**', 'vboxwrapper/**', 'wrapper/**', 'dockerwrapper/**', 'wslwrapper/**', 'worker/**' ]
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
This mainly removed flow runs on merge to master.
This is usually not needed since all the required verifications were already done during PR build. However, it will be required now to merge from master to the PR branch before doing the merge of the PR to be sure that nothing is broken. But this is usually done not so often, and in the majoroty if cases PR branch is already on the last master commit, so this won't happen to often. Also, removed ci runs when making push to the release branch: usually this is not needed as well, and only the tag push needs to trigger the ci.

In general, this will reduce build times and will generate less sporadic errors during ci runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop running CI on pushes to master and release branches. CI now runs on PRs to master and on release tags only, reducing redundant builds and flaky failures.

- **Refactors**
  - Removed push triggers to master and `client_release/**` across workflows; keep PR-to-master and tag triggers.
  - `guix_get_release_hash` now runs only on release tags (removed pull_request trigger).
  - Removed the nightly schedule from `source-code-check`.
  - Updated copyright year to 2026 in `android.yml` and `vcpkg_test.yml`.

- **Migration**
  - Before merging, update PR branches with the latest `master` to ensure CI runs and passes. Release builds are triggered by pushing tags only.

<sup>Written for commit 7bde4b9a75122d8d88106f8ac626075327662f8b. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7086?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

