### PR TITLE
client: optionally write RPC times to stdout

### DIFF
--- a/client/gui_rpc_server_ops.cpp
+++ b/client/gui_rpc_server_ops.cpp
@@ -17,6 +17,8 @@
 
 // GUI RPC server side (the actual RPCs)
 
+//#define PRINT_TIME      // write RPC times to stdout
+
 #include "cpp.h"
 
 #ifdef __APPLE__
@@ -1897,7 +1899,14 @@ static int handle_rpc_aux(GUI_RPC_CONN& grc) {
         if (gr.enable_network)  {
             gstate.gui_rpcs.time_of_last_rpc_needing_network = gstate.now;
         }
+#ifdef PRINT_TIME
+        double start = dtime();
+#endif
         (*gr.handler)(grc);
+#ifdef PRINT_TIME
+        int diff = (dtime()-start)*1000000;
+        printf("%s : %d microseconds \n", gr.req_tag, diff);
+#endif
         return 0;
     }
     grc.mfout.printf("<error>unrecognized op: %s</error>\n", grc.xp.parsed_tag);


### PR DESCRIPTION
... if you set an #define and recompile.
For (brief) testing only


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional stdout timing for GUI RPC handler calls to help with quick performance checks. Disabled by default; define `PRINT_TIME` at compile time to log the request tag and duration in microseconds.

<sup>Written for commit eb4ac96ae6401ce166ca4d283b9b700671e751ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

