### PR TITLE
client: use 'Podman' instead of 'Docker' in messages to user

### DIFF
--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -268,15 +268,15 @@ void CLIENT_STATE::show_host_info() {
                 );
             }
             if (!wsl.docker_version.empty()) {
-                msg_printf(NULL, MSG_INFO, "-      Podman version %s (%s)",
-                    wsl.docker_version.c_str(),
-                    docker_type_str(wsl.docker_type)
+                msg_printf(NULL, MSG_INFO, "-      %s version %s",
+                    docker_type_str(wsl.docker_type),
+                    wsl.docker_version.c_str()
                 );
             }
             if (!wsl.docker_compose_version.empty()) {
-                msg_printf(NULL, MSG_INFO, "-      Podman compose version %s (%s)",
-                    wsl.docker_compose_version.c_str(),
-                    docker_type_str(wsl.docker_compose_type)
+                msg_printf(NULL, MSG_INFO, "-      %s compose version %s",
+                    docker_type_str(wsl.docker_compose_type),
+                    wsl.docker_compose_version.c_str()
                 );
             }
             if (wsl.boinc_buda_runner_version) {
@@ -327,15 +327,15 @@ void CLIENT_STATE::show_host_info() {
 
 #ifndef _WIN64
     if (strlen(host_info.docker_version)) {
-        msg_printf(NULL, MSG_INFO, "Podman: version %s (%s)",
-            host_info.docker_version,
-            docker_type_str(host_info.docker_type)
+        msg_printf(NULL, MSG_INFO, "%s: version %s",
+            docker_type_str(host_info.docker_type),
+            host_info.docker_version
         );
     }
     if (strlen(host_info.docker_compose_version)) {
-        msg_printf(NULL, MSG_INFO, "Podman compose: version %s (%s)",
-            host_info.docker_compose_version,
-            docker_type_str(host_info.docker_compose_type)
+        msg_printf(NULL, MSG_INFO, "%s compose: version %s",
+            docker_type_str(host_info.docker_compose_type),
+            host_info.docker_compose_version
         );
     }
 #endif
@@ -2532,7 +2532,7 @@ void show_docker_messages() {
             }
         } else {
             msg_printf_notice(0, true, url,
-                "Podman is present but not using the BOINC WSL distro.  Some project apps may not function properly. We recommend that you install the BOINC WSL distro."
+                "Docker or Podman is present but not using the BOINC WSL distro.  Some project apps may not function properly. We recommend that you install the BOINC WSL distro."
             );
         }
 #endif

--- a/client/client_state.cpp
+++ b/client/client_state.cpp
@@ -268,13 +268,13 @@ void CLIENT_STATE::show_host_info() {
                 );
             }
             if (!wsl.docker_version.empty()) {
-                msg_printf(NULL, MSG_INFO, "-      Docker version %s (%s)",
+                msg_printf(NULL, MSG_INFO, "-      Podman version %s (%s)",
                     wsl.docker_version.c_str(),
                     docker_type_str(wsl.docker_type)
                 );
             }
             if (!wsl.docker_compose_version.empty()) {
-                msg_printf(NULL, MSG_INFO, "-      Docker compose version %s (%s)",
+                msg_printf(NULL, MSG_INFO, "-      Podman compose version %s (%s)",
                     wsl.docker_compose_version.c_str(),
                     docker_type_str(wsl.docker_compose_type)
                 );
@@ -328,13 +328,13 @@ void CLIENT_STATE::show_host_info() {
 
 #ifndef _WIN64
     if (strlen(host_info.docker_version)) {
-        msg_printf(NULL, MSG_INFO, "Docker: version %s (%s)",
+        msg_printf(NULL, MSG_INFO, "Podman: version %s (%s)",
             host_info.docker_version,
             docker_type_str(host_info.docker_type)
         );
     }
     if (strlen(host_info.docker_compose_version)) {
-        msg_printf(NULL, MSG_INFO, "Docker compose: version %s (%s)",
+        msg_printf(NULL, MSG_INFO, "Podman compose: version %s (%s)",
             host_info.docker_compose_version,
             docker_type_str(host_info.docker_compose_type)
         );
@@ -2509,15 +2509,15 @@ void show_docker_messages() {
         return;
     }
 
-    const char* url = "https://github.com/BOINC/boinc/wiki/Installing-Docker-on-Windows";
+    const char* url = "https://github.com/BOINC/boinc/wiki/Installing-Podman-on-Windows";
 #elif defined(__APPLE__)
-    const char* url = "https://github.com/BOINC/boinc/wiki/Installing-Docker-on-Mac";
+    const char* url = "https://github.com/BOINC/boinc/wiki/Installing-Podman-on-Mac";
 #else
-    const char* url = "https://github.com/BOINC/boinc/wiki/Installing-Docker-on-Linux";
+    const char* url = "https://github.com/BOINC/boinc/wiki/Installing-Podman-on-Linux";
 #endif
     if (!gstate.host_info.have_docker()) {
         msg_printf_notice(0, true, url,
-            "Some projects require Docker; we recommend that you install it."
+            "Some projects require Podman; we recommend that you install it."
         );
 #ifdef _WIN32
     } else {
@@ -2531,7 +2531,7 @@ void show_docker_messages() {
             }
         } else {
             msg_printf_notice(0, true, url,
-                "Docker is present but not using the BOINC WSL distro.  Some project apps may not function properly. We recommend that you install the BOINC WSL distro."
+                "Podman is present but not using the BOINC WSL distro.  Some project apps may not function properly. We recommend that you install the BOINC WSL distro."
             );
         }
 #endif

--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -899,7 +899,7 @@ bool APP_VERSION::disallowed_by_config(PROJECT *p) {
     }
     if (cc_config.dont_use_docker && strstr(plan_class, "docker")) {
         msg_printf(p, MSG_INFO,
-            "skipping Docker app: disabled in cc_config.xml"
+            "skipping Podman app: disabled in cc_config.xml"
         );
         return true;
     }

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -166,7 +166,7 @@ struct PROC_RESOURCES {
             }
         }
 
-        // if job uses Docker, make sure it's installed
+        // if job uses Podman, make sure it's installed
         //
         if (rp->uses_docker()) {
             if (!gstate.host_info.have_docker()) {

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -173,10 +173,10 @@ struct PROC_RESOURCES {
                 static bool first = true;
                 if (first) {
                     msg_printf(NULL, MSG_USER_ALERT,
-                        "Docker jobs are present but Podman/Docker not found; please install it."
+                        "Podman jobs are present but Podman not found; please install it."
                     );
                     msg_printf(NULL, MSG_USER_ALERT,
-                        "See https://github.com/BOINC/boinc/wiki/Installing-Docker"
+                        "See https://github.com/BOINC/boinc/wiki/Installing-Podman"
                     );
                     first = false;
                 }

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -409,7 +409,9 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
     //
     retval = dc.command("ps --all", out, false);
     if (retval) {
-        fprintf(stderr, "Podman command failed: ps --all\n");
+        fprintf(stderr, "%s command failed: ps --all\n",
+            docker_type_str(dc.type)
+        );
     } else {
         for (string line: out) {
             retval = dc.parse_container_name(line, name);
@@ -419,11 +421,14 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
             sprintf(cmd, "rm -f %s", name.c_str());
             retval = dc.command(cmd, out2, true);
             if (retval) {
-                fprintf(stderr, "Podman command failed: %s\n", cmd);
+                fprintf(stderr, "%s command failed: %s\n",
+                    docker_type_str(dc.type), cmd
+                );
                 continue;
             }
             msg_printf(NULL, MSG_INFO,
-                "Removed unused Podman container: %s", name.c_str()
+                "Removed unused %s container: %s",
+                docker_type_str(dc.type), name.c_str()
             );
         }
     }
@@ -432,7 +437,9 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
     //
     retval = dc.command("images", out, false);
     if (retval) {
-        fprintf(stderr, "Podman command failed: images\n");
+        fprintf(stderr, "%s command failed: images\n",
+            docker_type_str(dc.type)
+        );
     } else {
         for (string line: out) {
             retval = dc.parse_image_name(line, name);
@@ -442,11 +449,14 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
             sprintf(cmd, "image rm %s", name.c_str());
             retval = dc.command(cmd, out2, true);
             if (retval) {
-                fprintf(stderr, "Podman command failed: %s\n", cmd);
+                fprintf(stderr, "%s command failed: %s\n",
+                    docker_type_str(dc.type), cmd
+                );
                 continue;
             }
             msg_printf(NULL, MSG_INFO,
-                "Removed unused Podman image: %s", name.c_str()
+                "Removed unused %s image: %s",
+                docker_type_str(dc.type), name.c_str()
             );
         }
     }

--- a/client/cs_apps.cpp
+++ b/client/cs_apps.cpp
@@ -392,7 +392,7 @@ struct DOCKER_JOB_INFO {
     }
 };
 
-// clean up a Docker installation
+// clean up a Podman installation
 // (Unix: the host; Win: a WSL distro)
 //
 void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
@@ -409,7 +409,7 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
     //
     retval = dc.command("ps --all", out, false);
     if (retval) {
-        fprintf(stderr, "Docker command failed: ps --all\n");
+        fprintf(stderr, "Podman command failed: ps --all\n");
     } else {
         for (string line: out) {
             retval = dc.parse_container_name(line, name);
@@ -419,11 +419,11 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
             sprintf(cmd, "rm -f %s", name.c_str());
             retval = dc.command(cmd, out2, true);
             if (retval) {
-                fprintf(stderr, "Docker command failed: %s\n", cmd);
+                fprintf(stderr, "Podman command failed: %s\n", cmd);
                 continue;
             }
             msg_printf(NULL, MSG_INFO,
-                "Removed unused Docker container: %s", name.c_str()
+                "Removed unused Podman container: %s", name.c_str()
             );
         }
     }
@@ -432,7 +432,7 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
     //
     retval = dc.command("images", out, false);
     if (retval) {
-        fprintf(stderr, "Docker command failed: images\n");
+        fprintf(stderr, "Podman command failed: images\n");
     } else {
         for (string line: out) {
             retval = dc.parse_image_name(line, name);
@@ -442,17 +442,17 @@ void cleanup_docker(DOCKER_JOB_INFO &info, DOCKER_CONN &dc) {
             sprintf(cmd, "image rm %s", name.c_str());
             retval = dc.command(cmd, out2, true);
             if (retval) {
-                fprintf(stderr, "Docker command failed: %s\n", cmd);
+                fprintf(stderr, "Podman command failed: %s\n", cmd);
                 continue;
             }
             msg_printf(NULL, MSG_INFO,
-                "Removed unused Docker image: %s", name.c_str()
+                "Removed unused Podman image: %s", name.c_str()
             );
         }
     }
 }
 
-// remove old BOINC images and containers from Docker installations
+// remove old BOINC images and containers from Podman installations
 //
 void CLIENT_STATE::docker_cleanup() {
     // make lists of the images and containers used by active jobs
@@ -468,7 +468,7 @@ void CLIENT_STATE::docker_cleanup() {
         info.containers.push_back(s);
     }
 
-    // go through local Docker installations and remove
+    // go through local Podman installations and remove
     // BOINC images and containers not in the above lists
     //
 #ifdef _WIN32

--- a/client/cs_scheduler.cpp
+++ b/client/cs_scheduler.cpp
@@ -186,7 +186,7 @@ int CLIENT_STATE::make_scheduler_request(PROJECT* p) {
     set_n_usable_cpus();
 
 #ifdef __APPLE__
-    // if Podman hasn't inited yet, don't include Docker info in sched req
+    // if Podman hasn't inited yet, don't include Podman info in sched req
     char tmp[256];
     safe_strcpy(tmp, host_info.docker_version);
     if (host_info.docker_type == PODMAN && !host_info.podman_inited) {

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -1309,7 +1309,7 @@ bool HOST_INFO::get_docker_version_aux(DOCKER_TYPE type){
 #endif  // __APPLE__
 
 #ifdef __linux__
-    // if we're running as an unprivileged user, Docker/podman may not work.
+    // if we're running as an unprivileged user, Docker/Podman may not work.
     // Check by running the Hello World image.
     //
     // Since we do this every time on startup: delete the created container

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -467,20 +467,21 @@ static bool get_docker_version_aux(
             ret = true;
             if (version.empty()) {
                 msg_printf(0, MSG_INFO,
-                    "Podman version parse failed: %s", reply.c_str()
+                    "%s version parse failed: %s",
+                    dock_pod_name(type), reply.c_str()
                 );
             }
         } else {
-            msg_printf(0, MSG_INFO, "Podman detection in %s:",
-                wd.distro_name.c_str()
+            msg_printf(0, MSG_INFO, "%s detection in %s:",
+                dock_pod_name(type), wd.distro_name.c_str()
             );
             msg_printf(0, MSG_INFO, "-   cmd: %s", cmd.c_str());
             msg_printf(0, MSG_INFO, "-   output: %s", reply.c_str());
         }
         CloseHandle(rs.proc_handle);
     } else {
-        msg_printf(0, MSG_INFO, "Podman detection in %s:",
-            wd.distro_name.c_str()
+        msg_printf(0, MSG_INFO, "%s detection in %s:",
+            dock_pod_name(type), wd.distro_name.c_str()
         );
         msg_printf(0, MSG_INFO, "-   cmd failed: %s", cmd.c_str());
     }

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -468,12 +468,12 @@ static bool get_docker_version_aux(
             if (version.empty()) {
                 msg_printf(0, MSG_INFO,
                     "%s version parse failed: %s",
-                    dock_pod_name(type), reply.c_str()
+                    docker_type_str(type), reply.c_str()
                 );
             }
         } else {
             msg_printf(0, MSG_INFO, "%s detection in %s:",
-                dock_pod_name(type), wd.distro_name.c_str()
+                docker_type_str(type), wd.distro_name.c_str()
             );
             msg_printf(0, MSG_INFO, "-   cmd: %s", cmd.c_str());
             msg_printf(0, MSG_INFO, "-   output: %s", reply.c_str());
@@ -481,7 +481,7 @@ static bool get_docker_version_aux(
         CloseHandle(rs.proc_handle);
     } else {
         msg_printf(0, MSG_INFO, "%s detection in %s:",
-            dock_pod_name(type), wd.distro_name.c_str()
+            docker_type_str(type), wd.distro_name.c_str()
         );
         msg_printf(0, MSG_INFO, "-   cmd failed: %s", cmd.c_str());
     }

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -215,7 +215,7 @@ static bool got_both(WSL_DISTRO &wd) {
 // Get list of WSL distros usable by BOINC
 // For each of them:
 //      try to find the OS name and version
-//      see if Docker and docker compose are present, get versions
+//      see if Docker/Podman and compose are present, get versions
 // Return nonzero on error
 //
 int get_wsl_information(WSL_DISTROS &distros) {
@@ -380,7 +380,7 @@ int get_wsl_information(WSL_DISTROS &distros) {
             wd.libc_version = parse_ldd_libc(buf.c_str());
         }
 
-        // see if Docker is installed in the distro
+        // see if Podman/Docker is installed in the distro
         //
         get_docker_version(rs, wd);
         get_docker_compose_version(rs, wd);
@@ -467,11 +467,11 @@ static bool get_docker_version_aux(
             ret = true;
             if (version.empty()) {
                 msg_printf(0, MSG_INFO,
-                    "Docker version parse failed: %s", reply.c_str()
+                    "Podman version parse failed: %s", reply.c_str()
                 );
             }
         } else {
-            msg_printf(0, MSG_INFO, "Docker detection in %s:",
+            msg_printf(0, MSG_INFO, "Podman detection in %s:",
                 wd.distro_name.c_str()
             );
             msg_printf(0, MSG_INFO, "-   cmd: %s", cmd.c_str());
@@ -479,7 +479,7 @@ static bool get_docker_version_aux(
         }
         CloseHandle(rs.proc_handle);
     } else {
-        msg_printf(0, MSG_INFO, "Docker detection in %s:",
+        msg_printf(0, MSG_INFO, "Podman detection in %s:",
             wd.distro_name.c_str()
         );
         msg_printf(0, MSG_INFO, "-   cmd failed: %s", cmd.c_str());

--- a/client/log_flags.cpp
+++ b/client/log_flags.cpp
@@ -196,7 +196,7 @@ void CC_CONFIG::show() {
         msg_printf(NULL, MSG_INFO, "Config: don't use VirtualBox");
     }
     if (dont_use_docker) {
-        msg_printf(NULL, MSG_INFO, "Config: don't use Docker");
+        msg_printf(NULL, MSG_INFO, "Config: don't use Podman/Docker");
     }
     if (dont_use_wsl) {
         msg_printf(NULL, MSG_INFO, "Config: don't use Windows Subsystem for Linux");
@@ -386,6 +386,7 @@ int CC_CONFIG::parse_options_client(XML_PARSER& xp) {
             continue;
         }
         if (xp.parse_bool("dont_use_docker", dont_use_docker)) continue;
+        if (xp.parse_bool("dont_use_podman", dont_use_docker)) continue;
         if (xp.match_tag("exclude_gpu")) {
             EXCLUDE_GPU eg;
             retval = eg.parse(xp);

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -417,17 +417,6 @@ const char* docker_cli_prog(DOCKER_TYPE type) {
     return "unknown";
 }
 
-// display name
-//
-const char* docker_type_str(DOCKER_TYPE type) {
-    switch (type) {
-    case DOCKER: return "Docker";
-    case PODMAN: return "podman";
-    default: break;
-    }
-    return "unknown";
-}
-
 // parse a string like
 // Docker version 24.0.7, build 24.0.7-0ubuntu2~22.04.1
 // or

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -52,7 +52,6 @@ const char file_osrelease[] = "/etc/os-release";
 const char file_redhatrelease[] = "/etc/redhat-release";
 
 extern const char* docker_cli_prog(DOCKER_TYPE type);
-extern const char* docker_type_str(DOCKER_TYPE type);
 
 // if you add fields, update clear_host_info()
 
@@ -223,5 +222,19 @@ extern NXEventHandle gEventHandle;
 // is the filesystem remote? (Linux only)
 //
 extern int is_filesystem_remote(const char* path, bool&);
+
+// user-visible name
+//
+inline const char* docker_type_str(DOCKER_TYPE t) {
+    switch (t) {
+    case DOCKER:
+        return "Docker";
+    case PODMAN:
+        return "Podman";
+    case NONE:
+        break;
+    }
+    return "Unknown";
+}
 
 #endif

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -962,6 +962,7 @@ void PROJECT_LIST_ENTRY::clear() {
     platforms.clear();
     home.clear();
     image.clear();
+    is_account_manager = false;
 }
 
 bool compare_project_list_entry(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default to “Podman” in user-facing messages and help links, but show “Docker” when Docker is the detected runtime. Also fixes an uninitialized field in project list entries. Improves logs, host info, cleanup output, and WSL notices.

- **Refactors**
  - Messages use the detected runtime name (Docker/Podman) in host info and compose lines (e.g., “%s version %s”).
  - Install/help links now point to Podman; show a Podman install notice when missing; Windows WSL notices mention “Docker or Podman”.
  - Cleanup logs include the runtime (e.g., “Removed unused %s container/image”); CPU scheduler alerts refer to Podman when appropriate.
  - Inlined `docker_type_str()` in `hostinfo.h` with proper capitalization; removed old implementation and fixed a Windows build issue.
  - Initialized `PROJECT_LIST_ENTRY::is_account_manager` to false to avoid uninitialized state.

- **New Features**
  - Added `dont_use_podman` in `cc_config.xml` (alias of `dont_use_docker`); logs reflect “don’t use Podman/Docker” and skip Podman apps when disabled.

<sup>Written for commit 3ea21a72f9233f90f225f3c5f0d0b6e466aaf4e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

