### PR TITLE
client: fixes to NVIDIA GPU detection

### DIFF
--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -1,6 +1,6 @@
 // This file is part of BOINC.
-// http://boinc.berkeley.edu
-// Copyright (C) 2012 University of California
+// https://boinc.berkeley.edu
+// Copyright (C) 2026 University of California
 //
 // BOINC is free software; you can redistribute it and/or modify it
 // under the terms of the GNU Lesser General Public License
@@ -19,10 +19,10 @@
 
 #ifdef _WIN32
 #include "boinc_win.h"
-/* get annotation macros from sal.h */
-/* define the ones that don't exist */
+// get annotation macros from sal.h
+// define the ones that don't exist
 #include "sal.h"
-/* These are just an annotations.  They don't do anything */
+// These are just an annotations.  They don't do anything
 #ifndef __success
 #define __success(x)
 #endif
@@ -165,6 +165,8 @@ int nvidia_compare(COPROC_NVIDIA& c1, COPROC_NVIDIA& c2, bool loose) {
     return 0;
 }
 
+// NOTE: WE SHOULD BE GETTING THESE FROM AN NVIDIA .h FILE!
+//
 enum CUdevice_attribute_enum {
     CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1,
     CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2,
@@ -187,7 +189,9 @@ enum CUdevice_attribute_enum {
     CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY = 19,
     CU_DEVICE_ATTRIBUTE_PCI_BUS_ID = 33,
     CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID = 34,
-    CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = 50
+    CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = 50,
+    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75,
+    CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76
 };
 
 #ifdef _WIN32
@@ -214,6 +218,8 @@ CUDA_GDN p_cuDeviceGetName = NULL;
 CUDA_GDM p_cuDeviceTotalMem = NULL;
 CUDA_GDM p_cuDeviceTotalMem_v2 = NULL;
 CUDA_GDCC p_cuDeviceComputeCapability = NULL;
+    // as of Jul 2026 this is deprecated.
+    // Use it if present, else use DeviceGetAttribute()
 CUDA_CC p_cuCtxCreate = NULL;
 CUDA_CD p_cuCtxDestroy = NULL;
 CUDA_MA p_cuMemAlloc = NULL;
@@ -257,19 +263,19 @@ void COPROC_NVIDIA::get(
         gpu_warning(warnings, "No NVIDIA library found");
         return;
     }
-    p_cuDeviceGetCount = (CUDA_GDC)GetProcAddress( cudalib, "cuDeviceGetCount" );
-    p_cuDriverGetVersion = (CUDA_GDV)GetProcAddress( cudalib, "cuDriverGetVersion" );
-    p_cuInit = (CUDA_GDI)GetProcAddress( cudalib, "cuInit" );
-    p_cuDeviceGet = (CUDA_GDG)GetProcAddress( cudalib, "cuDeviceGet" );
-    p_cuDeviceGetAttribute = (CUDA_GDA)GetProcAddress( cudalib, "cuDeviceGetAttribute" );
-    p_cuDeviceGetName = (CUDA_GDN)GetProcAddress( cudalib, "cuDeviceGetName" );
-    p_cuDeviceTotalMem = (CUDA_GDM)GetProcAddress( cudalib, "cuDeviceTotalMem" );
+    p_cuDeviceGetCount = (CUDA_GDC)GetProcAddress(cudalib, "cuDeviceGetCount");
+    p_cuDriverGetVersion = (CUDA_GDV)GetProcAddress(cudalib, "cuDriverGetVersion");
+    p_cuInit = (CUDA_GDI)GetProcAddress(cudalib, "cuInit");
+    p_cuDeviceGet = (CUDA_GDG)GetProcAddress(cudalib, "cuDeviceGet");
+    p_cuDeviceGetAttribute = (CUDA_GDA)GetProcAddress(cudalib, "cuDeviceGetAttribute");
+    p_cuDeviceGetName = (CUDA_GDN)GetProcAddress(cudalib, "cuDeviceGetName");
+    p_cuDeviceTotalMem = (CUDA_GDM)GetProcAddress(cudalib, "cuDeviceTotalMem");
     p_cuDeviceTotalMem_v2 = (CUDA_GDM)GetProcAddress(cudalib, "cuDeviceTotalMem_v2");
-    p_cuDeviceComputeCapability = (CUDA_GDCC)GetProcAddress( cudalib, "cuDeviceComputeCapability" );
-    p_cuCtxCreate = (CUDA_CC)GetProcAddress( cudalib, "cuCtxCreate" );
-    p_cuCtxDestroy = (CUDA_CD)GetProcAddress( cudalib, "cuCtxDestroy" );
-    p_cuMemAlloc = (CUDA_MA)GetProcAddress( cudalib, "cuMemAlloc" );
-    p_cuMemFree = (CUDA_MF)GetProcAddress( cudalib, "cuMemFree" );
+    p_cuDeviceComputeCapability = (CUDA_GDCC)GetProcAddress(cudalib, "cuDeviceComputeCapability");
+    p_cuCtxCreate = (CUDA_CC)GetProcAddress(cudalib, "cuCtxCreate");
+    p_cuCtxDestroy = (CUDA_CD)GetProcAddress(cudalib, "cuCtxDestroy");
+    p_cuMemAlloc = (CUDA_MA)GetProcAddress(cudalib, "cuMemAlloc");
+    p_cuMemFree = (CUDA_MF)GetProcAddress(cudalib, "cuMemFree");
     p_cuMemGetInfo = (CUDA_MGI)GetProcAddress(cudalib, "cuMemGetInfo");
     p_cuMemGetInfo_v2 = (CUDA_MGI)GetProcAddress(cudalib, "cuMemGetInfo_v2");
 
@@ -309,19 +315,19 @@ void* cudalib = NULL;
         return;
     }
     p_cuDeviceGetCount = (int(*)(int*)) dlsym(cudalib, "cuDeviceGetCount");
