### PR TITLE
client: include 'name' element in 'coproc_intel_gpu' XML element

### DIFF
--- a/lib/coproc.cpp
+++ b/lib/coproc.cpp
@@ -382,7 +382,7 @@ void COPROC_NVIDIA::write_xml(MIOFILE& f, bool scheduler_rpc) {
         "   <have_cuda>%d</have_cuda>\n"
         "   <have_opencl>%d</have_opencl>\n",
         count,
-        cuda_prop.name,
+        have_cuda?cuda_prop.name:opencl_prop.name,
         available_ram,
         have_cuda ? 1 : 0,
         have_opencl ? 1 : 0
@@ -951,9 +951,11 @@ void COPROC_INTEL::write_xml(MIOFILE& f, bool scheduler_rpc) {
     f.printf(
         "<coproc_intel_gpu>\n"
         "   <count>%d</count>\n"
+        "   <name>%s</name>\n"
         "   <available_ram>%f</available_ram>\n"
         "   <have_opencl>%d</have_opencl>\n",
         count,
+        opencl_prop.name,
         available_ram,
         have_opencl ? 1 : 0
     );


### PR DESCRIPTION
This is redundant since it's in the OpenCL descriptor. But apparently older server software expects it.

Fixes #7133

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the 'name' element to the 'coproc_intel_gpu' XML and fall back to the OpenCL device name for NVIDIA when CUDA is unavailable. Restores compatibility with older server software and fixes #7133.

<sup>Written for commit e4758048180396a485bd7294dda64e2e5b810127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

