### PR TITLE
forum activity script: add comments, reduce verbosity

### DIFF
--- a/html/ops/update_forum_activities.php
+++ b/html/ops/update_forum_activities.php
@@ -17,12 +17,14 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// Update the 'activity' field of threads,
+// based on the number of recent posts.
+// This is needed for the 'sort by activity' option
+
 $cli_only = true;
 require_once("../inc/util_ops.inc");
 require_once("../inc/forum_db.inc");
 
-define('MAX_REWARD', 4096);
-define('SCALAR', 0.9);
 set_time_limit(0);
 
 echo date(DATE_RFC822), ": Starting\n";
@@ -41,7 +43,7 @@ foreach ($threads as $thread) {
     if ($is_helpdesk) {
         $diff = ($now - $thread->create_time)/86400;
         $activity = ($thread->sufferers+1)/$diff;
-        echo "thread $thread->id helpdesk $diff $activity\n";
+        //echo "thread $thread->id helpdesk $diff $activity\n";
     } else {
         $posts = BoincPost::enum("thread=$thread->id");
         $activity = 0;
@@ -51,7 +53,7 @@ foreach ($threads as $thread) {
             $diff /= 7*86400;
             $activity += pow(2, -$diff);
         }
-        echo "thread $thread->id forum $activity\n";
+        //echo "thread $thread->id forum $activity\n";
     }
     $thread->update("activity=$activity");
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified the forum activity updater and reduced console noise during runs. The logic for computing activity is unchanged.

- **Refactors**
  - Added header comments explaining the activity calculation and its use in “sort by activity”; no logic changes.
  - Commented out per-thread `echo` lines for helpdesk and forum threads to reduce verbosity.
  - Removed unused constants `MAX_REWARD` and `SCALAR`.

<sup>Written for commit 3cfab3b388753d1d548285dcc3def99de070260a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

