### PR TITLE
boinccmd: make --get_state and --get_simple_gui_info show same task info

### DIFF
--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -1595,16 +1595,24 @@ int RPC_CLIENT::get_simple_gui_info(SIMPLE_GUI_INFO& info) {
     retval = rpc.do_rpc("<get_simple_gui_info/>\n");
     if (!retval) {
         while (rpc.fin.fgets(buf, 256)) {
-            if (match_tag(buf, "</simple_gui_info>")) break;
-            else if (match_tag(buf, "<project>")) {
+            if (match_tag(buf, "</simple_gui_info>")) {
+                break;
+            }
+            if (match_tag(buf, "<project>")) {
                 PROJECT* project = new PROJECT();
                 project->parse(rpc.xp);
                 info.projects.push_back(project);
                 continue;
             }
-            else if (match_tag(buf, "<result>")) {
+            if (match_tag(buf, "<result>")) {
                 RESULT* result = new RESULT();
                 result->parse(rpc.xp);
+                for (PROJECT *p: info.projects) {
+                    if (!strcmp(p->master_url, result->project_url)) {
+                        result->project = p;
+                        break;
+                    }
+                }
                 info.results.push_back(result);
                 continue;
             }

--- a/lib/gui_rpc_client_print.cpp
+++ b/lib/gui_rpc_client_print.cpp
@@ -150,9 +150,8 @@ void RESULT::print() {
     printf("   WU name: %s\n", wu_name);
     if (project) {
         printf("   project: %s\n", project->project_name.c_str());
-    } else {
-        printf("   project URL: %s\n", project_url);
     }
+    printf("   project URL: %s\n", project_url);
     time_t foo = (time_t)received_time;
     printf("   received: %s", ctime(&foo));
     foo = (time_t)report_deadline;


### PR DESCRIPTION
Fixes #7081

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns boinccmd --get_state and --get_simple_gui_info so they show the same task info, including consistent project details. Fixes #7081.

- **Bug Fixes**
  - Link each result to its project in get_simple_gui_info by matching project_url to project master_url.
  - Always print the project URL; print the project name when available.

<sup>Written for commit e92f991d773129f7708164b551ea62add4b8d4da. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7092?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

