### PR TITLE
prefer openssl certstore on macos

### DIFF
--- a/client/http_curl.cpp
+++ b/client/http_curl.cpp
@@ -478,7 +478,7 @@ int HTTP_OP::libcurl_exec(
     curl_easy_setopt(curlEasy, CURLOPT_SSL_VERIFYPEER, 1L);
     //curl_easy_setopt(curlEasy, CURLOPT_SSL_VERIFYPEER, FALSE);
 
-    // MSW now uses schannel and Mac now uses Secure Transport
+    // MSW now uses schannel
     // so neither uses ca-bundle.crt
 #if (!defined(_WIN32) && !defined(__APPLE__))
     // if the above is nonzero, you need the following:
@@ -489,6 +489,19 @@ int HTTP_OP::libcurl_exec(
         //
         curl_easy_setopt(curlEasy, CURLOPT_CAINFO, CA_BUNDLE_FILENAME);
     }
+#endif
+
+#ifdef __APPLE__
+    // local override, call this only if a local copy of cert.pem exists
+    if (boinc_file_exists("cert.pem")) {
+        curl_easy_setopt(curlEasy, CURLOPT_CAINFO, "cert.pem");
+    // prefer openssl versions
+    } else if (boinc_file_exists("/opt/homebrew/etc/ca-certificates/cert.pem")) {
+        curl_easy_setopt(curlEasy, CURLOPT_CAINFO, "/opt/homebrew/etc/ca-certificates/cert.pem");
+    } else if (boinc_file_exists("/usr/local/etc/ca-certificates/cert.pem")) {
+        curl_easy_setopt(curlEasy, CURLOPT_CAINFO, "/usr/local/etc/ca-certificates/cert.pem");
+    }
+    // else the default "/etc/ssl/cert.pem"
 #endif
 
     // set the user agent as this boinc client & version


### PR DESCRIPTION
Fixes #6987

**Description of the Change**
It appears that /etc/ssl/cert.pem are outdated even on recent Macos versions which is causing trouble with recognizing new certificates.

**Alternate Designs**

**Release Notes**
Macos now prefers openssl certificates
/opt/homebrew/etc/ca-certificates/cert.pem
/usr/local/etc/ca-certificates/cert.pem
rather than the default
/etc/ssl/cert.pem

the certificate store can be overridden using a local
cert.pem

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer OpenSSL CA bundles on macOS to fix TLS failures caused by outdated `/etc/ssl/cert.pem`. The client now picks a better CA file automatically to recognize newer certificates.

- **Bug Fixes**
  - On macOS, set `CURLOPT_CAINFO` using the first existing path in this order: `cert.pem` (local), `/opt/homebrew/etc/ca-certificates/cert.pem`, `/usr/local/etc/ca-certificates/cert.pem`; otherwise fall back to `/etc/ssl/cert.pem`.
  - No changes for Windows or non-macOS builds.

<sup>Written for commit 4e97f29ae051ece27191ff3764bfcf555a9b768b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

