### PR TITLE
client: enforce swap usage limit pref

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -428,6 +428,10 @@ void ACTIVE_TASK_SET::get_memory_usage() {
         if (pi.swap_size > atp->peak_swap_size) {
             atp->peak_swap_size = pi.swap_size;
         }
+        boinc_total.working_set_size += pi.working_set_size;
+        boinc_total.working_set_size_smoothed += pi.working_set_size_smoothed;
+        boinc_total.swap_size += pi.swap_size;
+        boinc_total.page_fault_rate += pi.page_fault_rate;
 
         if (!first) {
             int pf = pi.page_fault_count - last_page_fault_count;
@@ -444,10 +448,6 @@ void ACTIVE_TASK_SET::get_memory_usage() {
                     pi.user_time,
                     pi.kernel_time
                 );
-                boinc_total.working_set_size += pi.working_set_size;
-                boinc_total.working_set_size_smoothed += pi.working_set_size_smoothed;
-                boinc_total.swap_size += pi.swap_size;
-                boinc_total.page_fault_rate += pi.page_fault_rate;
             }
         }
     }

--- a/client/app.cpp
+++ b/client/app.cpp
@@ -151,6 +151,7 @@ ACTIVE_TASK::ACTIVE_TASK() {
     sporadic_ca_state = CA_NONE;
     sporadic_ac_state = AC_NONE;
     sporadic_ignore_until = 0;
+    swap_kill_time = 0;
 }
 
 bool ACTIVE_TASK::process_exists() {

--- a/client/app.cpp
+++ b/client/app.cpp
@@ -128,7 +128,8 @@ ACTIVE_TASK::ACTIVE_TASK() {
     max_mem_usage = 0;
     have_trickle_down = false;
     send_upload_file_status = false;
-    too_large = false;
+    wss_too_large = false;
+    swap_too_large = false;
     needs_shmem = false;
     want_network = 0;
     abort_time = 0;
@@ -385,10 +386,9 @@ void ACTIVE_TASK_SET::get_memory_usage() {
         return;
     }
     PROCINFO boinc_total;
-    if (log_flags.mem_usage_debug) {
-        boinc_total.clear();
-        boinc_total.working_set_size_smoothed = 0;
-    }
+    boinc_total.clear();
+    boinc_total.working_set_size_smoothed = 0;
+
     for (ACTIVE_TASK* atp: active_tasks) {
         if (atp->task_state() == PROCESS_UNINITIALIZED) continue;
         if (atp->pid ==0) continue;
@@ -461,6 +461,17 @@ void ACTIVE_TASK_SET::get_memory_usage() {
                 boinc_total.page_fault_rate
             );
         }
+    }
+
+    // if memory limits exceeded, trigger reschedule
+    //
+    if (boinc_total.working_set_size > gstate.available_ram()) {
+        gstate.request_schedule_cpus("RAM limit exceeded");
+    }
+    if (boinc_total.swap_size
+        > (gstate.global_prefs.vm_max_used_frac)*gstate.host_info.m_swap
+    ) {
+        gstate.request_schedule_cpus("Swap limit exceeded");
     }
 
     // check for exclusive apps
@@ -840,7 +851,7 @@ int ACTIVE_TASK::write_gui(MIOFILE& fout) {
         "    <working_set_size>%f</working_set_size>\n"
         "    <working_set_size_smoothed>%f</working_set_size_smoothed>\n"
         "    <page_fault_rate>%f</page_fault_rate>\n"
-        "%s%s%s",
+        "%s%s%s%s",
         task_state(),
         app_version->version_num,
         slot,
@@ -854,7 +865,8 @@ int ACTIVE_TASK::write_gui(MIOFILE& fout) {
         procinfo.working_set_size,
         procinfo.working_set_size_smoothed,
         procinfo.page_fault_rate,
-        too_large?"   <too_large/>\n":"",
+        wss_too_large?"   <too_large/>\n":"",   // backward compatibility
+        swap_too_large?"   <swap_too_large/>\n":"",
         needs_shmem?"   <needs_shmem/>\n":"",
         want_network?"   <want_network/>\n":""
     );

--- a/client/app.h
+++ b/client/app.h
@@ -142,13 +142,14 @@ struct ACTIVE_TASK {
         // abort if memory usage exceeds this
     bool have_trickle_down;
     bool send_upload_file_status;
-    bool too_large;
+    bool wss_too_large;
         // Working set too large to run now; waiting for RAM
         // This is a slight misnomer.
         // It doesn't mean that this job itself is too large;
         // rather, it means that the last time we did CPU scheduling,
         // the set of jobs we tried to run was too big,
         // and this one came after we ran out of mem.
+    bool swap_too_large;
     bool needs_shmem;
         // waiting for a free shared memory segment
     int want_network;

--- a/client/app.h
+++ b/client/app.h
@@ -139,7 +139,10 @@ struct ACTIVE_TASK {
     double max_disk_usage;
         // abort if disk usage (in+out+temp) exceeds this
     double max_mem_usage;
-        // abort if memory usage exceeds this
+        // WU rsc_memory_bound
+        // the idea: abort if memory usage exceeds this
+        // but we don't do this because most projects
+        // don't give accurate rsc_memory_bound
     bool have_trickle_down;
     bool send_upload_file_status;
     bool wss_too_large;

--- a/client/app.h
+++ b/client/app.h
@@ -168,6 +168,8 @@ struct ACTIVE_TASK {
         // running past end of time slice because not checkpointed;
         // when we do checkpoint, reschedule
     double last_deadline_miss_time;
+    double swap_kill_time;
+        // last time this task was killed to free swap space
 
     APP_CLIENT_SHM app_client_shm;
         // core/app shared mem segment

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -941,7 +941,7 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
         // don't count RAM usage of non-CPU-intensive jobs
         //
         if (!atp->non_cpu_intensive()) {
-            total_wss -= atp->procinfo.working_set_size_smoothed;
+            total_wss += atp->procinfo.working_set_size_smoothed;
         }
     }
     if (total_wss > avail_ram) {

--- a/client/app_control.cpp
+++ b/client/app_control.cpp
@@ -857,19 +857,25 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
     bool did_anything = false;
     char buf[256];
 
-    double ram_left = gstate.available_ram();
+    double avail_ram = gstate.available_ram();
     double max_ram = gstate.max_available_ram();
+    double total_wss = 0;
 
     // Some slot dirs have lots of files,
     // so only check every min(disk_interval, 300) secs
     //
     double min_interval = gstate.global_prefs.disk_interval;
     if (min_interval < 300) min_interval = 300;
-    if (gstate.clock_change || gstate.now > last_disk_check_time + min_interval) {
+    if (gstate.clock_change
+        || gstate.now > last_disk_check_time + min_interval
+    ) {
         do_disk_check = true;
     }
     for (ACTIVE_TASK* atp: active_tasks) {
         if (atp->task_state() != PROCESS_EXECUTING) continue;
+
+        // check for elapsed time limit exceeded
+
         if (!atp->always_run() && (atp->elapsed_time > atp->max_elapsed_time)) {
             snprintf(buf, sizeof(buf), "exceeded elapsed time limit %.2f (%.2fG/%.2fG)",
                 atp->max_elapsed_time,
@@ -884,8 +890,9 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
             continue;
         }
 #if 0
+        // check WSS < wu.rsc_memory_bound
         // removing this for now because most projects currently
-        // have too-low values of workunit.rsc_memory_bound
+        // have too-low values of rsc_memory_bound
         // (causing lots of aborts)
         // and I don't think we can expect projects to provide
         // accurate bounds.
@@ -903,6 +910,9 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
             continue;
         }
 #endif
+        // is the WSS too large for the job to ever run (busy or idle)?
+        // If so abort it.
+        //
         if (atp->procinfo.working_set_size_smoothed > max_ram) {
             snprintf(buf, sizeof(buf), "working set size > client RAM limit: %.2fMB > %.2fMB",
                 atp->procinfo.working_set_size_smoothed/MEGA, max_ram/MEGA
@@ -915,6 +925,12 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
             did_anything = true;
             continue;
         }
+        // is the WSS too large for the current limit?
+        // If so, do reschedule, which will swap-kill it
+        //
+        if (atp->procinfo.working_set_size_smoothed > avail_ram) {
+            gstate.request_schedule_cpus("job RAM usage limit exceeded");
+        }
         if (do_disk_check || atp->peak_disk_usage == 0) {
             if (atp->check_max_disk_exceeded()) {
                 did_anything = true;
@@ -925,11 +941,11 @@ bool ACTIVE_TASK_SET::check_rsc_limits_exceeded() {
         // don't count RAM usage of non-CPU-intensive jobs
         //
         if (!atp->non_cpu_intensive()) {
-            ram_left -= atp->procinfo.working_set_size_smoothed;
+            total_wss -= atp->procinfo.working_set_size_smoothed;
         }
     }
-    if (ram_left < 0) {
-        gstate.request_schedule_cpus("RAM usage limit exceeded");
+    if (total_wss > avail_ram) {
+        gstate.request_schedule_cpus("total RAM usage limit exceeded");
     }
     if (do_disk_check) {
         last_disk_check_time = gstate.now;

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -325,6 +325,7 @@ struct CLIENT_STATE {
     void make_run_list(vector<RESULT*>&);
     bool enforce_run_list(vector<RESULT*>&);
     void append_unfinished_time_slice(vector<RESULT*>&);
+    bool swap_limit_check();
 
     double runnable_resource_share(int);
     void adjust_rec();

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -794,8 +794,137 @@ bool CLIENT_STATE::schedule_cpus() {
     //
     tasks_throttled = false;
 
-    make_run_list(run_list);
-    return enforce_run_list(run_list);
+    if (!swap_limit_check()) {
+        make_run_list(run_list);
+        return enforce_run_list(run_list);
+    }
+    return true;
+}
+
+// sort by decreasing deadline
+static bool compare_swap_preempt(void *p1, void *p2) {
+    ACTIVE_TASK *atp1 = (ACTIVE_TASK*)p1;
+    ACTIVE_TASK *atp2 = (ACTIVE_TASK*)p2;
+    if (atp1->result->report_deadline > atp2->result->report_deadline) return true;
+    if (atp1->result->report_deadline < atp2->result->report_deadline) return false;
+    return atp1 < atp2;
+}
+
+// sort by decreasing kill time
+static bool compare_swap_kill_time(void *p1, void *p2) {
+    ACTIVE_TASK *atp1 = (ACTIVE_TASK*)p1;
+    ACTIVE_TASK *atp2 = (ACTIVE_TASK*)p2;
+    if (atp1->swap_kill_time > atp2->swap_kill_time) return true;
+    if (atp1->swap_kill_time < atp2->swap_kill_time) return false;
+    return atp1 < atp2;
+}
+
+// if swap limit has been reached, we use different scheduling logic.
+// Return true if this is the case.
+//
+bool CLIENT_STATE::swap_limit_check() {
+    vector<RESULT*> run_list;
+
+    // compute swap usage of running tasks
+    //
+    double swap_usage = 0;
+    for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
+        if (atp->task_state() == PROCESS_EXECUTING) {
+            swap_usage += atp->procinfo.swap_size;
+        }
+    }
+
+    // compare usage with limit
+    //
+    double swap_limit = global_prefs.vm_max_used_frac*host_info.m_swap;
+    if (swap_usage > swap_limit) {
+        if (log_flags.cpu_sched_debug) {
+            msg_printf(NULL, MSG_INFO,
+                "[cpu_sched_debug] swap limit exceeded %.2fGB > %.2fGB",
+                swap_usage/GIGA, swap_limit/GIGA
+            );
+        }
+
+        // we're using too much swap.
+        // kill enough tasks to obey limit
+        //
+        vector<ACTIVE_TASK*> atps = active_tasks.active_tasks;
+        std::sort(atps.begin(), atps.end(), compare_swap_preempt);
+        for (ACTIVE_TASK* atp: atps) {
+            if (atp->task_state() != PROCESS_EXECUTING) {
+                continue;
+            }
+            if (log_flags.cpu_sched_debug) {
+                msg_printf(atp->result->project, MSG_INFO,
+                    "[cpu_sched_debug] killing %s", atp->result->name
+                );
+            }
+            atp->swap_kill_time = now;
+            atp->preempt(REMOVE_ALWAYS);
+                // this changes state to QUIT_PENDING
+            swap_usage -= atp->procinfo.swap_size;
+            if (swap_usage < swap_limit) {
+                break;
+            }
+        }
+        // runnable list is the rest of the tasks
+        for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
+            if (atp->task_state() == PROCESS_EXECUTING) {
+                run_list.push_back(atp->result);
+            }
+        }
+        enforce_run_list(run_list);
+    } else {
+        // here currently running tasks fit in swap
+        //
+        // make list of swap-killed tasks
+        vector<ACTIVE_TASK*> swap_kill_tasks;
+        for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
+            if (atp->swap_kill_time) {
+                swap_kill_tasks.push_back(atp);
+            }
+        }
+        // if no swap-killed tasks, use normal scheduling
+        if (swap_kill_tasks.empty()) {
+            return false;
+        }
+
+        if (log_flags.cpu_sched_debug) {
+            msg_printf(NULL, MSG_INFO,
+                "[cpu_sched_debug] checking for runnable swap-killed tasks"
+            );
+        }
+
+        // initial run list is running tasks
+        //
+        for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
+            if (atp->task_state() == PROCESS_EXECUTING) {
+                run_list.push_back(atp->result);
+            }
+        }
+        // see if we can run swap-killed tasks
+        std::sort(
+            swap_kill_tasks.begin(), swap_kill_tasks.end(),
+            compare_swap_kill_time
+        );
+        // run as many as will fit
+        //
+        for (ACTIVE_TASK *atp: swap_kill_tasks) {
+            if (swap_usage + atp->procinfo.swap_size > swap_limit) {
+                break;
+            }
+            if (log_flags.cpu_sched_debug) {
+                msg_printf(atp->result->project, MSG_INFO,
+                    "[cpu_sched_debug] restarting %s", atp->result->name
+                );
+            }
+            atp->swap_kill_time = 0;
+            run_list.push_back(atp->result);
+            swap_usage += atp->procinfo.swap_size;
+        }
+        enforce_run_list(run_list);
+    }
+    return true;
 }
 
 // Mark a job J as a deadline miss if either

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -801,21 +801,27 @@ bool CLIENT_STATE::schedule_cpus() {
     return true;
 }
 
-// sort by decreasing deadline
+// sort by increasing cpu_time - checkpoint_cpu_time;
+// that's how much CPU time will be lost if we kill that job
+//
 static bool compare_swap_preempt(void *p1, void *p2) {
     ACTIVE_TASK *atp1 = (ACTIVE_TASK*)p1;
     ACTIVE_TASK *atp2 = (ACTIVE_TASK*)p2;
-    if (atp1->result->report_deadline > atp2->result->report_deadline) return true;
-    if (atp1->result->report_deadline < atp2->result->report_deadline) return false;
+    double x1 = atp1->current_cpu_time - atp1->checkpoint_cpu_time;
+    double x2 = atp1->current_cpu_time - atp2->checkpoint_cpu_time;
+    if (x1 < x2) return true;
+    if (x1 > x2) return false;
     return atp1 < atp2;
 }
 
-// sort by decreasing kill time
-static bool compare_swap_kill_time(void *p1, void *p2) {
+// sort by increasing deadline; revive tasks with earlier dealines
+//
+static bool compare_swap_revive(void *p1, void *p2) {
     ACTIVE_TASK *atp1 = (ACTIVE_TASK*)p1;
     ACTIVE_TASK *atp2 = (ACTIVE_TASK*)p2;
-    if (atp1->swap_kill_time > atp2->swap_kill_time) return true;
-    if (atp1->swap_kill_time < atp2->swap_kill_time) return false;
+    if (atp1->result->report_deadline < atp2->result->report_deadline) return true;
+    if (atp1->result->report_deadline > atp2->result->report_deadline) return false;
+
     return atp1 < atp2;
 }
 
@@ -823,6 +829,10 @@ static bool compare_swap_kill_time(void *p1, void *p2) {
 // Return true if this is the case.
 //
 bool CLIENT_STATE::swap_limit_check() {
+    if (host_info.m_swap == 0) {
+        return false;
+    }
+
     vector<RESULT*> run_list;
 
     // compute swap usage of running tasks
@@ -905,7 +915,7 @@ bool CLIENT_STATE::swap_limit_check() {
         // see if we can run swap-killed tasks
         std::sort(
             swap_kill_tasks.begin(), swap_kill_tasks.end(),
-            compare_swap_kill_time
+            compare_swap_revive
         );
         // run as many as will fit
         //

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1457,10 +1457,10 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
                 if (atp->too_large) {
                     if (log_flags.mem_usage_debug) {
                         msg_printf(atp->result->project, MSG_INFO,
-                            "[mem_usage] job using too much memory, will preempt by quit"
+                            "[mem_usage] job using too much memory, will suspend"
                         );
                     }
-                    preempt_type = REMOVE_ALWAYS;
+                    preempt_type = REMOVE_NEVER;
                 }
                 atp->preempt(preempt_type);
                 break;

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -808,7 +808,7 @@ static bool compare_swap_preempt(void *p1, void *p2) {
     ACTIVE_TASK *atp1 = (ACTIVE_TASK*)p1;
     ACTIVE_TASK *atp2 = (ACTIVE_TASK*)p2;
     double x1 = atp1->current_cpu_time - atp1->checkpoint_cpu_time;
-    double x2 = atp1->current_cpu_time - atp2->checkpoint_cpu_time;
+    double x2 = atp2->current_cpu_time - atp2->checkpoint_cpu_time;
     if (x1 < x2) return true;
     if (x1 > x2) return false;
     return atp1 < atp2;
@@ -873,7 +873,7 @@ bool CLIENT_STATE::swap_limit_check() {
             atp->preempt(REMOVE_ALWAYS);
                 // this changes state to QUIT_PENDING
             swap_usage -= atp->procinfo.swap_size;
-            if (swap_usage < swap_limit) {
+            if (swap_usage <= swap_limit) {
                 break;
             }
         }

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -206,7 +206,7 @@ struct PROC_RESOURCES {
         // If so, don't reserve CPU/GPU for it, to avoid starvation scenario
         //
         bool may_not_run = false;
-        if (atp && atp->too_large) {
+        if (atp && (atp->wss_too_large || atp->swap_too_large)) {
             may_not_run = true;
         }
         if (rt) {
@@ -933,7 +933,8 @@ void CLIENT_STATE::make_run_list(vector<RESULT*>& run_list) {
         avp->max_working_set_size = 0;
     }
     for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
-        atp->too_large = false;
+        atp->wss_too_large = false;
+        atp->swap_too_large = false;
         double w = atp->procinfo.working_set_size_smoothed;
         APP_VERSION* avp = atp->app_version;
         if (w > avp->max_working_set_size) {
@@ -1238,6 +1239,8 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         ram_left -= sporadic_resources.mem_used;
     }
     double swap_left = (global_prefs.vm_max_used_frac)*host_info.m_swap;
+    bool check_swap = (host_info.m_swap != 0);
+        // in case couldn't measure swap on this host
 
     if (log_flags.mem_usage_debug) {
         msg_printf(0, MSG_INFO,
@@ -1272,7 +1275,10 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
     //
     assign_coprocs(run_list);
 
-    // scan the run list
+    // scan the run list.
+    // skip jobs that would exhaust a resource (CPUs, RAM, swap).
+    // for others, create ACTIVE_TASKs as needed,
+    // and mark as CPU_SCHED_SCHEDULED
     //
     for (RESULT* rp: run_list) {
         if (have_max_concurrent && max_concurrent_exceeded(rp)) {
@@ -1341,7 +1347,9 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         }
 
         // skip jobs whose 'expected working set size' (EWSS)
-        // is too large to fit in available RAM.
+        // is too large to fit in available RAM,
+        // or whose swap size is too large for available swap space.
+        //
         // To compute EWSS, we start with
         // - if the job has already run, its recent average WSS
         // - else if other jobs of this app version have run recently,
@@ -1353,23 +1361,25 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         // and then gets big.
         //
         double ewss = 0;
+        double eswap = 0;
         if (atp) {
-            atp->too_large = false;
+            atp->wss_too_large = false;
             ewss = atp->procinfo.working_set_size_smoothed;
+            eswap = atp->procinfo.swap_size;
         } else {
             ewss = rp->avp->max_working_set_size;
+            eswap = rp->avp->max_working_set_size;  // best guess
         }
         if (rp->project->strict_memory_bound) {
             ewss = std::max(ewss, rp->wup->rsc_memory_bound);
-        } else {
-            if (ewss == 0) {
-                ewss = rp->wup->rsc_memory_bound;
-            }
+        }
+        if (ewss == 0) {
+            ewss = rp->wup->rsc_memory_bound;
         }
 
         if (ewss > ram_left) {
             if (atp) {
-                atp->too_large = true;
+                atp->wss_too_large = true;
             }
             if (log_flags.cpu_sched_debug || log_flags.mem_usage_debug) {
                 msg_printf(rp->project, MSG_INFO,
@@ -1378,6 +1388,20 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
                 );
             }
             continue;
+        }
+        if (check_swap) {
+            if (eswap > swap_left) {
+                if (atp) {
+                    atp->swap_too_large = true;
+                }
+                if (log_flags.cpu_sched_debug || log_flags.mem_usage_debug) {
+                    msg_printf(rp->project, MSG_INFO,
+                        "[cpu_sched_debug] skipping %s: estimated swap (%.2fMB) exceeds swap left (%.2fMB)",
+                        rp->name,  eswap/MEGA, swap_left/MEGA
+                    );
+                }
+                continue;
+            }
         }
 
         // We've decided to run this job
@@ -1404,6 +1428,7 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         ncpus_used += rp->resource_usage.avg_ncpus;
         atp->next_scheduler_state = CPU_SCHED_SCHEDULED;
         ram_left -= ewss;
+        swap_left -= eswap;
         if (have_max_concurrent) {
             max_concurrent_inc(rp);
         }
@@ -1422,13 +1447,9 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         }
     }
 
-    bool check_swap = (host_info.m_swap != 0);
-        // in case couldn't measure swap on this host
-
-    // TODO: enforcement of swap space is broken right now
-
-    // preempt tasks as needed, and note whether there are any coproc jobs
-    // in QUIT_PENDING state (in which case we won't start new coproc jobs)
+    // Scan active tasks, preempt tasks as needed
+    // Note whether there are any coproc jobs in QUIT_PENDING state
+    // (in which case we won't start new coproc jobs)
     //
     bool coproc_quit_pending = false;
     for (ACTIVE_TASK* atp: active_tasks.active_tasks) {
@@ -1446,7 +1467,7 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
             switch (atp->task_state()) {
             case PROCESS_EXECUTING:
                 action = true;
-                if (check_swap && swap_left < 0) {
+                if (atp->swap_too_large) {
                     if (log_flags.mem_usage_debug) {
                         msg_printf(atp->result->project, MSG_INFO,
                             "[mem_usage] out of swap space, will preempt by quit"
@@ -1454,7 +1475,7 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
                     }
                     preempt_type = REMOVE_ALWAYS;
                 }
-                if (atp->too_large) {
+                if (atp->wss_too_large) {
                     if (log_flags.mem_usage_debug) {
                         msg_printf(atp->result->project, MSG_INFO,
                             "[mem_usage] job using too much memory, will suspend"
@@ -1490,6 +1511,8 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         }
     }
 
+    // scan active tasks and run those that are scheduled
+    //
     bool coproc_start_deferred = false;
     for (ACTIVE_TASK* atp: active_tasks.active_tasks) {
         if (atp->next_scheduler_state != CPU_SCHED_SCHEDULED) continue;
@@ -1550,7 +1573,6 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
             );
         }
         atp->scheduler_state = CPU_SCHED_SCHEDULED;
-        swap_left -= atp->procinfo.swap_size;
 
 #ifndef SIM
         // if we've been in this loop for > 10 secs,

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -799,7 +799,7 @@ void CLIENT_STATE::print_global_prefs() {
     //
 
     double swap_limit = global_prefs.vm_max_used_frac*host_info.m_swap;
-    msg_printf(NULL MSG_INFO,
+    msg_printf(NULL, MSG_INFO,
         "-  Don't used more than %.2fGB swap space (%.2f of %.2GB)",
         swap_limit/GIGA, global_prefs.vm_max_used_frac*100,
         host_info.m_swap/GIGA

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -800,7 +800,7 @@ void CLIENT_STATE::print_global_prefs() {
 
     double swap_limit = global_prefs.vm_max_used_frac*host_info.m_swap;
     msg_printf(NULL, MSG_INFO,
-        "-  Don't used more than %.2fGB swap space (%.2f of %.2GB)",
+        "-  Don't used more than %.2fGB swap space (%.2f of %.2fGB)",
         swap_limit/GIGA, global_prefs.vm_max_used_frac*100,
         host_info.m_swap/GIGA
     );

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -800,7 +800,7 @@ void CLIENT_STATE::print_global_prefs() {
 
     double swap_limit = global_prefs.vm_max_used_frac*host_info.m_swap;
     msg_printf(NULL, MSG_INFO,
-        "-  Don't used more than %.2fGB swap space (%.2f of %.2fGB)",
+        "-  Don't used more than %.2f GB swap space (%.0f%% of %.2f GB)",
         swap_limit/GIGA, global_prefs.vm_max_used_frac*100,
         host_info.m_swap/GIGA
     );

--- a/client/cs_prefs.cpp
+++ b/client/cs_prefs.cpp
@@ -798,6 +798,13 @@ void CLIENT_STATE::print_global_prefs() {
     // other prefs
     //
 
+    double swap_limit = global_prefs.vm_max_used_frac*host_info.m_swap;
+    msg_printf(NULL MSG_INFO,
+        "-  Don't used more than %.2fGB swap space (%.2f of %.2GB)",
+        swap_limit/GIGA, global_prefs.vm_max_used_frac*100,
+        host_info.m_swap/GIGA
+    );
+
     if (!global_prefs.run_on_batteries) {
         msg_printf(NULL, MSG_INFO,
             "-  Suspend if running on batteries"

--- a/clientgui/MainDocument.cpp
+++ b/clientgui/MainDocument.cpp
@@ -2646,8 +2646,10 @@ wxString result_description(RESULT* result, bool show_resources) {
             strBuffer += _("GPU suspended - ");
             strBuffer += suspend_reason_wxstring(status.gpu_suspend_reason);
         } else if (result->active_task) {
-            if (result->too_large) {
+            if (result->wss_too_large) {
                 strBuffer += _("Waiting for memory");
+            } else if (result->swap_too_large) {
+                strBuffer += _("Waiting for swap space");
             } else if (result->needs_shmem) {
                 strBuffer += _("Waiting for shared memory");
             } else if (result->want_network) {

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -293,7 +293,8 @@ struct RESULT {
         // actually, estimated elapsed time remaining
     double bytes_sent;
     double bytes_received;
-    bool too_large;
+    bool wss_too_large;
+    bool swap_too_large;
     bool needs_shmem;
     bool want_network;
     bool edf_scheduled;

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -704,7 +704,9 @@ int RESULT::parse(XML_PARSER& xp) {
         if (xp.parse_double("estimated_cpu_time_remaining", estimated_cpu_time_remaining)) continue;
         if (xp.parse_double("bytes_sent", bytes_sent)) continue;
         if (xp.parse_double("bytes_received", bytes_received)) continue;
-        if (xp.parse_bool("too_large", too_large)) continue;
+        if (xp.parse_bool("too_large", wss_too_large)) continue;
+            // backward compatibility
+        if (xp.parse_bool("swap_too_large", swap_too_large)) continue;
         if (xp.parse_bool("needs_shmem", needs_shmem)) continue;
         if (xp.parse_bool("want_network", want_network)) continue;
         if (xp.parse_bool("edf_scheduled", edf_scheduled)) continue;
@@ -762,7 +764,8 @@ void RESULT::clear() {
     estimated_cpu_time_remaining = 0;
     bytes_sent = 0;
     bytes_received = 0;
-    too_large = false;
+    wss_too_large = false;
+    swap_too_large = false;
     needs_shmem = false;
     want_network = false;
     edf_scheduled = false;

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -256,6 +256,7 @@ void GLOBAL_PREFS::defaults() {
     vm_max_used_frac = 0.75;
     work_buf_additional_days = 0.5;
     work_buf_min_days = 0.1;
+    vm_max_used_frac = 1.;
 
     override_file_present = false;
 


### PR DESCRIPTION
Previously we had the pref but ignored it.
Enforcing it is tricky because to a free a process's swap space,
you have to kill it, losing CPU time since last checkpoint.
Details are here: https://github.com/BOINC/boinc/wiki/Memory-management

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the swap usage limit (`vm_max_used_frac`) with scheduler logic that kills and revives tasks based on swap pressure, and tightens RAM handling. This reduces out-of-swap and OOM errors, and shows clearer UI states for memory vs swap limits.

- New Features
  - Enforce swap limit via `swap_limit_check()`:
    - When over limit, kill running tasks ordered by least uncheckpointed CPU time; revive killed tasks in deadline order as swap frees up.
    - Skip tasks whose estimated swap would exceed `swap_left`; trigger reschedule when total WSS, total swap, or any task’s WSS exceed current limits.
  - BOINC Manager shows “Waiting for swap space”; startup logs the effective swap cap.

- Refactors
  - Replace `too_large` with `wss_too_large` and add `swap_too_large` across client and GUI RPC; keep XML compatibility by still emitting `<too_large/>`.
  - RAM policy: if WSS > available RAM, suspend/wait; if WSS > max allowed RAM, abort.
  - Run-list enforces both RAM (`ram_left`) and swap (`swap_left`); preempt WSS with suspend, swap with quit.

<sup>Written for commit 12389396eb32009fcfe7132def063eec9df4dd8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

