### PR TITLE
docker_wrapper: pass HTTP and SOCKS proxy info to container in env vars

### DIFF
--- a/lib/unix_util.cpp
+++ b/lib/unix_util.cpp
@@ -56,7 +56,7 @@ static std::vector<char *> envstrings;
 int setenv(const char *name, const char *value, int overwrite) {
     char *buf;
     int rv;
-    // Name can't contant an equal sign.
+    // Name can't contain an equal sign.
     if (strchr(name,'=')) {
         errno=EINVAL;
         return -1;

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -797,6 +797,32 @@ int DOCKER_CONN::command(
     return 0;
 }
 
+// like the above, but run a shell command (not a Docker command)
+//
+#ifdef _WIN32
+int DOCKER_CONN::shell_command(
+    const char* cmd, vector<string> &out, bool verbose
+) {
+    char buf[1024];
+    int retval;
+    if (verbose) {
+        fprintf(stderr, "running WSL shell command: %s\n", cmd);
+    }
+    string output;
+
+    snprintf(buf, sizeof(buf), "%s 2>&1; echo EOM\n", cmd);
+    write_to_pipe(ctl_wc.in_write, buf);
+    retval = read_from_pipe(
+        ctl_wc.out_read, ctl_wc.proc_handle, output, CMD_TIMEOUT, "EOM"
+    );
+    if (retval) {
+        fprintf(stderr, "read_from_pipe() error: %s\n", boincerror(retval));
+        return retval;
+    }
+    out = split(output, '\n');
+}
+#endif
+
 // parse the output of 'docker images'
 // from the following, return 'boinc__app_test__test_wu'
 //

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -797,7 +797,8 @@ int DOCKER_CONN::command(
     return 0;
 }
 
-// like the above, but run a shell command (not a Docker command)
+// like the above, but run a shell command (not a Docker command).
+// We only need this in Win, to run commands in our WSL shell
 //
 #ifdef _WIN32
 int DOCKER_CONN::shell_command(
@@ -820,6 +821,7 @@ int DOCKER_CONN::shell_command(
         return retval;
     }
     out = split(output, '\n');
+    return 0;
 }
 #endif
 

--- a/lib/util.h
+++ b/lib/util.h
@@ -158,7 +158,16 @@ struct DOCKER_CONN {
 #else
     int init(DOCKER_TYPE);
 #endif
+
+    // issue a Docker command
     int command(const char* cmd, std::vector<std::string> &out, bool verbose);
+
+#ifdef _WIN32
+    // issue a shell command (e.g. 'export')
+    int shell_command(
+        const char* cmd, std::vector<std::string> &out, bool verbose
+    );
+#endif
 
     static const int CMD_TIMEOUT = 600;
         // timeout for docker commands.
@@ -181,6 +190,7 @@ extern std::string docker_container_name(
     const char* proj_url_esc,       // escaped project URL
     const char* result_name
 );
+
 // is the name (of a Docker image or container) a BOINC name?
 extern bool docker_is_boinc_name(const char* name);
 

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -573,8 +573,8 @@ int get_container_state(int &state) {
 }
 
 int create_container() {
-    char cmd[1024];
-    char slot_cmd[256], project_cmd[256], buf[256];
+    char cmd[4096];
+    char slot_cmd[256], project_cmd[256], buf[1024];
     vector<string> out;
     int retval;
 
@@ -608,14 +608,54 @@ int create_container() {
         slot_cmd, project_cmd
     );
 
-    // add command-line args, space-escaped if needed (Mac)
+    // add env var for command-line args, space-escaped if needed (Mac)
     //
     if (app_args.size()) {
-        char arg_buf[4096];
+        char arg_buf[1024];
         strcat(cmd, " -e ARGS=\"");
         get_app_args(arg_buf);
         strcat(cmd, arg_buf);
         strcat(cmd, "\"");
+    }
+    
+    // add env vars for proxy info
+    //
+    PROXY_INFO &pi = aid.proxy_info;
+    if (strlen(pi.http_server_name)) {
+        snprintf(buf, sizeof(buf), " -e HTTP_SERVER_NAME=\"%s\"", pi.http_server_name);
+        strcat(cmd, buf);
+    }
+    if (pi.http_server_port) {
+        snprintf(buf, sizeof(buf), " -e HTTP_SERVER_PORT=\"%d\"", pi.http_server_port);
+        strcat(cmd, buf);
+    }
+    if (strlen(pi.http_user_name)) {
+        snprintf(buf, sizeof(buf), " -e HTTP_USER_NAME=\"%s\"", pi.http_user_name);
+        strcat(cmd, buf);
+    }
+    if (strlen(pi.http_user_passwd)) {
+        snprintf(buf, sizeof(buf), " -e HTTP_USER_PASSWD=\"%s\"", pi.http_user_passwd);
+        strcat(cmd, buf);
+    }
+    if (strlen(pi.socks_server_name)) {
+        snprintf(buf, sizeof(buf), " -e SOCKS_SERVER_NAME=\"%s\"", pi.socks_server_name);
+        strcat(cmd, buf);
+    }
+    if (pi.socks_server_port) {
+        snprintf(buf, sizeof(buf), " -e SOCKS_SERVER_PORT=\"%d\"", pi.socks_server_port);
+        strcat(cmd, buf);
+    }
+    if (strlen(pi.socks5_user_name)) {
+        snprintf(buf, sizeof(buf), " -e SOCKS_USER_NAME=\"%s\"", pi.socks5_user_name);
+        strcat(cmd, buf);
+    }
+    if (strlen(pi.socks5_user_passwd)) {
+        snprintf(buf, sizeof(buf), " -e SOCKS_USER_PASSWD=\"%s\"", pi.socks5_user_passwd);
+        strcat(cmd, buf);
+    }
+    if (pi.socks5_remote_dns) {
+        snprintf(buf, sizeof(buf), " -e SOCKS_REMOTE_DNS=\"yes\"");
+        strcat(cmd, buf);
     }
 
     // add mounts and portmaps

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -617,46 +617,6 @@ int create_container() {
         strcat(cmd, arg_buf);
         strcat(cmd, "\"");
     }
-    
-    // add env vars for proxy info
-    //
-    PROXY_INFO &pi = aid.proxy_info;
-    if (strlen(pi.http_server_name)) {
-        snprintf(buf, sizeof(buf), " -e HTTP_SERVER_NAME=\"%s\"", pi.http_server_name);
-        strcat(cmd, buf);
-    }
-    if (pi.http_server_port) {
-        snprintf(buf, sizeof(buf), " -e HTTP_SERVER_PORT=\"%d\"", pi.http_server_port);
-        strcat(cmd, buf);
-    }
-    if (strlen(pi.http_user_name)) {
-        snprintf(buf, sizeof(buf), " -e HTTP_USER_NAME=\"%s\"", pi.http_user_name);
-        strcat(cmd, buf);
-    }
-    if (strlen(pi.http_user_passwd)) {
-        snprintf(buf, sizeof(buf), " -e HTTP_USER_PASSWD=\"%s\"", pi.http_user_passwd);
-        strcat(cmd, buf);
-    }
-    if (strlen(pi.socks_server_name)) {
-        snprintf(buf, sizeof(buf), " -e SOCKS_SERVER_NAME=\"%s\"", pi.socks_server_name);
-        strcat(cmd, buf);
-    }
-    if (pi.socks_server_port) {
-        snprintf(buf, sizeof(buf), " -e SOCKS_SERVER_PORT=\"%d\"", pi.socks_server_port);
-        strcat(cmd, buf);
-    }
-    if (strlen(pi.socks5_user_name)) {
-        snprintf(buf, sizeof(buf), " -e SOCKS_USER_NAME=\"%s\"", pi.socks5_user_name);
-        strcat(cmd, buf);
-    }
-    if (strlen(pi.socks5_user_passwd)) {
-        snprintf(buf, sizeof(buf), " -e SOCKS_USER_PASSWD=\"%s\"", pi.socks5_user_passwd);
-        strcat(cmd, buf);
-    }
-    if (pi.socks5_remote_dns) {
-        snprintf(buf, sizeof(buf), " -e SOCKS_REMOTE_DNS=\"yes\"");
-        strcat(cmd, buf);
-    }
 
     // add mounts and portmaps
     //
@@ -1015,6 +975,62 @@ void init_signal_handler() {
 }
 #endif
 
+// create env vars for proxy info.
+// These will
+// - be used by Podman in downloading image files
+// - be copied (by Podman) into the containers it creates
+//
+// NOTE: BOINC doesn't currently let you say whether
+// the client/proxy connection is SSL.
+// So we'll assume that it's not.
+//
+// examples
+//
+// protocol://username:password@hostname:port
+// http_proxy=http://192.168.1.100:8080
+// https_proxy=http://192.168.1.100:8080
+// http_proxy=https://192.168.1.100:8080 (we won't use this, see above)
+// http_proxy=socks5://127.0.0.1:1080
+// http_proxy=socks5h://127.0.0.1:1080 (if DNS is handled by SOCKS server)
+// https_proxy=socks5://127.0.0.1:1080
+// also (if noproxy_hosts is nonempty)
+// no_proxy="localhost,127.0.0.1"
+//
+void set_proxy_env_vars() {
+    char auth_buf[540], host_buf[600], value[2096];
+    PROXY_INFO &pi = aid.proxy_info;
+    if (strlen(pi.http_server_name)) {
+        sprintf(host_buf, "%s:%d", pi.http_server_name, pi.http_server_port);
+        if (strlen(pi.http_user_name)) {
+            sprintf(auth_buf, "%s:%s@", pi.http_user_name, pi.http_user_passwd);
+        } else {
+            auth_buf[0] = 0;
+        }
+        sprintf(value, "http://%s%s", auth_buf, host_buf);
+        setenv("http_proxy", value, 1);
+        setenv("https_proxy", value, 1);
+        setenv("HTTP_PROXY", value, 1);
+        setenv("HTTPS_PROXY", value, 1);
+    } else if (strlen(pi.socks_server_name)) {
+        sprintf(host_buf, "%s:%d", pi.socks_server_name, pi.socks_server_port);
+        if (strlen(pi.socks5_user_name)) {
+            sprintf(auth_buf, "%s:%s@", pi.socks5_user_name, pi.socks5_user_passwd);
+        } else {
+            auth_buf[0] = 0;
+        }
+        const char* protocol = pi.socks5_remote_dns?"socks5h":"socks5";
+        sprintf(value, "%s://%s%s", protocol, auth_buf, host_buf);
+        setenv("http_proxy", value, 1);
+        setenv("https_proxy", value, 1);
+        setenv("HTTP_PROXY", value, 1);
+        setenv("HTTPS_PROXY", value, 1);
+    }
+    if (strlen(pi.noproxy_hosts)) {
+        setenv("no_proxy", pi.noproxy_hosts, 1);
+        setenv("NO_PROXY", pi.noproxy_hosts, 1);
+    }
+}
+
 int main(int argc, char** argv) {
     BOINC_OPTIONS options;
     int retval;
@@ -1060,6 +1076,8 @@ int main(int argc, char** argv) {
         strcpy(image_name, "boinc");
         strcpy(container_name, "boinc");
         project_dir = "project";
+        boinc_parse_init_data_file();
+        boinc_get_init_data(aid);
         aid.ncpus = 1;
         aid.wu_cpu_time = 0;
     } else {
@@ -1069,6 +1087,10 @@ int main(int argc, char** argv) {
         get_container_name();
         cpu_time = aid.wu_cpu_time;
     }
+
+    // set env vars based on HTTP proxy info from client
+    //
+    set_proxy_env_vars();
 
     if (config.verbose) {
         config.print();

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -130,6 +130,16 @@ struct RSC_USAGE {
     }
 };
 
+struct ENV_VAR {
+    string name;
+    string value;
+
+    ENV_VAR(const char* n, const char* v) {
+        name = n;
+        value = v;
+    }
+};
+
 // verbosity levels
 #define VERBOSE_NONE    0
 #define VERBOSE_STD     1
@@ -206,6 +216,7 @@ vector<string> app_args;
 DOCKER_TYPE docker_type;
 string wsl_distro_name;
 double cpu_time = 0;
+vector<ENV_VAR> env_vars;
 
 inline bool verbose_std() {
     return config.verbose >= VERBOSE_STD;
@@ -618,6 +629,14 @@ int create_container() {
         strcat(cmd, "\"");
     }
 
+    // pass proxy env vars to container
+    // (Docker only; Podman does it automatically)
+    //
+    for (ENV_VAR e: env_vars) {
+        snprintf(buf, sizeof(buf), " -e %s=%s", e.name.c_str(), e.value.c_str());
+        strcat(cmd, buf);
+    }
+
     // add mounts and portmaps
     //
     for (string s: config.mounts) {
@@ -975,6 +994,16 @@ void init_signal_handler() {
 }
 #endif
 
+// set an env var in our context;
+// if we're using Docker, make a copy to pass to containers
+//
+void set_env_var(const char* name, const char* value) {
+    setenv(name, value, 1);
+    if (docker_type == DOCKER) {
+        env_vars.push_back(ENV_VAR(name, value));
+    }
+}
+
 // create env vars for proxy info.
 // These will
 // - be used by Podman in downloading image files
@@ -1007,10 +1036,10 @@ void set_proxy_env_vars() {
             auth_buf[0] = 0;
         }
         sprintf(value, "http://%s%s", auth_buf, host_buf);
-        setenv("http_proxy", value, 1);
-        setenv("https_proxy", value, 1);
-        setenv("HTTP_PROXY", value, 1);
-        setenv("HTTPS_PROXY", value, 1);
+        set_env_var("http_proxy", value);
+        set_env_var("https_proxy", value);
+        set_env_var("HTTP_PROXY", value);
+        set_env_var("HTTPS_PROXY", value);
     } else if (strlen(pi.socks_server_name)) {
         sprintf(host_buf, "%s:%d", pi.socks_server_name, pi.socks_server_port);
         if (strlen(pi.socks5_user_name)) {
@@ -1020,14 +1049,14 @@ void set_proxy_env_vars() {
         }
         const char* protocol = pi.socks5_remote_dns?"socks5h":"socks5";
         sprintf(value, "%s://%s%s", protocol, auth_buf, host_buf);
-        setenv("http_proxy", value, 1);
-        setenv("https_proxy", value, 1);
-        setenv("HTTP_PROXY", value, 1);
-        setenv("HTTPS_PROXY", value, 1);
+        set_env_var("http_proxy", value);
+        set_env_var("https_proxy", value);
+        set_env_var("HTTP_PROXY", value);
+        set_env_var("HTTPS_PROXY", value);
     }
     if (strlen(pi.noproxy_hosts)) {
-        setenv("no_proxy", pi.noproxy_hosts, 1);
-        setenv("NO_PROXY", pi.noproxy_hosts, 1);
+        set_env_var("no_proxy", pi.noproxy_hosts);
+        set_env_var("NO_PROXY", pi.noproxy_hosts);
     }
 }
 
@@ -1088,10 +1117,6 @@ int main(int argc, char** argv) {
         cpu_time = aid.wu_cpu_time;
     }
 
-    // set env vars based on HTTP proxy info from client
-    //
-    set_proxy_env_vars();
-
     if (config.verbose) {
         config.print();
     }
@@ -1130,6 +1155,12 @@ int main(int argc, char** argv) {
         }
         docker_type = aid.host_info.docker_type;
     }
+
+    // set env vars based on HTTP proxy info from client
+    // must call after docker_type is set
+    //
+    set_proxy_env_vars();
+
     retval = docker_conn.init(docker_type);
     if (retval) {
         fprintf(stderr, "docker_conn.init() failed: %d\n", retval);

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -1057,7 +1057,7 @@ void set_proxy_env_vars() {
         sprintf(value, "http://%s%s", auth_buf, host_buf);
         set_env_var("http_proxy", value);
         set_env_var("https_proxy", value);
-        set_env_var("HTTP_PROXY", value);
+        //set_env_var("HTTP_PROXY", value);
         set_env_var("HTTPS_PROXY", value);
     } else if (strlen(pi.socks_server_name)) {
         sprintf(host_buf, "%s:%d", pi.socks_server_name, pi.socks_server_port);
@@ -1070,7 +1070,7 @@ void set_proxy_env_vars() {
         sprintf(value, "%s://%s%s", protocol, auth_buf, host_buf);
         set_env_var("http_proxy", value);
         set_env_var("https_proxy", value);
-        set_env_var("HTTP_PROXY", value);
+        //set_env_var("HTTP_PROXY", value);
         set_env_var("HTTPS_PROXY", value);
     }
     if (strlen(pi.noproxy_hosts)) {

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -994,11 +994,24 @@ void init_signal_handler() {
 }
 #endif
 
-// set an env var in our context;
-// if we're using Docker, make a copy to pass to containers
+// set a proxy-related env var;
+// in Win we set this in our WSL instance with an 'export' command.
+// in Mac/Unix we set it in our own environment.
+// Podman or Docker will see this and use the proxy to fetch stuff.
+// We also want the var to be visible inside the container.
+// With Podman this happens automatically.
+// With Docker, we need to do it with -e args to the 'create' command,
+// so put them in the 'env_vars' vector.
 //
 void set_env_var(const char* name, const char* value) {
+#ifdef _WIN32
+    vector<string> out;
+    char buf[256];
+    sprintf(buf, "export %s=\"%s\"", name, value);
+    docker_conn.shell_command(buf, out, verbose_std());
+#else
     setenv(name, value, 1);
+#endif
     if (docker_type == DOCKER) {
         env_vars.push_back(ENV_VAR(name, value));
     }

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -633,7 +633,13 @@ int create_container() {
     // (Docker only; Podman does it automatically)
     //
     for (ENV_VAR e: env_vars) {
-        snprintf(buf, sizeof(buf), " -e %s=%s", e.name.c_str(), e.value.c_str());
+        const char *v = e.value.c_str();
+        // not sure it makes any difference, but check (user-supplied) value
+        if (strchr(v, '\'')) {
+            fprintf(stderr, "bad env var value %s\n", v);
+            continue;
+        }
+        snprintf(buf, sizeof(buf), " -e %s='%s'", e.name.c_str(), v);
         strcat(cmd, buf);
     }
 


### PR DESCRIPTION
see https://github.com/BOINC/boinc/wiki/Docker-apps#proxy-information

Fixes #7118

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the BOINC client’s HTTP/SOCKS proxy settings to containers via standard proxy env vars. Works with Podman and Docker; on Windows (WSL) we export vars; sanitizes values and skips `HTTP_PROXY` per curl.

- **New Features**
  - Sets `http_proxy`/`https_proxy`/`no_proxy` and uppercase `HTTPS_PROXY`/`NO_PROXY` from client config; supports SOCKS5/SOCKS5H; passes vars into Docker with `-e`; exports in WSL via `shell_command`.

- **Bug Fixes**
  - Sanitizes proxy env var values to block Docker command injection; fixes missing return in Windows shell command.

<sup>Written for commit 896296ed092ac6116a6e1506891722403553e944. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

