### PR TITLE
client: only get WSL distro size if it's boinc-buda-runner

### DIFF
--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -121,7 +121,10 @@ int CLIENT_STATE::get_disk_usages() {
     // include its disk image size
     //
     WSL_DISTRO *wd = host_info.wsl_distros.find_docker();
-    if (wd) {
+    if (wd
+        && wd.distro_name == BOINC_WSL_DISTRO_NAME
+        && !wd.base_path.empty()
+    ) {
         retval = dir_size_alloc(wd->base_path.c_str(), size);
         if (!retval) {
             client_disk_usage += size;

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -122,8 +122,8 @@ int CLIENT_STATE::get_disk_usages() {
     //
     WSL_DISTRO *wd = host_info.wsl_distros.find_docker();
     if (wd
-        && wd.distro_name == BOINC_WSL_DISTRO_NAME
-        && !wd.base_path.empty()
+        && wd->distro_name == BOINC_WSL_DISTRO_NAME
+        && !wd->base_path.empty()
     ) {
         retval = dir_size_alloc(wd->base_path.c_str(), size);
         if (!retval) {


### PR DESCRIPTION
... otherwise base_path is empty and it scans the entire filesystem

Fixes #7082

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only include WSL distro disk usage when the distro is the BOINC runner (`boinc-buda-runner`) and `base_path` is set. Prevents a full filesystem scan on Windows when `base_path` is empty (fixes #7082).

- **Bug Fixes**
  - Compute size only if `wd` exists, `wd->distro_name == BOINC_WSL_DISTRO_NAME`, and `!wd->base_path.empty()`.
  - Skip calculation otherwise to avoid scanning the entire filesystem.

<sup>Written for commit 09c867efae5fe95cf48fd6f96dba2704d9c53587. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7090?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