-    p_cuDriverGetVersion = (int(*)(int*)) dlsym( cudalib, "cuDriverGetVersion" );
-    p_cuInit = (int(*)(unsigned int)) dlsym( cudalib, "cuInit" );
-    p_cuDeviceGet = (int(*)(int*, int)) dlsym( cudalib, "cuDeviceGet" );
-    p_cuDeviceGetAttribute = (int(*)(int*, int, int)) dlsym( cudalib, "cuDeviceGetAttribute" );
-    p_cuDeviceGetName = (int(*)(char*, int, int)) dlsym( cudalib, "cuDeviceGetName" );
-    p_cuDeviceTotalMem = (int(*)(size_t*, int)) dlsym( cudalib, "cuDeviceTotalMem" );
+    p_cuDriverGetVersion = (int(*)(int*)) dlsym(cudalib, "cuDriverGetVersion");
+    p_cuInit = (int(*)(unsigned int)) dlsym(cudalib, "cuInit");
+    p_cuDeviceGet = (int(*)(int*, int)) dlsym(cudalib, "cuDeviceGet");
+    p_cuDeviceGetAttribute = (int(*)(int*, int, int)) dlsym(cudalib, "cuDeviceGetAttribute");
+    p_cuDeviceGetName = (int(*)(char*, int, int)) dlsym(cudalib, "cuDeviceGetName");
+    p_cuDeviceTotalMem = (int(*)(size_t*, int)) dlsym(cudalib, "cuDeviceTotalMem");
     p_cuDeviceTotalMem_v2 = (int(*)(size_t*, int)) dlsym(cudalib, "cuDeviceTotalMem_v2");
-    p_cuDeviceComputeCapability = (int(*)(int*, int*, int)) dlsym( cudalib, "cuDeviceComputeCapability" );
-    p_cuCtxCreate = (int(*)(void**, unsigned int, unsigned int)) dlsym( cudalib, "cuCtxCreate" );
-    p_cuCtxDestroy = (int(*)(void*)) dlsym( cudalib, "cuCtxDestroy" );
-    p_cuMemAlloc = (int(*)(unsigned int*, size_t)) dlsym( cudalib, "cuMemAlloc" );
-    p_cuMemFree = (int(*)(unsigned int)) dlsym( cudalib, "cuMemFree" );
-    p_cuMemGetInfo = (int(*)(size_t*, size_t*)) dlsym( cudalib, "cuMemGetInfo" );
+    p_cuDeviceComputeCapability = (int(*)(int*, int*, int)) dlsym(cudalib, "cuDeviceComputeCapability");
+    p_cuCtxCreate = (int(*)(void**, unsigned int, unsigned int)) dlsym(cudalib, "cuCtxCreate");
+    p_cuCtxDestroy = (int(*)(void*)) dlsym(cudalib, "cuCtxDestroy");
+    p_cuMemAlloc = (int(*)(unsigned int*, size_t)) dlsym(cudalib, "cuMemAlloc");
+    p_cuMemFree = (int(*)(unsigned int)) dlsym(cudalib, "cuMemFree");
+    p_cuMemGetInfo = (int(*)(size_t*, size_t*)) dlsym(cudalib, "cuMemGetInfo");
     p_cuMemGetInfo_v2 = (int(*)(size_t*, size_t*)) dlsym(cudalib, "cuMemGetInfo_v2");
 #endif
 
