### PR TITLE
client: fix swap limit stopping jobs from running

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -152,6 +152,7 @@ ACTIVE_TASK::ACTIVE_TASK() {
     sporadic_ac_state = AC_NONE;
     sporadic_ignore_until = 0;
     swap_kill_time = 0;
+    ignore_swap_limit = false;
 }
 
 bool ACTIVE_TASK::process_exists() {

--- a/client/app.h
+++ b/client/app.h
@@ -175,7 +175,8 @@ struct ACTIVE_TASK {
         // last time this task was killed to free swap space
     bool ignore_swap_limit;
         // run this job even if it's over the swap limit;
-        // set when nothing else can run.
+        // set when it's the only one holding swap, or when nothing
+        // else can run.
         // enforce_run_list() clears it on every exit path
 
     APP_CLIENT_SHM app_client_shm;

--- a/client/app.h
+++ b/client/app.h
@@ -173,6 +173,10 @@ struct ACTIVE_TASK {
     double last_deadline_miss_time;
     double swap_kill_time;
         // last time this task was killed to free swap space
+    bool ignore_swap_limit;
+        // run this job even if it's over the swap limit;
+        // set when nothing else can run.
+        // enforce_run_list() clears it on every exit path
 
     APP_CLIENT_SHM app_client_shm;
         // core/app shared mem segment

--- a/client/client_state.h
+++ b/client/client_state.h
@@ -323,7 +323,7 @@ struct CLIENT_STATE {
     void make_run_list(vector<RESULT*>&);
     bool enforce_run_list(vector<RESULT*>&);
     void append_unfinished_time_slice(vector<RESULT*>&);
-    bool swap_limit_check();
+    void swap_limit_check();
 
     double runnable_resource_share(int);
     void adjust_rec();

--- a/client/client_types.cpp
+++ b/client/client_types.cpp
@@ -873,6 +873,7 @@ void APP_VERSION::init() {
     graphics_exec_path[0] = 0;
     graphics_exec_file[0] = 0;
     max_rss = 0;
+    max_swap_usage = 0;
     is_vbox_app = false;
     is_docker_app = false;
     is_wrapper = false;

--- a/client/client_types.h
+++ b/client/client_types.h
@@ -372,6 +372,10 @@ struct APP_VERSION {
         // to use this much RAM,
         // so that we don't run a long sequence of jobs,
         // each of which turns out not to fit in available RAM
+    double max_swap_usage;
+        // same, for swap space.
+        // Zero unless this app version's jobs are actually swapping,
+        // so it imposes no limit on a system under no memory pressure
     bool is_vbox_app;
         // set if plan class includes "vbox"
     bool is_docker_app;

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -794,11 +794,9 @@ bool CLIENT_STATE::schedule_cpus() {
     //
     tasks_throttled = false;
 
-    if (!swap_limit_check()) {
-        make_run_list(run_list);
-        return enforce_run_list(run_list);
-    }
-    return true;
+    swap_limit_check();
+    make_run_list(run_list);
+    return enforce_run_list(run_list);
 }
 
 // sort by increasing cpu_time - checkpoint_cpu_time;
@@ -825,22 +823,23 @@ static bool compare_swap_revive(void *p1, void *p2) {
     return atp1 < atp2;
 }
 
-// if swap limit has been reached, we use different scheduling logic.
-// Return true if this is the case.
+// Enforce the swap limit: kill jobs if we're over it, revive
+// swap-killed ones if we're under it.  Scheduling itself is
+// make_run_list()'s and enforce_run_list()'s business either way.
 //
-bool CLIENT_STATE::swap_limit_check() {
+void CLIENT_STATE::swap_limit_check() {
     if (!is_swap_defined()) {
-        return false;
+        return;
     }
-
-    vector<RESULT*> run_list;
 
     // compute swap usage of running tasks
     //
     double swap_usage = 0;
+    int n_executing = 0;
     for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
         if (atp->task_state() == PROCESS_EXECUTING) {
             swap_usage += atp->procinfo.swap_usage;
+            n_executing++;
         }
     }
 
@@ -877,13 +876,6 @@ bool CLIENT_STATE::swap_limit_check() {
                 break;
             }
         }
-        // runnable list is the rest of the tasks
-        for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
-            if (atp->task_state() == PROCESS_EXECUTING) {
-                run_list.push_back(atp->result);
-            }
-        }
-        enforce_run_list(run_list);
     } else {
         // here currently running tasks fit in swap
         //
@@ -894,9 +886,9 @@ bool CLIENT_STATE::swap_limit_check() {
                 swap_kill_tasks.push_back(atp);
             }
         }
-        // if no swap-killed tasks, use normal scheduling
+        // if no swap-killed tasks, there's nothing to revive
         if (swap_kill_tasks.empty()) {
-            return false;
+            return;
         }
 
         if (log_flags.cpu_sched_debug) {
@@ -905,23 +897,20 @@ bool CLIENT_STATE::swap_limit_check() {
             );
         }
 
-        // initial run list is running tasks
-        //
-        for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
-            if (atp->task_state() == PROCESS_EXECUTING) {
-                run_list.push_back(atp->result);
-            }
-        }
         // see if we can run swap-killed tasks
         std::sort(
             swap_kill_tasks.begin(), swap_kill_tasks.end(),
             compare_swap_revive
         );
-        // run as many as will fit
+        // revive as many as will fit.
+        // The list is in deadline order; skip one that doesn't fit
+        // rather than stopping, so it can't veto the smaller jobs
+        // behind it
         //
+        int n_revived = 0;
         for (ACTIVE_TASK *atp: swap_kill_tasks) {
             if (swap_usage + atp->procinfo.swap_usage > swap_limit) {
-                break;
+                continue;
             }
             if (log_flags.cpu_sched_debug) {
                 msg_printf(atp->result->project, MSG_INFO,
@@ -929,12 +918,33 @@ bool CLIENT_STATE::swap_limit_check() {
                 );
             }
             atp->swap_kill_time = 0;
-            run_list.push_back(atp->result);
             swap_usage += atp->procinfo.swap_usage;
+            n_revived++;
         }
-        enforce_run_list(run_list);
+
+        // a swap-killed job's figure is from when it last ran, and
+        // nothing updates it meanwhile, so it can only be an
+        // over-estimate.  If nothing runs and nothing fits, we'd sit
+        // idle on a number that can never improve; run the
+        // earliest-deadline job anyway.
+        // enforce_run_list() applies the same test, so exempt it
+        //
+        if (!n_revived && !n_executing) {
+            ACTIVE_TASK* atp = swap_kill_tasks[0];
+            if (log_flags.cpu_sched_debug) {
+                msg_printf(atp->result->project, MSG_INFO,
+                    "[cpu_sched_debug] restarting %s: nothing else can run",
+                    atp->result->name
+                );
+            }
+            atp->ignore_swap_limit = true;
+            atp->swap_kill_time = 0;
+        }
+
+        // whatever is still swap-killed doesn't stop the rest of the
+        // client.  enforce_run_list() applies the same test to each
+        // job's own figure
     }
-    return true;
 }
 
 // Mark a job J as a deadline miss if either
@@ -1343,6 +1353,12 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
     // check whether GPUs are usable
     //
     if (check_coprocs_usable()) {
+        // exemptions apply to the scan below only;
+        // don't let one leak into a later pass
+        //
+        for (ACTIVE_TASK* atp: active_tasks.active_tasks) {
+            atp->ignore_swap_limit = false;
+        }
         request_schedule_cpus("GPU usability change");
         return true;
     }
@@ -1524,10 +1540,12 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         //
         double erss = 0;
         double eswap = 0;
+        bool ignore_swap_limit = false;
         if (atp) {
             atp->rss_too_large = false;
             erss = atp->procinfo.rss_smoothed;
             eswap = atp->procinfo.swap_usage;
+            ignore_swap_limit = atp->ignore_swap_limit;
         } else {
             erss = rp->avp->max_rss;
             eswap = rp->avp->max_swap_usage;
@@ -1555,7 +1573,7 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         // says.  It can be negative: an always_run job is charged above
         // without a test
         //
-        if (check_swap && eswap > 0) {
+        if (check_swap && !ignore_swap_limit && eswap > 0) {
             if (eswap > swap_left) {
                 if (atp) {
                     atp->swap_too_large = true;
@@ -1598,6 +1616,13 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         if (have_max_concurrent) {
             max_concurrent_inc(rp);
         }
+    }
+
+    // exemptions apply to the scan above only.
+    // Clear them here, not in it; it skips jobs before reading the flag
+    //
+    for (ACTIVE_TASK* atp: active_tasks.active_tasks) {
+        atp->ignore_swap_limit = false;
     }
 
     // if CPUs are starved, ask for more jobs

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1551,7 +1551,11 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
             }
             continue;
         }
-        if (check_swap) {
+        // a job that uses no swap can't exhaust it, whatever swap_left
+        // says.  It can be negative: an always_run job is charged above
+        // without a test
+        //
+        if (check_swap && eswap > 0) {
             if (eswap > swap_left) {
                 if (atp) {
                     atp->swap_too_large = true;

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -836,10 +836,14 @@ void CLIENT_STATE::swap_limit_check() {
     //
     double swap_usage = 0;
     int n_executing = 0;
+    int n_swappers = 0;
     for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
         if (atp->task_state() == PROCESS_EXECUTING) {
             swap_usage += atp->procinfo.swap_usage;
             n_executing++;
+            if (atp->procinfo.swap_usage > 0) {
+                n_swappers++;
+            }
         }
     }
 
@@ -863,6 +867,28 @@ void CLIENT_STATE::swap_limit_check() {
             if (atp->task_state() != PROCESS_EXECUTING) {
                 continue;
             }
+
+            // a job that holds no swap frees none by dying.
+            // The sort is by how much CPU time a kill would lose, which
+            // says nothing about swap, so these turn up here as often as
+            // any other job
+            //
+            if (atp->procinfo.swap_usage <= 0) {
+                continue;
+            }
+
+            // leave the last job that holds swap running.
+            // We're still over the limit, so this job exceeds it by
+            // itself, and killing it would gain us nothing.
+            // enforce_run_list() applies the same test, so exempt it
+            // there too; otherwise it preempts the job by quit and,
+            // with no swap_kill_time set, nothing ever revives it.
+            //
+            if (n_swappers == 1) {
+                atp->ignore_swap_limit = true;
+                break;
+            }
+
             if (log_flags.cpu_sched_debug) {
                 msg_printf(atp->result->project, MSG_INFO,
                     "[cpu_sched_debug] killing %s", atp->result->name
@@ -872,6 +898,7 @@ void CLIENT_STATE::swap_limit_check() {
             atp->preempt(REMOVE_ALWAYS);
                 // this changes state to QUIT_PENDING
             swap_usage -= atp->procinfo.swap_usage;
+            n_swappers--;
             if (swap_usage <= swap_limit) {
                 break;
             }

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1065,11 +1065,12 @@ void CLIENT_STATE::make_run_list(vector<RESULT*>& run_list) {
         }
     }
 
-    // compute max working set size for app versions
-    // (max of working sets of currently running jobs)
+    // compute max RSS and max swap usage for app versions
+    // (max over currently running jobs)
     //
     for (APP_VERSION *avp: app_versions) {
         avp->max_rss = 0;
+        avp->max_swap_usage = 0;
     }
     for (ACTIVE_TASK *atp: active_tasks.active_tasks) {
         atp->rss_too_large = false;
@@ -1078,6 +1079,19 @@ void CLIENT_STATE::make_run_list(vector<RESULT*>& run_list) {
         APP_VERSION* avp = atp->app_version;
         if (w > avp->max_rss) {
             avp->max_rss = w;
+        }
+        // count swap only while the process exists.
+        // Unlike RSS, swap usage depends on memory pressure rather than
+        // on the job itself, and get_memory_usage() stops updating it
+        // once the process is gone.
+        // Counting a stale figure here would charge unstarted jobs of
+        // this app version for it indefinitely.
+        //
+        if (atp->process_exists()) {
+            double s = atp->procinfo.swap_usage;
+            if (s > avp->max_swap_usage) {
+                avp->max_swap_usage = s;
+            }
         }
         atp->result->not_started = false;
     }
@@ -1516,7 +1530,7 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
             eswap = atp->procinfo.swap_usage;
         } else {
             erss = rp->avp->max_rss;
-            eswap = rp->avp->max_rss;  // best guess
+            eswap = rp->avp->max_swap_usage;
         }
         if (rp->project->strict_memory_bound) {
             erss = std::max(erss, rp->wup->rsc_memory_bound);

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -1397,10 +1397,14 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         print_job_list(run_list);
     }
 
-    // Set next_scheduler_state to PREEMPT for all tasks
+    // Set next_scheduler_state to PREEMPT for all tasks.
+    // Clear the mem-limit flags here, not in the scan below that sets
+    // them; the scan skips some jobs before reaching it
     //
     for (ACTIVE_TASK* atp: active_tasks.active_tasks) {
         atp->next_scheduler_state = CPU_SCHED_PREEMPTED;
+        atp->rss_too_large = false;
+        atp->swap_too_large = false;
     }
 
     int i=0;
@@ -1435,9 +1439,11 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         ram_left -= sporadic_resources.mem_used;
     }
     double swap_left = 0;
+    double swap_limit = 0;
     bool check_swap = false;
     if (is_swap_defined()) {
-        swap_left = (global_prefs.vm_max_used_frac)*host_info.m_swap;
+        swap_limit = (global_prefs.vm_max_used_frac)*host_info.m_swap;
+        swap_left = swap_limit;
         check_swap = true;
     }
 
@@ -1569,7 +1575,6 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         double eswap = 0;
         bool ignore_swap_limit = false;
         if (atp) {
-            atp->rss_too_large = false;
             erss = atp->procinfo.rss_smoothed;
             eswap = atp->procinfo.swap_usage;
             ignore_swap_limit = atp->ignore_swap_limit;
@@ -1598,12 +1603,21 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
         }
         // a job that uses no swap can't exhaust it, whatever swap_left
         // says.  It can be negative: an always_run job is charged above
-        // without a test
+        // without a test, and so is a job exempted from the limit
         //
         if (check_swap && !ignore_swap_limit && eswap > 0) {
             if (eswap > swap_left) {
                 if (atp) {
                     atp->swap_too_large = true;
+
+                    // it doesn't fit even on an idle host, so waiting
+                    // won't help.  If the process is gone its swap died
+                    // with it, so drop the figure rather than block the
+                    // job on it for good; a live one is measured again
+                    //
+                    if (eswap > swap_limit && !atp->process_exists()) {
+                        atp->procinfo.swap_usage = 0;
+                    }
                 }
                 if (log_flags.cpu_sched_debug || log_flags.mem_usage_debug) {
                     msg_printf(rp->project, MSG_INFO,
@@ -1701,6 +1715,13 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
                     }
                     preempt_type = REMOVE_NEVER;
                 }
+
+                // if we're quitting it to free swap space, say so;
+                // swap_limit_check() is what revives it
+                //
+                if (preempt_type == REMOVE_ALWAYS) {
+                    atp->swap_kill_time = now;
+                }
                 atp->preempt(preempt_type);
                 break;
             case PROCESS_SUSPENDED:
@@ -1710,6 +1731,19 @@ bool CLIENT_STATE::enforce_run_list(vector<RESULT*>& run_list) {
                 if (atp->result->uses_gpu()) {
                     atp->preempt(REMOVE_ALWAYS);
                     request_schedule_cpus("removed suspended GPU task");
+                    break;
+                }
+
+                // a suspended process still holds its swap space, so if
+                // it can't fit even on an idle host, leaving it in
+                // memory blocks it for good.  Anything less than that
+                // it can wait out; quitting costs it its checkpoint
+                //
+                if (atp->swap_too_large
+                    && atp->procinfo.swap_usage > swap_limit
+                ) {
+                    atp->swap_kill_time = now;
+                    atp->preempt(REMOVE_ALWAYS);
                     break;
                 }
 

--- a/lib/prefs.cpp
+++ b/lib/prefs.cpp
@@ -253,10 +253,9 @@ void GLOBAL_PREFS::defaults() {
     suspend_cpu_usage = 25;
 #endif
     suspend_if_no_recent_input = 0;
-    vm_max_used_frac = 0.75;
+    vm_max_used_frac = 1.;
     work_buf_additional_days = 0.5;
     work_buf_min_days = 0.1;
-    vm_max_used_frac = 1.;
 
     override_file_present = false;
 

--- a/lib/procinfo.cpp
+++ b/lib/procinfo.cpp
@@ -44,9 +44,13 @@ void add_child_totals(PROCINFO& procinfo, PROC_MAP& pm, PROC_MAP::iterator i) {
         PROC_MAP::iterator i2 = pm.find(child_pid);
         if (i2 == pm.end()) continue;
         PROCINFO& p = i2->second;
-        if (p.scanned) {
-            return;     // cycle in graph - shouldn't happen
-        }
+
+        // already counted: either a cycle in the graph,
+        // or a pid that's also in the app's other_pids.
+        // Skip just this one; its siblings still need scanning.
+        //
+        if (p.scanned) continue;
+
         procinfo.kernel_time += p.kernel_time;
         procinfo.user_time += p.user_time;
         p.scanned = true;
@@ -72,6 +76,15 @@ void procinfo_app(
     PROC_MAP::iterator i;
     for (i=pm.begin(); i!=pm.end(); ++i) {
         PROCINFO& p = i->second;
+        if (graphics_exec_file && !strcmp(p.command, graphics_exec_file)) {
+            p.is_boinc_app = true;
+        }
+
+        // an other_pid is typically a child of the app's main process,
+        // in which case add_child_totals() has already counted it
+        //
+        if (p.scanned) continue;
+
         if (p.id == procinfo.id
             || (other_pids && in_vector(p.id, *other_pids))
         ) {
@@ -89,9 +102,6 @@ void procinfo_app(
             // look for child processes
             //
             add_child_totals(procinfo, pm, i);
-        }
-        if (graphics_exec_file && !strcmp(p.command, graphics_exec_file)) {
-            p.is_boinc_app = true;
         }
     }
 }


### PR DESCRIPTION
Fixes #7132 and #7146.

In both cases the swap limit stops jobs from running even though nothing is
swapping.

On Linux the client estimates an unstarted job's swap usage from the app
version's max RSS, which is the wrong quantity. It charges a job for memory it
may never swap out, so with 8 GB of swap and a 4 GB app you get two jobs no
matter what. I now track max swap usage separately. When nothing is swapping
that's zero, so it imposes no limit.
On Android swap is zram, which the RAM limit already covers and which you can't
resize without root. I excluded it there, the same way it already is on macOS.

Three other things turned up while I was in there. `procinfo_app()` counts a
process twice when an app reports a helper PID that is also a descendant of its
main process, the swap-kill scheduler can stall the client permanently, and
`defaults()` sets `vm_max_used_frac` twice. Details are in the commit messages.

Each commit stands alone and builds. I tested the Android and desktop clients.
I couldn't exercise the swap-kill and revive paths, since they need real swap
pressure with `vm_max_used_frac` below 100%.

I think this is worth releasing sooner than usual.
The client simply runs fewer tasks than it should.

Happy to change anything or drop parts of it. I'd rather see the problem fixed
than these particular patches merged, and if the approach is wrong, I hope it is still useful.

LLMs usage: I used Claude (opus 4.6 and deepseek v4 preview) for the commit messages and to clean up my English.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes swap-limit logic that stalled jobs even when nothing was swapping by using real swap usage, keeping enforcement out of scheduling, and disabling swap limits on Android. Also fixes process accounting overcounts and makes swap-kill/revive reliable so jobs always make progress. Fixes #7132 and #7146; addresses #7191.

- **Bug Fixes**
  - Estimate unstarted jobs’ swap from `APP_VERSION::max_swap_usage` (from live running tasks), not RSS; use it in scheduling.
  - Keep swap-limit handling out of scheduling: `swap_limit_check()` only kills/revives; always build/enforce the run list; skip non-fitting revivals and, if nothing fits, revive one with a one-pass exemption (cleared on all exits, including GPU-usable early return).
  - Avoid pointless kills: don’t kill zero-swap tasks and don’t kill the last task that holds swap; exempt these from the swap check.
  - Never refuse zero-swap jobs even if swap_left is negative.
  - Set/clear `swap_kill_time` consistently and hand enforcement quits to the revive loop; drop stale swap figures when a process has exited.
  - Disable swap enforcement on Android (zram) by treating swap as undefined (same as macOS).
  - Correct process accounting: skip already-scanned PIDs when `other_pid` overlaps children and in child aggregation; run the graphics-executable check for every process.
  - Remove dead assignment in `GLOBAL_PREFS::defaults()` so `vm_max_used_frac` stays 1.0.

<sup>Written for commit 57a7548f30be90a1c897a20aefa4ca708e60cfed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

