### PR TITLE
client: log messages: don't say 'virtual size' when you mean 'swap usage'

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -230,9 +230,9 @@ void CLIENT_STATE::show_host_info() {
     nbytes_to_string(host_info.m_nbytes, 0, buf, sizeof(buf));
     if (is_swap_defined()) {
         nbytes_to_string(host_info.m_swap, 0, buf2, sizeof(buf2));
-        msg_printf(NULL, MSG_INFO, "Memory: %s physical, %s virtual", buf, buf2);
+        msg_printf(NULL, MSG_INFO, "Memory: %s RAM, %s swap space", buf, buf2);
     } else {
-        msg_printf(NULL, MSG_INFO, "Memory: %s physical", buf);
+        msg_printf(NULL, MSG_INFO, "Memory: %s RAM", buf);
     }
 
     nbytes_to_string(host_info.d_total, 0, buf, sizeof(buf));

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -850,7 +850,7 @@ bool CLIENT_STATE::swap_limit_check() {
     if (swap_usage > swap_limit) {
         if (log_flags.cpu_sched_debug) {
             msg_printf(NULL, MSG_INFO,
-                "[cpu_sched_debug] virtual size limit exceeded: %.2f GB > %.2f GB",
+                "[cpu_sched_debug] swap usage limit exceeded: %.2f GB > %.2f GB",
                 swap_usage/GIGA, swap_limit/GIGA
             );
         }
@@ -1494,18 +1494,18 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
             }
         }
 
-        // skip jobs whose 'expected working set size' (EWSS)
-        // is too large to fit in available RAM,
-        // or whose swap size is too large for available swap space.
+        // skip jobs whose 'expected resident set size' (erss)
+        // exceeds available RAM,
+        // or whose swap usage exceeds available swap space.
         //
-        // To compute EWSS, we start with
-        // - if the job has already run, its recent average WSS
+        // To compute erss, we start with
+        // - if the job has already run, its recent average RSS
         // - else if other jobs of this app version have run recently,
-        //      the max of their WSSs
+        //      the max of their RSSs
         // - else the WU's rsc_memory_bound
         // If project->strict_memory_bound is set,
         // we max the above with wu.rsc_memory_bound.
-        // This is to handle apps (like CPDN) whose WSS is small for a while
+        // This is to handle apps (like CPDN) whose RSS is small for a while
         // and then gets big.
         //
         double erss = 0;
@@ -1544,7 +1544,7 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
                 }
                 if (log_flags.cpu_sched_debug || log_flags.mem_usage_debug) {
                     msg_printf(rp->project, MSG_INFO,
-                        "[cpu_sched_debug] skipping %s: virtual size (%.2f GB) exceeds swap left (%.2f GB)",
+                        "[cpu_sched_debug] skipping %s: swap usage (%.2f GB) exceeds swap left (%.2f GB)",
                         rp->name,  eswap/GIGA, swap_left/GIGA
                     );
                 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified memory-related logging to use correct terms: host info now shows RAM and swap, and CPU scheduler logs report swap usage (not “virtual size”).

- **Bug Fixes**
  - Host startup message now prints “Memory: <RAM>, <swap space>”.
  - CPU scheduler debug logs now say “swap usage limit exceeded” and “swap usage exceeds swap left”.

- **Refactors**
  - Updated comments to use “expected resident set size (erss)” and RSS instead of EWSS/WSS.

<sup>Written for commit e1f00adfed58ece4c04aa54e41982f9047c35624. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