@@ -349,10 +355,12 @@ void* cudalib = NULL;
         gpu_warning(warnings, "cuDeviceTotalMem() missing from NVIDIA library");
         goto leave;
     }
+#if 0
     if (!p_cuDeviceComputeCapability) {
         gpu_warning(warnings, "cuDeviceComputeCapability() missing from NVIDIA library");
         goto leave;
     }
+#endif
     if (!p_cuMemAlloc) {
         gpu_warning(warnings, "cuMemAlloc() missing from NVIDIA library");
         goto leave;
@@ -416,36 +424,98 @@ void* cudalib = NULL;
             gpu_warning(warnings, buf);
             goto leave;
         }
-        (*p_cuDeviceComputeCapability)(&cc.cuda_prop.major, &cc.cuda_prop.minor, device);
+
+        // use deprecated API function if present, else newer one
+        if (p_cuDeviceComputeCapability) {
+            (*p_cuDeviceComputeCapability)(&cc.cuda_prop.major, &cc.cuda_prop.minor, device);
+        } else {
+            (*p_cuDeviceGetAttribute)(
+                &cc.cuda_prop.major,
+                CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device
+            );
+            (*p_cuDeviceGetAttribute)(
+                &cc.cuda_prop.minor,
+                CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device
+            );
+        }
         if (p_cuDeviceTotalMem_v2) {
             (*p_cuDeviceTotalMem_v2)(&global_mem, device);
         } else {
             (*p_cuDeviceTotalMem)(&global_mem, device);
         }
         cc.cuda_prop.totalGlobalMem = (double) global_mem;
-        (*p_cuDeviceGetAttribute)(&itemp, CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK, device);
+        (*p_cuDeviceGetAttribute)(
+            &itemp, CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK, device
+        );
         cc.cuda_prop.sharedMemPerBlock = (double) itemp;
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.regsPerBlock, CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.warpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, device);
-        (*p_cuDeviceGetAttribute)(&itemp, CU_DEVICE_ATTRIBUTE_MAX_PITCH, device);
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.regsPerBlock,
+            CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.warpSize, CU_DEVICE_ATTRIBUTE_WARP_SIZE, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &itemp, CU_DEVICE_ATTRIBUTE_MAX_PITCH, device
+        );
         cc.cuda_prop.memPitch = (double) itemp;
-        retval = (*p_cuDeviceGetAttribute)(&cc.cuda_prop.maxThreadsPerBlock, CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK, device);
-        retval = (*p_cuDeviceGetAttribute)(&cc.cuda_prop.maxThreadsDim[0], CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.maxThreadsDim[1], CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.maxThreadsDim[2], CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.maxGridSize[0], CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.maxGridSize[1], CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.maxGridSize[2], CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.clockRate, CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device);
-        (*p_cuDeviceGetAttribute)(&itemp, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY, device);
+        retval = (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.maxThreadsPerBlock,
+            CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK, device
+        );
+        retval = (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.maxThreadsDim[0],
+            CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.maxThreadsDim[1],
+            CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.maxThreadsDim[2],
+            CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.maxGridSize[0],
+            CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.maxGridSize[1],
+            CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.maxGridSize[2],
+            CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.clockRate,
+            CU_DEVICE_ATTRIBUTE_CLOCK_RATE, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &itemp, CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY, device
+        );
         cc.cuda_prop.totalConstMem = (double) itemp;
