### PR TITLE
create_work: XML-escape sub_appname (BUDA app name)

### DIFF
--- a/tools/create_work.cpp
+++ b/tools/create_work.cpp
@@ -504,12 +504,15 @@ int main(int argc, char** argv) {
             int _argc;
             char* _argv[100], value_buf[MAX_QUERY_LEN];
 
-            char additional_xml[256];
+            char additional_xml[256], sub_appname_esc[2048];
             additional_xml[0] = 0;
             if (strlen(jd.sub_appname)) {
+                xml_escape(
+                    jd.sub_appname, sub_appname_esc, sizeof(sub_appname_esc)
+                );
                 snprintf(additional_xml, sizeof(additional_xml),
                     "   <sub_appname>%s</sub_appname>",
-                    jd.sub_appname
+                    sub_appname_esc
                 );
             }
 
@@ -615,9 +618,13 @@ void JOB_DESC::create() {
     char additional_xml[256];
     additional_xml[0] = 0;
     if (strlen(sub_appname)) {
+        char sub_appname_esc[2048];
+        xml_escape(
+            sub_appname, sub_appname_esc, sizeof(sub_appname_esc)
+        );
         snprintf(additional_xml, sizeof(additional_xml),
             "   <sub_appname>%s</sub_appname>",
-            sub_appname
+            sub_appname_esc
         );
     }
     int retval = create_work2(


### PR DESCRIPTION
Otherwise, if the name e.g. contains '&', it breaks the XML

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
XML-escape `sub_appname` when generating job XML so names with characters like '&' don't break XML. Applied in both main() and JOB_DESC::create().

<sup>Written for commit 2c46c7ba5edce5944527ac8a5cce27198cd60f7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

