### PR TITLE
[linux] Fix crash during client startup

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -495,7 +495,7 @@ static void set_client_priority() {
 int CLIENT_STATE::init() {
     int retval;
     unsigned int i;
-    char buf[256];
+    char buf[MAXPATHLEN];
 
     srand((unsigned int)time(0));
     now = dtime();


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a client startup crash on Linux by using MAXPATHLEN for the path buffer in CLIENT_STATE::init. Prevents overflow when paths exceed 256 bytes.

<sup>Written for commit a435311d15d49f9093bf9fa756fb0cff987738b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

