### PR TITLE
Mac fix permissions if BOINC Data / BOINC podman dirs moved

### DIFF
--- a/client/check_security.cpp
+++ b/client/check_security.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -419,9 +419,15 @@ int use_sandbox, int isManager, char* path_to_error, int len
     }
 
     if (use_sandbox) {
+#ifdef __APPLE__
         // "BOINC Podman" Directory is in "/Library/Application/Support/"
-        // directory, alongside "BOINC Data" directory
+        // directory. But we can't get its path relative to the "BOINC Data"
+        // dir because a user can move the "BOINC Data" dir as described in
+        // https://github.com/BOINC/boinc/wiki/Tools-for-MacOS
+        snprintf(full_path, sizeof(full_path), "/Library/Application Support/%s", PODMAN_DIR);
+#else
         snprintf(full_path, sizeof(full_path), "%s/../%s", dir_path, PODMAN_DIR);
+#endif
         retval = stat(full_path, &sbuf);
         if (retval)
             return -1071;

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -576,6 +576,8 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
         sprintf(buf1, "%s:%s", boinc_project_user_name, boinc_project_group_name);
         // chown -R boinc_master:boinc_master "/Library/Application Support/BOINC Data"
         err = DoSudoPosixSpawn(chownPath, "-RL", buf1, fullpath, NULL, NULL, NULL);
+        if (err)
+            return err;
 
         // Set owner and group of BOINC podman directory itself
         sprintf(buf1, "%s:%s", boinc_master_user_name, boinc_project_group_name);

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -305,10 +305,8 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
         return err;
 #endif
 
-    strlcpy(fullpath, BOINCDataDirPath, MAXPATHLEN);
-
     // Does BOINC Data directory exist?
-    result = stat(fullpath, &sbuf);
+    result = stat(BOINCDataDirPath, &sbuf);
     isDirectory = S_ISDIR(sbuf.st_mode);
     if ((result != noErr) || (! isDirectory))
         return dirNFErr;                    // BOINC Data Directory does not exist
@@ -316,7 +314,7 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
     // Set owner and group of BOINC Data directory's contents
     sprintf(buf1, "%s:%s", boinc_master_user_name, boinc_master_group_name);
     // chown -R boinc_master:boinc_master "/Library/Application Support/BOINC Data"
-    err = DoSudoPosixSpawn(chownPath, "-R", buf1, BOINCDataDirPath, NULL, NULL, NULL);
+    err = DoSudoPosixSpawn(chownPath, "-RL", buf1, BOINCDataDirPath, NULL, NULL, NULL);
     if (err)
         return err;
 
@@ -552,15 +550,18 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
     }       // slots directory
 
     // Does podman directory exist?
-    strlcpy(fullpath, BOINCDataDirPath, MAXPATHLEN);
-    strlcat(fullpath, "/", MAXPATHLEN);
 #ifdef __APPLE__
     // On the Mac, we can't put the Podman directory inside the BOINC Data
     // directory because this routine would modify the permissions of
     // Podman's files, which must be different for different files.
     // So we put the "BOINC Podman" Directory in the directory
-    // "/Library/Application/Support/", alongside "BOINC Data" directory
-    strlcat(fullpath, "../", MAXPATHLEN);
+    // "/Library/Application/Support/". But we can't get its path relative
+    // to BOINCDataDirPath because a user can move the "BOINC Data" dir as
+    // described in https://github.com/BOINC/boinc/wiki/Tools-for-MacOS
+    strlcpy(fullpath, "/Library/Application Support/", MAXPATHLEN);
+#else
+    strlcpy(fullpath, BOINCDataDirPath, MAXPATHLEN);
+    strlcat(fullpath, "/../", MAXPATHLEN);
 #endif
     strlcat(fullpath, PODMAN_DIR, MAXPATHLEN);
     result = stat(fullpath, &sbuf);
@@ -574,7 +575,7 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
         // Set owner and group of BOINC podman directory's contents)
         sprintf(buf1, "%s:%s", boinc_project_user_name, boinc_project_group_name);
         // chown -R boinc_master:boinc_master "/Library/Application Support/BOINC Data"
