### PR TITLE
[windows][installer] fix crash on update

### DIFF
--- a/clientsetup/win/boinccas.cpp
+++ b/clientsetup/win/boinccas.cpp
@@ -151,7 +151,7 @@ UINT BOINCCABase::GetRegistryValue(const tstring& strName,
         return ERROR_INSTALL_FAILURE;
     }
 
-    if (strValue.back() == _T('\0')) {
+    if (!strValue.empty() && strValue.back() == _T('\0')) {
         strValue.pop_back();
     }
 

--- a/tests/unit-tests/boinccas/test_boinccas_CARestoreSetupState.cpp
+++ b/tests/unit-tests/boinccas/test_boinccas_CARestoreSetupState.cpp
@@ -362,6 +362,122 @@ namespace test_boinccas {
     }
 
     TEST_F(test_boinccas_CARestoreSetupState,
+        SetupStateRestored_Set_Empty_Registry_Values) {
+        const auto result = openMsi();
+        ASSERT_EQ(0u, result);
+
+        ASSERT_TRUE(setRegistryValue("SETUPSTATESTORED", "TRUE"));
+        ASSERT_EQ("TRUE", getRegistryValue("SETUPSTATESTORED"));
+
+        ASSERT_TRUE(setRegistryValue("INSTALLDIR", ""));
+        ASSERT_TRUE(setRegistryValue("DATADIR", ""));
+        ASSERT_TRUE(setRegistryValue("LAUNCHPROGRAM", ""));
+        ASSERT_TRUE(setRegistryValue("LAUNCHWSLIMAGEINSTALLER", ""));
+        ASSERT_TRUE(setRegistryValue("BOINC_MASTER_USERNAME", ""));
+        ASSERT_TRUE(setRegistryValue("BOINC_PROJECT_USERNAME", ""));
+        ASSERT_TRUE(setRegistryValue("ENABLELAUNCHATLOGON", ""));
+        ASSERT_TRUE(setRegistryValue("ENABLESCREENSAVER", ""));
+        ASSERT_TRUE(setRegistryValue("ENABLEPROTECTEDAPPLICATIONEXECUTION3", ""));
+        ASSERT_TRUE(setRegistryValue("ENABLEUSEBYALLUSERS", ""));
+
+        EXPECT_TRUE(getRegistryValue("INSTALLDIR").empty());
+        EXPECT_TRUE(getRegistryValue("DATADIR").empty());
+        EXPECT_TRUE(getRegistryValue("LAUNCHPROGRAM").empty());
+        EXPECT_TRUE(getRegistryValue("LAUNCHWSLIMAGEINSTALLER").empty());
+        EXPECT_TRUE(getRegistryValue("BOINC_MASTER_USERNAME").empty());
+        EXPECT_TRUE(getRegistryValue("BOINC_PROJECT_USERNAME").empty());
+        EXPECT_TRUE(getRegistryValue("ENABLELAUNCHATLOGON").empty());
+        EXPECT_TRUE(getRegistryValue("ENABLESCREENSAVER").empty());
+        EXPECT_TRUE(getRegistryValue(
+            "ENABLEPROTECTEDAPPLICATIONEXECUTION3").empty());
+        EXPECT_TRUE(getRegistryValue("ENABLEUSEBYALLUSERS").empty());
+        EXPECT_TRUE(getRegistryValue("UpgradingTo").empty());
+
+        auto [errorcode, value] = getMsiProperty("OVERRIDE_INSTALLDIR");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("OVERRIDE_DATADIR");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("OVERRIDE_LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_BOINC_MASTER_USERNAME");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_BOINC_PROJECT_USERNAME");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_ENABLELAUNCHATLOGON");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_ENABLESCREENSAVER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_ENABLEPROTECTEDAPPLICATIONEXECUTION3");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("OVERRIDE_ENABLEUSEBYALLUSERS");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+
+        ASSERT_EQ(0u, executeAction());
+
+        std::tie(errorcode, value) = getMsiProperty("DATADIR");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ(getDefaultDataPath(), value);
+
+        std::tie(errorcode, value) = getMsiProperty("INSTALLDIR");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("LAUNCHPROGRAM");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("1", value);
+        std::tie(errorcode, value) =
+            getMsiProperty("LAUNCHWSLIMAGEINSTALLER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_EQ("1", value);
+        std::tie(errorcode, value) = getMsiProperty("BOINC_MASTER_USERNAME");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("BOINC_PROJECT_USERNAME");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("ENABLELAUNCHATLOGON");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("ENABLESCREENSAVER");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) =
+            getMsiProperty("ENABLEPROTECTEDAPPLICATIONEXECUTION3");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("ENABLEUSEBYALLUSERS");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("ALLUSERS");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("ProductVersion");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+        std::tie(errorcode, value) = getMsiProperty("IS_MAJOR_UPGRADE");
+        EXPECT_EQ(static_cast<unsigned int>(ERROR_SUCCESS), errorcode);
+        EXPECT_TRUE(value.empty());
+    }
+
+    TEST_F(test_boinccas_CARestoreSetupState,
         SetupStateRestored_Set_Prev_Data_Set_No_Override_Data) {
         const auto result = openMsi();
         ASSERT_EQ(0u, result);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a Windows installer crash during updates by safely handling empty registry strings in the custom action.

- **Bug Fixes**
  - Guard against empty values before trimming the trailing null in `BOINCCABase::GetRegistryValue`.
  - Added `SetupStateRestored_Set_Empty_Registry_Values` unit test to ensure no crash and correct defaults when registry values are empty.

<sup>Written for commit c33cbb812e57d22226c8a108ca8ef8f31b3216e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

