### PR TITLE
manager: Add  temporary code to debug issue #7150

### DIFF
--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -19,6 +19,8 @@
 #pragma implementation "AsyncRPC.h"
 #endif
 
+#define PRINT_DEBUG_INFO 1
+
 #ifdef _WIN32
 #include "boinc_win.h"
 #endif
@@ -38,6 +40,68 @@
 #include "SkinManager.h"
 #include "DlgEventLog.h"
 #include "util.h"
+
+#if PRINT_DEBUG_INFO
+static void print_with_time_stamp(const char *format, ...);
+
+const char *RPC_DEBUG_NAMES[] = {
+    "RPC_ZERO",
+    "RPC_AUTHORIZE",
+    "RPC_EXCHANGE_VERSIONS",
+    "RPC_GET_STATE",
+    "RPC_GET_RESULTS",
+    "RPC_GET_FILE_TRANSFERS",
+    "RPC_GET_SIMPLE_GUI_INFO1",
+    "RPC_GET_SIMPLE_GUI_INFO2",
+    "RPC_GET_PROJECT_STATUS1",
+    "RPC_GET_PROJECT_STATUS2",
+    "RPC_GET_ALL_PROJECTS_LIST",  // 10
+    "RPC_GET_DISK_USAGE",
+    "RPC_PROJECT_OP",
+    "RPC_SET_RUN_MODE",
+    "RPC_SET_GPU_MODE",
+    "RPC_SET_NETWORK_MODE",
+    "RPC_GET_SCREENSAVER_TASKS",
+    "RPC_RUN_BENCHMARKS",
+    "RPC_SET_PROXY_SETTINGS",
+    "RPC_GET_PROXY_SETTINGS",
+    "RPC_GET_MESSAGES",       // 20
+    "RPC_FILE_TRANSFER_OP",
+    "RPC_RESULT_OP",
+    "RPC_GET_HOST_INFO",
+    "RPC_QUIT",
+    "RPC_ACCT_MGR_INFO",
+    "RPC_GET_STATISTICS",
+    "RPC_NETWORK_AVAILABLE",
+    "RPC_GET_PROJECT_INIT_STATUS",
+    "RPC_GET_PROJECT_CONFIG",
+    "RPC_GET_PROJECT_CONFIG_POLL",    // 30
+    "RPC_LOOKUP_ACCOUNT",
+    "RPC_LOOKUP_ACCOUNT_POLL",
+    "RPC_CREATE_ACCOUNT",
+    "RPC_CREATE_ACCOUNT_POLL",
+    "RPC_PROJECT_ATTACH",
+    "RPC_PROJECT_ATTACH_FROM_FILE",
+    "RPC_PROJECT_ATTACH_POLL",
+    "RPC_ACCT_MGR_RPC",
+    "RPC_ACCT_MGR_RPC_POLL",
+    "RPC_GET_NEWER_VERSION",      // 40
+    "RPC_READ_GLOBAL_PREFS_OVERRIDE",
+    "RPC_READ_CC_CONFIG",
+    "RPC_GET_CC_STATUS",
+    "RPC_GET_GLOBAL_PREFS_FILE",
+    "RPC_GET_GLOBAL_PREFS_WORKING",
+    "RPC_GET_GLOBAL_PREFS_WORKING_STRUCT",
+    "RPC_GET_GLOBAL_PREFS_OVERRIDE",
+    "RPC_SET_GLOBAL_PREFS_OVERRIDE",
+    "RPC_GET_GLOBAL_PREFS_OVERRIDE_STRUCT",
+    "RPC_SET_GLOBAL_PREFS_OVERRIDE_STRUCT",   // 50
+    "RPC_GET_NOTICES",
+    "RPC_GET_CC_CONFIG",
+    "RPC_SET_CC_CONFIG",
+	"RPC_SET_LANGUAGE"
+};
+#endif
 
 extern bool s_bSkipExitConfirmation;
 
@@ -508,6 +572,10 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
         }
     }
 
+#if PRINT_DEBUG_INFO
+    print_with_time_stamp("RequestRPC %s", RPC_DEBUG_NAMES[(int)request.which_rpc]);
+#endif
+
     if ((request.rpcType == RPC_TYPE_WAIT_FOR_COMPLETION) && (request.resultPtr == NULL)) {
         request.resultPtr = &retval;
     }
