### PR TITLE
upgrade script: make it work when stop_web present

### DIFF
--- a/html/inc/boinc_db.inc
+++ b/html/inc/boinc_db.inc
@@ -76,8 +76,8 @@ class BoincDb {
         $user = project_config_val('db_user');
         $name = project_config_val('db_name');
         $passwd = project_config_val('db_passwd');
-        if (!$name || !$user || !$passwd) {
-            error_log("BoincDb::get_aux(): must specify DB name, user, passwd");
+        if (!$name || !$user) {
+            error_log("BoincDb::get_aux(): must specify DB name and user");
             return;
         }
         $retval = $instance->init_conn($user, $passwd, $host, $name);
@@ -125,6 +125,19 @@ class BoincDb {
         } else {
             error_page("Can't connect to database");
         }
+    }
+
+    // connect to DB from a CLI script, e.g. ops/db_update.php
+    //
+    static function get_cli() {
+        if (isset(self::$instance)) {
+            return self::$instance;
+        }
+        self::get_aux(0);
+        if (self::$instance) {
+            return self::$instance;
+        }
+        die("can't connect to DB");
     }
 
     static function close() {

--- a/html/ops/autolock.php
+++ b/html/ops/autolock.php
@@ -32,8 +32,7 @@ if ($argc > 2) {
 $t = time_str(time());
 echo "starting at $t\n";
 $t = time() - $max_age_days*86400;
-$db = BoincDb::get();
-if (!$db) die("can't open DB\n");
+$db = BoincDb::get_cli();
 $db->do_query("update ".$db->db_name.".thread, ".$db->db_name.".forum set ".$db->db_name.".thread.locked=1 where ".$db->db_name.".thread.forum=".$db->db_name.".forum.id and ".$db->db_name.".forum.parent_type=0 and ".$db->db_name.".thread.timestamp<$t and ".$db->db_name.".thread.locked=0 and ".$db->db_name.".thread.sticky=0");
 $n = $db->affected_rows();
 $t = time_str(time());

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -20,13 +20,10 @@
 // Don't run this unless you know what you're doing!
 
 $cli_only = true;
+
 require_once("../inc/util_ops.inc");
 
-$db = BoincDb::get_cli();
-if (!$db) {
-    echo "db_update.php: Can't open database\n";
-    exit;
-}
+BoincDb::get_cli();
 
 set_time_limit(0);
 

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -22,7 +22,7 @@
 $cli_only = true;
 require_once("../inc/util_ops.inc");
 
-$db = BoincDb::get(0);
+$db = BoincDb::get_cli();
 if (!$db) {
     echo "db_update.php: Can't open database\n";
     exit;

--- a/html/ops/delete_spammers.php
+++ b/html/ops/delete_spammers.php
@@ -276,7 +276,7 @@ function delete_profiles_strict() {
 
 function delete_users($no_hosts, $no_posts, $no_teams, $have_url) {
     global $test, $min_days, $max_days;
-    $db = BoincDb::get();
+    $db = BoincDb::get_cli();
     $query = "select a.* from user a ";
     if ($no_hosts) {
         $query .= " left join host c on c.userid=a.id ";

--- a/html/ops/delete_spammers.php
+++ b/html/ops/delete_spammers.php
@@ -126,11 +126,15 @@ ini_set('display_errors', true);
 ini_set('display_startup_errors', true);
 ini_set('memory_limit', '4G');
 
+$cli_only = true;
+
 require_once("../inc/db.inc");
 require_once("../inc/profile.inc");
 require_once("../inc/forum.inc");
 require_once("../inc/user_util.inc");
-db_init();
+require_once("../inc/util_ops.inc");
+
+BoincDb::get_cli();
 
 $min_days = 0;
 $max_days = 0;

--- a/html/ops/errorwus.php
+++ b/html/ops/errorwus.php
@@ -16,17 +16,25 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// web interface for showing error WUs
+
 require_once("../inc/common_defs.inc");
 require_once("../inc/util_ops.inc");
 require_once("../inc/cache.inc");
 
-// User - configuarble variables
+// User - configurable variables
+
 // seconds to cache this page
-// this page runs a scan of the two largest tables, so this shouldn't be done more often than necessary
+// this page runs a scan of the two largest tables,
+// so this shouldn't be done more often than necessary
 $cache_sec = 1800;
-// Number that determines how many client errors are necessary for a WU to show up in this list.
-// This number is added to min_quorum of the WU, so a value of 1 means that there must be more than
+
+// Number that determines how many client errors are necessary
+// for a WU to show up in this list.
+// This number is added to min_quorum of the WU,
+// so a value of 1 means that there must be more than
 // (min_quorum + 1) errors for a WU to show up in this list.
+
 $notification_level = get_int("level", true);
 if (!$notification_level) {
     $notification_level = 1;
@@ -105,7 +113,8 @@ function get_error_wus() {
     global $notification_level;
     global $appid_filter;
 
-    // this query is obviously expensive for big projects but if there is a replica this does not impact the project
+    // this query is obviously expensive for big projects
+    // but if there is a replica this does not impact the project
     $db = BoincDb::get(true);
     $dbresult = $db->do_query("
         SELECT id, name, appid, unsent, in_progress, successes, compute_errors,

--- a/html/ops/notify.php
+++ b/html/ops/notify.php
@@ -28,9 +28,12 @@
 //
 
 $cli_only = true;
+
 require_once("../inc/boinc_db.inc");
 require_once("../inc/util_ops.inc");
 require_once("../project/project.inc");
+
+BoincDb::get_cli();
 
 // delete notifications older than 90 days
 //

--- a/html/ops/notify.php
+++ b/html/ops/notify.php
@@ -59,7 +59,7 @@ Do not reply to this email.
 }
 
 function send_notify_emails() {
-    $db = BoincDb::get();
+    $db = BoincDb::get_cli();
 
     $t = time() - (86400 + 3600);  // 1-hour slop factor
     $query = "select notify.* from ".$db->db_name.".notify, ".$db->db_name.".forum_preferences where forum_preferences.pm_notification=2 and notify.userid = forum_preferences.userid and notify.create_time > $t";

--- a/html/ops/pass_percentage_by_appversion.php
+++ b/html/ops/pass_percentage_by_appversion.php
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// web page showing stats per app version
+
 require_once("../inc/util_ops.inc");
 
 admin_page_head("Result summary per app version");

--- a/html/ops/pass_percentage_by_platform.php
+++ b/html/ops/pass_percentage_by_platform.php
@@ -16,6 +16,8 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+// web page showing stats per platform
+
 require_once("../inc/util_ops.inc");
 
 admin_page_head("Result summary per app version");

--- a/html/ops/purge_trickles.php
+++ b/html/ops/purge_trickles.php
@@ -27,8 +27,8 @@
 //    same, trickle down
 
 require_once("../inc/boinc_db.inc");
-$db = BoincDb::get();
-if (!$db) die("no DB connection");
+
+$db = BoincDb::get_cli();
 
 if ($argc == 1) {
     $db->do_query("delete from msg_from_host where handled <> 0");

--- a/html/ops/repair_forums.php
+++ b/html/ops/repair_forums.php
@@ -46,7 +46,7 @@ function cleanup_orphan_threads() {
 // Fix this.
 //
 function remove_backslashes($table, $field) {
-    $db = BoincDb::get();
+    $db = BoincDb::get_cli();
     $query = "update ".$db->db_name.".$table set $field=replace(replace($field, '\\\\\\\"', '\\\"'), '\\\\\\'', '\'')";
     $db->do_query($query);
 }

--- a/html/ops/repair_profile_pictures.php
+++ b/html/ops/repair_profile_pictures.php
@@ -23,7 +23,7 @@ ini_set("memory_limit", "1023M");
 $cli_only = true;
 require_once("../inc/util_ops.inc");
 
-BoincDb::get();
+BoincDb::get_cli();
 
 $profiles = BoincProfile::enum("");
 

--- a/html/ops/single_job_setup.php
+++ b/html/ops/single_job_setup.php
@@ -24,7 +24,6 @@
 // Run this from project home dir.
 // usage: html/ops/single_job_setup path-to-boinc_samples
 
-
 ini_set('error_reporting', E_ALL);
 
 // globals
@@ -55,7 +54,7 @@ function get_includes() {
     $c = getcwd();
     chdir('html/ops');
     require_once('../inc/util_ops.inc');
-    BoincDb::get();
+    BoincDb::get_cli();
     chdir($c);
 }
 

--- a/html/ops/size_census.php
+++ b/html/ops/size_census.php
@@ -36,7 +36,7 @@ function do_app($app) {
     // enumerate the host_app_versions for this app,
     // joined to the host
 
-    $db = BoincDb::get();
+    $db = BoincDb::get_cli();
     $query = "select et_avg, host.on_frac, host.active_frac, host.gpu_active_frac, app_version.plan_class " .
         " from DBNAME.host_app_version, DBNAME.host, DBNAME.app_version " .
         " where host_app_version.app_version_id = app_version.id " .

--- a/html/ops/size_census.php
+++ b/html/ops/size_census.php
@@ -26,11 +26,16 @@
 // --all_apps: compute quantiles for all apps;
 // use this during setup and testing.
 
+$cli_only = true;
+
 error_reporting(E_ALL);
 ini_set('display_errors', true);
 ini_set('display_startup_errors', true);
 
 require_once("../inc/util.inc");
+require_once("../inc/util_ops.inc");
+
+BoincDb::get_cli();
 
 function do_app($app) {
     // enumerate the host_app_versions for this app,

--- a/html/ops/submit_init_priority.php
+++ b/html/ops/submit_init_priority.php
@@ -24,8 +24,13 @@
 //   result.priority
 // based on existing batches
 
+$cli_only = true;
+
 require_once("../inc/boinc_db.inc");
+require_once("../inc/util_ops.inc");
 require_once("../inc/submit_db.inc");
+
+BoincDb::get_cli();
 
 function process_batch($b) {
     $app = BoincApp::lookup_id($b->app_id);

--- a/html/ops/submit_init_priority.php
+++ b/html/ops/submit_init_priority.php
@@ -37,7 +37,7 @@ function process_batch($b) {
         $credit_total = $b->credit_canonical/$b->fraction_done;
         $fpops_total = $credit_total*(86400e9/200);
     } else {
-        $db = BoincDb::get();
+        $db = BoincDb::get_cli();
         $fpops_total = $db->sum(
             "workunit", "rsc_fpops_est*target_nresults", "where batch=$b->id"
         );


### PR DESCRIPTION
BoincDb::get() aborted when stop_web present.
But when doing 'upgrade' we want it to be present.
So add BoincDb::get_cli(), which doesn't do this,
and which reports errors as 1-line messages rather than
emitting a web page.

Also: allow empty DB password

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let CLI upgrade and ops scripts connect to the DB when `stop_web` is present, with 1-line error output. Also allow empty DB passwords and standardize CLI script setup.

- **New Features**
  - Added `BoincDb::get_cli()` that bypasses the `stop_web` check and exits with a 1-line error on failure.
  - Relaxed DB config in `get_aux()` to accept empty passwords (DB name and user still required).

- **Refactors**
  - Updated CLI scripts to use `BoincDb::get_cli()` and standardized init: set `$cli_only = true`, require `util_ops.inc`, then call `BoincDb::get_cli()` (e.g., `autolock.php`, `db_update.php`, `purge_trickles.php`, `repair_forums.php`, `repair_profile_pictures.php`, `single_job_setup.php`, `size_census.php`, `delete_spammers.php`, `notify.php`, `submit_init_priority.php`).

<sup>Written for commit 985516cf36285bb80b7ea24f43e96e607283701e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

