### PR TITLE
Fix android build

### DIFF
--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -260,6 +260,11 @@ vcpkgDir()
     echo $vcpkg_dir
 }
 
+# Temporary fix for the issue of the missing zlib dependency in the libcurl pkg config
+libcurl_pc_file=$(vcpkgDir $arch)/lib/pkgconfig/libcurl.pc
+grep -q '^Requires:.*\bzlib\b' $libcurl_pc_file || sed -i '/^Requires:/ s/openssl/openssl,zlib/' $libcurl_pc_file
+# End of the temporary fix
+
 list_apps_name="boinc_gahp uc2 ucn multi_thread sleeper sporadic worker wrapper wrappture_example fermi"
 
 NeonTest()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Android build by removing stale `vcpkg` `.pc` files, improving `pkg-config`-based `libcurl` detection, and patching `libcurl.pc` to require `zlib`. Prevents wrong linker flags and resolves “cannot find -lssl” and missing `zlib` links.

- **Bug Fixes**
  - Deployment: remove `3rdParty/android/vcpkg/*.pc` to avoid stale `pkg-config` metadata.
  - Configure: add `AC_MSG_WARN` traces in `m4/libcurl.m4` to print `LIBCURL_CPPFLAGS`/`LIBCURL`, detect static vs shared, and log when `SSL_LIBS` are appended for Android.
  - CI: in `android/buildAndroidBOINC-CI.sh`, ensure `libcurl.pc` includes `zlib` in `Requires:` (patch when missing).

<sup>Written for commit 80809971357ef250341b884e56be408931eebacb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

