### PR TITLE
[windows] Add boinc-buda-runner-wsl-installer to the installer

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -223,29 +223,29 @@ jobs:
           - platform: arm64
             runner: windows-11-arm
           - installation_type: normal
-            argument_list_alpha: "/quiet /qn /l*v alpha.log"
-            argument_list_release: "/quiet /qn /l*v release.log"
-            argument_list_install: "/quiet /qn /l*v install.log"
+            argument_list_alpha: "/quiet /qn /l*v alpha.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
+            argument_list_release: "/quiet /qn /l*v release.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
+            argument_list_install: "/quiet /qn /l*v install.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
             argument_list_prepare: ""
           - installation_type: service
-            argument_list_alpha: "/quiet /qn /norestart /l*v alpha.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
-            argument_list_release: "/quiet /qn /norestart /l*v release.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
-            argument_list_install: "/quiet /qn /norestart /l*v install.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_alpha: "/quiet /qn /norestart /l*v alpha.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_release: "/quiet /qn /norestart /l*v release.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_install: "/quiet /qn /norestart /l*v install.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
             argument_list_prepare: ""
           - installation_type: test_acct_mgr_login
-            argument_list_alpha: "/quiet /qn /l*v alpha.log"
-            argument_list_release: "/quiet /qn /l*v release.log"
-            argument_list_install: "/quiet /qn /l*v install.log ACCTMGR_LOGIN=test ACCTMGR_PASSWORDHASH=0123456789abcdef"
+            argument_list_alpha: "/quiet /qn /l*v alpha.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
+            argument_list_release: "/quiet /qn /l*v release.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
+            argument_list_install: "/quiet /qn /l*v install.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 ACCTMGR_LOGIN=test ACCTMGR_PASSWORDHASH=0123456789abcdef"
             argument_list_prepare: ""
           - installation_type: test_client_auth_file
-            argument_list_alpha: "/quiet /qn /norestart /l*v alpha.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
-            argument_list_release: "/quiet /qn /norestart /l*v release.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
-            argument_list_install: "/quiet /qn /norestart /l*v install.log ENABLEPROTECTEDAPPLICATIONEXECUTION3=1 BOINC_PROJECT_USERNAME=test_user BOINC_PROJECT_PASSWORD=qwerty123456!@#$%^"
+            argument_list_alpha: "/quiet /qn /norestart /l*v alpha.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_release: "/quiet /qn /norestart /l*v release.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 ENABLEPROTECTEDAPPLICATIONEXECUTION3=1"
+            argument_list_install: "/quiet /qn /norestart /l*v install.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 ENABLEPROTECTEDAPPLICATIONEXECUTION3=1 BOINC_PROJECT_USERNAME=test_user BOINC_PROJECT_PASSWORD=qwerty123456!@#$%^"
             argument_list_prepare: '--create-user --username test_user --password "qwerty123456!@#$%^"'
           - installation_type: test_proj_init_file
-            argument_list_alpha: "/quiet /qn /l*v alpha.log"
-            argument_list_release: "/quiet /qn /l*v release.log"
-            argument_list_install: "/quiet /qn /l*v install.log PROJINIT_URL=https://test.com PROJINIT_NAME=test PROJINIT_AUTH=abcdef1234567890"
+            argument_list_alpha: "/quiet /qn /l*v alpha.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
+            argument_list_release: "/quiet /qn /l*v release.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
+            argument_list_install: "/quiet /qn /l*v install.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0 PROJINIT_URL=https://test.com PROJINIT_NAME=test PROJINIT_AUTH=abcdef1234567890"
             argument_list_prepare: ""
       fail-fast: false
     steps:

--- a/clientsetup/win/CACheckWSLSupport.cpp
+++ b/clientsetup/win/CACheckWSLSupport.cpp
@@ -1,0 +1,84 @@
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "boinccas.h"
+
+typedef VOID(WINAPI* RtlGetNtVersionNumbersPtr)(LPDWORD lpMajorVersion,
+    LPDWORD lpMinorVersion, LPDWORD lpBuildNumber);
+
+class CACheckWSLSupport : public BOINCCABase {
+public:
+    virtual ~CACheckWSLSupport() = default;
+    explicit CACheckWSLSupport(MSIHANDLE hMSIHandle) :
+        BOINCCABase(hMSIHandle, _T("CACheckWSLSupport"),
+            _T("Check WSL Support")) {}
+private:
+    UINT OnExecution() override final {
+        auto hNTDllLib = GetModuleHandle(_T("ntdll.dll"));
+        if (hNTDllLib == nullptr) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        auto rtlGetVersionNumbers =
+            reinterpret_cast<RtlGetNtVersionNumbersPtr>(
+            GetProcAddress(hNTDllLib, "RtlGetNtVersionNumbers"));
+
+        if (!rtlGetVersionNumbers) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        DWORD major, minor, build;
+        rtlGetVersionNumbers(&major, &minor, &build);
+        DWORD buildNumber = build & 0xFFFF;
+
+        // WSL is supported on Windows 10 version 2004 (build 19041) and later
+        // or version 1903 (build 18362) and later.
+        // Windows 11 is fully supported (major version 10 build 22000).
+
+        auto isWSLSupported = false;
+        if (major > 10 || (major == 10 && buildNumber >= 18362)) {
+            isWSLSupported = true;
+        }
+
+        if (isWSLSupported) {
+            SetProperty(_T("INSTALLWSLIMAGEINSTALLER"), _T("1"));
+            tstring strLaunchBOINCWslImageInstaller;
+            const auto returnValue = GetProperty(_T("LAUNCHWSLIMAGEINSTALLER"),
+                strLaunchBOINCWslImageInstaller);
+            if (returnValue) {
+                return returnValue;
+            }
+            if (!strLaunchBOINCWslImageInstaller.empty() &&
+                strLaunchBOINCWslImageInstaller != _T("1")) {
+                SetProperty(_T("LAUNCHWSLIMAGEINSTALLER"), _T(""));
+            }
+            else {
+                SetProperty(_T("LAUNCHWSLIMAGEINSTALLER"), _T("1"));
+            }
+        }
+        else {
+            SetProperty(_T("INSTALLWSLIMAGEINSTALLER"), _T(""));
+            SetProperty(_T("LAUNCHWSLIMAGEINSTALLER"), _T(""));
+        }
+
+        return ERROR_SUCCESS;
+    }
+};
+
+UINT __stdcall CheckWSLSupport(MSIHANDLE hInstall) {
+    return CACheckWSLSupport(hInstall).Execute();
+}

--- a/clientsetup/win/CACleanupOldBinaries.cpp
+++ b/clientsetup/win/CACleanupOldBinaries.cpp
@@ -39,7 +39,7 @@ private:
             return ERROR_INSTALL_FAILURE;
         }
 
