### PR TITLE
Fix out-of-bounds read in lf_terminate() on empty input

### DIFF
--- a/lib/str_util.cpp
+++ b/lib/str_util.cpp
@@ -824,7 +824,7 @@ void strip_translation(char* p) {
 
 char* lf_terminate(char* p) {
     int n = (int)strlen(p);
-    if (p[n-1] == '\n') {
+    if (n>0 && p[n-1] == '\n') {
         return p;
     }
     p = (char*)realloc(p, n+2);

--- a/tests/unit-tests/lib/test_str_util.cpp
+++ b/tests/unit-tests/lib/test_str_util.cpp
@@ -300,6 +300,11 @@ namespace test_str_util {
         strcpy(buf, "lf\n ending\n");
         buf = lf_terminate(buf);
         EXPECT_STREQ(buf, "lf\n ending\n");
+        // empty string must not read p[-1]; should become a single newline
+        strcpy(buf, "");
+        buf = lf_terminate(buf);
+        EXPECT_STREQ(buf, "\n");
+        free(buf);
     }
 
     TEST_F(test_str_util, is_valid_filename) {


### PR DESCRIPTION
**Description of the Change**

`lf_terminate()` in `lib/str_util.cpp` read `p[strlen(p)-1]` without checking for an empty string. When passed `""`, `strlen` is 0 and it reads `p[-1]` — one byte before the buffer (a heap-buffer-overflow read).

This is reachable, not theoretical: `GUI_URLS::init()` (`sched/sched_types.cpp`) calls `lf_terminate()` on the contents of `gui_urls.xml` as returned by `read_file_malloc()`, which returns a valid 1-byte `""` buffer for a 0-byte file. An empty `gui_urls.xml` therefore triggers the out-of-bounds read, and the function also returns the string *without* appending the trailing newline its callers expect.

The fix guards the dereference with `n>0`. For empty input the function now correctly returns `"\n"` (falling through to the existing realloc path).

Verified with AddressSanitizer using the verbatim function bodies:
- **Original:** aborts with `heap-buffer-overflow` — `READ of size 1`, one byte before a `malloc(1)` region, at `lf_terminate`.
- **Fixed:** clean run, behavior preserved — `""`→`"\n"`, `"no lf"`→`"no lf\n"`, `"has lf\n"` unchanged.

A regression case for empty input was added to the existing `lf_terminate` unit test in `tests/unit-tests/lib/test_str_util.cpp`.

**Alternate Designs**

Considered special-casing the empty string to return a freshly allocated `"\n"` early, but the single `n>0` guard is the minimal change and reuses the existing realloc/append path that already yields the correct result.

**Release Notes**

Fix an out-of-bounds read in `lf_terminate()` when given an empty string (e.g. an empty `gui_urls.xml`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix an out-of-bounds read in lf_terminate() for empty strings and ensure empty input returns a newline. Prevents crashes when parsing an empty gui_urls.xml.

- **Bug Fixes**
  - Guarded access to p[n-1] with n > 0 in lf_terminate() to avoid a heap-buffer-overflow on empty input.
  - Added a regression test; verified behavior: "" → "\n", "no lf" → "no lf\n", "has lf\n" unchanged.

<sup>Written for commit 0b61628ef9ea1545bb89f70cfaa994166883b2af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