-        (*p_cuDeviceGetAttribute)(&itemp, CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT, device);
+        (*p_cuDeviceGetAttribute)(
+            &itemp, CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT, device
+        );
         cc.cuda_prop.textureAlignment = (double) itemp;
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.deviceOverlap, CU_DEVICE_ATTRIBUTE_GPU_OVERLAP, device);
-        (*p_cuDeviceGetAttribute)(&cc.cuda_prop.multiProcessorCount, CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device);
-        (*p_cuDeviceGetAttribute)(&cc.pci_info.bus_id, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, device);
-        (*p_cuDeviceGetAttribute)(&cc.pci_info.device_id, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, device);
-        (*p_cuDeviceGetAttribute)(&cc.pci_info.domain_id, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, device);
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.deviceOverlap,
+            CU_DEVICE_ATTRIBUTE_GPU_OVERLAP, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.cuda_prop.multiProcessorCount,
+            CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.pci_info.bus_id, CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.pci_info.device_id, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, device
+        );
+        (*p_cuDeviceGetAttribute)(
+            &cc.pci_info.domain_id, CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, device
+        );
         if (cc.cuda_prop.major <= 0) continue;  // major == 0 means emulation
         if (cc.cuda_prop.major > 100) continue;  // e.g. 9999 is an error
 #ifdef SIM