-        constexpr std::array<std::wstring_view, 12> filesToDelete = {
+        constexpr std::array<std::wstring_view, 13> filesToDelete = {
             _T("boinc.exe"),
             _T("boincmgr.exe"),
             _T("boinccmd.exe"),
@@ -51,7 +51,8 @@ private:
             _T("dbghelp.dll"),
             _T("dbghelp95.dll"),
             _T("srcsrv.dll"),
-            _T("symsrv.dll")
+            _T("symsrv.dll"),
+            _T("boinc-buda-runner-wsl-installer.exe")
         };
 
         for (auto file : filesToDelete) {

--- a/clientsetup/win/CALaunchBOINCWSLInstaller.cpp
+++ b/clientsetup/win/CALaunchBOINCWSLInstaller.cpp
@@ -1,0 +1,123 @@
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "boinccas.h"
+#include <openssl/evp.h>
+#include "win_util.h"
+
+class CALaunchBOINCWSLInstaller : public BOINCCABase {
+public:
+    virtual ~CALaunchBOINCWSLInstaller() = default;
+    explicit CALaunchBOINCWSLInstaller(MSIHANDLE hMSIHandle) :
+        BOINCCABase(hMSIHandle, _T("CALaunchBOINCWSLInstaller"),
+            _T("Launching BOINC WSL Installer")) {
+    }
+private:
+    UINT OnExecution() override final {
+        tstring strInstallDirectory;
+
+        auto uiReturnValue =
+            GetProperty(_T("INSTALLDIR"), strInstallDirectory);
+        if (uiReturnValue != ERROR_SUCCESS) {
+            return uiReturnValue;
+        }
+        if (strInstallDirectory.empty()) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        auto strBuffer = strInstallDirectory +
+            tstring(_T("\\boinc-buda-runner-wsl-installer.exe"));
+
+        tstring strCheckSum;
+        uiReturnValue =
+            GetProperty(_T("boinc_buda_runner_wsl_installer_checksum"),
+            strCheckSum);
+        if (uiReturnValue != ERROR_SUCCESS) {
+            return uiReturnValue;
+        }
+        if (strCheckSum.empty()) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        //verify the installer executable's checksum before launching it
+        std::ifstream file(strBuffer, std::ios::binary);
+        if (!file.is_open()) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(
+            EVP_MD_CTX_new(), EVP_MD_CTX_free);
+        if (!ctx) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        if (EVP_DigestInit_ex(ctx.get(), EVP_sha256(), nullptr) != 1) {
+            return ERROR_INSTALL_FAILURE;
+        }
+        constexpr auto bufferSize = 8192u;
+        std::array<char, bufferSize> buffer;
+        while (file.read(buffer.data(), bufferSize)) {
+            if (EVP_DigestUpdate(ctx.get(), buffer.data(),
+                file.gcount()) != 1) {
+                return ERROR_INSTALL_FAILURE;
+            }
+        }
+        if (EVP_DigestUpdate(ctx.get(), buffer.data(), file.gcount()) != 1) {
+            return ERROR_INSTALL_FAILURE;
+        }
+        std::array<unsigned char, EVP_MAX_MD_SIZE> hash;
+        unsigned int hashSize = 0;
+        if (EVP_DigestFinal_ex(ctx.get(), hash.data(), &hashSize) != 1) {
+            return ERROR_INSTALL_FAILURE;
+        }
+        std::ostringstream hashStringStream;
+        for (size_t i = 0; i < hashSize; ++i) {
+            hashStringStream << std::hex << std::setw(2) << std::setfill('0')
+                << std::nouppercase << static_cast<int>(hash[i]);
+        }
+        auto calculatedHash = _T("sha256:") +
+            boinc_ascii_to_wide(hashStringStream.str());
+
+        if (calculatedHash != strCheckSum) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        // Surround the installer path with quotes in case there are spaces in the path
+        strBuffer = tstring(_T("\"")) + strBuffer + tstring(_T("\""));
+        PROCESS_INFORMATION ProcInfo = { 0 };
+        STARTUPINFO StartupInfo = { 0 };
+        // create process with the elevated permissions
+        // inherited from the installer process
+        if (!CreateProcess(nullptr, const_cast<wchar_t*>(strBuffer.data()),
+            nullptr, nullptr, FALSE, 0, nullptr, nullptr, &StartupInfo,
+            &ProcInfo)) {
+            return ERROR_INSTALL_FAILURE;
+        }
+
+        // Wait until the installer process exits before returning from this custom action
+        WaitForSingleObject(ProcInfo.hProcess, INFINITE);
+
+        CloseHandle(ProcInfo.hThread);
+        CloseHandle(ProcInfo.hProcess);
+
+        return ERROR_SUCCESS;
+    }
+};
+
+UINT __stdcall LaunchBOINCWSLInstaller(MSIHANDLE hInstall) {
+    return CALaunchBOINCWSLInstaller(hInstall).Execute();
+}

--- a/clientsetup/win/CARestoreExecutionState.cpp
+++ b/clientsetup/win/CARestoreExecutionState.cpp
@@ -56,6 +56,12 @@ private:
         SetProperty(_T("BOINC_PROJECT_USERNAME"),
             strBOINCProjectAccountUsername);
 
+        tstring strLaunchBOINCWslImageInstaller;
+        GetRegistryValue(_T("LAUNCHWSLIMAGEINSTALLER"),
+            strLaunchBOINCWslImageInstaller);
+        SetProperty(_T("LAUNCHWSLIMAGEINSTALLER"),
+            strLaunchBOINCWslImageInstaller);
+
         return ERROR_SUCCESS;
     }
 };

--- a/clientsetup/win/CARestoreSetupState.cpp
+++ b/clientsetup/win/CARestoreSetupState.cpp
@@ -70,6 +70,26 @@ private:
                 }
             }
 
+            tstring strOverrideLaunchWSLImageInstaller;
+            GetProperty(_T("OVERRIDE_LAUNCHWSLIMAGEINSTALLER"),
+                strOverrideLaunchWSLImageInstaller);
+            if (!strOverrideLaunchWSLImageInstaller.empty()) {
+                SetProperty(_T("LAUNCHWSLIMAGEINSTALLER"),
+                    strOverrideLaunchWSLImageInstaller);
+            }
+            else {
+                tstring strLaunchWSLImageInstaller;
+                GetRegistryValue(_T("LAUNCHWSLIMAGEINSTALLER"),
+                    strLaunchWSLImageInstaller);
+                if (strLaunchWSLImageInstaller == _T("1") ||
+                    strLaunchWSLImageInstaller.empty()) {
+                    SetProperty(_T("LAUNCHWSLIMAGEINSTALLER"), _T("1"));
+                }
+                else {
+                    SetProperty(_T("LAUNCHWSLIMAGEINSTALLER"), _T(""));
+                }
+            }
+
             tstring strOverrideBOINCMasterAccountUsername;
             GetProperty(_T("OVERRIDE_BOINC_MASTER_USERNAME"),
                 strOverrideBOINCMasterAccountUsername);

--- a/clientsetup/win/CASaveExecutionState.cpp
+++ b/clientsetup/win/CASaveExecutionState.cpp
@@ -61,6 +61,12 @@ private:
             SetRegistryValue(_T("LAUNCHPROGRAM"), _T(""));
         }
 
+        tstring strLaunchBOINCWslImageInstaller;
+        GetProperty(_T("LAUNCHWSLIMAGEINSTALLER"),
+            strLaunchBOINCWslImageInstaller);
+        SetRegistryValue(_T("LAUNCHWSLIMAGEINSTALLER"),
+            strLaunchBOINCWslImageInstaller);
+
         return ERROR_SUCCESS;
     }
 };

--- a/clientsetup/win/CASaveSetupState.cpp
+++ b/clientsetup/win/CASaveSetupState.cpp
@@ -43,6 +43,16 @@ private:
             SetRegistryValue(_T("LAUNCHPROGRAM"), _T("0"));
         }
 
+        tstring strLaunchBOINCWslImageInstaller;
+        GetProperty(_T("LAUNCHWSLIMAGEINSTALLER"),
+            strLaunchBOINCWslImageInstaller);
+        if (_T("1") == strLaunchBOINCWslImageInstaller) {
+            SetRegistryValue(_T("LAUNCHWSLIMAGEINSTALLER"), _T("1"));
+        }
+        else {
+            SetRegistryValue(_T("LAUNCHWSLIMAGEINSTALLER"), _T("0"));
+        }
+
         tstring strBOINCMasterAccountUsername;
         GetProperty(_T("BOINC_MASTER_USERNAME"),
             strBOINCMasterAccountUsername);