@@ -657,8 +725,28 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
         // undesirable recursion.
         //
         if (m_RPCWaitDlg) {
+#if PRINT_DEBUG_INFO
+        print_with_time_stamp("***************************");
+    print_with_time_stamp("Showing Communicating dialog for %s", RPC_DEBUG_NAMES[(int)request.which_rpc]);
+    if (RPC_requests.size() == 1) {
+        print_with_time_stamp("No prior RPC requests on queue");
+    } else {
+        print_with_time_stamp("RPC request queue:");
+        int n = (int) RPC_requests.size();
+            for (int i=0; i<n; ++i) {
+            print_with_time_stamp("    %d: %s", i, RPC_DEBUG_NAMES[(int)RPC_requests[i].which_rpc]);
+        }
+    }
+
+#endif
             response = m_RPCWaitDlg->ShowModal();
-            // Remember time the dialog was closed for use by RunPeriodicRPCs()
+#if PRINT_DEBUG_INFO
+    print_with_time_stamp("Closed Communicating dialog for %s with %s",
+        RPC_DEBUG_NAMES[(int)request.which_rpc],
+        response == wxID_OK ? "OK" : "Cancel");
+        print_with_time_stamp("***************************");
+#endif
+           // Remember time the dialog was closed for use by RunPeriodicRPCs()
             m_dtLasAsyncRPCDlgTime = wxDateTime::Now();
             if (response != wxID_OK) {
                 // TODO: If user presses Cancel in Please Wait dialog but request
@@ -772,6 +860,10 @@ void CMainDocument::HandleCompletedRPC() {
     // called from RequestRPC, the CRPCFinishedEvent will still be
     // on the event queue, so we get called twice.  Check for this here.
     if (current_rpc_request.which_rpc == 0) return; // already handled by a call from RequestRPC
+
+#if PRINT_DEBUG_INFO
+    print_with_time_stamp("HandleCompletedRPC %s", RPC_DEBUG_NAMES[(int)current_rpc_request.which_rpc]);
+#endif
 
     // Find our completed request in the queue
     n = (int) RPC_requests.size();
@@ -1126,6 +1218,10 @@ AsyncRPCDlg::AsyncRPCDlg() : wxDialog( NULL, wxID_ANY, wxT(""), wxDefaultPositio
 
 
 void AsyncRPCDlg::OnExit(wxCommandEvent& WXUNUSED(eventUnused)) {
+#if PRINT_DEBUG_INFO
+    print_with_time_stamp("Closed Communicating dialog with \"Exit Manager\"");
+    print_with_time_stamp("***************************");
+#endif
     EndModal(wxID_EXIT);
 }
 
@@ -1165,3 +1261,30 @@ void CMainDocument::TestAsyncRPC() {
 }
 
 #endif
+
+#if PRINT_DEBUG_INFO
+
+#include <time.h>
+#include <sys/time.h>
+
+static void print_with_time_stamp(const char *format, ...) {
+    va_list args;
+    char buf[256];
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+    time_t cur_time = tv.tv_sec;
+    struct tm *info = localtime(&cur_time);
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", info);
+    fputs(buf, stderr);
+    fprintf(stderr, ".%06d  ", tv.tv_usec);
+
+    va_start(args, format);
+    vfprintf(stderr, format, args);
+    va_end(args);
+
+    fputs("\n", stderr);
+    fflush(stderr);
+}
+#endif
+

--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -20,7 +20,8 @@
 #endif
 
 #define PRINT_DEBUG_INFO 1
-#define PRINT_ONLY_DEMAND_RPC_INFO 0
+#define PRINT_ONLY_DEMAND_RPC_INFO 1
+extern int saved_errno;
 
 #ifdef _WIN32
 #include "boinc_win.h"
@@ -905,7 +906,12 @@ void CMainDocument::HandleCompletedRPC() {
     }
 
     retval = current_rpc_request.retval;
-
+    if (retval) {
+        print_with_time_stamp("RPC %s returned error %d with errno=%d %s",
+                            RPC_DEBUG_NAMES[(int)current_rpc_request.which_rpc],
+                            retval, saved_errno,
+                            (saved_errno == 0) ? "" : strerror(errno));
+    }
 
     if (current_rpc_request.completionTime) {
         *(current_rpc_request.completionTime) = wxDateTime::Now();

--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #define PRINT_DEBUG_INFO 1
+#define PRINT_ONLY_DEMAND_RPC_INFO 0
 
 #ifdef _WIN32
 #include "boinc_win.h"
@@ -573,7 +574,12 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
     }
 
 #if PRINT_DEBUG_INFO
-    print_with_time_stamp("RequestRPC %s", RPC_DEBUG_NAMES[(int)request.which_rpc]);
+#if PRINT_ONLY_DEMAND_RPC_INFO
+    if (request.rpcType == RPC_TYPE_WAIT_FOR_COMPLETION)
+#endif
+    {
+        print_with_time_stamp("RequestRPC %s", RPC_DEBUG_NAMES[(int)request.which_rpc]);
+    }
 #endif
 
     if ((request.rpcType == RPC_TYPE_WAIT_FOR_COMPLETION) && (request.resultPtr == NULL)) {
@@ -862,7 +868,12 @@ void CMainDocument::HandleCompletedRPC() {
     if (current_rpc_request.which_rpc == 0) return; // already handled by a call from RequestRPC
 
 #if PRINT_DEBUG_INFO
-    print_with_time_stamp("HandleCompletedRPC %s", RPC_DEBUG_NAMES[(int)current_rpc_request.which_rpc]);
+#if PRINT_ONLY_DEMAND_RPC_INFO
+    if (current_rpc_request.rpcType == RPC_TYPE_WAIT_FOR_COMPLETION)
+#endif
+    {
+        print_with_time_stamp("HandleCompletedRPC %s", RPC_DEBUG_NAMES[(int)current_rpc_request.which_rpc]);
+    }
 #endif
 
     // Find our completed request in the queue

--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -743,7 +743,7 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
 #if PRINT_DEBUG_INFO
     print_with_time_stamp("Closed Communicating dialog for %s with %s",
         RPC_DEBUG_NAMES[(int)request.which_rpc],
-        response == wxID_OK ? "OK" : "Cancel");
+        response == wxID_OK ? "OK" : (response == wxID_EXIT ? "Exit" : "Cancel"));
         print_with_time_stamp("***************************");
 #endif
            // Remember time the dialog was closed for use by RunPeriodicRPCs()

--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -743,7 +743,7 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
 #if PRINT_DEBUG_INFO
     print_with_time_stamp("Closed Communicating dialog for %s with %s",
         RPC_DEBUG_NAMES[(int)request.which_rpc],
-        response == wxID_OK ? "OK" : (response == wxID_EXIT ? "Exit" : "Cancel"));
+        response == wxID_OK ? "OK" : (response == wxID_EXIT ? "Exit BOINC Manager" : "Cancel"));
         print_with_time_stamp("***************************");
 #endif
            // Remember time the dialog was closed for use by RunPeriodicRPCs()
@@ -1218,10 +1218,6 @@ AsyncRPCDlg::AsyncRPCDlg() : wxDialog( NULL, wxID_ANY, wxT(""), wxDefaultPositio
 
 
 void AsyncRPCDlg::OnExit(wxCommandEvent& WXUNUSED(eventUnused)) {
-#if PRINT_DEBUG_INFO
-    print_with_time_stamp("Closed Communicating dialog with \"Exit Manager\"");
-    print_with_time_stamp("***************************");
-#endif
     EndModal(wxID_EXIT);
 }
 

--- a/lib/gui_rpc_client.cpp
+++ b/lib/gui_rpc_client.cpp
@@ -53,6 +53,8 @@ using std::vector;
 
 //#define SHOW_MSGS
 
+int saved_errno;
+
 RPC_CLIENT::RPC_CLIENT() {
     sock = -1;
     start_time = 0;
@@ -338,16 +340,27 @@ RPC::~RPC() {
 //
 int RPC::do_rpc(const char* req) {
     int retval;
+saved_errno = 0;
 
     //fprintf(stderr, "RPC::do_rpc rpc_client->sock = '%d'", rpc_client->sock);
-    if (rpc_client->sock == -1) return ERR_CONNECT;
+//    if (rpc_client->sock == -1) return ERR_CONNECT;
+    if (rpc_client->sock == -1) {
+        saved_errno = errno;
+        return ERR_CONNECT;
+     }
 #ifdef SHOW_MSGS
     puts(req);
 #endif
     retval = rpc_client->send_request(req);
-    if (retval) return retval;
+    if (retval) {
+saved_errno = errno;
+        return retval;
+    }
     retval = rpc_client->get_reply(mbuf);
-    if (retval) return retval;
+    if (retval) {
+saved_errno = errno;
+        return retval;
+    }
     fin.init_buf_read(mbuf);
 #ifdef SHOW_MSGS
     puts(mbuf);


### PR DESCRIPTION
Add temporary debugging code to Manager to:
 * show time each RPC request is added to asynchronous RPC queue
 * show time each RPC request completes
 * RPC causing "Communicating with client" dialog to appear
 * all RPCs in queue when the dialog appears
 * whether the dialog was dismissed automatically because RPC completed (wxID_OK), user clicked Cancel (wxID_CANCEL) or use clicked "Exit BOINC Manager (wxID_EXIT).

Built on BOINC 8.2.15 rather than master to avoid the possibility that later changes to master might affect the problems reported in issue #7150

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compile-time gated debug logging in the Manager to trace async RPCs and diagnose “Communicating with client” stalls. Logs each RPC enqueue/completion with microsecond timestamps and RPC names, prints when the dialog opens/closes with the queue and close reason, logs RPC errors, and adds `PRINT_ONLY_DEMAND_RPC_INFO` to limit the enqueue/completion logging to demand RPCs.

<sup>Written for commit d14ce1a37db76abf88ecfdd09ae46a96a479c485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

