### PR TITLE
web: add page showing detail breakdown of host by CPU type and OS

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -424,15 +424,17 @@ function error_page($msg) {
     exit();
 }
 
-function start_table_str($class="", $style="") {
-    $s = $style?'style="'.$style.'"':'';
-    return '<div class="table">
-      <table '.$s.' width="100%" class="table table-condensed '.$class.'" >
-    ';
+function start_table_str($class='', $extra='') {
+    return sprintf(
+'<div class="table">
+    <table width="100%%" class="table table-condensed %s" %s>
+',
+        $class, $extra
+    );
 }
 
-function start_table($class="", $style="") {
-    echo start_table_str($class, $style);
+function start_table($class='', $extra='') {
+    echo start_table_str($class, $extra);
 }
 
 function end_table_str() {
@@ -548,6 +550,37 @@ function row_heading($x, $class='bg-primary') {
     echo sprintf('<tr><th class="%s" colspan=99>%s</th></tr>
         ', $class, $x
     );
+}
+
+// functions for DataTables (sortable tables)
+
+// pass to page_head()
+//
+function data_tables_head_extra() {
+    return '
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.8/css/dataTables.bootstrap4.min.css" crossorigin="anonymous">
+    <script type="text/javascript" src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/1.13.8/js/dataTables.bootstrap4.min.js" crossorigin="anonymous"></script>
+';
+}
+
+function data_tables_script($id) {
+return sprintf('
+<script type="text/javascript">
+jQuery(document).ready(function() {
+    // Check if table exists
+    if (jQuery("#%s").length) {
+        jQuery("#%s").DataTable({
+            "paging": false,        // Disable DataTables pagination (use existing navigation)
+            "searching": false,     // Disable search box (not needed)
+            "info": false,          // Disable info text (e.g., "Showing 1 to 10 of 57 entries")
+            "order": []             // No default sort, keep database order
+        });
+    }
+});
+</script>
+', $id, $id
+);
 }
 
 function url_tokens($auth) {

--- a/html/ops/manage_apps.php
+++ b/html/ops/manage_apps.php
@@ -205,7 +205,7 @@ function show_form($all) {
         <form action=$action_url method=POST>
     ";
 
-    start_table("align='center' ");
+    start_table('', 'align="center";);
 
     table_header("Name", "Description", "&nbsp;");
 

--- a/html/ops/manage_apps.php
+++ b/html/ops/manage_apps.php
@@ -205,7 +205,7 @@ function show_form($all) {
         <form action=$action_url method=POST>
     ";
 
-    start_table('', 'align="center";);
+    start_table('', 'align="center"');
 
     table_header("Name", "Description", "&nbsp;");
 

--- a/html/ops/manage_consent_types.php
+++ b/html/ops/manage_consent_types.php
@@ -67,7 +67,7 @@ function mct_show_form() {
     if (!in_rops()) {
         echo "<strong>HELP: ProjectSpecific=0 consent types are defined by BOINC. You may add and remove project-specific consent types using this form.</strong>";
     }
-    start_table("");
+    start_table();
     table_header(
         "Name",
         "Description",
@@ -135,7 +135,7 @@ function mct_show_form() {
         <form action=manage_consent_types.php method=POST>
     ";
 
-    start_table("align='center' ");
+    start_table('', 'align="center"');
 
     table_header("Name", "Description", "&nbsp;");
 

--- a/html/ops/manage_special_users.php
+++ b/html/ops/manage_special_users.php
@@ -23,7 +23,7 @@ db_init();
 
 admin_page_head('Manage user privileges');
 
-start_table("align=\"center\"");
+start_table('', 'align="center"');
 row1("Current special users", '9');
 
 echo "<tr><td>User</td>";

--- a/html/user/os_stats.php
+++ b/html/user/os_stats.php
@@ -1,0 +1,226 @@
+<?php
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+// show a breakdown of hosts by CPU type and OS
+//
+// This queries all hosts w/ recent credit.
+// Might be slow for projects w/ huge number of these
+
+require_once('../inc/boinc_db.inc');
+require_once('../inc/util.inc');
+
+//  proc_type
+//      os_name
+//          os_version
+//              os_detail
+//  Intel
+//      Windows
+//          10
+//              Core x64 Edition
+//              Enterprise x64 Edition
+//          11
+//      Linux
+//          Ubuntu
+//              20.04.6 LTS
+//          Debian
+//  ARM
+//      Linux
+//      Darwin
+//          23.4.0
+
+function make_entry() {
+    $x = new StdClass;
+    $x->count = 0;
+    $x->credit = 0;
+    $x->children = [];
+    return $x;
+}
+
+function inc_entry($host, $entry) {
+    $entry->count += 1;
+    $entry->credit += $host->expavg_credit;
+}
+
+function add_host(&$hosts, $host) {
+    inc_entry($host, $hosts);
+    if (!array_key_exists($host->proc_type, $hosts->children)) {
+        $hosts->children[$host->proc_type] = make_entry();
+    }
+    $x = &$hosts->children[$host->proc_type];
+    inc_entry($host, $x);
+    if (!array_key_exists($host->os_name, $x->children)) {
+        $x->children[$host->os_name] = make_entry();
+    }
+    $y = &$x->children[$host->os_name];
+    inc_entry($host, $y);
+    if (!array_key_exists($host->os_version, $y->children)) {
+        $y->children[$host->os_version] = make_entry();
+    }
+    $z = &$y->children[$host->os_version];
+    inc_entry($host, $z);
+    if (!array_key_exists($host->os_detail, $z->children)) {
+        $z->children[$host->os_detail] = make_entry();
+    }
+    $a = &$z->children[$host->os_detail];
+    inc_entry($host, $a);
+}
+
+function compare($x, $y) {
+    if ($x->count < $y->count) return 1;
+    if ($x->count > $y->count) return -1;
+    return 0;
+}
+
+function sort_entry(&$entry) {
+    uasort($entry->children, 'compare');
+}
+
+function sort_all(&$hosts) {
+    sort_entry($hosts);
+    foreach ($hosts->children as $x) {
+        sort_entry($x);
+        foreach ($x->children as $y) {
+            sort_entry($y);
+            foreach ($y->children as $z) {
+                sort_entry($z);
+            }
+        }
+    }
+}
+
+function show($hosts) {
+    page_head("Host stats", null, false, '', data_tables_head_extra());
+    start_table('table-striped', 'id="results-table"');
+    echo "<thead>";
+    table_header('CPU type', 'OS', 'OS version', 'OS release', 'Count', 'Recent credit');
+    echo "</thead><tbody>";
+    table_row('Total', '', '', '', $hosts->count, $hosts->credit);
+    foreach ($hosts->children as $proc_type=>$entry) {
+        table_row($proc_type, 'all', '', '', $entry->count, $entry->credit);
+        foreach ($entry->children as $os_name=>$entry) {
+            table_row($proc_type, "$os_name", 'all', '', $entry->count, $entry->credit);
+            foreach ($entry->children as $os_version=>$entry) {
+                table_row($proc_type, $os_name, "$os_version", 'all', $entry->count, $entry->credit);
+                foreach ($entry->children as $os_detail=>$entry) {
+                    if (!$os_detail) continue;
+                    table_row($proc_type, $os_name, $os_version, $os_detail, $entry->count, $entry->credit);
+                }
+            }
+        }
+    }
+    echo "</tbody>";
+    end_table();
+    echo data_tables_script('results-table');
+    page_tail();
+}
+
+function parse_host($p_vendor, $os_name, $os_version) {
+    $x = new StdClass;
+    if (strstr($p_vendor, 'Intel')
+        || strstr($p_vendor, 'AMD')
+    ) {
+        $x->proc_type = 'Intel';
+    } else if (strstr($p_vendor, 'ARM')
+        || strstr($p_vendor, 'Apple')
+    ) {
+        $x->proc_type = 'ARM';
+    } else {
+        $x->proc_type = "Other CPU type ($p_vendor)";
+    }
+
+    if (strstr($os_name, 'Windows')) {
+        $x->os_name = 'Windows';
+        $n = strrpos($os_name, ' ');
+        if ($n === false) {
+            $x->os_version = 'Unknown version';
+        } else {
+            $x->os_version = substr($os_name, $n+1);
+        }
+        $n = strpos($os_version, ',');
+        if ($n === false) {
+            $x->os_detail = $os_version;
+        } else {
+            $x->os_detail = substr($os_version, 0, $n);
+        }
+    } else if (strstr($os_name, 'Linux')) {
+        $x->os_name = 'Linux';
+        $n = strrpos($os_name, ' ');
+        if ($n === false) {
+            $x->os_version = 'Unknown distro';
+        } else {
+            $x->os_version = substr($os_name, $n+1);
+        }
+        if (strstr($os_version, 'Fedora')) {
+            $x->os_version = 'Fedora';
+        }
+        if (strstr($os_version, 'Arch')) {
+            $x->os_version = 'Arch';
+        }
+        if (strstr($os_version, 'Debian')) {
+            $x->os_version = 'Debian';
+        }
+        $n = strpos($os_version, '[');
+        if ($n === false) {
+            $x->os_detail = $os_version;
+        } else {
+            $x->os_detail = substr($os_version, 0, $n-1);
+        }
+    } else if (strstr($os_name, 'Darwin')) {
+        $x->os_name = 'Darwin';
+        $x->os_version = $os_version;
+        $x->os_detail = '';
+    } else if (strstr($os_name, 'Android')) {
+        $x->os_name = 'Android';
+        $n = strpos($os_version, ' ');
+        if ($n === false) {
+            $n = strpos($os_version, '_');
+        }
+        if ($n === false) {
+            $n = strpos($os_version, '-');
+        }
+        if ($n === false) {
+            $x->os_version = 'Unknown version';
+        } else {
+            $x->os_version = substr($os_version, 0, $n);
+        }
+        $x->os_detail = '';
+    } else {
+        $x->os_name = "Other OS ($os_name)";
+        $x->os_version = $os_version;
+        $x->os_detail = '';
+    }
+    return $x;
+}
+
+function main() {
+    $hosts = BoincHost::enum_fields('p_vendor, os_name, os_version, expavg_credit',
+        'expavg_credit > 0'
+    );
+    $host_entries = make_entry();
+    foreach ($hosts as $h) {
+        $x = parse_host($h->p_vendor, $h->os_name, $h->os_version);
+        $x->expavg_credit = $h->expavg_credit;
+        add_host($host_entries, $x);
+    }
+    sort_all($host_entries);
+    show($host_entries);
+}
+
+main();
+
+?>

--- a/html/user/os_stats.php
+++ b/html/user/os_stats.php
@@ -112,13 +112,22 @@ function show($hosts) {
     table_row('Total', '', '', '', $hosts->count, $hosts->credit);
     foreach ($hosts->children as $proc_type=>$entry) {
         table_row($proc_type, 'all', '', '', $entry->count, $entry->credit);
-        foreach ($entry->children as $os_name=>$entry) {
-            table_row($proc_type, "$os_name", 'all', '', $entry->count, $entry->credit);
-            foreach ($entry->children as $os_version=>$entry) {
-                table_row($proc_type, $os_name, "$os_version", 'all', $entry->count, $entry->credit);
-                foreach ($entry->children as $os_detail=>$entry) {
+        foreach ($entry->children as $os_name=>$entry2) {
+            table_row(
+                $proc_type, "$os_name", 'all', '',
+                $entry2->count, $entry2->credit
+            );
+            foreach ($entry->children as $os_version=>$entry3) {
+                table_row(
+                    $proc_type, $os_name, "$os_version", 'all',
+                    $entry3->count, $entry3->credit
+                );
+                foreach ($entry->children as $os_detail=>$entry4) {
                     if (!$os_detail) continue;
-                    table_row($proc_type, $os_name, $os_version, $os_detail, $entry->count, $entry->credit);
+                    table_row(
+                        $proc_type, $os_name, $os_version, $os_detail,
+                        $entry4->count, $entry4->credit
+                    );
                 }
             }
         }


### PR DESCRIPTION
(including Linux distros and versions).

Add support (using jquery DataTables) for make tables column-sortable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new host stats page that breaks down active hosts by CPU type and OS (including Linux distros/versions) with sortable columns and totals. Also adds `DataTables` support and updates table helpers so ops pages can pass extra attributes like alignment.

- **New Features**
  - New page `html/user/os_stats.php`: CPU type → OS → version → release with counts and recent credit; groups sorted by count; parses Windows, Linux (Ubuntu/Debian/Fedora/Arch), Darwin, and Android.
  - `DataTables` integration and helpers: adds `data_tables_head_extra()`/`data_tables_script($id)` for column sorting (paging/search/info off; safe init only if table exists). Updates `start_table_str($class, $extra)`/`start_table($class, $extra)` and centers tables in ops pages.

<sup>Written for commit ba5ed655630a2181a78bdcee410b318fb0cead46. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7093?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