--- a/clientsetup/win/boinccas.def
+++ b/clientsetup/win/boinccas.def
@@ -46,3 +46,5 @@ EXPORTS
 	DeleteBOINCGroups
 	DeleteBOINCAccounts
 	AnnounceUpgrade
+	LaunchBOINCWSLInstaller
+	CheckWSLSupport

--- a/installer/FileTable.cpp
+++ b/installer/FileTable.cpp
@@ -193,6 +193,9 @@ FileTable::FileTable(const std::vector<Directory>& directories,
                     file.getFilepath().string());
                 if (!version.empty()) {
                     file.setVersion(version);
+                    if (language == 0) {
+                        file.setLanguage("1033");
+                    }
                 }
                 file.setFilesize(static_cast<int>(
                     GetFileSize(file.getFilepath().string())));

--- a/installer/include/Checkbox.json
+++ b/installer/include/Checkbox.json
@@ -15,6 +15,10 @@
         {
             "Property": "LAUNCHPROGRAM",
             "Value": "1"
+        },
+        {
+            "Property": "LAUNCHWSLIMAGEINSTALLER",
+            "Value": "1"
         }
     ]
 }

--- a/installer/include/CustomAction.json
+++ b/installer/include/CustomAction.json
@@ -7,6 +7,12 @@
             "Target": "AnnounceUpgrade"
         },
         {
+            "Action": "CACheckWSLSupport",
+            "Type": 1,
+            "Source": "boinccas.dll",
+            "Target": "CheckWSLSupport"
+        },
+        {
             "Action": "CACleanupOldBinaries",
             "Type": 1,
             "Source": "boinccas.dll",
@@ -107,6 +113,12 @@
             "Type": 65,
             "Source": "boinccas.dll",
             "Target": "LaunchBOINCTray"
+        },
+        {
+            "Action": "CALaunchBOINCWSLInstaller",
+            "Type": 65,
+            "Source": "boinccas.dll",
+            "Target": "LaunchBOINCWSLInstaller"
         },
         {
             "Action": "CARestoreExecutionState",

--- a/installer/include/Directory.json
+++ b/installer/include/Directory.json
@@ -949,6 +949,17 @@
                                     ]
                                 },
                                 {
+                                    "Feature_": "BOINCWSLImageInstaller",
+                                    "Component": "_BOINCWSLImageInstaller",
+                                    "Attributes": 256,
+                                    "Condition": "INSTALLWSLIMAGEINSTALLER = 1",
+                                    "Files": [
+                                        {
+                                            "FilePath": "..\\win_build\\Build\\%%PLATFORM%%\\%%CONFIGURATION%%\\boinc-buda-runner-wsl-installer.exe"
+                                        }
+                                    ]
+                                },
+                                {
                                     "Feature_": "BOINC",
                                     "Component": "_BOINCSvcCtrl",
                                     "Attributes": 256,

--- a/installer/include/Feature.json
+++ b/installer/include/Feature.json
@@ -45,6 +45,15 @@
                     "Level": 1,
                     "Directory_": "INSTALLDIR",
                     "Attributes": 18
+                },
+                {
+                    "Feature": "BOINCWSLImageInstaller",
+                    "Title": "IDS_FEATURE_BOINC_WSL_IMAGE_INSTALLER_NAME",
+                    "Description": "IDS_FEATURE_BOINC_WSL_IMAGE_INSTALLER_DESCRIPTION",
+                    "Display": 1,
+                    "Level": 1,
+                    "Directory_": "INSTALLDIR",
+                    "Attributes": 2
                 }
             ]
         }

--- a/installer/include/InstallExecuteSequence.json
+++ b/installer/include/InstallExecuteSequence.json
@@ -29,6 +29,11 @@
             "Sequence": 6605
         },
         {
+            "Action": "CACheckWSLSupport",
+            "Condition": "REMOVE <> \"ALL\"",
+            "Sequence": 990
+        },
+        {
             "Action": "CACreateBOINCAccounts",
             "Condition": "REMOVE <> \"ALL\" AND ENABLEPROTECTEDAPPLICATIONEXECUTION3 = 1",
             "Sequence": 1546

--- a/installer/include/Property.json
+++ b/installer/include/Property.json
@@ -61,8 +61,16 @@
             "Value": "100"
         },
         {
+            "Property": "INSTALLWSLIMAGEINSTALLER",
+            "Value": "1"
+        },
+        {
             "Property": "InstallChoice",
             "Value": "AR"
+        },
+        {
+            "Property": "LAUNCHWSLIMAGEINSTALLER",
+            "Value": "1"
         },
         {
             "Property": "LAUNCHPROGRAM",
@@ -150,7 +158,7 @@
         },
         {
             "Property": "SecureCustomProperties",
-            "Value": "ACTPROP_E913E54D_5080_42EC_A312_B21948BA1C02;INSTALLDIR;ENABLEPROTECTEDAPPLICATIONEXECUTION3;LAUNCHPROGRAM;ISACTIONPROP1;ISACTIONPROP2"
+            "Value": "ACTPROP_E913E54D_5080_42EC_A312_B21948BA1C02;INSTALLDIR;ENABLEPROTECTEDAPPLICATIONEXECUTION3;LAUNCHPROGRAM;ISACTIONPROP1;ISACTIONPROP2;LAUNCHWSLIMAGEINSTALLER"
         },
         {
             "Property": "UpgradeCode",
@@ -167,6 +175,10 @@
         {
             "Property": "_IsMaintenance",
             "Value": "Reinstall"
+        },
+        {
+            "Property": "boinc_buda_runner_wsl_installer_checksum",
+            "Value": "sha256:ca7497a4695c91de15d952642950ce8f8d15d45cf2167702ed061217125dd066"
         }
     ]
 }

--- a/installer/include/dialog/SetupCompleteSuccess.json
+++ b/installer/include/dialog/SetupCompleteSuccess.json
@@ -58,7 +58,7 @@
             "X": 151,
             "Y": 114,
             "Width": 10,
-            "Height": 9,
+            "Height": 13,
             "Attributes": 2,
             "Property": "LAUNCHPROGRAM",
             "Control_Next": "LaunchProgramText",
@@ -75,15 +75,50 @@
             "X": 165,
             "Y": 114,
             "Width": 198,
-            "Height": 15,
+            "Height": 13,
             "Attributes": 65538,
             "Property": "NewProperty1",
             "Text": "IDS_NEW_STRING2",
-            "Control_Next": "OK",
+            "Control_Next": "LaunchWSLImageInstallerCheck",
             "Conditions": [
                 {
                     "Action": "Show",
                     "Condition": "PROGRAMFILETOLAUNCHATEND <> \"\" And ACTION <> \"ADMIN\" And RETURN_VALIDATEINSTALL = \"1\" And RETURN_REBOOTREQUESTED = \"0\" And NOT Installed"
+                }
+            ]
+        },
+        {
+            "Control": "LaunchWSLImageInstallerCheck",
+            "Type": "CheckBox",
+            "X": 151,
+            "Y": 132,
+            "Width": 10,
+            "Height": 13,
+            "Attributes": 2,
+            "Property": "LAUNCHWSLIMAGEINSTALLER",
+            "Control_Next": "LaunchWSLImageInstallerText",
+            "Conditions": [
+                {
+                    "Action": "Show",
+                    "Condition": "INSTALLWSLIMAGEINSTALLER And ACTION = \"INSTALL\" And RETURN_VALIDATEINSTALL = \"1\" And RETURN_REBOOTREQUESTED = \"0\" And NOT Installed"
+                }
+            ]
+        },
+        {
+            "Control": "LaunchWSLImageInstallerText",
+            "Type": "Text",
+            "X": 165,
+            "Y": 132,
+            "Width": 198,
+            "Height": 13,
+            "Attributes": 65538,
+            "Property": "NewProperty2",
+            "Text": "IDS_NEW_STRING3",
+            "Control_Next": "OK",
+            "Conditions": [
+                {
+                    "Action": "Show",
+                    "Condition": "INSTALLWSLIMAGEINSTALLER And ACTION = \"INSTALL\" And RETURN_VALIDATEINSTALL = \"1\" And RETURN_REBOOTREQUESTED = \"0\" And NOT Installed"
                 }
             ]
         },
