### PR TITLE
base64.h: Fix missing <string> on Windows.

### DIFF
--- a/lib/base64.h
+++ b/lib/base64.h
@@ -18,11 +18,8 @@
 #ifndef BOINC_BASE64_H
 #define BOINC_BASE64_H
 
-#ifndef _WIN32
-#include <cstdio>
-#include <cstdlib>
+#include <stddef.h>
 #include <string>
-#endif
 
 class InvalidBase64Exception
 {


### PR DESCRIPTION
In reviewing https://github.com/microsoft/vcpkg/pull/53221 GPT 5.6 Sol observes:

> The installed [`lib/base64.h`](https://github.com/BOINC/boinc/blob/3422898505b74c637a4b530a94b63be90bdf025b/lib/base64.h#L19-L40) is not self-contained on Windows: it uses `std::string` unconditionally but includes `<string>` only for non-Windows builds. Consumers must include `<string>` first. This defect also exists in 8.2.13

In addition to the AI report observe that "size_t" rather than std::size_t is used, so it should be using <stddef.h> rather than <cstddef>, and <cstdio> is not used at all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make lib/base64.h self-contained on Windows by including <string> unconditionally and the correct header for size_t. Fixes build issues where consumers had to include <string> first.

- **Bug Fixes**
  - Include <string> on all platforms.
  - Include <stddef.h> for size_t; remove unused <cstdio> and <cstdlib>.

<sup>Written for commit 90613f0485034a1d0221f60a3f4de47e883d8943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

