### PR TITLE
Android: link 64-bit client binaries with 16 KB page alignment

### DIFF
--- a/android/build_boinc_arm64.sh
+++ b/android/build_boinc_arm64.sh
@@ -39,7 +39,7 @@ export CXX=aarch64-linux-android21-clang++
 export LD=aarch64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export LDFLAGS="$CONFIG_LDFLAGS -llog -fPIE -pie -latomic -static-libstdc++"
+export LDFLAGS="$CONFIG_LDFLAGS -llog -fPIE -pie -latomic -static-libstdc++ -Wl,-z,max-page-size=16384"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 
 MAKE_FLAGS=""

--- a/android/build_boinc_x86_64.sh
+++ b/android/build_boinc_x86_64.sh
@@ -39,7 +39,7 @@ export CXX=x86_64-linux-android21-clang++
 export LD=x86_64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export LDFLAGS="$CONFIG_LDFLAGS -llog -fPIE -pie -latomic -static-libstdc++"
+export LDFLAGS="$CONFIG_LDFLAGS -llog -fPIE -pie -latomic -static-libstdc++ -Wl,-z,max-page-size=16384"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 
 MAKE_FLAGS=""

--- a/android/build_example_arm64.sh
+++ b/android/build_example_arm64.sh
@@ -57,7 +57,7 @@ export CXX=aarch64-linux-android21-clang++
 export LD=aarch64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21 -I$TCINCLUDES/include -I$BOINC -I$BOINC_LIB_DIR -I$BOINC_API_DIR -I$BOINC_ZIP_DIR"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall  -funroll-loops -fexceptions -O3 -fomit-frame-pointer -I$TCINCLUDES/include -fPIE -D__ANDROID_API__=21 -I$BOINC -I$BOINC_LIB_DIR -I$BOINC_API_DIR -I$BOINC_ZIP_DIR"
-export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -lz"
+export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -lz -Wl,-z,max-page-size=16384"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 
 MAKE_FLAGS=""

--- a/android/build_example_x86_64.sh
+++ b/android/build_example_x86_64.sh
@@ -57,7 +57,7 @@ export CXX=x86_64-linux-android21-clang++
 export LD=x86_64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21 -I$TCINCLUDES/include -I$BOINC -I$BOINC_LIB_DIR -I$BOINC_API_DIR -I$BOINC_ZIP_DIR"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall  -funroll-loops -fexceptions -O3 -fomit-frame-pointer -I$TCINCLUDES/include -fPIE -D__ANDROID_API__=21 -I$BOINC -I$BOINC_LIB_DIR -I$BOINC_API_DIR -I$BOINC_ZIP_DIR"
-export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -lz"
+export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -lz -Wl,-z,max-page-size=16384"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 
 MAKE_FLAGS=""

--- a/android/build_libraries_arm64.sh
+++ b/android/build_libraries_arm64.sh
@@ -59,7 +59,7 @@ export CXX=aarch64-linux-android21-clang++
 export LD=aarch64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
+export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -Wl,-z,max-page-size=16384"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 
 MAKE_FLAGS=""

--- a/android/build_libraries_x86_64.sh
+++ b/android/build_libraries_x86_64.sh
@@ -59,7 +59,7 @@ export CXX=x86_64-linux-android21-clang++
 export LD=x86_64-linux-android-ld
 export CFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -DDECLARE_TIMEZONE -Wall -I$TCINCLUDES/include -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
 export CXXFLAGS="--sysroot=$TCSYSROOT -DANDROID -DANDROID_64 -Wall -I$TCINCLUDES/include -funroll-loops -fexceptions -O3 -fomit-frame-pointer -fPIE -D__ANDROID_API__=21"
-export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++"
+export LDFLAGS="$CONFIG_LDFLAGS -L$TCSYSROOT/usr/lib -L$TCINCLUDES/lib -llog -fPIE -pie -latomic -static-libstdc++ -Wl,-z,max-page-size=16384"
 export GDB_CFLAGS="--sysroot=$TCSYSROOT -Wall -g -I$TCINCLUDES/include"
 
 MAKE_FLAGS=""


### PR DESCRIPTION
Fixes #7194

**Description of the Change**

Adds `-Wl,-z,max-page-size=16384` to the link flags of the arm64 and x86_64 client builds, so the client binaries load on Android devices with 16 KB page-size kernels. Today they are linked with 4 KB ELF segment alignment (PT_LOAD align 0x1000 in the current CI binaries), which a 16 KB kernel refuses to load: the app UI runs but the native client silently never starts. Details and reproduction are in #7194.

16 KB aligned binaries remain fully compatible with 4 KB kernels, so nothing changes for existing devices. The 32-bit ABIs are unchanged since 16 KB page-size kernels only exist for 64-bit.

**Verification (all done)**

- [x] The CI artifacts from this PR's own Android run have PT_LOAD alignment 0x4000: verified by parsing the ELF program headers of the x86_64 and arm64-v8a client binaries from the run artifacts.
- [x] Runtime test on a 16 KB kernel (Android 15 google_apis_ps16k x86_64 emulator, getconf PAGE_SIZE confirms 16384): the current 4 KB aligned client reproducibly fails to start there (the Monitor loops on "not found in ps output"), and the same app repacked with this PR's CI-built client starts normally, the UI connects, and it keeps running with no errors.
- [x] Control on a standard 4 KB Android 14 (API 34) x86_64 emulator: the 16 KB aligned client starts and runs exactly like before, so no regression on existing devices.

**Alternate Designs**

Building separate 16 KB variants of the client was not considered seriously since a single 16 K aligned binary works on both page sizes. Adding the flag to the 32-bit ABIs too was considered and skipped as meaningless there, though it would be harmless.

**Release Notes**

Android: BOINC now works on devices with 16 KB memory page kernels.