-        err = DoSudoPosixSpawn(chownPath, "-R", buf1, fullpath, NULL, NULL, NULL);
+        err = DoSudoPosixSpawn(chownPath, "-RL", buf1, fullpath, NULL, NULL, NULL);
 
         // Set owner and group of BOINC podman directory itself
         sprintf(buf1, "%s:%s", boinc_master_user_name, boinc_project_group_name);
@@ -853,6 +854,7 @@ static OSStatus CreateUserAndGroup(char * user_name, char * group_name) {
     extern char     **environ;
     pid_t           thePid = 0;
     int             status = 0;
+    struct stat     sbuf;
 
     // OS 10.4 has problems with Accounts pane if we create uid or gid > 501
     pw = getpwnam(user_name);
@@ -962,7 +964,10 @@ setGroupForUser:
     if (err)
         return err;
 
-    DoSudoPosixSpawn("/bin/mkdir", "-m", "0755", buf2, NULL, NULL, NULL);
+    err = stat(buf2, &sbuf);
+    if (err) {
+        DoSudoPosixSpawn("/bin/mkdir", "-m", "0755", buf2, NULL, NULL, NULL);
+    }
 
     // Fix the directory's permissions if created by an earlier version of BOINC.
     DoSudoPosixSpawn(chmodPath, "-f", "0755", buf2, NULL, NULL, NULL);

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -313,8 +313,8 @@ int SetBOINCDataOwnersGroupsAndPermissions() {
 
     // Set owner and group of BOINC Data directory's contents
     sprintf(buf1, "%s:%s", boinc_master_user_name, boinc_master_group_name);
-    // chown -R boinc_master:boinc_master "/Library/Application Support/BOINC Data"
-    err = DoSudoPosixSpawn(chownPath, "-RL", buf1, BOINCDataDirPath, NULL, NULL, NULL);
+    // chown -RH boinc_master:boinc_master "/Library/Application Support/BOINC Data"
+    err = DoSudoPosixSpawn(chownPath, "-RH", buf1, BOINCDataDirPath, NULL, NULL, NULL);
     if (err)
         return err;
 

--- a/mac_build/Mac_SA_Insecure.sh
+++ b/mac_build/Mac_SA_Insecure.sh
@@ -57,6 +57,7 @@
 # Updated 8/25/25 to add Run_Podman and BOINC podman directory
 # Updated 5/2/26 to delete directories /Users/boinc_master & /Users/boinc_project
 # Updated 5/26/26 BOINC Podman dir is in standard location even if BOINC Data was moved
+# Updated 6/10/26 to work even if BOINC Podman dir was moved via symbolic link
 #
 
 function remove_boinc_users() {
@@ -130,7 +131,7 @@ fi
 if [ -d "/Library/Application Support/BOINC podman" ] ; then
     # We must not modify permissions of any of Podman's data so just set
     # their owner and grpup
-    chown -R ${user}:${group} "/Library/Application Support/BOINC podman"
+    chown -RL ${user}:${group} "/Library/Application Support/BOINC podman"
 fi
 
 if [ -x /Applications/BOINCManager.app/Contents/MacOS/BOINCManager ] ; then

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -76,7 +76,7 @@
 # Updated 11/9/25 to create "BOINC podman" directory if not present (for bare client)
 # Updated 5/7/26 to set home directories for users boinc_master & boinc_project
 # Updated 5/26/26 put BOINC Podman dir in standard location even if BOINC Data was moved
-# Updated 6/10/26 to work even if BOINC Podman dir was moved via symbolic link
+# Updated 6/11/26 to work even if BOINC Podman dir was moved via symbolic link
 #
 # WARNING: do not use this script with versions of BOINC older than 7.20.4
 
@@ -316,11 +316,12 @@ if [ ! -d "/Library/Application Support/BOINC podman" ] ; then
 fi
 # We must not modify permissions of any of Podman's data so just set
 # their owner and group
-cd "/Library/Application Support/BOINC podman"
-chown -R boinc_project:boinc_project .
-# Set owner and permissions for the BOINC podman directory itself
-# but not its contents.
-set_perm . boinc_master boinc_project 0770
+if cd "/Library/Application Support/BOINC podman"; then
+    chown -R boinc_project:boinc_project .
+    # Set owner and permissions for the BOINC podman directory itself
+    # but not its contents.
+    set_perm . boinc_master boinc_project 0770
+fi
 
 if [ -x /Applications/BOINCManager.app/Contents/MacOS/BOINCManager ] ; then
     set_perm  /Applications/BOINCManager.app/Contents/MacOS/BOINCManager boinc_master boinc_master 0555

--- a/mac_build/Mac_SA_Secure.sh
+++ b/mac_build/Mac_SA_Secure.sh
@@ -76,6 +76,7 @@
 # Updated 11/9/25 to create "BOINC podman" directory if not present (for bare client)
 # Updated 5/7/26 to set home directories for users boinc_master & boinc_project
 # Updated 5/26/26 put BOINC Podman dir in standard location even if BOINC Data was moved
+# Updated 6/10/26 to work even if BOINC Podman dir was moved via symbolic link
 #
 # WARNING: do not use this script with versions of BOINC older than 7.20.4
 
@@ -315,10 +316,11 @@ if [ ! -d "/Library/Application Support/BOINC podman" ] ; then
 fi
 # We must not modify permissions of any of Podman's data so just set
 # their owner and group
-chown -R boinc_project:boinc_project "/Library/Application Support/BOINC podman"
+cd "/Library/Application Support/BOINC podman"
+chown -R boinc_project:boinc_project .
 # Set owner and permissions for the BOINC podman directory itself
 # but not its contents.
-set_perm "/Library/Application Support/BOINC podman" boinc_master boinc_project 0770
+set_perm . boinc_master boinc_project 0770
 
 if [ -x /Applications/BOINCManager.app/Contents/MacOS/BOINCManager ] ; then
     set_perm  /Applications/BOINCManager.app/Contents/MacOS/BOINCManager boinc_master boinc_master 0555

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -565,14 +565,14 @@ fprintf(stdout, "Starting privileged tool (stdout)\n");
     // We don't customize BOINC Data directory name for branding
 //    callPosixSpawn ("rm -rf \"/Library/Application Support/BOINC Data\"");
     pw = getpwnam(loginName);
-    sprintf(cmd, "chown -RL %d:%d \"/Library/Application Support/BOINC Data\"", pw->pw_uid, pw->pw_gid);
+    sprintf(cmd, "chown -RH %d:%d \"/Library/Application Support/BOINC Data\"", pw->pw_uid, pw->pw_gid);
     callPosixSpawn (cmd);
     callPosixSpawn("chmod -R u+rw-s,g+r-w-s,o+r-w \"/Library/Application Support/BOINC Data\"");
     callPosixSpawn("chmod 600 \"/Library/Application Support/BOINC Data/gui_rpc_auth.cfg\"");
 
     // Phase 7: Set BOINC podman owner and group to logged in user
     pw = getpwnam(loginName);
-    sprintf(cmd, "chown -RL %d:%d \"/Library/Application Support/BOINC podman\"", pw->pw_uid, pw->pw_gid);
+    sprintf(cmd, "chown -RH %d:%d \"/Library/Application Support/BOINC podman\"", pw->pw_uid, pw->pw_gid);
     callPosixSpawn (cmd);
 
     // Phase 8: step through all users and do user-specific cleanup

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
 // http://boinc.berkeley.edu
-// Copyright (C) 2025 University of California
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -565,12 +565,17 @@ fprintf(stdout, "Starting privileged tool (stdout)\n");
     // We don't customize BOINC Data directory name for branding
 //    callPosixSpawn ("rm -rf \"/Library/Application Support/BOINC Data\"");
     pw = getpwnam(loginName);
-    sprintf(cmd, "chown -R %d:%d \"/Library/Application Support/BOINC Data\"", pw->pw_uid, pw->pw_gid);
+    sprintf(cmd, "chown -RL %d:%d \"/Library/Application Support/BOINC Data\"", pw->pw_uid, pw->pw_gid);
     callPosixSpawn (cmd);
     callPosixSpawn("chmod -R u+rw-s,g+r-w-s,o+r-w \"/Library/Application Support/BOINC Data\"");
     callPosixSpawn("chmod 600 \"/Library/Application Support/BOINC Data/gui_rpc_auth.cfg\"");
 
-    // Phase 7: step through all users and do user-specific cleanup
+    // Phase 7: Set BOINC podman owner and group to logged in user
+    pw = getpwnam(loginName);
+    sprintf(cmd, "chown -RL %d:%d \"/Library/Application Support/BOINC podman\"", pw->pw_uid, pw->pw_gid);
+    callPosixSpawn (cmd);
+
+    // Phase 8: step through all users and do user-specific cleanup
     CleanupAllVisibleUsers();
 
     // Use of sudo here may help avoid a warning alert from MacOS

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -564,17 +564,18 @@ fprintf(stdout, "Starting privileged tool (stdout)\n");
     // Phase 6: Set BOINC Data owner and group to logged in user
     // We don't customize BOINC Data directory name for branding
 //    callPosixSpawn ("rm -rf \"/Library/Application Support/BOINC Data\"");
-    pw = getpwnam(loginName);
-    sprintf(cmd, "chown -RH %d:%d \"/Library/Application Support/BOINC Data\"", pw->pw_uid, pw->pw_gid);
-    callPosixSpawn (cmd);
+    if ((pw = getpwnam(loginName)) != NULL) {
+        sprintf(cmd, "chown -RH %d:%d \"/Library/Application Support/BOINC Data\"", pw->pw_uid, pw->pw_gid);
+        callPosixSpawn (cmd);
+    }
     callPosixSpawn("chmod -R u+rw-s,g+r-w-s,o+r-w \"/Library/Application Support/BOINC Data\"");
     callPosixSpawn("chmod 600 \"/Library/Application Support/BOINC Data/gui_rpc_auth.cfg\"");
 
     // Phase 7: Set BOINC podman owner and group to logged in user
-    pw = getpwnam(loginName);
-    sprintf(cmd, "chown -RH %d:%d \"/Library/Application Support/BOINC podman\"", pw->pw_uid, pw->pw_gid);
-    callPosixSpawn (cmd);
-
+    if ((pw = getpwnam(loginName)) != NULL) {
+        sprintf(cmd, "chown -RH %d:%d \"/Library/Application Support/BOINC podman\"", pw->pw_uid, pw->pw_gid);
+        callPosixSpawn (cmd);
+    }
     // Phase 8: step through all users and do user-specific cleanup
     CleanupAllVisibleUsers();
 


### PR DESCRIPTION
On the Mac, the _BOINC Data_  directory can be moved to a different parent folder or even to different drive, using the method explained [here](https://github.com/BOINC/boinc/wiki/Tools-for-MacOS#moving-boinc-manager-or-boinc-data-folder-to-a-different-drive). 
But because of the addition of the _BOINC Podman_ directory and other changes to BOINC over time, moving the _BOINC Data_  directory caused BOINC to refuse to run due to permissions errors, even after running the _Mac_SA_Secure.sh_ script or after running the installer again..

This PR fixes that problem. It also allows the user to fix the permissions by running the installer again after moving the directory, as an alternative to  using the script.

In addition, this PR allows the user to move the _BOINC podman_ directory using a similar method, in addition to or instead of moving the _BOINC Data_  directory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS permission errors when the BOINC Data or `BOINC podman` directories are moved (including via symlinks). You can rerun the installer, security scripts, or uninstaller to repair ownership and permissions so BOINC runs again.

- **Bug Fixes**
  - Use an absolute path for the `BOINC podman` directory on macOS; no longer derived from the BOINC Data path.
  - Follow symlinks when fixing ownership across installer, security scripts, and uninstaller (`chown -RH` for BOINC Data; `-RL` for `BOINC podman`).
  - In `Mac_SA_Secure.sh`, operate inside the `BOINC podman` directory to preserve file permissions and handle symlinked moves; set only the directory’s permissions.
  - Safer setup: avoid recreating existing dirs and apply correct ownership/permissions; uninstaller also resets `BOINC podman` ownership to the logged-in user.

<sup>Written for commit d584de8abaf5258659dd175d3b7d89f071b6ef9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

