### PR TITLE
Client (Win): add support for GPU access from Podman jobs

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -208,14 +208,6 @@ void CLIENT_STATE::show_host_info() {
     if (n_usable_cpus != host_info.p_ncpus) {
         msg_printf(NULL, MSG_INFO, "Using %d CPUs", n_usable_cpus);
     }
-#if 0
-    if (host_info.m_cache > 0) {
-        msg_printf(NULL, MSG_INFO,
-            "Processor: %s cache",
-            buf
-        );
-    }
-#endif
     msg_printf(NULL, MSG_INFO,
         "Processor features: %s", host_info.p_features
     );
@@ -226,7 +218,7 @@ void CLIENT_STATE::show_host_info() {
     strip_whitespace(buf);
     pclose(f);
     msg_printf(NULL, MSG_INFO,
-        "OS: Mac OS X %s (%s %s)", buf,
+        "OS: MacOS %s (%s %s)", buf,
         host_info.os_name, host_info.os_version
     );
 #else
@@ -299,6 +291,14 @@ void CLIENT_STATE::show_host_info() {
                         msg_printf(NULL, MSG_INFO, "-      Disk usage: %s", buf);
                     }
                 }
+            }
+            foreach (WSL_GPU &wg: wsl.wslgpus) {
+                msg_printf(NULL, MSG_INFO,
+                    "-      Usable GPU: %s,%s%s",
+                    wg.name.c_str(),
+                    wg.has_cuda?" CUDA":"",
+                    wg.has_opencl?" OpenCL":""
+                );
             }
         }
     }

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -292,7 +292,7 @@ void CLIENT_STATE::show_host_info() {
                     }
                 }
             }
