### PR TITLE
Add StartupWMClass to desktop file

### DIFF
--- a/clientgui/res/boinc.desktop
+++ b/clientgui/res/boinc.desktop
@@ -4,6 +4,7 @@ Type=Application
 Name=BOINC Manager
 Path=/var/lib/boinc
 Exec=boincmgr
+StartupWMClass=boincmgr
 Icon=boinc
 Terminal=false
 Keywords=computation;science;


### PR DESCRIPTION
Fixes #3810

**Description of the Change**
This allows desktop environments like GNOME to match the window with the associated desktop file and show the appropriate icon for it.

**Alternate Designs**
Rename desktop file from `boinc.desktop` to `boincmgr.desktop`, or set the program name with `g_set_prgname("boinc")`.

**Release Notes**
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add StartupWMClass=boincmgr to the `boinc.desktop` file so GNOME and other desktops correctly match the BOINC Manager window and display the right icon. Fixes #3810.

<sup>Written for commit 58b8772a5406db347bdd0ee8adde21967a369b71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