@@ -556,7 +626,9 @@ void COPROC_NVIDIA::correlate(
 //   from the scheduler.  Note that it was abandoned
 //   due to repeated calls crashing the driver.
 //
-static void get_available_nvidia_ram(COPROC_NVIDIA &cc, vector<string>& warnings) {
+static void get_available_nvidia_ram(
+    COPROC_NVIDIA &cc, vector<string>& warnings
+) {
     int retval;
     size_t memfree = 0, memtotal = 0;
     int device;
@@ -599,8 +671,7 @@ static void get_available_nvidia_ram(COPROC_NVIDIA &cc, vector<string>& warnings
     }
     if (p_cuMemGetInfo_v2) {
         retval = (*p_cuMemGetInfo_v2)(&memfree, &memtotal);
-    }
-    else {
+    } else {
         retval = (*p_cuMemGetInfo)(&memfree, &memtotal);
     }
     if (retval) {
@@ -646,7 +717,10 @@ bool COPROC_NVIDIA::check_running_graphics_app() {
         int device, kernel_timeout;
         retval = (*p_cuDeviceGet)(&device, j);
         if (!retval) {
-            retval = (*p_cuDeviceGetAttribute)(&kernel_timeout, CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT, device);
+            retval = (*p_cuDeviceGetAttribute)(
+                &kernel_timeout, CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT,
+                device
+            );
             if (!retval && !kernel_timeout) {
                 new_val = false;
             }

--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -429,14 +429,29 @@ void* cudalib = NULL;
         if (p_cuDeviceComputeCapability) {
             (*p_cuDeviceComputeCapability)(&cc.cuda_prop.major, &cc.cuda_prop.minor, device);
         } else {
-            (*p_cuDeviceGetAttribute)(
+            retval = (*p_cuDeviceGetAttribute)(
                 &cc.cuda_prop.major,
                 CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device
             );
-            (*p_cuDeviceGetAttribute)(
+            // we can't use the GPU if we don't know its compute capability
+            if (retval) {
+                snprintf(buf, sizeof(buf),
+                    "cuDeviceGetAttribute() returned %d", retval
+                );
+                gpu_warning(warnings, buf);
+                goto leave;
+            }
+            retval = (*p_cuDeviceGetAttribute)(
                 &cc.cuda_prop.minor,
                 CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device
             );
+            if (retval) {
+                snprintf(buf, sizeof(buf),
+                    "cuDeviceGetAttribute() returned %d", retval
+                );
+                gpu_warning(warnings, buf);
+                goto leave;
+            }
         }
         if (p_cuDeviceTotalMem_v2) {
             (*p_cuDeviceTotalMem_v2)(&global_mem, device);

--- a/client/gpu_nvidia.cpp
+++ b/client/gpu_nvidia.cpp
@@ -218,7 +218,7 @@ CUDA_GDN p_cuDeviceGetName = NULL;
 CUDA_GDM p_cuDeviceTotalMem = NULL;
 CUDA_GDM p_cuDeviceTotalMem_v2 = NULL;
 CUDA_GDCC p_cuDeviceComputeCapability = NULL;
-    // as of Jul 2026 this is deprecated.
+    // this was deprecated in ~2019 and may be removed.
     // Use it if present, else use DeviceGetAttribute()
 CUDA_CC p_cuCtxCreate = NULL;
 CUDA_CD p_cuCtxDestroy = NULL;
@@ -355,12 +355,9 @@ void* cudalib = NULL;
         gpu_warning(warnings, "cuDeviceTotalMem() missing from NVIDIA library");
         goto leave;
     }
-#if 0
-    if (!p_cuDeviceComputeCapability) {
-        gpu_warning(warnings, "cuDeviceComputeCapability() missing from NVIDIA library");
-        goto leave;
-    }
-#endif
+
+    // don't check p_cuDeviceComputeCapability (see above)
+
     if (!p_cuMemAlloc) {
         gpu_warning(warnings, "cuMemAlloc() missing from NVIDIA library");
         goto leave;

--- a/client/gpu_opencl.cpp
+++ b/client/gpu_opencl.cpp
@@ -806,8 +806,7 @@ leave:
 }
 
 void COPROCS::correlate_opencl(
-    bool use_all,
-    IGNORE_GPU_INSTANCE& ignore_gpu_instance
+    bool use_all, IGNORE_GPU_INSTANCE& ignore_gpu_instance
 ) {
     if (nvidia_opencls.size() > 0) {
         if (nvidia.have_cuda) { // If CUDA already found the "best" NVIDIA GPU
@@ -815,12 +814,17 @@ void COPROCS::correlate_opencl(
                 nvidia_opencls, ignore_gpu_instance[PROC_TYPE_NVIDIA_GPU]
             );
         } else {
+            // We don't have CUDA, just OpenCL.
+            // Find the most capable ones.
+            //
             nvidia.find_best_opencls(
                 use_all, nvidia_opencls, ignore_gpu_instance[PROC_TYPE_NVIDIA_GPU]
             );
             nvidia.cuda_prop.totalGlobalMem = nvidia.opencl_prop.global_mem_size;
             nvidia.available_ram = nvidia.opencl_prop.global_mem_size;
             nvidia.cuda_prop.clockRate = nvidia.opencl_prop.max_clock_frequency * 1000;
+            nvidia.cuda_prop.major = nvidia.opencl_prop.nv_compute_capability_major;
+            nvidia.cuda_prop.minor = nvidia.opencl_prop.nv_compute_capability_minor;
             safe_strcpy(nvidia.cuda_prop.name, nvidia.opencl_prop.name);
         }
     }
@@ -1191,6 +1195,9 @@ void COPROC::merge_opencl(
     }
 }
 
+// From the given list of OpenCL descriptions,
+// find the most capable and copy it to *this.
+// See if there are others that are equivalent and set count and IDs.
 // This is called for ATI GPUs without CAL or NVIDIA GPUs without CUDA
 //
 void COPROC::find_best_opencls(


### PR DESCRIPTION
1) The cuDeviceComputeCapability() function in the CUDA library was deprecated some time ago (2019?) and may be removed in the future. Currently CUDA GPU detection fails if this function is absent. Instead, use cuDeviceGetAttribute() instead.

Fixes #7196

2) If we find an NVIDIA GPU via OpenCL and not CUDA, set its compute capability in the CUDA_DEVICE_PROP; that's what is used by the server plan-class logic.

Fixes #7197

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes NVIDIA GPU detection to work without the deprecated CUDA API and for OpenCL-only NVIDIA GPUs. Adds error checks and removes unused `#ifdef` code to make detection robust and ensure correct plan-class selection.

- **Bug Fixes**
  - CUDA: Fallback to `cuDeviceGetAttribute()` (compute capability major/minor) when `cuDeviceComputeCapability()` is missing; add error checks and warnings for CUDA attribute/memory queries.
  - OpenCL-only NVIDIA: Populate `CUDA_DEVICE_PROP` (compute capability, memory, clock rate, name) from OpenCL so scheduler logic works.

- **Refactors**
  - Removed unused `#ifdef` code paths in GPU detection.

<sup>Written for commit 8acdd541104db4d7a5a2a5698797a8ad4bc6b956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

