### PR TITLE
Fix problem with banishment votes (#7202)

### DIFF
--- a/html/user/forum_banishment_vote.php
+++ b/html/user/forum_banishment_vote.php
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+require_once('../inc/util_basic.inc');
 require_once('../inc/util.inc');
 require_once('../inc/forum_db.inc');
 require_once('../inc/forum_banishment_vote.inc');
@@ -24,7 +25,7 @@ if (DISABLE_FORUMS) error_page("Forums are disabled");
 
 check_get_args(array("action", "userid"));
 
-$config = get_config();
+$config = project_config_object();
 
 $logged_in_user = get_logged_in_user();
 BoincForumPrefs::lookup($logged_in_user);

--- a/html/user/forum_banishment_vote_action.php
+++ b/html/user/forum_banishment_vote_action.php
@@ -25,7 +25,7 @@ if (DISABLE_FORUMS) error_page("Forums are disabled");
 
 check_get_args(array("action", "userid", "tnow", "ttok"));
 
-$config = get_config();
+$config = project_config_object();
 
 $logged_in_user = get_logged_in_user();
 BoincForumPrefs::lookup($logged_in_user);


### PR DESCRIPTION
Fixes #7202

**Description of the Change**
Replaces get_config() in forum_banishment_vote*.php with project_config_object()


**Alternate Designs**
None. 

**Release Notes**
The get_config() function was removed several months ago in favor of project_config_object().  For some reason these files were missed when the change was made.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace deprecated get_config() with project_config_object() in forum banishment vote endpoints and add util_basic.inc to load config helpers, restoring functionality after the config API change. Fixes #7202.

<sup>Written for commit 38f394a263769756f37d35581c134a0380ff6843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

