### PR TITLE
web: require login for some pages; try to reduce bot activity

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -95,6 +95,12 @@ if (!defined('NO_STATS')) {
 if (!defined('NO_GLOBAL_PREFS')) {
     define('NO_GLOBAL_PREFS', false);
 }
+if (!defined('REQUIRE_LOGIN')) {
+    define('REQUIRE_LOGIN', true);
+}
+if (!defined('REQUIRE_LOGIN_FORUM')) {
+    define('REQUIRE_LOGIN_FORUM', true);
+}
 
 // the 'home page' of the logged-in user.
 // go here after login, account creation, team operations, etc.

--- a/html/user/apps.php
+++ b/html/user/apps.php
@@ -18,6 +18,10 @@
 
 require_once("../inc/util.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 BoincDb::get(true);
 
 function main() {

--- a/html/user/apps.php
+++ b/html/user/apps.php
@@ -18,11 +18,11 @@
 
 require_once("../inc/util.inc");
 
+BoincDb::get(true);
+
 if (REQUIRE_LOGIN) {
     get_logged_in_user();
 }
-
-BoincDb::get(true);
 
 function main() {
     if (get_str('xml', true)) {

--- a/html/user/apps.php
+++ b/html/user/apps.php
@@ -18,11 +18,11 @@
 
 require_once("../inc/util.inc");
 
-BoincDb::get(true);
-
 if (REQUIRE_LOGIN) {
     get_logged_in_user();
 }
+
+BoincDb::get(true);
 
 function main() {
     if (get_str('xml', true)) {

--- a/html/user/forum_forum.php
+++ b/html/user/forum_forum.php
@@ -23,6 +23,10 @@ require_once('../inc/time.inc');
 require_once('../inc/forum.inc');
 require_once('../inc/pm.inc');
 
+if (REQUIRE_LOGIN_FORUM) {
+    get_logged_in_user();
+}
+
 // show a forum.
 // $user is null if not logged in
 //

--- a/html/user/forum_get_data.php
+++ b/html/user/forum_get_data.php
@@ -16,6 +16,11 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// RPC to return user's posts as XML
+
+// this is a bad idea; deprecating
+die('deprecated');
+
 require_once("../inc/forum_db.inc");
 require_once("../inc/util.inc");
 require_once("../inc/xml.inc");

--- a/html/user/forum_help_desk.php
+++ b/html/user/forum_help_desk.php
@@ -22,6 +22,10 @@ require_once('../inc/time.inc');
 
 if (DISABLE_FORUMS) error_page("Forums are disabled");
 
+if (REQUIRE_LOGIN_FORUM) {
+    get_logged_in_user();
+}
+
 check_get_args(array());
 
 $user = get_logged_in_user(false);
@@ -29,7 +33,7 @@ $user = get_logged_in_user(false);
 page_head(tra("Questions and answers"));
 
 echo "<p>".
-    tra("Talk live via Skype with a volunteer, in any of several languages. Go to %1 BOINC Online Help %2.", "<a href=\"https://boinc.berkeley.edu/help.php\">", "</a>").
+    tra("Email help volunteer, in any of several languages. Go to %1 BOINC Online Help %2.", "<a href=\"https://boinc.berkeley.edu/help.php\">", "</a>").
     "</p>";
 
 show_forum_header($user);

--- a/html/user/forum_index.php
+++ b/html/user/forum_index.php
@@ -23,6 +23,10 @@ require_once('../inc/forum.inc');
 require_once('../inc/pm.inc');
 require_once('../inc/time.inc');
 
+if (REQUIRE_LOGIN_FORUM) {
+    get_logged_in_user();
+}
+
 function show_forum_summary($forum) {
     switch ($forum->parent_type) {
     case 0:

--- a/html/user/forum_reply.php
+++ b/html/user/forum_reply.php
@@ -30,7 +30,7 @@ require_once('../inc/akismet.inc');
 
 if (DISABLE_FORUMS) error_page("Forums are disabled");
 
-$logged_in_user = get_logged_in_user(true);
+$logged_in_user = get_logged_in_user();
 BoincForumPrefs::lookup($logged_in_user);
 check_banished($logged_in_user);
 if (VALIDATE_EMAIL_TO_POST) {

--- a/html/user/forum_report_post.php
+++ b/html/user/forum_report_post.php
@@ -16,9 +16,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// Some posts may contain material that is not suited for public
-// viewing. This file allows people to report such posts
-// For this file to work the project must have defined who
+// Let people report posts that violate rules.
+// The project must define who
 // should receive such reports (in the configuration file)
 
 require_once('../inc/util.inc');

--- a/html/user/forum_search.php
+++ b/html/user/forum_search.php
@@ -24,6 +24,10 @@ require_once('../inc/forum.inc');
 
 if (DISABLE_FORUMS) error_page("Forums are disabled");
 
+if (REQUIRE_LOGIN_FORUM) {
+    get_logged_in_user();
+}
+
 check_get_args(array("forumid"));
 
 page_head(tra("Forum search"));

--- a/html/user/forum_search_action.php
+++ b/html/user/forum_search_action.php
@@ -25,6 +25,10 @@ require_once('../inc/forum.inc');
 
 if (DISABLE_FORUMS) error_page("Forums are disabled");
 
+if (REQUIRE_LOGIN_FORUM) {
+    get_logged_in_user();
+}
+
 check_get_args(array());
 
 // Searches for the keywords in the $keyword_list array in thread titles.

--- a/html/user/forum_thread.php
+++ b/html/user/forum_thread.php
@@ -23,6 +23,10 @@ require_once('../inc/util.inc');
 require_once('../inc/forum.inc');
 require_once('../inc/news.inc');
 
+if (REQUIRE_LOGIN_FORUM) {
+    get_logged_in_user();
+}
+
 $threadid = get_int('id');
 $sort_style = get_int('sort', true);
 $temp_sort_style = get_int('temp_sort_style', true);

--- a/html/user/forum_user_posts.php
+++ b/html/user/forum_user_posts.php
@@ -23,6 +23,10 @@ require_once('../inc/user.inc');
 
 if (DISABLE_FORUMS) error_page("Forums are disabled");
 
+if (REQUIRE_LOGIN_FORUM) {
+    get_logged_in_user();
+}
+
 check_get_args(array("userid", "offset"));
 
 $userid = get_int("userid");

--- a/html/user/hosts_user.php
+++ b/html/user/hosts_user.php
@@ -23,6 +23,10 @@ require_once("../inc/boinc_db.inc");
 require_once("../inc/util.inc");
 require_once("../inc/host.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("show_all", "rev", "sort", "userid"));
 
 $show_all = get_int("show_all", true);

--- a/html/user/per_app_list.php
+++ b/html/user/per_app_list.php
@@ -26,6 +26,10 @@
 require_once("../inc/util.inc");
 require_once("../inc/team.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array(
     "is_team",
     "appid",

--- a/html/user/profile_menu.php
+++ b/html/user/profile_menu.php
@@ -21,7 +21,13 @@ require_once("../inc/util.inc");
 require_once("../inc/profile.inc");
 require_once("../inc/uotd.inc");
 
-if (DISABLE_PROFILES) error_page("Profiles are disabled");
+if (DISABLE_PROFILES) {
+    error_page("Profiles are disabled");
+}
+
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
 
 check_get_args(array("cmd", "pic"));
 

--- a/html/user/profile_search_action.php
+++ b/html/user/profile_search_action.php
@@ -21,6 +21,10 @@ require_once("../inc/util.inc");
 
 if (DISABLE_PROFILES) error_page("Profiles are disabled");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("search_string", "offset"));
 
 function show_profile_link2($profile, $n) {

--- a/html/user/result.php
+++ b/html/user/result.php
@@ -21,6 +21,10 @@
 require_once("../inc/util.inc");
 require_once("../inc/result.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 $x = get_int("resultid", true);
 if ($x) {
     $result = BoincResult::lookup_id($x);

--- a/html/user/results.php
+++ b/html/user/results.php
@@ -25,7 +25,11 @@ require_once("../inc/result.inc");
 check_get_args(array("hostid", "userid", "offset", "appid", "state", "show_names"));
 
 if (!project_config_bool("show_results")) {
-    error_page(tra("This feature is turned off temporarily"));
+    error_page(tra('This feature is disabled.'));
+}
+
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
 }
 
 BoincDb::get(true);

--- a/html/user/results.php
+++ b/html/user/results.php
@@ -28,11 +28,11 @@ if (!project_config_bool("show_results")) {
     error_page(tra('This feature is disabled.'));
 }
 
+BoincDb::get(true);
+
 if (REQUIRE_LOGIN) {
     get_logged_in_user();
 }
-
-BoincDb::get(true);
 
 $results_per_page = 20;
 

--- a/html/user/results.php
+++ b/html/user/results.php
@@ -28,11 +28,11 @@ if (!project_config_bool("show_results")) {
     error_page(tra('This feature is disabled.'));
 }
 
-BoincDb::get(true);
-
 if (REQUIRE_LOGIN) {
     get_logged_in_user();
 }
+
+BoincDb::get(true);
 
 $results_per_page = 20;
 

--- a/html/user/show_host_detail.php
+++ b/html/user/show_host_detail.php
@@ -21,6 +21,10 @@ require_once("../inc/util.inc");
 require_once("../inc/user.inc");
 require_once("../inc/host.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("hostid", "ipprivate"));
 
 BoincDb::get(true);

--- a/html/user/show_user.php
+++ b/html/user/show_user.php
@@ -54,6 +54,9 @@ if ($format=="xml"){
 
     show_user_xml($user, $show_hosts);
 } else {
+    if (REQUIRE_LOGIN) {
+        get_logged_in_user();
+    }
     // The page may be presented in many different languages,
     // so here we cache the data instead
     //
@@ -86,6 +89,8 @@ if ($format=="xml"){
         error_page("No such user");
     }
 
+    // display data differently if user is looking at themselves
+    //
     $logged_in_user = get_logged_in_user(false);
     $myself = $logged_in_user && ($logged_in_user->id == $user->id);
 

--- a/html/user/team_lookup.php
+++ b/html/user/team_lookup.php
@@ -28,6 +28,12 @@ $format = get_str("format", true);
 $team_id = get_int("team_id", true);
 $team_ids = get_str("team_ids", true);
 
+if ($format != 'xml') {
+    if (REQUIRE_LOGIN) {
+        get_logged_in_user();
+    }
+}
+
 BoincDb::get(true);
 
 if ($team_id || $team_ids || ($format == 'xml')) {

--- a/html/user/team_members.php
+++ b/html/user/team_members.php
@@ -22,6 +22,10 @@ require_once("../inc/cache.inc");
 
 if (DISABLE_TEAMS) error_page("Teams are disabled");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("sort_by", "offset", "teamid"));
 
 $sort_by = get_str("sort_by", true);

--- a/html/user/team_search.php
+++ b/html/user/team_search.php
@@ -24,6 +24,10 @@ include_once("../inc/xml.inc");
 
 if (DISABLE_TEAMS) error_page("Teams are disabled");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("keywords", "active", "country", "type", "submit", "xml"));
 
 // Merge list1 into list2.

--- a/html/user/top_hosts.php
+++ b/html/user/top_hosts.php
@@ -24,6 +24,10 @@ require_once("../inc/boinc_db.inc");
 
 check_get_args(array("sort_by", "offset"));
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 $hosts_per_page = project_config_val("hosts_per_page");
 if (!$hosts_per_page) {
     $hosts_per_page = 20;

--- a/html/user/top_teams.php
+++ b/html/user/top_teams.php
@@ -23,6 +23,10 @@ require_once("../inc/db.inc");
 
 if (DISABLE_TEAMS) error_page("Teams are disabled");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("sort_by", "type", "offset"));
 
 $teams_per_page = project_config_val("teams_per_page");

--- a/html/user/top_users.php
+++ b/html/user/top_users.php
@@ -21,6 +21,10 @@ require_once("../inc/util.inc");
 require_once("../inc/user.inc");
 require_once("../inc/boinc_db.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("sort_by", "offset"));
 
 $users_per_page = project_config_val("users_per_page");

--- a/html/user/user_search.php
+++ b/html/user/user_search.php
@@ -20,6 +20,10 @@ require_once("../inc/boinc_db.inc");
 require_once("../inc/util.inc");
 require_once("../inc/user.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 function show_user($user) {
     $x = [];
     $y = [];

--- a/html/user/workunit.php
+++ b/html/user/workunit.php
@@ -23,6 +23,10 @@ require_once("../inc/boinc_db.inc");
 require_once("../inc/result.inc");
 require_once("../inc/keywords.inc");
 
+if (REQUIRE_LOGIN) {
+    get_logged_in_user();
+}
+
 check_get_args(array("wuid"));
 
 function keyword_string($kwds) {


### PR DESCRIPTION
Add two flags in html/project/project.inc
REQUIRE_LOGIN
    Require login for pages that show results, workunit, hosts,
    teams, users, profiles, and app versions.
REQUIRE_LOGIN_FORUM
    Require login for forum pages (most of them already required it).

The goal is to reduce the links visible to robots, and thereby reduce the load on the web server.

The flags default to true.
If a project wants non-logged-in people (and bots) to be able to see things, they can set one or both flags to false.

Fixes #7119 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require login by default for results, workunit, host, team, user, profile, app version, and forum pages to cut bot traffic and server load. Also defers DB connections on these routes unless needed.

- **New Features**
  - Added `REQUIRE_LOGIN` and `REQUIRE_LOGIN_FORUM` in `html/inc/util.inc` (default true).
  - Enforced login via `get_logged_in_user()` on affected pages.
  - Deferred DB opens until after login or only when required on some pages.
  - Cleanups: deprecated `html/user/forum_get_data.php`; updated help desk text; simplified the “feature disabled” message.

- **Migration**
  - To keep pages public, set `REQUIRE_LOGIN` and/or `REQUIRE_LOGIN_FORUM` to false in `html/project/project.inc`.

<sup>Written for commit a421699ee08f3741c29f56a2778d94eac227d5da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

