### PR TITLE
 client: add gui_rpc_msg_debug log flag

### DIFF
--- a/client/gui_rpc_server.cpp
+++ b/client/gui_rpc_server.cpp
@@ -454,6 +454,8 @@ void GUI_RPC_CONN_SET::got_select(FDSET_GROUP& fg) {
 
     if (lsock < 0) return;
 
+    // new connection on our listening socket?
+    //
     if (FD_ISSET(lsock, &fg.read_fds)) {
         struct sockaddr_storage addr;
 
@@ -468,9 +470,16 @@ void GUI_RPC_CONN_SET::got_select(FDSET_GROUP& fg) {
             return;
         }
 
+        if (log_flags.gui_rpc_debug) {
+            msg_printf(0, MSG_INFO, "[gui_rpc] got GUI RPC connection");
+        }
+
         BOINC_SOCKLEN_T addr_len = sizeof(addr);
         sock = accept(lsock, (struct sockaddr*)&addr, (BOINC_SOCKLEN_T*)&addr_len);
         if (sock == -1) {
+            if (log_flags.gui_rpc_debug) {
+                msg_printf(0, MSG_INFO, "[gui_rpc] accept() failed");
+            }
             return;
         }
 
@@ -515,7 +524,7 @@ void GUI_RPC_CONN_SET::got_select(FDSET_GROUP& fg) {
             }
             if (log_flags.gui_rpc_debug) {
                 msg_printf(0, MSG_INFO,
-                    "[gui_rpc] got new GUI RPC connection"
+                    "[gui_rpc] new GUI RPC connection: sock %d", sock
                 );
             }
             insert(gr);
@@ -528,6 +537,11 @@ void GUI_RPC_CONN_SET::got_select(FDSET_GROUP& fg) {
     while (iter != gui_rpcs.end()) {
         gr = *iter;
         if (FD_ISSET(gr->sock, &fg.exc_fds)) {
+            if (log_flags.gui_rpc_debug) {
+                msg_printf(0, MSG_INFO,
+                    "[gui_rpc] GUI RPC connection failed: sock %d", gr->sock
+                );
+            }
             delete gr;
             iter = gui_rpcs.erase(iter);
             continue;
@@ -545,8 +559,8 @@ void GUI_RPC_CONN_SET::got_select(FDSET_GROUP& fg) {
             if (retval) {
                 if (log_flags.gui_rpc_debug) {
                     msg_printf(NULL, MSG_INFO,
-                        "[gui_rpc] handler returned %d, closing socket\n",
-                        retval
+                        "[gui_rpc] handler returned %d, closing socket %d\n",
+                        retval, gr->sock
                     );
                 }
                 delete gr;
@@ -561,11 +575,6 @@ void GUI_RPC_CONN_SET::got_select(FDSET_GROUP& fg) {
 // called when client is shutting down
 //
 void GUI_RPC_CONN_SET::close() {
-    if (log_flags.gui_rpc_debug) {
-        msg_printf(NULL, MSG_INFO,
-            "[gui_rpc] closing GUI RPC listening socket %d\n", lsock
-        );
-    }
     if (lsock >= 0) {
         boinc_close_socket(lsock);
         lsock = -1;
@@ -574,32 +583,6 @@ void GUI_RPC_CONN_SET::close() {
         delete gui_rpcs[i];
     }
     gui_rpcs.clear();
-}
-
-// this is called when we're ready to auto-update;
-// set flags to send quit messages to screensaver and local manager
-//
-void GUI_RPC_CONN_SET::send_quits() {
-    for (unsigned int i=0; i<gui_rpcs.size(); i++) {
-        GUI_RPC_CONN* gr = gui_rpcs[i];
-        if (gr->au_ss_state == AU_SS_GOT) {
-            gr->au_ss_state = AU_SS_QUIT_REQ;
-        }
-        if (gr->au_mgr_state == AU_MGR_GOT && gr->is_local) {
-            gr->au_mgr_state = AU_MGR_QUIT_REQ;
-        }
-    }
-}
-
-// check whether the quit messages have actually been sent
-//
-bool GUI_RPC_CONN_SET::quits_sent() {
-    for (unsigned int i=0; i<gui_rpcs.size(); i++) {
-        GUI_RPC_CONN* gr = gui_rpcs[i];
-        if (gr->au_ss_state == AU_SS_QUIT_REQ) return false;
-        if (gr->au_mgr_state == AU_MGR_QUIT_REQ) return false;
-    }
-    return true;
 }
 
 void* gui_rpc_handler(void* p) {

--- a/client/gui_rpc_server.h
+++ b/client/gui_rpc_server.h
@@ -117,8 +117,6 @@ public:
     int init_unix_domain();
     void close();
     bool recent_rpc_needs_network(double interval);
-    void send_quits();
-    bool quits_sent();
     bool poll();
     void set_notice_refresh() {
         for (unsigned int i=0; i<gui_rpcs.size(); i++) {

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -2015,9 +2015,9 @@ int GUI_RPC_CONN::handle_rpc() {
     }
     request_msg[request_nbytes] = 0;
 
-    if (log_flags.gui_rpc_debug) {
+    if (log_flags.gui_rpc_msg_debug) {
         msg_printf(0, MSG_INFO,
-            "[gui_rpc] GUI RPC Command = '%s'\n", request_msg
+            "[gui_rpc] GUI RPC request = '%s'\n", request_msg
         );
     }
 
@@ -2061,7 +2061,7 @@ int GUI_RPC_CONN::handle_rpc() {
             *p = 0;
             http_request = false;
         } else {
-            if (log_flags.gui_rpc_debug) {
+            if (log_flags.gui_rpc_msg_debug) {
                 msg_printf(0, MSG_INFO,
                     "[gui_rpc] partial GUI RPC Command = '%s'\n", request_msg
                 );
@@ -2129,11 +2129,13 @@ int GUI_RPC_CONN::handle_rpc() {
     }
     if (p) {
         send(sock, p, n, 0);
-        if (log_flags.gui_rpc_debug) {
+        if (log_flags.gui_rpc_msg_debug) {
             if (!http_request) {
-                p[n-1]=0;   // replace 003 with NULL
+                p[n-1] = 0;   // replace 003 with NULL
             }
-            if (n > 128) p[128] = 0;
+            if (n > 128) {
+                p[128] = 0;
+            }
             msg_printf(0, MSG_INFO,
                 "[gui_rpc] GUI RPC reply: '%s'\n", p
             );

--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -1862,13 +1862,24 @@ GUI_RPC gui_rpcs[] = {
 static int handle_rpc_aux(GUI_RPC_CONN& grc) {
     int retval = 0;
     grc.mfin.init_buf_read(grc.request_msg);
-    if (grc.xp.get_tag()) {    // parse <boinc_gui_rpc_request>
+
+    // parse <boinc_gui_rpc_request>
+    //
+    if (grc.xp.get_tag()) {
         grc.mfout.printf("<error>missing boinc_gui_rpc_request tag</error>\n");
         return 0;
     }
-    if (grc.xp.get_tag()) {    // parse the request tag
+    // parse the request tag
+    //
+    if (grc.xp.get_tag()) {
         grc.mfout.printf("<error>missing request</error>\n");
         return 0;
+    }
+    if (log_flags.gui_rpc_debug) {
+        msg_printf(0, MSG_INFO,
+            "[gui_rpc] got request %s on socket %d",
+            grc.xp.parsed_tag, grc.sock
+        );
     }
     for (unsigned int i=0; i<sizeof(gui_rpcs)/sizeof(GUI_RPC); i++) {
         GUI_RPC& gr = gui_rpcs[i];
@@ -1898,13 +1909,19 @@ static int handle_rpc_aux(GUI_RPC_CONN& grc) {
 static bool is_http_post_request(char* buf) {
     if (strstr(buf, "POST") != buf) return false;
     char* p = strstr(buf, "Content-Length: ");
-    if (!p) return false;
+    if (!p) {
+        return false;
+    }
     p += strlen("Content-Length: ");
     int n = atoi(p);
     p = strstr(p, HTTP_HEADER_DELIM);
-    if (!p) return false;
+    if (!p) {
+        return false;
+    }
     p += 4;
-    if ((int)strlen(p) < n) return false;
+    if ((int)strlen(p) < n) {
+        return false;
+    }
     return true;
 }
 

--- a/clientgui/DlgDiagnosticLogFlags.cpp
+++ b/clientgui/DlgDiagnosticLogFlags.cpp
@@ -52,7 +52,7 @@ CDlgDiagnosticLogFlags::CDlgDiagnosticLogFlags(wxWindow* parent) :
                 wxDEFAULT_DIALOG_STYLE|wxRESIZE_BORDER
             ) {
 
-    CSkinAdvanced*     pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
+    CSkinAdvanced* pSkinAdvanced = wxGetApp().GetSkinManager()->GetAdvanced();
     CMainDocument* pDoc = wxGetApp().GetDocument();
 
     wxASSERT(pDoc);
@@ -63,7 +63,7 @@ CDlgDiagnosticLogFlags::CDlgDiagnosticLogFlags(wxWindow* parent) :
 
     wxString title;
     title.Printf(
-        _("%s Diagnostic Log Flags"),
+        _("%s event log options"),
         pSkinAdvanced->GetApplicationShortName().c_str()
     );
 
@@ -81,7 +81,7 @@ CDlgDiagnosticLogFlags::CDlgDiagnosticLogFlags(wxWindow* parent) :
     m_headingSizer = new wxFlexGridSizer( 1 );
 
     m_headingText.Printf(
-        _("These flags enable various types of diagnostic messages in the Event Log.")
+        _("These flags enable various types of messages in the Event Log.")
     );
 
     m_heading = new wxStaticText(this, wxID_ANY, m_headingText);

--- a/lib/cc_config.cpp
+++ b/lib/cc_config.cpp
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-#include "cc_config.h"
-
 #ifdef _WIN32
 #include "boinc_win.h"
 #else
@@ -73,6 +71,7 @@ int LOG_FLAGS::parse(XML_PARSER& xp) {
         if (xp.parse_bool("disk_usage_debug", disk_usage_debug)) continue;
         if (xp.parse_bool("file_xfer_debug", file_xfer_debug)) continue;
         if (xp.parse_bool("gui_rpc_debug", gui_rpc_debug)) continue;
+        if (xp.parse_bool("gui_rpc_msg_debug", gui_rpc_msg_debug)) continue;
         if (xp.parse_bool("heartbeat_debug", heartbeat_debug)) continue;
         if (xp.parse_bool("http_debug", http_debug)) continue;
         if (xp.parse_bool("http_xfer_debug", http_xfer_debug)) continue;
@@ -124,6 +123,7 @@ int LOG_FLAGS::write(MIOFILE& out) {
         "        <disk_usage_debug>%d</disk_usage_debug>\n"
         "        <file_xfer_debug>%d</file_xfer_debug>\n"
         "        <gui_rpc_debug>%d</gui_rpc_debug>\n"
+        "        <gui_rpc_msg_debug>%d</gui_rpc_msg_debug>\n"
         "        <heartbeat_debug>%d</heartbeat_debug>\n"
         "        <http_debug>%d</http_debug>\n"
         "        <http_xfer_debug>%d</http_xfer_debug>\n"
@@ -168,6 +168,7 @@ int LOG_FLAGS::write(MIOFILE& out) {
         disk_usage_debug ? 1 : 0,
         file_xfer_debug ? 1 : 0,
         gui_rpc_debug ? 1 : 0,
+        gui_rpc_msg_debug ? 1 : 0,
         heartbeat_debug ? 1 : 0,
         http_debug ? 1 : 0,
         http_xfer_debug ? 1 : 0,

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -85,6 +85,7 @@ struct LOG_FLAGS {
     bool file_xfer_debug;
         // show completion of FILE_XFER
     bool gui_rpc_debug;
+    bool gui_rpc_msg_debug;
     bool heartbeat_debug;
     bool http_debug;
     bool http_xfer_debug;
@@ -130,7 +131,7 @@ struct LOG_FLAGS {
         file_xfer = true;
         sched_ops = true;
     }
-    void init();
+    void init();    // clears all flags
     int parse(XML_PARSER&);
     void show();
     int write(MIOFILE& out);

--- a/lib/cc_config.h
+++ b/lib/cc_config.h
@@ -131,7 +131,7 @@ struct LOG_FLAGS {
         file_xfer = true;
         sched_ops = true;
     }
-    void init();    // clears all flags
+    void init();    // sets defaults (only above flags set)
     int parse(XML_PARSER&);
     void show();
     int write(MIOFILE& out);


### PR DESCRIPTION
The new flag prints the request and reply messages (verbose).
gui_rpc_debug just prints connection info and RPC commands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `gui_rpc_msg_debug` log flag to print full GUI RPC request and reply messages. Keeps `gui_rpc_debug` focused on connection-level events and command tags, with clearer socket IDs and error logs.

- **New Features**
  - Added `gui_rpc_msg_debug` flag; logs full GUI RPC requests/replies.
  - Expanded `gui_rpc_debug` logs with socket IDs, connection/accept/handler errors, and request tag.
  - Wired flag into `cc_config.xml` parse/write.

- **Refactors**
  - Removed unused `send_quits()` and `quits_sent()` from GUI RPC server.
  - Tweaked Manager UI text: title now “event log options”; heading mentions “messages” instead of “diagnostic messages”.

<sup>Written for commit b9d7e516e006af9742ae83aabd3ab745c2552832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