@@ -117,10 +152,16 @@
                     "Ordering": 2
                 },
                 {
+                    "Event": "DoAction",
+                    "Argument": "CALaunchBOINCWSLInstaller",
+                    "Condition": "INSTALLWSLIMAGEINSTALLER And LAUNCHWSLIMAGEINSTALLER And (ACTION <> \"ADMIN\")",
+                    "Ordering": 3
+                },
+                {
                     "Event": "EndDialog",
                     "Argument": "Exit",
                     "Condition": "1",
-                    "Ordering": 2
+                    "Ordering": 4
                 }
             ]
         },

--- a/installer/locale/en.json
+++ b/installer/locale/en.json
@@ -2872,6 +2872,14 @@
         "Value": "BOINC Screensaver"
     },
     {
+        "Id": "IDS_FEATURE_BOINC_WSL_IMAGE_INSTALLER_DESCRIPTION",
+        "Value": "The BOINC WSL Image Installer"
+    },
+    {
+        "Id": "IDS_FEATURE_BOINC_WSL_IMAGE_INSTALLER_NAME",
+        "Value": "BOINC WSL Image Installer"
+    },
+    {
         "Id": "IDS_NEXT",
         "Value": "&Next >"
     },
@@ -3457,7 +3465,7 @@
     },
     {
         "Id": "IDS_STRING39",
-        "Value": "[ProductName] requires that your computer is running Windows XP or newer."
+        "Value": "[ProductName] requires that your computer is running Windows Vista or newer."
     },
     {
         "Id": "IDS_STRING4",
@@ -3494,6 +3502,10 @@
     {
         "Id": "IDS_NEW_STRING2",
         "Value": "Launch the BOINC Manager"
+    },
+    {
+        "Id": "IDS_NEW_STRING3",
+        "Value": "Launch the installation of the BOINC WSL Distro"
     },
     {
         "Id": "IDS_NEW_STRING27",

--- a/tests/unit-tests/boinccas/test_boinccas_CACheckWSLSupport.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CACheckWSLSupport.cpp
@@ -1,0 +1,69 @@
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "boinccas_helper.h"
+
+namespace test_boinccas {
+    class test_boinccas_CACheckWSLSupport :
+        public test_boinccas_TestBase {
+    protected:
+        test_boinccas_CACheckWSLSupport() :
+            test_boinccas_TestBase("CheckWSLSupport") {}
+    };
+
+#ifdef BOINCCAS_TEST
+    TEST_F(test_boinccas_CACheckWSLSupport,
+        CheckDefaultValues) {
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+
+        EXPECT_EQ(0u, executeAction());
+
+        auto [errorcode, returnValue] =
+            getMsiProperty("INSTALLWSLIMAGEINSTALLER");
+        ASSERT_EQ(0u, errorcode);
+        EXPECT_EQ("1", returnValue);
+
+        std::tie(errorcode, returnValue) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        ASSERT_EQ(0u, errorcode);
+        EXPECT_EQ("1", returnValue);
+    }
+
+    TEST_F(test_boinccas_CACheckWSLSupport,
+        CheckValuesSet) {
+        insertMsiProperties({
+            {"INSTALLWSLIMAGEINSTALLER", "0"},
+            {"LAUNCHWSLIMAGEINSTALLER", "0"}
+            });
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+
+        EXPECT_EQ(0u, executeAction());
+
+        auto [errorcode, returnValue] =
+            getMsiProperty("INSTALLWSLIMAGEINSTALLER");
+        ASSERT_EQ(0u, errorcode);
+        EXPECT_EQ("1", returnValue);
+
+        std::tie(errorcode, returnValue) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        ASSERT_EQ(0u, errorcode);
+        EXPECT_TRUE(returnValue.empty());
+    }
+#endif
+}

--- a/tests/unit-tests/boinccas/test_boinccas_CACleanupOldBinaries.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CACleanupOldBinaries.cpp
@@ -49,6 +49,7 @@ namespace test_boinccas {
             createDummyFile(dirPath / "dbghelp95.dll");
             createDummyFile(dirPath / "srcsrv.dll");
             createDummyFile(dirPath / "symsrv.dll");
+            createDummyFile(dirPath / "boinc-buda-runner-wsl-installer.exe");
         }
 
         std::filesystem::path testDir;

--- a/tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCManager.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCManager.cpp
@@ -18,9 +18,10 @@
 #include "boinccas_helper.h"
 
 namespace test_boinccas {
-    constexpr auto executableName = "boincmgr.exe";
     class test_boinccas_CALaunchBOINCManager : public test_boinccas_TestBase {
     protected:
+        const std::string executableName = "boincmgr.exe";
+
         test_boinccas_CALaunchBOINCManager() :
             test_boinccas_TestBase("LaunchBOINCManager") {
         }

--- a/tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCTray.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCTray.cpp
@@ -18,9 +18,10 @@
 #include "boinccas_helper.h"
 
 namespace test_boinccas {
-    constexpr auto executableName = "boinctray.exe";
     class test_boinccas_CALaunchBOINCTray : public test_boinccas_TestBase {
     protected:
+        const std::string executableName = "boinctray.exe";
+
         test_boinccas_CALaunchBOINCTray() :
             test_boinccas_TestBase("LaunchBOINCTray") {
         }

--- a/tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCWSLInstaller.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCWSLInstaller.cpp
@@ -1,0 +1,267 @@
+// This file is part of BOINC.
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
+//
+// BOINC is free software; you can redistribute it and/or modify it
+// under the terms of the GNU Lesser General Public License
+// as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+//
+// BOINC is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
+
+#include "boinccas_helper.h"
+#include <openssl/evp.h>
+#include <thread>
+
+namespace test_boinccas {
+    class test_boinccas_CALaunchBOINCWSLInstaller :
+        public test_boinccas_TestBase {
+    protected:
+        const std::string executableName =
+            "boinc-buda-runner-wsl-installer.exe";
+
+        test_boinccas_CALaunchBOINCWSLInstaller() :
+            test_boinccas_TestBase("LaunchBOINCWSLInstaller") {}
+
+        void TearDown() override {
+            const auto processId = findProcessByName(executableName);
+            if (processId != 0) {
+                EXPECT_TRUE(killProcessById(processId));
+            }
+            for (auto i = 0u; i < 5u; ++i) {
+                if (!isProcessRunning(executableName)) {
+                    break;
+                }
+                Sleep(1000);
+            }
+            if (!testDir.empty() && std::filesystem::exists(testDir)) {
+                std::filesystem::remove_all(testDir);
+            }
+        }
+
+        DWORD findProcessByName(const std::string& processName) {
+            const auto snapshot =
+                CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+            if (snapshot == INVALID_HANDLE_VALUE) {
+                return 0;
+            }
+            wil::unique_handle snapshotHandle(snapshot);
+
+            PROCESSENTRY32 processEntry;
+            processEntry.dwSize = sizeof(PROCESSENTRY32);
+            if (!Process32First(snapshot, &processEntry)) {
+                return 0;
+            }
+            do {
+                if (processName == processEntry.szExeFile) {
+                    return processEntry.th32ProcessID;
+                }
+            } while (Process32Next(snapshot, &processEntry));
+            return 0;
+        }
+
+        bool isProcessRunning(const std::string& processName) {
+            return findProcessByName(processName) != 0;
+        }
+
+        bool killProcessById(DWORD processId) {
+            const auto processHandle =
+                OpenProcess(PROCESS_TERMINATE, FALSE, processId);
+            if (!processHandle) {
+                return false;
+            }
+            wil::unique_handle processHandleWrapper(processHandle);
+            return TerminateProcess(processHandleWrapper.get(), 0) == TRUE;
+        }
+
+        std::string getFileHash(const std::filesystem::path& filePath) {
+            std::ifstream file(filePath, std::ios::binary);
+            if (!file) {
+                return {};
+            }
+
+            std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> ctx(
+                EVP_MD_CTX_new(), EVP_MD_CTX_free);
+            if (!ctx) {
+                return {};
+            }
+
+            if (EVP_DigestInit_ex(ctx.get(), EVP_sha256(), nullptr) != 1) {
+                return {};
+            }
+            constexpr auto bufferSize = 8192u;
+            std::array<char, bufferSize> buffer;
+            while (file.read(buffer.data(), bufferSize)) {
+                if (EVP_DigestUpdate(ctx.get(), buffer.data(),
+                    file.gcount()) != 1) {
+                    return {};
+                }
+            }
+            if (EVP_DigestUpdate(ctx.get(), buffer.data(),
+                file.gcount()) != 1) {
+                return {};
+            }
+            std::array<unsigned char, EVP_MAX_MD_SIZE> hash;
+            unsigned int hashSize = 0;
+            if (EVP_DigestFinal_ex(ctx.get(), hash.data(), &hashSize) != 1) {
+                return {};
+            }
+            std::ostringstream hashStringStream;
+            for (size_t i = 0; i < hashSize; ++i) {
+                hashStringStream << std::hex << std::setw(2)
+                    << std::setfill('0') << std::nouppercase
+                    << static_cast<int>(hash[i]);
+            }
+            return "sha256:" + hashStringStream.str();
+        }
+
+        std::filesystem::path testDir;
+    };
+
+#ifdef BOINCCAS_TEST
+    TEST_F(test_boinccas_CALaunchBOINCWSLInstaller,
+        Empty_INSTALLDIR_Property) {
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+
+        EXPECT_NE(0u, executeAction());
+    }
+
+    TEST_F(test_boinccas_CALaunchBOINCWSLInstaller,
+        NonExistent_INSTALLDIR_Directory) {
+        const auto dir =
+            std::filesystem::current_path() /= "non_existent_directory";
+        insertMsiProperties({
+            {"INSTALLDIR", dir.string()}
+            });
+
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+
+        EXPECT_NE(0u, executeAction());
+    }
+
+    TEST_F(test_boinccas_CALaunchBOINCWSLInstaller,
+        Empty_INSTALLDIR_Directory) {
+        testDir = std::filesystem::current_path() /= "empty";
+        std::filesystem::create_directory(testDir);
+        insertMsiProperties({
+            {"INSTALLDIR", testDir.string()}
+            });
+
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+
+        EXPECT_NE(0u, executeAction());
+    }
+
+    TEST_F(test_boinccas_CALaunchBOINCWSLInstaller,
+        NonEmpty_INSTALLDIR_Directory_No_Hash) {
+        testDir = std::filesystem::current_path() /= "non_empty";
+        std::filesystem::create_directory(testDir);
+
+        ASSERT_TRUE(std::filesystem::copy_file("unittest_dummy_gui.exe",
+            testDir / executableName));
+        auto executableFound = false;
+        for (auto i = 0u; i < 5u; ++i) {
+            executableFound =
+                std::filesystem::exists(testDir / executableName);
+            if (executableFound) {
+                break;
+            }
+            Sleep(1000);
+        }
+        ASSERT_TRUE(executableFound);
+
+        insertMsiProperties({
+            {"INSTALLDIR", testDir.string()}
+            });
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+        EXPECT_NE(0u, executeAction());
+    }
+
+    TEST_F(test_boinccas_CALaunchBOINCWSLInstaller,
+        NonEmpty_INSTALLDIR_Directory_Invalid_Hash) {
+        testDir = std::filesystem::current_path() /= "non_empty";
+        std::filesystem::create_directory(testDir);
+
+        ASSERT_TRUE(std::filesystem::copy_file("unittest_dummy_gui.exe",
+            testDir / executableName));
+        auto executableFound = false;
+        for (auto i = 0u; i < 5u; ++i) {
+            executableFound =
+                std::filesystem::exists(testDir / executableName);
+            if (executableFound) {
+                break;
+            }
+            Sleep(1000);
+        }
+        ASSERT_TRUE(executableFound);
+
+        insertMsiProperties({
+            {"INSTALLDIR", testDir.string()},
+            {"boinc_buda_runner_wsl_installer_checksum",
+            "invalid_checksum"}
+            });
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+        EXPECT_NE(0u, executeAction());
+    }
+
+    TEST_F(test_boinccas_CALaunchBOINCWSLInstaller,
+        NonEmpty_INSTALLDIR_Directory_ValidHash) {
+        testDir = std::filesystem::current_path() /= "non_empty";
+        std::filesystem::create_directory(testDir);
+
+        ASSERT_TRUE(std::filesystem::copy_file("unittest_dummy_gui.exe",
+            testDir / executableName));
+        auto executableFound = false;
+        for (auto i = 0u; i < 5u; ++i) {
+            executableFound =
+                std::filesystem::exists(testDir / executableName);
+            if (executableFound) {
+                break;
+            }
+            Sleep(1000);
+        }
+        ASSERT_TRUE(executableFound);
+
+        insertMsiProperties({
+            {"INSTALLDIR", testDir.string()},
+            {"boinc_buda_runner_wsl_installer_checksum",
+            getFileHash(testDir / executableName)}
+            });
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+
+        auto processFound = false;
+        auto terminatorThread = std::thread([this, &processFound]() {
+            for (auto i = 0u; i < 10u; ++i) {
+                const auto processId = findProcessByName(executableName);
+                if (processId != 0) {
+                    processFound = true;
+                    Sleep(100);
+                    killProcessById(processId);
+                    break;
+                }
+                Sleep(500);
+            }
+        });
+
+        EXPECT_EQ(0u, executeAction());
+        EXPECT_TRUE(processFound);
+
+        if (terminatorThread.joinable()) {
+            terminatorThread.join();
+        }
+    }
+
+#endif
+}

--- a/tests/unit-tests/boinccas/test_boinccas_CARestoreExecutionState.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CARestoreExecutionState.cpp
@@ -58,6 +58,10 @@ namespace test_boinccas {
         std::tie(errorcode, value) = getMsiProperty("BOINC_PROJECT_USERNAME");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
+
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
     }
 
     TEST_F(test_boinccas_CARestoreExecutionState,
@@ -88,6 +92,10 @@ namespace test_boinccas {
         std::tie(errorcode, value) = getMsiProperty("BOINC_PROJECT_USERNAME");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
+
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
     }
 
     TEST_F(test_boinccas_CARestoreExecutionState,
@@ -99,6 +107,7 @@ namespace test_boinccas {
             "RETURN_BOINC_MASTER_USERNAME", "test_master"));
         ASSERT_TRUE(setRegistryValue(
             "RETURN_BOINC_PROJECT_USERNAME", "test_project"));
+        ASSERT_TRUE(setRegistryValue("LAUNCHWSLIMAGEINSTALLER", "8"));
 
         const auto result = openMsi();
         ASSERT_EQ(0u, result);
@@ -124,6 +133,10 @@ namespace test_boinccas {
         std::tie(errorcode, value) = getMsiProperty("BOINC_PROJECT_USERNAME");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("test_project", value);
+
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("8", value);
     }
 #endif
 }

--- a/tests/unit-tests/boinccas/test_boinccas_CARestoreSetupState.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CARestoreSetupState.cpp
@@ -77,6 +77,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
             getMsiProperty("OVERRIDE_BOINC_MASTER_USERNAME");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
@@ -111,6 +115,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");
@@ -154,6 +162,7 @@ namespace test_boinccas {
         EXPECT_TRUE(getRegistryValue("INSTALLDIR").empty());
         EXPECT_TRUE(getRegistryValue("DATADIR").empty());
         EXPECT_TRUE(getRegistryValue("LAUNCHPROGRAM").empty());
+        EXPECT_TRUE(getRegistryValue("LAUNCHWSLIMAGEINSTALLER").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_MASTER_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_PROJECT_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("ENABLELAUNCHATLOGON").empty());
@@ -170,6 +179,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("OVERRIDE_LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) =
@@ -207,6 +220,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");
@@ -250,6 +267,7 @@ namespace test_boinccas {
         EXPECT_TRUE(getRegistryValue("INSTALLDIR").empty());
         EXPECT_TRUE(getRegistryValue("DATADIR").empty());
         EXPECT_TRUE(getRegistryValue("LAUNCHPROGRAM").empty());
+        EXPECT_TRUE(getRegistryValue("LAUNCHWSLIMAGEINSTALLER").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_MASTER_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_PROJECT_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("ENABLELAUNCHATLOGON").empty());
@@ -266,6 +284,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("OVERRIDE_LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) =
@@ -303,6 +325,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("1", value);
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("1", value);
         std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");
@@ -348,6 +374,8 @@ namespace test_boinccas {
         ASSERT_EQ("data_test", getRegistryValue("DATADIR"));
         ASSERT_TRUE(setRegistryValue("LAUNCHPROGRAM", "1"));
         ASSERT_EQ("1", getRegistryValue("LAUNCHPROGRAM"));
+        ASSERT_TRUE(setRegistryValue("LAUNCHWSLIMAGEINSTALLER", "1"));
+        ASSERT_EQ("1", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         ASSERT_TRUE(setRegistryValue("BOINC_MASTER_USERNAME", "test_master"));
         ASSERT_EQ("test_master", getRegistryValue("BOINC_MASTER_USERNAME"));
         ASSERT_TRUE(setRegistryValue("BOINC_PROJECT_USERNAME", "test_project"));
@@ -370,6 +398,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("OVERRIDE_LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) =
@@ -407,6 +439,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("install_test", value);
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("1", value);
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("1", value);
         std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");
@@ -452,6 +488,8 @@ namespace test_boinccas {
         ASSERT_EQ("data_test", getRegistryValue("DATADIR"));
         ASSERT_TRUE(setRegistryValue("LAUNCHPROGRAM", "2"));
         ASSERT_EQ("2", getRegistryValue("LAUNCHPROGRAM"));
+        ASSERT_TRUE(setRegistryValue("LAUNCHWSLIMAGEINSTALLER", "1"));
+        ASSERT_EQ("1", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         ASSERT_TRUE(setRegistryValue("BOINC_MASTER_USERNAME", "test_master"));
         ASSERT_EQ("test_master", getRegistryValue("BOINC_MASTER_USERNAME"));
         ASSERT_TRUE(setRegistryValue("BOINC_PROJECT_USERNAME", "test_project"));
@@ -474,6 +512,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) = getMsiProperty("OVERRIDE_LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
         std::tie(errorcode, value) =
@@ -513,6 +555,10 @@ namespace test_boinccas {
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("1", value);
         std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("test_master", value);
@@ -554,6 +600,7 @@ namespace test_boinccas {
         EXPECT_TRUE(getRegistryValue("INSTALLDIR").empty());
         EXPECT_TRUE(getRegistryValue("DATADIR").empty());
         EXPECT_TRUE(getRegistryValue("LAUNCHPROGRAM").empty());
+        EXPECT_TRUE(getRegistryValue("LAUNCHWSLIMAGEINSTALLER").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_MASTER_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_PROJECT_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("ENABLELAUNCHATLOGON").empty());
@@ -575,6 +622,12 @@ namespace test_boinccas {
 
         setMsiProperty("OVERRIDE_LAUNCHPROGRAM", "0");
         std::tie(errorcode, value) = getMsiProperty("OVERRIDE_LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("0", value);
+
+        setMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER", "0");
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("0", value);
 
@@ -626,6 +679,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("install_test_override", value);
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("0", value);
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("0", value);
         std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");
@@ -671,6 +728,8 @@ namespace test_boinccas {
         ASSERT_EQ("data_test", getRegistryValue("DATADIR"));
         ASSERT_TRUE(setRegistryValue("LAUNCHPROGRAM", "1"));
         ASSERT_EQ("1", getRegistryValue("LAUNCHPROGRAM"));
+        ASSERT_TRUE(setRegistryValue("LAUNCHWSLIMAGEINSTALLER", "1"));
+        ASSERT_EQ("1", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         ASSERT_TRUE(setRegistryValue("BOINC_MASTER_USERNAME", "test_master"));
         ASSERT_EQ("test_master", getRegistryValue("BOINC_MASTER_USERNAME"));
         ASSERT_TRUE(setRegistryValue("BOINC_PROJECT_USERNAME", "test_project"));
@@ -698,6 +757,12 @@ namespace test_boinccas {
 
         setMsiProperty("OVERRIDE_LAUNCHPROGRAM", "0");
         std::tie(errorcode, value) = getMsiProperty("OVERRIDE_LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("0", value);
+
+        setMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER", "0");
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("0", value);
 
@@ -749,6 +814,10 @@ namespace test_boinccas {
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("install_test_override", value);
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("0", value);
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         EXPECT_EQ("0", value);
         std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");

--- a/tests/unit-tests/boinccas/test_boinccas_CASaveExecutionState.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CASaveExecutionState.cpp
@@ -39,6 +39,7 @@ namespace test_boinccas {
         EXPECT_EQ(0u, executeAction());
 
         EXPECT_TRUE(getRegistryValue("LAUNCHPROGRAM").empty());
+        EXPECT_TRUE(getRegistryValue("LAUNCHWSLIMAGEINSTALLER").empty());
         EXPECT_TRUE(getRegistryValue("RETURN_REBOOTREQUESTED").empty());
         EXPECT_TRUE(getRegistryValue("RETURN_VALIDATEINSTALL").empty());
         EXPECT_TRUE(getRegistryValue("RETURN_BOINC_MASTER_USERNAME").empty());
@@ -52,6 +53,11 @@ namespace test_boinccas {
 
         setMsiProperty("LAUNCHPROGRAM", "1");
         auto [errorcode, value] = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        ASSERT_EQ("1", value);
+
+        setMsiProperty("LAUNCHWSLIMAGEINSTALLER", "1");
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         ASSERT_EQ("1", value);
 
@@ -78,6 +84,7 @@ namespace test_boinccas {
         EXPECT_EQ(0u, executeAction());
 
         EXPECT_EQ("1", getRegistryValue("LAUNCHPROGRAM"));
+        EXPECT_EQ("1", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         EXPECT_EQ("0", getRegistryValue("RETURN_REBOOTREQUESTED"));
         EXPECT_EQ("1", getRegistryValue("RETURN_VALIDATEINSTALL"));
         EXPECT_EQ("master_test",
@@ -93,6 +100,11 @@ namespace test_boinccas {
 
         setMsiProperty("LAUNCHPROGRAM", "1");
         auto [errorcode, value] = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        ASSERT_EQ("1", value);
+
+        setMsiProperty("LAUNCHWSLIMAGEINSTALLER", "1");
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         ASSERT_EQ("1", value);
 
@@ -119,6 +131,7 @@ namespace test_boinccas {
         EXPECT_EQ(0u, executeAction());
 
         EXPECT_TRUE(getRegistryValue("LAUNCHPROGRAM").empty());
+        EXPECT_EQ("1", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         EXPECT_EQ("1", getRegistryValue("RETURN_REBOOTREQUESTED"));
         EXPECT_EQ("1", getRegistryValue("RETURN_VALIDATEINSTALL"));
         EXPECT_EQ("master_test",
@@ -134,6 +147,11 @@ namespace test_boinccas {
 
         setMsiProperty("LAUNCHPROGRAM", "1");
         auto [errorcode, value] = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        ASSERT_EQ("1", value);
+
+        setMsiProperty("LAUNCHWSLIMAGEINSTALLER", "1");
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         ASSERT_EQ("1", value);
 
@@ -160,6 +178,7 @@ namespace test_boinccas {
         EXPECT_EQ(0u, executeAction());
 
         EXPECT_TRUE(getRegistryValue("LAUNCHPROGRAM").empty());
+        EXPECT_EQ("1", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         EXPECT_EQ("0", getRegistryValue("RETURN_REBOOTREQUESTED"));
         EXPECT_EQ("0", getRegistryValue("RETURN_VALIDATEINSTALL"));
         EXPECT_EQ("master_test",

--- a/tests/unit-tests/boinccas/test_boinccas_CASaveSetupState.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CASaveSetupState.cpp
@@ -41,6 +41,7 @@ namespace test_boinccas {
         EXPECT_TRUE(getRegistryValue("INSTALLDIR").empty());
         EXPECT_TRUE(getRegistryValue("DATADIR").empty());
         EXPECT_EQ("0", getRegistryValue("LAUNCHPROGRAM"));
+        EXPECT_EQ("0", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         EXPECT_TRUE(getRegistryValue("BOINC_MASTER_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_PROJECT_USERNAME").empty());
         EXPECT_EQ("0", getRegistryValue("ENABLELAUNCHATLOGON"));
@@ -68,6 +69,11 @@ namespace test_boinccas {
 
         setMsiProperty("LAUNCHPROGRAM", "1");
         std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        ASSERT_EQ("1", value);
+
+        setMsiProperty("LAUNCHWSLIMAGEINSTALLER", "1");
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         ASSERT_EQ("1", value);
 
@@ -107,6 +113,7 @@ namespace test_boinccas {
         EXPECT_EQ("test", getRegistryValue("INSTALLDIR"));
         EXPECT_EQ("test_data", getRegistryValue("DATADIR"));
         EXPECT_EQ("1", getRegistryValue("LAUNCHPROGRAM"));
+        EXPECT_EQ("1", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         EXPECT_EQ("master_test", getRegistryValue("BOINC_MASTER_USERNAME"));
         EXPECT_EQ("project_test", getRegistryValue("BOINC_PROJECT_USERNAME"));
         EXPECT_EQ("1", getRegistryValue("ENABLELAUNCHATLOGON"));
@@ -126,6 +133,11 @@ namespace test_boinccas {
         auto [errorcode, value] = getMsiProperty("LAUNCHPROGRAM");
         EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
         ASSERT_EQ("2", value);
+
+        setMsiProperty("LAUNCHWSLIMAGEINSTALLER", "7");
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        ASSERT_EQ("7", value);
 
         setMsiProperty("ENABLELAUNCHATLOGON", "3");
         std::tie(errorcode, value) = getMsiProperty("ENABLELAUNCHATLOGON");
@@ -153,6 +165,7 @@ namespace test_boinccas {
         EXPECT_TRUE(getRegistryValue("INSTALLDIR").empty());
         EXPECT_TRUE(getRegistryValue("DATADIR").empty());
         EXPECT_EQ("0", getRegistryValue("LAUNCHPROGRAM"));
+        EXPECT_EQ("0", getRegistryValue("LAUNCHWSLIMAGEINSTALLER"));
         EXPECT_TRUE(getRegistryValue("BOINC_MASTER_USERNAME").empty());
         EXPECT_TRUE(getRegistryValue("BOINC_PROJECT_USERNAME").empty());
         EXPECT_EQ("0", getRegistryValue("ENABLELAUNCHATLOGON"));

--- a/tests/unit-tests/boinccas/test_boinccas_CAShutdownBOINCManager.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CAShutdownBOINCManager.cpp
@@ -18,10 +18,11 @@
 #include "boinccas_helper.h"
 
 namespace test_boinccas {
-    constexpr auto executableName = "boincmgr.exe";
     class test_boinccas_CAShutdownBOINCManager :
         public test_boinccas_TestBase {
     protected:
+        const std::string executableName = "boincmgr.exe";
+
         test_boinccas_CAShutdownBOINCManager() :
             test_boinccas_TestBase("ShutdownBOINCManager") {
         }

--- a/tests/unit-tests/boinccas/test_boinccas_CAShutdownBOINCScreensaver.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CAShutdownBOINCScreensaver.cpp
@@ -18,10 +18,11 @@
 #include "boinccas_helper.h"
 
 namespace test_boinccas {
-    constexpr auto executableName = "boinc.scr";
     class test_boinccas_CAShutdownBOINCScreensaver :
         public test_boinccas_TestBase {
     protected:
+        const std::string executableName = "boinc.scr";
+
         test_boinccas_CAShutdownBOINCScreensaver() :
             test_boinccas_TestBase("ShutdownBOINCScreensaver") {
         }

--- a/win_build/boinccas.vcxproj
+++ b/win_build/boinccas.vcxproj
@@ -13,14 +13,14 @@
   <Import Project="boinc.props" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>../win_build;../lib;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../win_build;../lib;$(VcpkgInstalledDir)/include/openssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>stdafx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <PreprocessorDefinitions>_USRDLL;BOINCCAS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>atls.lib;msi.lib;delayimp.lib;netapi32.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>atls.lib;msi.lib;delayimp.lib;netapi32.lib;version.lib;libcrypto.lib;libssl.lib;Ws2_32.Lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">libcmtd.lib;libcpmtd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)'=='Release'">libcmt.lib;libcpmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>netapi32.dll;advapi32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
@@ -32,6 +32,7 @@
   <ItemGroup>
     <ClCompile Include="..\clientsetup\win\boinccas.cpp" />
     <ClCompile Include="..\clientsetup\win\CAAnnounceUpgrade.cpp" />
+    <ClCompile Include="..\clientsetup\win\CACheckWSLSupport.cpp" />
     <ClCompile Include="..\clientsetup\win\CACleanupOldBinaries.cpp" />
     <ClCompile Include="..\clientsetup\win\CACreateAcctMgrLoginFile.cpp" />
     <ClCompile Include="..\clientsetup\win\CACreateBOINCAccounts.cpp" />
@@ -49,6 +50,7 @@
     <ClCompile Include="..\clientsetup\win\CAGrantBOINCUsersRights.cpp" />
     <ClCompile Include="..\clientsetup\win\CALaunchBOINCManager.cpp" />
     <ClCompile Include="..\clientsetup\win\CALaunchBOINCTray.cpp" />
+    <ClCompile Include="..\clientsetup\win\CALaunchBOINCWSLInstaller.cpp" />
     <ClCompile Include="..\clientsetup\win\CARestoreExecutionState.cpp" />
     <ClCompile Include="..\clientsetup\win\CARestorePermissionBOINCData.cpp" />
     <ClCompile Include="..\clientsetup\win\CARestoreSetupState.cpp" />

--- a/win_build/installer_msi.vcxproj
+++ b/win_build/installer_msi.vcxproj
@@ -14,6 +14,16 @@
     <TargetExt>.msi</TargetExt>
     <ReplaceWildcardsInProjectItems>true</ReplaceWildcardsInProjectItems>
   </PropertyGroup>
+  <PropertyGroup>
+    <BoincWslInstaller>$(OutDir)boinc-buda-runner-wsl-installer.exe</BoincWslInstaller>
+    <BoincWslInstallerVersion>2.3.2</BoincWslInstallerVersion>
+    <BoincWslInstallerGuardFile>$(BoincWslInstaller)_$(BoincWslInstallerVersion).lock</BoincWslInstallerGuardFile>
+    <BoincWslInstallerDownloadUrl>https://github.com/BOINC/boinc-buda-runner-wsl-installer/releases/download/v$(BoincWslInstallerVersion)/boinc-buda-runner-wsl-installer.exe</BoincWslInstallerDownloadUrl>
+  </PropertyGroup>
+  <Target Name="DownloadBoincWslInstaller" BeforeTargets="ClCompile" Condition="!Exists($(BoincWslInstaller)) Or !Exists($(BoincWslInstallerGuardFile))">
+    <DownloadFile SourceUrl="$(BoincWslInstallerDownloadUrl)" DestinationFolder="$(OutDir)" />
+    <Touch Files="$(BoincWslInstallerGuardFile)" AlwaysCreate="true" />
+  </Target>
   <ItemGroup>
     <None Include="..\installer\boinc.json" />
     <None Include="..\installer\include\ActionText.json" />
@@ -71,6 +81,7 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
   <PropertyGroup>
+    <CustomBuildAfterTargets>DownloadBoincWslInstaller</CustomBuildAfterTargets>
     <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/win_build/unittests.vcxproj
+++ b/win_build/unittests.vcxproj
@@ -16,7 +16,7 @@
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>../win_build;../lib;../zip;../api;../samples/vboxwrapper;../tests/unit-tests/win;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../win_build;../lib;../zip;../api;../samples/vboxwrapper;../tests/unit-tests/win;$(VcpkgInstalledDir)/include/openssl/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <ForcedIncludeFiles>pch.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
@@ -24,7 +24,7 @@
       <PreprocessorDefinitions Condition="'$(BOINCCAS_TEST)' == 'true'">BOINCCAS_TEST;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>gtest_main.lib;gmock_main.lib;zip.lib;atls.lib;ole32.lib;wsock32.lib;psapi.lib;msi.lib;cabinet.lib;Version.lib;tinyxml2.lib;Netapi32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>gtest_main.lib;gmock_main.lib;zip.lib;atls.lib;ole32.lib;wsock32.lib;psapi.lib;msi.lib;cabinet.lib;Version.lib;tinyxml2.lib;Netapi32.lib;libcrypto.lib;libssl.lib;Ws2_32.Lib;Crypt32.Lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">zsd.lib;libcmtd.lib;libcpmtd.lib;comsuppwd.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)'=='Release'">zs.lib;libcmt.lib;libcpmt.lib;comsuppw.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(Configuration)'=='Debug'">$(VcpkgInstalledDir)/debug/lib/manual-link;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -38,6 +38,7 @@
     <ClCompile Include="..\tests\unit-tests\boinccas\registry_helper.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\user_group_helper.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CAAnnounceUpgrade.cpp" />
+    <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CACheckWSLSupport.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CACleanupOldBinaries.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CACreateAcctMgrLoginFile.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CACreateBOINCAccounts.cpp" />
@@ -55,6 +56,7 @@
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CAGrantBOINCUsersRights.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CALaunchBOINCManager.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CALaunchBOINCTray.cpp" />
+    <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CALaunchBOINCWSLInstaller.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CARestoreExecutionState.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CARestorePermissionBOINCData.cpp" />
     <ClCompile Include="..\tests\unit-tests\boinccas\test_boinccas_CARestoreSetupState.cpp" />

--- a/win_build/unittests.vcxproj.filters
+++ b/win_build/unittests.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClInclude Include="../tests/unit-tests/boinccas/test_boinccas_CAAnnounceUpgrade.cpp">
       <Filter>boinccas</Filter>
     </ClInclude>
+    <ClInclude Include="../tests/unit-tests/boinccas/test_boinccas_CACheckWSLSupport.cpp">
+      <Filter>boinccas</Filter>
+    </ClInclude>
     <ClInclude Include="../tests/unit-tests/boinccas/test_boinccas_CACleanupOldBinaries.cpp">
       <Filter>boinccas</Filter>
     </ClInclude>
@@ -94,6 +97,9 @@
       <Filter>boinccas</Filter>
     </ClInclude>
     <ClInclude Include="../tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCTray.cpp">
+      <Filter>boinccas</Filter>
+    </ClInclude>
+    <ClInclude Include="../tests/unit-tests/boinccas/test_boinccas_CALaunchBOINCWSLInstaller.cpp">
       <Filter>boinccas</Filter>
     </ClInclude>
     <ClInclude Include="../tests/unit-tests/boinccas/test_boinccas_CARestoreExecutionState.cpp">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Integrates `boinc-buda-runner-wsl-installer.exe` into the Windows MSI. The installer detects WSL, bundles the helper only when supported, verifies its SHA-256, and can launch it after setup.

- **New Features**
  - Detects WSL via `CACheckWSLSupport`; sets `INSTALLWSLIMAGEINSTALLER` and `LAUNCHWSLIMAGEINSTALLER`.
  - Adds feature `BOINCWSLImageInstaller` to include the helper only when supported.
  - Adds `CALaunchBOINCWSLInstaller` to verify `boinc_buda_runner_wsl_installer_checksum` (SHA-256) and launch the helper elevated (links `libcrypto`/`libssl`).
  - Adds a success-screen checkbox to “Launch the installation of the BOINC WSL Distro” (shown only when supported).
  - Persists `LAUNCHWSLIMAGEINSTALLER` in the registry; supports `OVERRIDE_LAUNCHWSLIMAGEINSTALLER`; cleans up old copies, including the helper EXE; CI disables launch with `OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0`.
  - MSI build downloads the helper (v2.3.2) during packaging; unit tests cover new actions and flows; minor installer tweaks (set language to 1033 for versioned files; update OS requirement text to “Vista or newer”).

- **Migration**
  - To disable launching in unattended/CI installs, pass `OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0` to msiexec.
  - To update the bundled helper, change `BoincWslInstallerVersion` in `win_build/installer_msi.vcxproj` and update `boinc_buda_runner_wsl_installer_checksum` in `installer/include/Property.json`.
  - Ensure OpenSSL is available for builds linking `boinccas.dll` and unit tests.

<sup>Written for commit 9c9137160caa28f27fe32f9767cddced5c8ee013. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