-            foreach (WSL_GPU &wg: wsl.wslgpus) {
+            for (WSL_GPU &wg: wsl.wsl_gpus) {
                 msg_printf(NULL, MSG_INFO,
                     "-      Usable GPU: %s,%s%s",
                     wg.name.c_str(),

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -18,6 +18,8 @@
 // enumerate the WSL distros on this host.
 // For each one, see if it contains Podman or Docker, and get the version
 
+#include <nlohmann/json.hpp>
+
 #include "boinc_win.h"
 #include "win_util.h"
 
@@ -30,6 +32,7 @@
 
 using std::vector;
 using std::string;
+using nlohmann::json;
 
 // timeout for commands run in WSL container
 // If something goes wrong we don't want client to hang
@@ -38,6 +41,8 @@ using std::string;
 
 static void get_docker_version(WSL_CMD&, WSL_DISTRO&);
 static void get_docker_compose_version(WSL_CMD&, WSL_DISTRO&);
+
+static int get_json_gpu(json::basic_json&, WSL_GPU&)) {
 
 // scan the registry to get the list of all WSL distros on this host.
 // See https://patrickwu.space/2020/07/19/wsl-related-registry/
@@ -403,6 +408,37 @@ int get_wsl_information(WSL_DISTROS &distros) {
             }
         }
 
+        // parse gpus.json if present.
+        //
+        while (1) {
+            if (rs.run_program_in_wsl(
+                wd, "cat /home/boinc/gpus.json; echo EOM")
+            ) {
+                break;
+            }
+            string buf;
+            read_from_pipe(rs.out_read, rs.proc_handle, buf, CMD_TIMEOUT, "EOM");
+            json d;
+            d.json::parse(s, nullptr, false);   // no exceptions
+            if (d.is_discarded()) {
+                msg_printf(0, MSG_INFO,
+                    "Can't parse gpus.json in WSL distro %s", wd.name
+                );
+                break;
+            }
+
+            for (auto &el: d) {
+                WSL_GPU wg;
+                if (get_json_gpu(el, wg)) {
+                    msg_printf(0, MSG_INFO,
+                        "Can't parse GPU element in gpus.json"
+                    );
+                    continue;
+                }
+                gpus.push_back(wg);
+            }
+        }
+
         distros.distros.push_back(wd);
     }
 
@@ -473,4 +509,30 @@ static bool get_docker_compose_version_aux(
 static void get_docker_compose_version(WSL_CMD& rs, WSL_DISTRO &wd) {
     if (get_docker_compose_version_aux(rs, wd, PODMAN)) return;
     get_docker_compose_version_aux(rs, wd, DOCKER);
+}
+
+// populate the WSL_GPU with data from the JSON object
+//
+int get_json_gpu(json::basic_json& el, WSL_GPU& wg)) {
+    try {
+        wg.name = el["name"].get<string>();
+    } catch (...) {
+        return -1;
+    }
+    bool b;
+    try {
+        wg.has_cuda = el["has_cuda"].get<bool>();
+    } catch (...) {
+        wg.has_cuda = false;
+    }
+    try {
+        wg.has_opencl = el["has_opencl"].get<bool>();
+    } catch (...) {
+        wg.has_opencl = false;
+    }
+    try {
+        wg.has_metal = el["has_metal"].get<bool>();
+    } catch (...) {
+        wg.has_metal = false;
+    }
 }

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -418,7 +418,11 @@ int get_wsl_information(WSL_DISTROS &distros) {
             }
             string buf;
             read_from_pipe(rs.out_read, rs.proc_handle, buf, CMD_TIMEOUT, "EOM");
-            buf.erase(buf.size() - 4);
+            size_t x = buf.find("EOM");
+            if (x == string::npos) {
+                break;
+            }
+            buf.erase(x);
             json d;
             try {
                 d = json::parse(buf);
@@ -519,11 +523,11 @@ static void get_docker_compose_version(WSL_CMD& rs, WSL_DISTRO &wd) {
 int get_json_gpu(const nlohmann::json& el, WSL_GPU& wg) {
     try {
         wg.name = el["name"].get<string>();
+        wg.has_cuda = el.value("has_cuda", false);
+        wg.has_opencl = el.value("has_opencl", false);
     }
     catch (...) {
         return -1;
     }
-    wg.has_cuda = el.value("has_cuda", false);
-    wg.has_opencl = el.value("has_opencl", false);
     return 0;
 }

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -42,7 +42,7 @@ using nlohmann::json;
 static void get_docker_version(WSL_CMD&, WSL_DISTRO&);
 static void get_docker_compose_version(WSL_CMD&, WSL_DISTRO&);
 
-static int get_json_gpu(json::basic_json&, WSL_GPU&)) {
+static int get_json_gpu(const nlohmann::json&, WSL_GPU&);
 
 // scan the registry to get the list of all WSL distros on this host.
 // See https://patrickwu.space/2020/07/19/wsl-related-registry/
@@ -418,11 +418,13 @@ int get_wsl_information(WSL_DISTROS &distros) {
             }
             string buf;
             read_from_pipe(rs.out_read, rs.proc_handle, buf, CMD_TIMEOUT, "EOM");
+            buf.erase(buf.size() - 4);
             json d;
-            d.json::parse(s, nullptr, false);   // no exceptions
-            if (d.is_discarded()) {
+            try {
+                d = json::parse(buf);
+            } catch (...) {
                 msg_printf(0, MSG_INFO,
-                    "Can't parse gpus.json in WSL distro %s", wd.name
+                    "Can't parse gpus.json in WSL distro %s", wd.distro_name.c_str()
                 );
                 break;
             }
@@ -435,8 +437,9 @@ int get_wsl_information(WSL_DISTROS &distros) {
                     );
                     continue;
                 }
-                gpus.push_back(wg);
+                wd.wsl_gpus.push_back(wg);
             }
+            break;
         }
 
         distros.distros.push_back(wd);
@@ -513,26 +516,14 @@ static void get_docker_compose_version(WSL_CMD& rs, WSL_DISTRO &wd) {
 
 // populate the WSL_GPU with data from the JSON object
 //
-int get_json_gpu(json::basic_json& el, WSL_GPU& wg)) {
+int get_json_gpu(const nlohmann::json& el, WSL_GPU& wg) {
     try {
         wg.name = el["name"].get<string>();
-    } catch (...) {
+    }
+    catch (...) {
         return -1;
     }
-    bool b;
-    try {
-        wg.has_cuda = el["has_cuda"].get<bool>();
-    } catch (...) {
-        wg.has_cuda = false;
-    }
-    try {
-        wg.has_opencl = el["has_opencl"].get<bool>();
-    } catch (...) {
-        wg.has_opencl = false;
-    }
-    try {
-        wg.has_metal = el["has_metal"].get<bool>();
-    } catch (...) {
-        wg.has_metal = false;
-    }
+    wg.has_cuda = el.value("has_cuda", false);
+    wg.has_opencl = el.value("has_opencl", false);
+    return 0;
 }

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -409,6 +409,10 @@ struct HOST {
     inline bool low_turnaround() {
         return _error_rate > 0;
     }
+    // for scheduler: see if client is Win
+    inline bool is_windows() {
+        return strcasestr(os_name, "windows") != NULL;
+    }
 };
 
 struct HOST_DELETED {

--- a/lib/win_util.h
+++ b/lib/win_util.h
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// Windows-specific utility functions 
+
 #ifndef BOINC_WIN_UTIL_H
 #define BOINC_WIN_UTIL_H
 

--- a/lib/win_util.h
+++ b/lib/win_util.h
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// Windows-specific utility functions 
+// Windows-specific utility functions
 
 #ifndef BOINC_WIN_UTIL_H
 #define BOINC_WIN_UTIL_H

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -70,7 +70,7 @@ void WSL_DISTRO::write_xml(MIOFILE& f) {
     }
     if (!libc_version.empty()) {
         f.printf(
-            "           <libc_version>%s</libc_version>\n",
+            "            <libc_version>%s</libc_version>\n",
             libc_version.c_str()
         );
     }
@@ -223,18 +223,18 @@ int WSL_DISTROS::boinc_distro_version() {
 
 void WSL_GPU::write_xml(MIOFILE& f) {
     f.printf(
-"    <wsl_gpu>\n"
-"        <name>%s</name>\n",
+"            <wsl_gpu>\n"
+"                <name>%s</name>\n",
         name.c_str()
     );
     if (has_cuda) {
-        f.printf("        <has_cuda/>\n");
+        f.printf("                <has_cuda/>\n");
     }
     if (has_opencl) {
-        f.printf("        <has_opencl/>\n");
+        f.printf("                <has_opencl/>\n");
     }
     f.printf(
-"    </wsl_gpu>\n"
+"            </wsl_gpu>\n"
     );
 }
 

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -246,6 +246,8 @@ void WSL_GPU::write_xml(MIOFILE& f) {
     );
 }
 
+#endif  // _USING_FCGI_
+
 int WSL_GPU::parse(XML_PARSER &xp) {
     clear();
     while (!xp.get_tag()) {
@@ -259,5 +261,3 @@ int WSL_GPU::parse(XML_PARSER &xp) {
     }
     return 0;
 }
-
-#endif  // _USING_FCGI_

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -218,6 +218,8 @@ WSL_DISTRO* WSL_DISTROS::find_docker() {
     return NULL;
 }
 
+#endif  // _USING_FCGI_
+
 int WSL_DISTROS::boinc_distro_version() {
     for (WSL_DISTRO &wd: distros) {
         if (wd.distro_name == BOINC_WSL_DISTRO_NAME) {
@@ -245,8 +247,6 @@ void WSL_GPU::write_xml(MIOFILE& f) {
 "            </wsl_gpu>\n"
     );
 }
-
-#endif  // _USING_FCGI_
 
 int WSL_GPU::parse(XML_PARSER &xp) {
     clear();

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -90,6 +90,9 @@ void WSL_DISTRO::write_xml(MIOFILE& f) {
             docker_compose_type
         );
     }
+    for (WSL_GPU &wg: wsl_gpus) {
+        wg.write_xml();
+    }
     f.printf(
         "        </distro>\n"
     );
@@ -214,6 +217,37 @@ int WSL_DISTROS::boinc_distro_version() {
         if (wd.distro_name == BOINC_WSL_DISTRO_NAME) {
             return wd.boinc_buda_runner_version;
         }
+    }
+    return 0;
+}
+
+void WSL_GPU::write_xml(MIOFILE& f) {
+    f.printf(
+"    <wsl_gpu>\n"
+"        <name>%s</name>\n",
+        name
+    );
+    if (has_cuda) {
+        f.printf("        <has_cuda/>\n");
+    }
+    if (has_opencl) {
+        f.printf("        <has_opencl/>\n");
+    }
+    f.printf(
+"    </wsl_gpu>\n"
+    );
+}
+
+int parse(XML_PARSER &xp) {
+    clear();
+    while (!xp.get_tag()) {
+        if (xp.match_tag("/wsl_gpu")) {
+            if (name.empty()) return -1;
+            break;
+        }
+        if (xp.parse_string("name", name)) continue;
+        if (xp.parse_bool("has_cuda", has_cuda)) continue;
+        if (xp.parse_bool("has_opencl", has_opencl)) continue;
     }
     return 0;
 }

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -91,7 +91,7 @@ void WSL_DISTRO::write_xml(MIOFILE& f) {
         );
     }
     for (WSL_GPU &wg: wsl_gpus) {
-        wg.write_xml();
+        wg.write_xml(f);
     }
     f.printf(
         "        </distro>\n"
@@ -225,7 +225,7 @@ void WSL_GPU::write_xml(MIOFILE& f) {
     f.printf(
 "    <wsl_gpu>\n"
 "        <name>%s</name>\n",
-        name
+        name.c_str()
     );
     if (has_cuda) {
         f.printf("        <has_cuda/>\n");
@@ -238,7 +238,7 @@ void WSL_GPU::write_xml(MIOFILE& f) {
     );
 }
 
-int parse(XML_PARSER &xp) {
+int WSL_GPU::parse(XML_PARSER &xp) {
     clear();
     while (!xp.get_tag()) {
         if (xp.match_tag("/wsl_gpu")) {

--- a/lib/wslinfo.cpp
+++ b/lib/wslinfo.cpp
@@ -123,6 +123,12 @@ int WSL_DISTRO::parse(XML_PARSER& xp) {
             docker_compose_type = (DOCKER_TYPE) i;
             continue;
         }
+        if (xp.match_tag("wsl_gpu")) {
+            WSL_GPU wg;
+            if (wg.parse(xp) == 0) {
+                wsl_gpus.push_back(wg);
+            }
+        }
     }
     return ERR_XML_PARSE;
 }
@@ -202,7 +208,7 @@ WSL_DISTRO* WSL_DISTROS::find_docker() {
             return &wd;
         }
     }
-    // if not found, use any old distro
+    // if not found, use any distro that has Podman or Docker
     //
     for (WSL_DISTRO &wd: distros) {
         if (!wd.docker_version.empty()) {
@@ -222,10 +228,12 @@ int WSL_DISTROS::boinc_distro_version() {
 }
 
 void WSL_GPU::write_xml(MIOFILE& f) {
+    char buf[256];
+    xml_escape(name.c_str(), buf, sizeof(buf));
     f.printf(
 "            <wsl_gpu>\n"
 "                <name>%s</name>\n",
-        name.c_str()
+        buf
     );
     if (has_cuda) {
         f.printf("                <has_cuda/>\n");

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -79,7 +79,7 @@ struct WSL_DISTRO {
         // if this distro is boinc_buda_runner, the version
     std::string base_path;
         // the dir where the disk image (.vhdx file) is stored
-    vector<WSL_GPU> wsl_gpus;
+    std::vector<WSL_GPU> wsl_gpus;
         // info on the GPUs that are usable
         // from containers running in the distro
 

--- a/lib/wslinfo.h
+++ b/lib/wslinfo.h
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// structs describing WSL (Windows Subsystem for Linux) distros.
+// Structs describing WSL (Windows Subsystem for Linux) distros.
 // Used in Win client and also in server code (for plan class logic)
 
 #ifndef BOINC_WSLINFO_H
@@ -28,6 +28,27 @@
 #include "common_defs.h"
 
 #define BOINC_WSL_DISTRO_NAME "boinc-buda-runner"
+
+// A GPU type that is usable from a particular distro.
+// This info is obtained from the 'gpus.json' file,
+// typically created by the distro installer
+//
+struct WSL_GPU {
+    std::string name;
+        // CPU, NVIDIA, AMD, intel_gpu, apple_gpu
+        // or (for OpenCL) model name
+        // e.g. strings containing Mali, Adreno, etc.
+    bool has_opencl;
+    bool has_cuda;
+
+    void write_xml(MIOFILE&);
+    int parse(XML_PARSER&);
+    void clear() {
+        name.clear();
+        has_opencl = false;
+        has_cuda = false;
+    }
+};
 
 // describes a WSL (Windows Subsystem for Linux) distro,
 // and its Docker features
@@ -58,6 +79,9 @@ struct WSL_DISTRO {
         // if this distro is boinc_buda_runner, the version
     std::string base_path;
         // the dir where the disk image (.vhdx file) is stored
+    vector<WSL_GPU> wsl_gpus;
+        // info on the GPUs that are usable
+        // from containers running in the distro
 
     WSL_DISTRO(){
         clear();

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -229,20 +229,18 @@ bool PLAN_CLASS_SPEC::opencl_check(OPENCL_DEVICE_PROP& opencl_prop) {
 }
 
 // the client is Win and it's a Docker/GPU plan class.
-// See whether the WSL distro has the needed GPU support
+// See whether a WSL distro has the needed GPU support
 //
 bool PLAN_CLASS_SPEC::check_wsl_gpu(SCHEDULER_REQUEST& sreq, string gpu_name) {
-    if (sreq.host.wsl_distros.distros.empty()) {
-        return false;
-    }
-    WSL_DISTRO &wd = sreq.host.wsl_distros.distros[0];
-    for (WSL_GPU &wg: wd.wsl_gpus) {
-        if (wg.name == gpu_name) {
-            if (cuda) {
-                return wg.has_cuda;
-            }
-            if (opencl) {
-                return wg.has_opencl;
+    for (WSL_DISTRO &wd: sreq.host.wsl_distros.distros) {
+        for (WSL_GPU &wg: wd.wsl_gpus) {
+            if (wg.name == gpu_name) {
+                if (cuda && wg.has_cuda) {
+                    return true;
+                }
+                if (opencl && wg.has_opencl) {
+                    return true;
+                }
             }
         }
     }
@@ -259,6 +257,8 @@ bool PLAN_CLASS_SPEC::check(
     COPROC* cpp = NULL;
     bool can_use_multicore = true;
     string msg;
+    bool opencl_other = false;
+        // plan class selects a GPU type other than NVIDIA/AMD/intel/apple
 
     if (infeasible_random && drand()<infeasible_random) {
         return false;
@@ -935,6 +935,7 @@ bool PLAN_CLASS_SPEC::check(
             }
             return false;
         }
+        opencl_other = true;
     } else if (strlen(gpu_type)) {
         cpp = sreq.coprocs.lookup_type(gpu_type);
         if (!cpp) {
@@ -945,8 +946,9 @@ bool PLAN_CLASS_SPEC::check(
             }
             return false;
         }
+        opencl_other = true;
     }
-    if (cpp) {
+    if (opencl_other) {
         if (config.debug_version_select) {
             log_messages.printf(MSG_NORMAL,
                 "[version] plan_class_spec: OpenCL coproc %s found\n", cpp->type

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -228,8 +228,30 @@ bool PLAN_CLASS_SPEC::opencl_check(OPENCL_DEVICE_PROP& opencl_prop) {
     return true;
 }
 
-// See whether the given host/user can be sent this plan class.
-// If so return the resource usage and estimated FLOPS in hu.
+// the client is Win and it's a Docker/GPU plan class.
+// See whether the WSL distro has the needed GPU support
+//
+bool PLAN_CLASS_SPEC::check_wsl_gpu(SCHEDULER_REQUEST& sreq, string gpu_name) {
+    if (sreq.host.wsl_distros.distros.empty()) {
+        return false;
+    }
+    WSL_DISTRO &wd = sreq.host.wsl_distros.distros[0];
+    for (WSL_GPU &wg: wd.wsl_gpus) {
+        if (wg.name == gpu_name) {
+            if (cuda) {
+                return wg.has_cuda;
+            }
+            if (opencl) {
+                return wg.has_opencl;
+            }
+        }
+    }
+    return false;
+}
+
+// See whether the given host/user can be sent an app version
+// with this plan class.
+// If so, return the resource usage and estimated FLOPS in hu.
 //
 bool PLAN_CLASS_SPEC::check(
     SCHEDULER_REQUEST& sreq, HOST_USAGE& hu, const WORKUNIT* wu
@@ -704,7 +726,6 @@ bool PLAN_CLASS_SPEC::check(
             }
         }
 
-
         if (min_cal_target && cp.attribs.target < min_cal_target) {
             if (config.debug_version_select) {
                 log_messages.printf(MSG_NORMAL,
@@ -749,6 +770,15 @@ bool PLAN_CLASS_SPEC::check(
                 log_messages.printf(MSG_NORMAL,
                     "[version] plan_class_spec: no CAL, driver version couldn't be determined\n"
                 );
+            }
+        }
+
+        if (sreq.host.is_windows() && docker) {
+            if (!check_wsl_gpu(sreq, "amd")) {
+                log_messages.printf(MSG_NORMAL,
+                    "AMD GPU not supported in WSL"
+                );
+                return false;
             }
         }
 
@@ -822,6 +852,15 @@ bool PLAN_CLASS_SPEC::check(
             log_messages.printf(MSG_NORMAL, "%s\n", msg.c_str());
         }
 
+        if (sreq.host.is_windows() && docker) {
+            if (!check_wsl_gpu(sreq, "nvidia")) {
+                log_messages.printf(MSG_NORMAL,
+                    "NVIDIA GPU not supported in WSL"
+                );
+                return false;
+            }
+        }
+
     // Intel GPU
     //
     } else if (strstr(gpu_type, "intel") == gpu_type) {
@@ -841,6 +880,15 @@ bool PLAN_CLASS_SPEC::check(
         }
         if (cp.bad_gpu_peak_flops("Intel GPU", msg)) {
             log_messages.printf(MSG_NORMAL, "%s\n", msg.c_str());
+        }
+
+        if (sreq.host.is_windows() && docker) {
+            if (!check_wsl_gpu(sreq, "intel")) {
+                log_messages.printf(MSG_NORMAL,
+                    "Intel GPU not supported in WSL"
+                );
+                return false;
+            }
         }
 
     // Apple GPU
@@ -906,6 +954,15 @@ bool PLAN_CLASS_SPEC::check(
         }
         if (cpp->bad_gpu_peak_flops("OpenCL coproc", msg)) {
             log_messages.printf(MSG_NORMAL, "%s\n", msg.c_str());
+        }
+
+        if (sreq.host.is_windows() && docker) {
+            if (!check_wsl_gpu(sreq, cpp->type)) {
+                log_messages.printf(MSG_NORMAL,
+                    "OpenCL %s GPU not supported in WSL", cpp->type
+                );
+                return false;
+            }
         }
     }
 

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -16,7 +16,7 @@
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 // Plan class specifications in XML
-// See https://github.com/BOINC/boinc/wiki/AppPlanSpec
+// See https://github.com/BOINC/boinc/wiki/Plan-classes
 
 #include <string>
 #include <vector>
@@ -124,10 +124,11 @@ struct PLAN_CLASS_SPEC {
     vector<int> exclude_vbox_version;
     bool vm_accel_required;
 
+    PLAN_CLASS_SPEC();
     int parse(XML_PARSER&);
     bool opencl_check(OPENCL_DEVICE_PROP&);
     bool check(SCHEDULER_REQUEST& sreq, HOST_USAGE& hu, const WORKUNIT* wu);
-    PLAN_CLASS_SPEC();
+    bool check_wsl_gpu(SCHEDULER_REQUEST& sreq, std::string gpu_name);
 };
 
 struct PLAN_CLASS_SPECS {


### PR DESCRIPTION
- Client: get list of usable GPUs from 'gpus.json' file in WSL distro: the name,
and whether CUDA and/or OpenCL are supported. Convey this info in scheduler requests.

- Scheduler: If sending a Docker/GPU plan class to a Win host,
look at the WSL GPU list sent from the client,
and make sure it can handle that GPU type, and CUDA or OpenCL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WSL-aware GPU capability reporting on Windows and gates Docker/Podman GPU plan classes so we only send containers the host can run. Parses each distro’s `gpus.json` with `nlohmann/json`, sends the data in scheduler requests, and logs it at startup.

- **New Features**
  - Client (Win): Parse and report WSL GPUs (name, CUDA/OpenCL), include in scheduler-request XML, and show in startup logs.
  - Scheduler: On Windows, for container GPU plan classes, check the WSL GPU list for the required vendor or OpenCL device name and capability before selecting a version.

- **Bug Fixes**
  - Fix FCGI build by adjusting preprocessor guards around WSL GPU XML and restoring needed helpers; tidy XML formatting.

<sup>Written for commit d8089a8351de119a512e26acf27029c8b9467344. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

