### PR TITLE
docker_wrapper: read complete lines from command output

### DIFF
--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -369,8 +369,13 @@ int run_command(const char *cmd, vector<string> &out) {
         fprintf(stderr, "popen() failed: %s\n", cmd);
         return ERR_FOPEN;
     }
+    string s;
     while (fgets(buf, 256, fp)) {
-        out.push_back(buf);
+        s += buf;
+        if (strchr(buf, '\n')) {
+            out.push_back(s);
+            s.clear();
+        }
     }
     int exit_status = pclose(fp);
     if (exit_status) {


### PR DESCRIPTION
Fixes #7111

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `run_command` returns complete lines from command output by buffering fragments until a newline before pushing to `out`. This prevents fragmented entries when commands emit lines longer than the read buffer.

<sup>Written for commit 20478a46c5b7cda0934191ebe479017cbd56fcc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

