### PR TITLE
client: show "install Podman" messages only in certain cases

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -84,7 +84,6 @@ boinc_client_SOURCES = \
     net_stats.cpp \
     pers_file_xfer.cpp \
     project.cpp \
-    project_list.cpp \
     result.cpp \
     rr_sim.cpp \
     sandbox.cpp \

--- a/client/acct_setup.cpp
+++ b/client/acct_setup.cpp
@@ -326,7 +326,8 @@ void CLIENT_STATE::process_autologin(bool first) {
 
     // check that project ID is valid, get URL
     //
-    retval = project_list.read_file();       // get project list
+    ALL_PROJECTS_LIST apl;
+    retval = apl.read_file(ALL_PROJECTS_LIST_FILENAME);    // get project list
     if (retval) {
         msg_printf(NULL, MSG_INFO,
             "Error reading project list: %s", boincerror(retval)
@@ -334,7 +335,7 @@ void CLIENT_STATE::process_autologin(bool first) {
         boinc_delete_file(ACCOUNT_DATA_FILENAME);
         return;
     }
-    PROJECT_LIST_ITEM *pli = project_list.lookup(project_id);
+    PROJECT_LIST_ENTRY *pli = apl.lookup_id(project_id);
     if (!pli) {
         if (first) {
             // we may have an outdated project list.
@@ -362,7 +363,7 @@ void CLIENT_STATE::process_autologin(bool first) {
     }
 
     if (!pli->is_account_manager) {
-        if (lookup_project(pli->master_url.c_str())) {
+        if (lookup_project(pli->url.c_str())) {
             msg_printf(NULL, MSG_INFO,
                 "Already attached to %s", pli->name.c_str()
             );
@@ -391,12 +392,12 @@ void CLIENT_STATE::process_autologin(bool first) {
 }
 
 int LOOKUP_LOGIN_TOKEN_OP::do_rpc(
-    PROJECT_LIST_ITEM* _pli, int user_id, const char* login_token
+    PROJECT_LIST_ENTRY* _pli, int user_id, const char* login_token
 ) {
     char url[1024];
     pli = _pli;
     snprintf(url, sizeof(url), "%slogin_token_lookup.php?user_id=%d&token=%s",
-        pli->master_url.c_str(), user_id, login_token
+        pli->url.c_str(), user_id, login_token
     );
     return gui_http->do_rpc(this, url, LOGIN_TOKEN_LOOKUP_REPLY, false);
 }
@@ -450,17 +451,17 @@ void LOOKUP_LOGIN_TOKEN_OP::handle_reply(int http_op_retval) {
             "Using account manager %s", pli->name.c_str()
         );
         safe_strcpy(gstate.acct_mgr_info.project_name, pli->name.c_str());
-        safe_strcpy(gstate.acct_mgr_info.master_url, pli->master_url.c_str());
+        safe_strcpy(gstate.acct_mgr_info.master_url, pli->url.c_str());
         safe_strcpy(gstate.acct_mgr_info.user_name, user_name.c_str());
         safe_strcpy(gstate.acct_mgr_info.authenticator, authenticator.c_str());
         gstate.acct_mgr_info.write_info();
     } else {
         msg_printf(NULL, MSG_INFO, "Attaching to project %s", pli->name.c_str());
         gstate.add_project(
-            pli->master_url.c_str(), authenticator.c_str(),
+            pli->url.c_str(), authenticator.c_str(),
             pli->name.c_str(), "", false
         );
-        PROJECT *p = gstate.lookup_project(pli->master_url.c_str());
+        PROJECT *p = gstate.lookup_project(pli->url.c_str());
         if (p) {
             safe_strcpy(p->user_name, user_name.c_str());
             safe_strcpy(p->team_name, team_name.c_str());

--- a/client/acct_setup.h
+++ b/client/acct_setup.h
@@ -19,7 +19,7 @@
 #define BOINC_ACCT_SETUP_H
 
 #include "error_numbers.h"
-#include "project_list.h"
+#include "util.h"
 #include "gui_http.h"
 
 struct ACCOUNT_IN {
@@ -91,14 +91,14 @@ struct GET_PROJECT_LIST_OP: public GUI_HTTP_OP {
 
 struct LOOKUP_LOGIN_TOKEN_OP: public GUI_HTTP_OP {
     int error_num;
-    PROJECT_LIST_ITEM* pli;
+    PROJECT_LIST_ENTRY* pli;
 
     LOOKUP_LOGIN_TOKEN_OP(GUI_HTTP* p){
         error_num = BOINC_SUCCESS;
         gui_http = p;
     }
     virtual ~LOOKUP_LOGIN_TOKEN_OP(){}
-    int do_rpc(PROJECT_LIST_ITEM*, int user_id, const char* login_token);
+    int do_rpc(PROJECT_LIST_ENTRY*, int user_id, const char* login_token);
     virtual void handle_reply(int http_op_retval);
 };
 

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -2553,7 +2553,7 @@ void show_docker_messages() {
             for (PROJECT_LIST_ENTRY *ple: apl.projects) {
                 if (!strcmp(p->master_url, ple->url.c_str())) {
                     for (string plat: ple->platforms) {
-                        if (strstr("docker", plat.c_str())) {
+                        if (strstr(plat.c_str(), "docker")) {
                             show = true;
                             break;
                         }

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -310,7 +310,6 @@ void CLIENT_STATE::show_host_info() {
     show_docker_messages();
 #endif
 
-
     if (strlen(host_info.virtualbox_version)) {
         msg_printf(NULL, MSG_INFO,
             "VirtualBox version: %s",
@@ -2491,16 +2490,18 @@ void CLIENT_STATE::init_result_resource_usage(PROJECT *p) {
 }
 
 // shows messages (as notices) related to Docker and WSL:
-// All platforms: if no Docker, suggest they install it
-// Win:
-//      if Docker but not our WSL distro, suggest they use ours
-//      if they have our distro but not current, suggest upgrade
-//
 // Called on startup, and after doing a get-version RPC
+// to get boinc-buda-runner version
 //
 #ifndef ANDROID
 void show_docker_messages() {
+    if (cc_config.dont_use_docker) {
+        return;
+    }
 #ifdef _WIN32
+    if (cc_config.dont_use_wsl) {
+        return;
+    }
     // don't show message if OS is too old for WSL
     //
     if (gstate.host_info.major_version < 10
@@ -2515,12 +2516,8 @@ void show_docker_messages() {
 #else
     const char* url = "https://github.com/BOINC/boinc/wiki/Installing-Docker-on-Linux";
 #endif
-    if (!gstate.host_info.have_docker()) {
-        msg_printf_notice(0, true, url,
-            "Some projects require Docker; we recommend that you install it."
-        );
+    if (gstate.host_info.have_docker()) {
 #ifdef _WIN32
-    } else {
         int bdv = gstate.host_info.wsl_distros.boinc_distro_version();
         if (bdv) {
             if (bdv < gstate.latest_boinc_buda_runner_version) {
@@ -2535,6 +2532,46 @@ void show_docker_messages() {
             );
         }
 #endif
+        return;
+    }
+
+    // here Docker is not present.
+    // Tell the user to install it if either
+    // - we're using Science United, or
+    // - we're attached to a project that has a Docker app
+    //
+    bool show = false;
+    if (gstate.acct_mgr_info.using_am() && gstate.acct_mgr_info.dynamic) {
+        show = true;
+    } else {
+        ALL_PROJECTS_LIST apl;
+        int retval = apl.read_file(ALL_PROJECTS_LIST_FILENAME);
+        if (retval) {
+            return;
+        }
+        for (PROJECT *p: gstate.projects) {
+            for (PROJECT_LIST_ENTRY *ple: apl.projects) {
+                if (!strcmp(p->master_url, ple->url.c_str())) {
+                    for (string plat: ple->platforms) {
+                        if (strstr("docker", plat.c_str())) {
+                            show = true;
+                            break;
+                        }
+                    }
+                }
+                if (show) {
+                    break;
+                }
+            }
+            if (show) {
+                break;
+            }
+        }
+    }
+    if (show) {
+        msg_printf_notice(0, true, url,
+            "Some projects require Podman; we recommend that you install it."
+        );
     }
 }
 #endif

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -51,7 +51,6 @@ using std::vector;
 #include "net_stats.h"
 #include "pers_file_xfer.h"
 #include "prefs.h"
-#include "project_list.h"
 #include "scheduler_op.h"
 #include "time_stats.h"
 
@@ -244,7 +243,6 @@ struct CLIENT_STATE {
         // the time we last successfully fetched the project list
     bool autologin_in_progress;
     bool autologin_fetching_project_list;
-    PROJECT_LIST project_list;
     void process_autologin(bool first);
 
 // --------------- app_test.cpp:

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -1208,9 +1208,18 @@ void ShowSecurityError(const char *format, ...) {
     va_end(args);
 }
 
+// return time of day (seconds since 1970) as a double
+// ??? should use dtime() from lib/util.cpp
+//
+static double dtime2(void) {
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    return tv.tv_sec + (tv.tv_usec/1.e6);
+}
+
 // Uses usleep to sleep for full duration even if a signal is received
 static void SleepSeconds(double seconds) {
-    double end_time = dtime() + seconds - 0.01;
+    double end_time = dtime2() + seconds - 0.01;
     // sleep() and usleep() can be interrupted by SIGALRM,
     // so we may need multiple calls
     //
@@ -1220,7 +1229,7 @@ static void SleepSeconds(double seconds) {
         } else {
             usleep((int)fmod(seconds*1000000, 1000000));
         }
-        seconds = end_time - dtime();
+        seconds = end_time - dtime2();
         if (seconds <= 0) break;
     }
 }

--- a/clientgui/mac/SetupSecurity.cpp
+++ b/clientgui/mac/SetupSecurity.cpp
@@ -29,6 +29,7 @@
 #include <spawn.h>
 
 #include "file_names.h"
+#include "util.h"
 #include "mac_util.h"
 #include "SetupSecurity.h"
 
@@ -44,7 +45,6 @@ static OSStatus DoSudoPosixSpawn(const char *pathToTool, char *arg1, char *arg2,
 static OSStatus SetFakeMasterNames(void);
 #endif
 static OSStatus CreateUserAndGroup(char * user_name, char * group_name);
-static double dtime(void);
 static void SleepSeconds(double seconds);
 
 #if VERBOSE_TEST
@@ -1206,15 +1206,6 @@ void ShowSecurityError(const char *format, ...) {
     va_start(args, format);
     vfprintf(stderr, format, args);
     va_end(args);
-}
-
-
-// return time of day (seconds since 1970) as a double
-//
-static double dtime(void) {
-    struct timeval tv;
-    gettimeofday(&tv, 0);
-    return tv.tv_sec + (tv.tv_usec/1.e6);
 }
 
 // Uses usleep to sleep for full duration even if a signal is received

--- a/lib/gui_rpc_client.h
+++ b/lib/gui_rpc_client.h
@@ -49,6 +49,7 @@
 #include "network.h"
 #include "notice.h"
 #include "prefs.h"
+#include "util.h"
 
 struct GUI_URL {
     std::string name;
@@ -71,46 +72,6 @@ struct DAILY_STATS {
     int parse(XML_PARSER&);
 };
 
-
-struct PROJECT_LIST_ENTRY {
-    std::string name;
-    std::string url;
-    std::string web_url;
-    std::string general_area;
-    std::string specific_area;
-    std::string description;
-    std::string home;       // sponsoring organization
-    std::string image;      // URL of logo
-    std::vector<std::string> platforms;
-        // platforms supported by project, or empty
-
-    PROJECT_LIST_ENTRY();
-
-    int parse(XML_PARSER&);
-    void clear();
-};
-
-struct AM_LIST_ENTRY {
-    std::string name;
-    std::string url;
-    std::string description;
-    std::string image;
-
-    AM_LIST_ENTRY();
-
-    int parse(XML_PARSER&);
-    void clear();
-};
-
-struct ALL_PROJECTS_LIST {
-    std::vector<PROJECT_LIST_ENTRY*> projects;
-    std::vector<AM_LIST_ENTRY*> account_managers;
-
-    ALL_PROJECTS_LIST();
-
-    void clear();
-    void alpha_sort();
-};
 
 struct RSC_DESC {
     double backoff_time;

--- a/lib/gui_rpc_client_ops.cpp
+++ b/lib/gui_rpc_client_ops.cpp
@@ -148,114 +148,6 @@ int GUI_URL::parse(XML_PARSER& xp) {
     return ERR_XML_PARSE;
 }
 
-
-PROJECT_LIST_ENTRY::PROJECT_LIST_ENTRY() {
-    clear();
-}
-
-int PROJECT_LIST_ENTRY::parse(XML_PARSER& xp) {
-    string platform;
-
-    while (!xp.get_tag()) {
-        if (xp.match_tag("/project")) return 0;
-        if (xp.parse_string("name", name)) continue;
-        if (xp.parse_string("url", url)) {
-            continue;
-        }
-        if (xp.parse_string("web_url", web_url)) {
-            continue;
-        }
-        if (xp.parse_string("general_area", general_area)) continue;
-        if (xp.parse_string("specific_area", specific_area)) continue;
-        if (xp.parse_string("description", description)) {
-            continue;
-        }
-        if (xp.parse_string("home", home)) continue;
-        if (xp.parse_string("image", image)) continue;
-        if (xp.match_tag("platforms")) {
-            while (!xp.get_tag()) {
-                if (xp.match_tag("/platforms")) break;
-                if (xp.parse_string("name", platform)) {
-                    platforms.push_back(platform);
-                }
-            }
-        }
-        xp.skip_unexpected(false, "");
-    }
-    return ERR_XML_PARSE;
-}
-
-void PROJECT_LIST_ENTRY::clear() {
-    name.clear();
-    url.clear();
-    web_url.clear();
-    general_area.clear();
-    specific_area.clear();
-    description.clear();
-    platforms.clear();
-    home.clear();
-    image.clear();
-}
-
-AM_LIST_ENTRY::AM_LIST_ENTRY() {
-    clear();
-}
-
-int AM_LIST_ENTRY::parse(XML_PARSER& xp) {
-    while (!xp.get_tag()) {
-        if (xp.match_tag("/account_manager")) return 0;
-        if (xp.parse_string("name", name)) continue;
-        if (xp.parse_string("url", url)) continue;
-        if (xp.parse_string("description", description)) continue;
-        if (xp.parse_string("image", image)) continue;
-    }
-    return 0;
-}
-
-void AM_LIST_ENTRY::clear() {
-    name.clear();
-    url.clear();
-    description.clear();
-    image.clear();
-}
-
-ALL_PROJECTS_LIST::ALL_PROJECTS_LIST() {
-}
-
-bool compare_project_list_entry(
-    const PROJECT_LIST_ENTRY* a, const PROJECT_LIST_ENTRY* b
-) {
-#ifdef _WIN32
-    return _stricmp(a->name.c_str(), b->name.c_str()) < 0;
-#else
-    return strcasecmp(a->name.c_str(), b->name.c_str()) < 0;
-#endif
-}
-
-bool compare_am_list_entry(const AM_LIST_ENTRY* a, const AM_LIST_ENTRY* b) {
-#ifdef _WIN32
-    return _stricmp(a->name.c_str(), b->name.c_str()) < 0;
-#else
-    return strcasecmp(a->name.c_str(), b->name.c_str()) < 0;
-#endif
-}
-
-void ALL_PROJECTS_LIST::alpha_sort() {
-    sort(projects.begin(), projects.end(), compare_project_list_entry);
-    sort(account_managers.begin(), account_managers.end(), compare_am_list_entry);
-}
-
-void ALL_PROJECTS_LIST::clear() {
-    for (PROJECT_LIST_ENTRY *p: projects) {
-        delete p;
-    }
-    for (AM_LIST_ENTRY *am: account_managers) {
-        delete am;
-    }
-    projects.clear();
-    account_managers.clear();
-}
-
 PROJECT::PROJECT() {
     clear();
 }
@@ -1655,37 +1547,13 @@ int RPC_CLIENT::get_project_status(PROJECTS& p) {
 int RPC_CLIENT::get_all_projects_list(ALL_PROJECTS_LIST& pl) {
     int retval = 0;
     SET_LOCALE sl;
-    MIOFILE mf;
-    PROJECT_LIST_ENTRY* project;
-    AM_LIST_ENTRY* am;
+    //MIOFILE mf;
     RPC rpc(this);
-
-    pl.clear();
 
     retval = rpc.do_rpc("<get_all_projects_list/>\n");
     if (retval) return retval;
-    while (!rpc.xp.get_tag()) {
-        if (rpc.xp.match_tag("/projects")) break;
-        else if (rpc.xp.match_tag("project")) {
-            project = new PROJECT_LIST_ENTRY();
-            retval = project->parse(rpc.xp);
-            if (!retval) {
-                pl.projects.push_back(project);
-            } else {
-                delete project;
-            }
-            continue;
-        } else if (rpc.xp.match_tag("account_manager")) {
-            am = new AM_LIST_ENTRY();
-            retval = am->parse(rpc.xp);
-            if (!retval) {
-                pl.account_managers.push_back(am);
-            } else {
-                delete am;
-            }
-            continue;
-        }
-    }
+    retval = pl.parse(rpc.xp);
+    if (retval) return retval;
 
     pl.alpha_sort();
 

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -916,7 +916,12 @@ int PROJECT_LIST_ENTRY::parse(XML_PARSER& xp) {
     string platform;
 
     while (!xp.get_tag()) {
-        if (xp.match_tag("/project")) return 0;
+        if (xp.match_tag("/project")) {
+            if (id == 0) return ERR_XML_PARSE;
+            if (url.empty()) return ERR_XML_PARSE;
+            if (name.empty()) return ERR_XML_PARSE;
+            return 0;
+        }
         if (xp.match_tag("/account_manager")) return 0;
         if (xp.parse_string("name", name)) continue;
         if (xp.parse_int("id", id)) continue;
@@ -959,9 +964,6 @@ void PROJECT_LIST_ENTRY::clear() {
     image.clear();
 }
 
-ALL_PROJECTS_LIST::ALL_PROJECTS_LIST() {
-}
-
 bool compare_project_list_entry(
     const PROJECT_LIST_ENTRY* a, const PROJECT_LIST_ENTRY* b
 ) {
@@ -994,7 +996,9 @@ int ALL_PROJECTS_LIST::parse(XML_PARSER &xp) {
 
     clear();
     while (!xp.get_tag()) {
-        if (xp.match_tag("/projects")) break;
+        if (xp.match_tag("/projects")) {
+            return 0;
+        }
         else if (xp.match_tag("project")) {
             entry = new PROJECT_LIST_ENTRY();
             retval = entry->parse(xp);
@@ -1017,7 +1021,7 @@ int ALL_PROJECTS_LIST::parse(XML_PARSER &xp) {
             continue;
         }
     }
-    return 0;
+    return ERR_XML_PARSE;
 }
 
 int ALL_PROJECTS_LIST::read_file(const char* filename) {

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -47,6 +47,7 @@
 #include <string>
 #include <cstring>
 #include <cmath>
+#include <algorithm>
 #if HAVE_IEEEFP_H
 #include <ieeefp.h>
 extern "C" {
@@ -716,6 +717,8 @@ string parse_ldd_libc(const char* input) {
     return s;
 }
 
+// ------------ Docker stuff follows ------------
+
 // Set up to issue Docker commands.
 // On Win this requires connecting to a shell in the WSL distro
 //
@@ -902,4 +905,130 @@ string docker_container_name(
 bool docker_is_boinc_name(const char* name) {
     return strstr(name, "boinc__") == name;
 }
+
+// ------------ all_projects_list.xml stuff follows ---------
+
+PROJECT_LIST_ENTRY::PROJECT_LIST_ENTRY() {
+    clear();
+}
+
+int PROJECT_LIST_ENTRY::parse(XML_PARSER& xp) {
+    string platform;
+
+    while (!xp.get_tag()) {
+        if (xp.match_tag("/project")) return 0;
+        if (xp.match_tag("/account_manager")) return 0;
+        if (xp.parse_string("name", name)) continue;
+        if (xp.parse_int("id", id)) continue;
+        if (xp.parse_string("url", url)) {
+            continue;
+        }
+        if (xp.parse_string("web_url", web_url)) {
+            continue;
+        }
+        if (xp.parse_string("general_area", general_area)) continue;
+        if (xp.parse_string("specific_area", specific_area)) continue;
+        if (xp.parse_string("description", description)) {
+            continue;
+        }
+        if (xp.parse_string("home", home)) continue;
+        if (xp.parse_string("image", image)) continue;
+        if (xp.match_tag("platforms")) {
+            while (!xp.get_tag()) {
+                if (xp.match_tag("/platforms")) break;
+                if (xp.parse_string("name", platform)) {
+                    platforms.push_back(platform);
+                }
+            }
+        }
+        xp.skip_unexpected(false, "");
+    }
+    return ERR_XML_PARSE;
+}
+
+void PROJECT_LIST_ENTRY::clear() {
+    name.clear();
+    id = 0;
+    url.clear();
+    web_url.clear();
+    general_area.clear();
+    specific_area.clear();
+    description.clear();
+    platforms.clear();
+    home.clear();
+    image.clear();
+}
+
+ALL_PROJECTS_LIST::ALL_PROJECTS_LIST() {
+}
+
+bool compare_project_list_entry(
+    const PROJECT_LIST_ENTRY* a, const PROJECT_LIST_ENTRY* b
+) {
+#ifdef _WIN32
+    return _stricmp(a->name.c_str(), b->name.c_str()) < 0;
+#else
+    return strcasecmp(a->name.c_str(), b->name.c_str()) < 0;
+#endif
+}
+
+void ALL_PROJECTS_LIST::alpha_sort() {
+    sort(projects.begin(), projects.end(), compare_project_list_entry);
+    sort(account_managers.begin(), account_managers.end(), compare_project_list_entry);
+}
+
+void ALL_PROJECTS_LIST::clear() {
+    for (PROJECT_LIST_ENTRY *p: projects) {
+        delete p;
+    }
+    for (PROJECT_LIST_ENTRY *am: account_managers) {
+        delete am;
+    }
+    projects.clear();
+    account_managers.clear();
+}
+
+int ALL_PROJECTS_LIST::parse(XML_PARSER &xp) {
+    PROJECT_LIST_ENTRY* entry;
+    int retval;
+
+    clear();
+    while (!xp.get_tag()) {
+        if (xp.match_tag("/projects")) break;
+        else if (xp.match_tag("project")) {
+            entry = new PROJECT_LIST_ENTRY();
+            retval = entry->parse(xp);
+            if (!retval) {
+                entry->is_account_manager = false;
+                projects.push_back(entry);
+            } else {
+                delete entry;
+            }
+            continue;
+        } else if (xp.match_tag("account_manager")) {
+            entry = new PROJECT_LIST_ENTRY();
+            retval = entry->parse(xp);
+            if (!retval) {
+                entry->is_account_manager = true;
+                account_managers.push_back(entry);
+            } else {
+                delete entry;
+            }
+            continue;
+        }
+    }
+    return 0;
+}
+
+int ALL_PROJECTS_LIST::read_file(const char* filename) {
+    FILE* f = fopen(filename, "r");
+    if (!f) return ERR_FOPEN;
+    MIOFILE mf;
+    mf.init_file(f);
+    XML_PARSER xp(&mf);
+    int retval = parse(xp);
+    fclose(f);
+    return retval;
+}
+
 #endif  // _USING_FCGI

--- a/lib/util.h
+++ b/lib/util.h
@@ -146,6 +146,8 @@ extern double simtime;
 #define time(x) ((int)simtime)
 #endif
 
+// -------- Docker-related stuff; could move to a different file
+
 // represents a connection to a Docker/Podman installation
 // used from docker_wrapper and the client
 //
@@ -193,5 +195,55 @@ extern std::string docker_container_name(
 
 // is the name (of a Docker image or container) a BOINC name?
 extern bool docker_is_boinc_name(const char* name);
+
+// -------- stuff related to all_projects_list.xml;
+// could move to a different file
+
+// the following can represent either a project or an AM
+
+struct PROJECT_LIST_ENTRY {
+    std::string name;
+    int id;
+    std::string url;
+    std::string web_url;
+    std::string general_area;
+    std::string specific_area;
+    std::string description;
+    std::string home;       // sponsoring organization
+    std::string image;      // URL of logo
+    std::vector<std::string> platforms;
+        // platforms supported by project, or empty
+    bool is_account_manager;
+
+    PROJECT_LIST_ENTRY();
+
+    int parse(XML_PARSER&);
+    void clear();
+};
+
+struct ALL_PROJECTS_LIST {
+    std::vector<PROJECT_LIST_ENTRY*> projects;
+    std::vector<PROJECT_LIST_ENTRY*> account_managers;
+
+    ALL_PROJECTS_LIST();
+
+    void clear();
+    int parse(XML_PARSER&);
+    int read_file(const char* filename);
+    void alpha_sort();
+    PROJECT_LIST_ENTRY* lookup_id(int id) {
+        for (PROJECT_LIST_ENTRY *p: projects) {
+            if (p->id == id) {
+                return p;
+            }
+        }
+        for (PROJECT_LIST_ENTRY *p: account_managers) {
+            if (p->id == id) {
+                return p;
+            }
+        }
+        return NULL;
+    }
+};
 
 #endif

--- a/lib/util.h
+++ b/lib/util.h
@@ -225,7 +225,10 @@ struct ALL_PROJECTS_LIST {
     std::vector<PROJECT_LIST_ENTRY*> projects;
     std::vector<PROJECT_LIST_ENTRY*> account_managers;
 
-    ALL_PROJECTS_LIST();
+    ALL_PROJECTS_LIST(){}
+    ~ALL_PROJECTS_LIST() {
+        clear();
+    }
 
     void clear();
     int parse(XML_PARSER&);

--- a/lib/util.h
+++ b/lib/util.h
@@ -229,6 +229,9 @@ struct ALL_PROJECTS_LIST {
     ~ALL_PROJECTS_LIST() {
         clear();
     }
+    // make it non-copyable
+    ALL_PROJECTS_LIST(const ALL_PROJECTS_LIST&) = delete;
+    ALL_PROJECTS_LIST& operator=(const ALL_PROJECTS_LIST&) = delete;
 
     void clear();
     int parse(XML_PARSER&);

--- a/mac_installer/uninstall.cpp
+++ b/mac_installer/uninstall.cpp
@@ -71,7 +71,6 @@ OSErr GetCurrentScreenSaverSelection(passwd *pw, char *moduleName, size_t maxLen
 OSErr SetScreenSaverSelection(char *moduleName, char *modulePath, int type);
 static pid_t FindProcessPID(char* name, pid_t thePID);
 static int KillOneProcess(char* name);
-static double dtime(void);
 static void SleepSeconds(double seconds);
 static void GetPreferredLanguages();
 static void LoadPreferredLanguages();
@@ -1533,7 +1532,7 @@ static int KillOneProcess(char* name) {
 
 // return time of day (seconds since 1970) as a double
 //
-static double dtime(void) {
+static double dtime2(void) {
     struct timeval tv;
     gettimeofday(&tv, 0);
     return tv.tv_sec + (tv.tv_usec/1.e6);
@@ -1541,7 +1540,7 @@ static double dtime(void) {
 
 // Uses usleep to sleep for full duration even if a signal is received
 static void SleepSeconds(double seconds) {
-    double end_time = dtime() + seconds - 0.01;
+    double end_time = dtime2() + seconds - 0.01;
     // sleep() and usleep() can be interrupted by SIGALRM,
     // so we may need multiple calls
     //
@@ -1551,7 +1550,7 @@ static void SleepSeconds(double seconds) {
         } else {
             usleep((int)fmod(seconds*1000000, 1000000));
         }
-        seconds = end_time - dtime();
+        seconds = end_time - dtime2();
         if (seconds <= 0) break;
     }
 }


### PR DESCRIPTION
Namely:
- the client is attached to a project that has Podman apps
- the client is using Science United

Also: we had two separate chunks of code for parsing all_projects_list.xml. Combine these into one (in lib/util)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show “Install Podman” only when it’s relevant, and consolidate `all_projects_list.xml` parsing into `lib/util` to remove duplicate code and simplify lookups. Adds another macOS build fix to avoid duplicate `dtime()` symbols.

- **New Features**
  - Only show the install message if:
    - Using Science United (dynamic AM), or
    - Attached to a project that lists the `docker` platform.
  - Respect `dont_use_docker` and, on Windows, `dont_use_wsl`; skip notices on unsupported Windows.
  - Keep WSL/runner notices on Windows when Docker/Podman is present.

- **Refactors**
  - Moved `all_projects_list.xml` parsing to `lib/util` as `ALL_PROJECTS_LIST` with `parse()`, `read_file()`, `alpha_sort()`, and `lookup_id()`; unified entries via `PROJECT_LIST_ENTRY` with `id` and `is_account_manager`.
  - Removed duplicate structs/parsers from `lib/gui_rpc_client*`; `get_all_projects_list` now uses `ALL_PROJECTS_LIST::parse()`. Updated account attach to use `lookup_id()` and `url`. Dropped `project_list.cpp` and the old `PROJECT_LIST` member.
  - macOS: include `util.h` in `clientgui/mac/SetupSecurity.cpp` and rename duplicate `dtime()` to `dtime2`; also rename duplicate `dtime()` in `mac_installer/uninstall.cpp` to fix builds.

<sup>Written for commit 51d23b91cd7020c3f3ce51bf6876f3f09b36ddff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

