### PR TITLE
web: fix bug in BUDA app deletion

### DIFF
--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -462,7 +462,13 @@ function variant_delete() {
             unlink($phys_path);
             unlink("$phys_path.md5");
         }
-        system(sprintf('rm -r %s', escapeshellarg("$buda_root/$app")), $ret);
+        system(
+            sprintf(
+                'rm -r %s',
+                escapeshellarg("$buda_root/$app/$variant")
+            ),
+            $ret
+        );
         if ($ret) {
             error_page("delete failed");
         }
@@ -491,7 +497,13 @@ function app_delete() {
         if ($vars) {
             error_page("You must delete all variants first.");
         }
-        system("rm -r $buda_root/$app", $ret);
+        system(
+            sprintf(
+                'rm -r %s',
+                escapeshellarg("$buda_root/$app")
+            ),
+            $ret
+        );
         if ($ret) {
             error_page('delete failed');
         }

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -491,8 +491,7 @@ function app_delete() {
         if ($vars) {
             error_page("You must delete all variants first.");
         }
-        system("rm $buda_root/$app/desc.json", $ret);
-        system("rmdir $buda_root/$app", $ret);
+        system("rm -r $buda_root/$app", $ret);
         if ($ret) {
             error_page('delete failed');
         }

--- a/html/user/buda.php
+++ b/html/user/buda.php
@@ -462,7 +462,7 @@ function variant_delete() {
             unlink($phys_path);
             unlink("$phys_path.md5");
         }
-        system("rm -r $buda_root/$app/$variant", $ret);
+        system(sprintf('rm -r %s', escapeshellarg("$buda_root/$app")), $ret);
         if ($ret) {
             error_page("delete failed");
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix BUDA app and variant deletion by shell-escaping paths and using a single recursive directory removal. This prevents partial deletes and ensures both variant folders and the app directory are fully removed when variants are gone.

<sup>Written for commit f1fa950d0d66ddc47d00bce80c99f0e4f2276066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

