### PR TITLE
Manager: dark mode Notices background should not be completely black

### DIFF
--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -157,9 +157,9 @@ void CNoticeListCtrl::SetItemCount(int newCount) {
     m_itemCount = newCount;
     if (wxGetApp().GetIsDarkMode()){
 #if wxUSE_WEBVIEW
-        m_noticesBody =  wxT("<html><style>body{background-color:black;color:white;a:link {color:#0080FF;}}</style><head></head><body><font face=helvetica>");
+        m_noticesBody =  wxT("<html><style>body{background-color:#121212;color:#e0e0e0;a:link {color:#0080FF;}}</style><head></head><body><font face=helvetica>");
 #else
-        m_noticesBody =  wxT("<html><head></head><body bgcolor=black><font face=helvetica color=white bgcolor=black>");
+        m_noticesBody =  wxT("<html><head></head><body bgcolor=#121212><font face=helvetica color=#e0e0e0 bgcolor=#121212>");
 #endif
     } else {
         m_noticesBody =  wxT("<html><head></head><body><font face=helvetica>");

--- a/clientgui/NoticeListCtrl.cpp
+++ b/clientgui/NoticeListCtrl.cpp
@@ -104,9 +104,9 @@ bool CNoticeListCtrl::Create( wxWindow* parent ) {
 
     if (wxGetApp().GetIsDarkMode()){
 #if wxUSE_WEBVIEW
-        m_noticesBody = wxT("<html><style>body{background-color:black;color:white;a:link {color:#0080FF;}}</style><head></head><body></body></html>");
+        m_noticesBody = wxT("<html><style>body{background-color:#121212;color:#e0e0e0;a:link {color:#0080FF;}}</style><head></head><body></body></html>");
 #else
-        m_noticesBody = wxT("<html><head></head><body bgcolor=black></body></html>");
+        m_noticesBody = wxT("<html><head></head><body bgcolor=#121212></body></html>");
 #endif
     } else {
         m_noticesBody = wxT("<html><head></head><body></body></html>");


### PR DESCRIPTION
AI recommends #121212 for dark and #e0e0e0 for light

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update dark mode styling for Manager Notices: background #121212 and text #e0e0e0 for better readability. Applied in both webview and non-webview, including SetItemCount font color.

<sup>Written for commit 5a35836dd06715c18335063946ae5cbbbf21acdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

