### PR TITLE
docker_wrapper: increase buffer sizes

### DIFF
--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -188,9 +188,11 @@ int procinfo_setup(PROC_MAP& pm) {
         if (!f) continue;
         if (fread(&prusage, sizeof(prusage_t), 1, f) == 1) {
             p.user_time = (float)prusage.pr_utime.tv_sec
-                + ((float)prusage.pr_utime.tv_nsec)/1e+9;
+                + ((float)prusage.pr_utime.tv_nsec)/1e+9
+            ;
             p.kernel_time = (float)prusage.pr_stime.tv_sec
-                + ((float)prusage.pr_utime.tv_nsec)/1e+9;
+                + ((float)prusage.pr_stime.tv_nsec)/1e+9
+            ;
         }
         fclose(f);
         p.is_boinc_app = (p.id == pid || strcasestr(p.command, "boinc"));

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -100,10 +100,11 @@ static inline char* skip_spaces(char* p, int n) {
 int PROC_STAT::parse_stat(char* buf) {
     pid = atoi(buf);
     char *p = strchr(buf, '(');
+    if (!p) return 1;
     char *q = strchr(p, ')');
-    if (!p || !q) return 1;
+    if (!q) return 1;
     *q = 0;
-    strcpy(command, p+1);
+    safe_strcpy(command, p+1);
     q += 4;
     ppid = atoi(q);
     q = skip_spaces(q, 10);
@@ -178,7 +179,7 @@ int procinfo_setup(PROC_MAP& pm) {
             p.parentid = psinfo.pr_ppid;
             p.virtual_size = psinfo.pr_size*1024.;
             p.rss = psinfo.pr_rssize * 1024.;
-            strlcpy(p.command, psinfo.pr_fname, sizeof(p.command));
+            safe_strcpy(p.command, psinfo.pr_fname);
         }
         fclose(f);
         snprintf(pidpath, sizeof(pidpath), "/proc/%s/usage", piddir->d_name);
@@ -186,10 +187,10 @@ int procinfo_setup(PROC_MAP& pm) {
         f = fopen(pidpath, "r");
         if (!f) continue;
         if (fread(&prusage, sizeof(prusage_t), 1, f) == 1) {
-            p.user_time = (float)prusage.pr_utime.tv_sec +
-                ((float)prusage.pr_utime.tv_nsec)/1e+9;
-            p.kernel_time = (float)prusage.pr_stime.tv_sec +
-                ((float)prusage.pr_utime.tv_nsec)/1e+9;
+            p.user_time = (float)prusage.pr_utime.tv_sec
+                + ((float)prusage.pr_utime.tv_nsec)/1e+9;
+            p.kernel_time = (float)prusage.pr_stime.tv_sec
+                + ((float)prusage.pr_utime.tv_nsec)/1e+9;
         }
         fclose(f);
         p.is_boinc_app = (p.id == pid || strcasestr(p.command, "boinc"));
@@ -213,12 +214,11 @@ int procinfo_setup(PROC_MAP& pm) {
         p.clear();
         p.id = ps.pid;
         p.parentid = ps.ppid;
-        p.virtual_size = (double)ps.virtual_size;
         // times are in jiffies, need seconds
         // assumes 100 jiffies per second
         p.user_time = (double)ps.utime / 100.;
         p.kernel_time = (double)ps.stime / 100.;
-        strlcpy(p.command, ps.command, sizeof(p.command));
+        safe_strcpy(p.command, ps.command);
         p.is_boinc_app = (p.id == pid || strcasestr(p.command, "boinc"));
         p.is_low_priority = (ps.priority == 39);
             // Internally Linux stores the process priority as nice + 20

--- a/samples/docker_wrapper/docker_wrapper.cpp
+++ b/samples/docker_wrapper/docker_wrapper.cpp
@@ -414,7 +414,7 @@ int image_exists(bool &exists) {
 }
 
 int build_image() {
-    char cmd[256];
+    char cmd[1024];
     vector<string> out;
     int retval;
 
@@ -558,7 +558,7 @@ int get_container_state(int &state) {
     retval = docker_conn.command(cmd, out, verbose_all());
     if (retval) return retval;
     for (string line: out) {
-        char buf[256];
+        char buf[1024];
         safe_strcpy(buf, line.c_str());
         if (strstr(buf, container_name)) {
             char *p = strchr(buf, '|');
@@ -585,7 +585,7 @@ int get_container_state(int &state) {
 
 int create_container() {
     char cmd[4096];
-    char slot_cmd[256], project_cmd[256], buf[1024];
+    char slot_cmd[1024], project_cmd[1024], buf[1024];
     vector<string> out;
     int retval;
 
@@ -1012,7 +1012,7 @@ void init_signal_handler() {
 void set_env_var(const char* name, const char* value) {
 #ifdef _WIN32
     vector<string> out;
-    char buf[256];
+    char buf[1024];
     sprintf(buf, "export %s=\"%s\"", name, value);
     docker_conn.shell_command(buf, out, verbose_std());
 #else

--- a/sched/script_validator.cpp
+++ b/sched/script_validator.cpp
@@ -53,6 +53,7 @@
 
 #include "validate_util2.h"
 #include "error_numbers.h"
+#include "str_replace.h"
 #include "boinc_db.h"
 #include "sched_util.h"
 #include "validate_util.h"
@@ -131,15 +132,15 @@ int init_result(const RESULT& result, void*&) {
         string& s = init_script[i];
         if (s == "files") {
             for (unsigned j=0; j<paths.size(); j++) {
-                strcat(cmd, " ");
-                strcat(cmd, paths[j].c_str());
+                safe_strcat(cmd, " ");
+                safe_strcat(cmd, paths[j].c_str());
             }
         } else if (s == "runtime") {
             sprintf(buf, " %f", result.elapsed_time);
-            strcat(cmd, buf);
+            safe_strcat(cmd, buf);
         } else if (s == "result_id") {
             sprintf(buf, " %lu", result.id);
-            strcat(cmd, buf);
+            safe_strcat(cmd, buf);
         }
     }
     retval = system(cmd);
@@ -167,7 +168,7 @@ int compare_results(RESULT& r1, void*, RESULT const& r2, void*, bool& match) {
         return 0;
     }
 
-    char buf[256];
+    char buf[4096];
     vector<string> paths1, paths2;
     int retval;
 
@@ -188,26 +189,26 @@ int compare_results(RESULT& r1, void*, RESULT const& r2, void*, bool& match) {
         string& s = compare_script[i];
         if (s == "files") {
             for (unsigned j=0; j<paths1.size(); j++) {
-                strcat(cmd, " ");
-                strcat(cmd, paths1[j].c_str());
+                safe_strcat(cmd, " ");
+                safe_strcat(cmd, paths1[j].c_str());
             }
         } else if (s == "files2") {
             for (unsigned j=0; j<paths2.size(); j++) {
-                strcat(cmd, " ");
-                strcat(cmd, paths2[j].c_str());
+                safe_strcat(cmd, " ");
+                safe_strcat(cmd, paths2[j].c_str());
             }
         } else if (s == "runtime") {
             sprintf(buf, " %f", r1.elapsed_time);
-            strcat(cmd, buf);
+            safe_strcat(cmd, buf);
         } else if (s == "result_id") {
             sprintf(buf, " %lu", r1.id);
-            strcat(cmd, buf);
+            safe_strcat(cmd, buf);
         } else if (s == "runtime2") {
             sprintf(buf, " %f", r2.elapsed_time);
-            strcat(cmd, buf);
+            safe_strcat(cmd, buf);
         } else if (s == "result_id2") {
             sprintf(buf, " %lu", r2.id);
-            strcat(cmd, buf);
+            safe_strcat(cmd, buf);
         }
     }
     retval = system(cmd);


### PR DESCRIPTION
should fix problem with long workunit names.

Also fix a couple of AI issues (no functional change)

Fixes # (I can't find the issue)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase buffer sizes and switch to safe string ops to prevent truncation and crashes with long workunit/container names and long command lines. Also harden `/proc` parsing and fix a small non-Linux Unix system time calculation error.

- **Bug Fixes**
  - `samples/docker_wrapper/docker_wrapper.cpp`: expand buffers (to 1024/4096) in build, state, create, and env-var paths; use safer copies.
  - `sched/script_validator.cpp`: enlarge command buffers and replace `strcat` with `safe_strcat` when appending files, runtimes, and IDs.
  - `lib/procinfo_unix.cpp`: guard missing parentheses when parsing `stat`, use `safe_strcpy` for `command`, and correct nanosecond handling in kernel/user time on non-Linux Unix.

<sup>Written for commit cac89a3f73641f6ef03cbeaba25d1f0bfeb0a084. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

