### PR TITLE
Mac_SA_Secure.sh, Mac_SA_Insecure.sh always use the standard path for BOINC podman directory

### DIFF
--- a/mac_build/Mac_SA_Insecure.sh
+++ b/mac_build/Mac_SA_Insecure.sh
@@ -56,6 +56,7 @@
 # Updated 1/27/11 for BOINC versions 6.8.19, 6.10.30 and 6.11.1
 # Updated 8/25/25 to add Run_Podman and BOINC podman directory
 # Updated 5/2/26 to delete directories /Users/boinc_master & /Users/boinc_project
+# Updated 5/26/26 BOINC Podman dir is in standard location even if BOINC Data was moved
 #
 
 function remove_boinc_users() {
@@ -126,10 +127,10 @@ chown root:${group} switcher/AppStats
 chmod 4550 switcher/AppStats
 fi
 
-if [ -d "../BOINC podman" ] ; then
+if [ -d "/Library/Application Support/BOINC podman" ] ; then
     # We must not modify permissions of any of Podman's data so just set
     # their owner and grpup
-    chown -R ${user}:${group} "../BOINC podman"
+    chown -R ${user}:${group} "/Library/Application Support/BOINC podman"
 fi
 
 if [ -x /Applications/BOINCManager.app/Contents/MacOS/BOINCManager ] ; then

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -75,9 +75,9 @@
 # Updated 8/27/25 to allow podman to stat items under BOINC Data directory
 # Updated 11/9/25 to create "BOINC podman" directory if not present (for bare client)
 # Updated 5/7/26 to set home directories for users boinc_master & boinc_project
+# Updated 5/26/26 put BOINC Podman dir in standard location even if BOINC Data was moved
 #
-# WARNING: do not use this script with versions of BOINC older
-# than 7.20.4
+# WARNING: do not use this script with versions of BOINC older than 7.20.4
 
 function make_boinc_user() {
     DarwinVersion=`uname -r`;
@@ -310,15 +310,15 @@ fi
 
 # Though "BOINC podman" directory is not used on older
 # versions of BOINC, it doesn't hurt to add it to them
-if [ ! -d "../BOINC podman" ] ; then
-    mkdir "../BOINC podman"
+if [ ! -d "/Library/Application Support/BOINC podman" ] ; then
+    mkdir "/Library/Application Support/BOINC podman"
 fi
 # We must not modify permissions of any of Podman's data so just set
 # their owner and group
-chown -R boinc_project:boinc_project "../BOINC podman"
+chown -R boinc_project:boinc_project "/Library/Application Support/BOINC podman"
 # Set owner and permissions for the BOINC podman directory itself
 # but not its contents.
-set_perm "../BOINC podman" boinc_master boinc_project 0770
+set_perm "/Library/Application Support/BOINC podman" boinc_master boinc_project 0770
 
 if [ -x /Applications/BOINCManager.app/Contents/MacOS/BOINCManager ] ; then
     set_perm  /Applications/BOINCManager.app/Contents/MacOS/BOINCManager boinc_master boinc_master 0555


### PR DESCRIPTION
In the utility scripts _Mac_SA_Secure.sh_ and _Mac_SA_Insecure.sh_, always use the standard path for the _BOINC podman_ directory. Do not assume its path is relative to the _BOINC Data_ directory, in case the _BOINC Data_ directory has been moved as described [here](https://github.com/BOINC/boinc/wiki/Tools-for-MacOS#moving-boinc-manager-or-boinc-data-folder-to-a-different-drive).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always use the standard absolute path for the BOINC Podman directory in `Mac_SA_Secure.sh` and `Mac_SA_Insecure.sh` to work even when the BOINC Data folder has been moved.

- **Bug Fixes**
  - Use `/Library/Application Support/BOINC podman` instead of a path relative to BOINC Data.
  - Ensure the directory exists, set correct owner/group, and set directory permissions without modifying Podman data contents.

<sup>Written for commit f3fa8eb7d8ee60a7f5f596275d7033dbbf727558. Summary will update on new commits. <a href="https://cubic.dev/pr/BOINC/boinc/pull/7098?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

