### PR TITLE
Fix out-of-bounds access in escape_project_url() on empty result

### DIFF
--- a/lib/url.cpp
+++ b/lib/url.cpp
@@ -303,10 +303,10 @@ bool valid_master_url(char* buf) {
 
 void escape_project_url(char *in, char* out) {
     escape_url_readable(in, out);
-    char& last = out[strlen(out)-1];
+    size_t n = strlen(out);
     // remove trailing _
-    if (last == '_') {
-        last = '\0';
+    if (n>0 && out[n-1] == '_') {
+        out[n-1] = '\0';
     }
 }
 

--- a/tests/unit-tests/lib/test_url.cpp
+++ b/tests/unit-tests/lib/test_url.cpp
@@ -219,6 +219,16 @@ namespace test_url {
         strncpy(url, "https://secure.example.com/Dollar$", sizeof (url));
         escape_project_url(url, buf);
         EXPECT_STREQ(buf, "secure.example.com_Dollar");
+
+        //Nothing after the scheme: must not read/write out of bounds (was out[-1]).
+        strncpy(url, "http://", sizeof (url));
+        escape_project_url(url, buf);
+        EXPECT_STREQ(buf, "");
+
+        //Empty input: must not read/write out of bounds.
+        strncpy(url, "", sizeof (url));
+        escape_project_url(url, buf);
+        EXPECT_STREQ(buf, "");
     }
 
 }


### PR DESCRIPTION
**Description of the Change**

`escape_project_url()` in `lib/url.cpp` bound a reference to `out[strlen(out)-1]` without checking for an empty string:

```c
escape_url_readable(in, out);
char& last = out[strlen(out)-1];   // out[-1] when out is ""
if (last == '_') { last = '\0'; }
```

`escape_url_readable()` produces an **empty** `out` whenever the input has nothing after the `://` scheme separator (e.g. `"http://"`) or is itself empty. In that case `strlen(out)` is 0, so `out[strlen(out)-1]` indexes `out[(size_t)-1]` — one byte *before* the buffer. The `if (last == '_')` then **reads** that byte, and when it happens to be `_` the function **writes** `'\0'` there — an out-of-bounds write.

`escape_project_url()` is called throughout the client on `project->master_url` (`cs_apps.cpp`, `cs_notice.cpp`, `file_names.cpp`, `project.cpp`, `app_ipc.cpp`), so a malformed or scheme-only master URL can reach it.

The fix guards the trailing-`_` trim with a length check; behavior is unchanged for non-empty results.

Verified with AddressSanitizer using the verbatim function bodies:
- **Original:** aborts with `heap-buffer-overflow` — `READ of size 1`, one byte before the buffer — for input `"http://"`.
- **Fixed:** clean run, and the existing trim behavior is preserved (`"http://x/"` → `"x"`, `"…/Dollar$"` → `"…_Dollar"`).

Adds empty-input regression cases (`"http://"` and `""`) to the existing `escape_project_url` unit test in `tests/unit-tests/lib/test_url.cpp`.

**Alternate Designs**

Could have early-returned on an empty `out`, but the single length-guarded condition is the smallest change and keeps the existing control flow.

**Release Notes**

Fix an out-of-bounds memory access in `escape_project_url()` when given a URL with nothing after the scheme (e.g. `http://`) or an empty string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix out-of-bounds access in `escape_project_url()` when the escaped result is empty (e.g., `http://` or empty input).

- **Bug Fixes**
  - Guard trailing `_` trim with a length check to avoid accessing `out[-1]`.
  - Added unit tests for `http://` and empty input; behavior unchanged for non-empty outputs.
  - Verified with AddressSanitizer: original crashed on `http://`; fixed version is clean.

<sup>Written for commit 3869bebbadf773a891ad3d5c104f875ce0d458dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

