### PR TITLE
web: fix banishment voting

### DIFF
--- a/html/inc/forum_banishment_vote.inc
+++ b/html/inc/forum_banishment_vote.inc
@@ -51,10 +51,9 @@ function vote_is_in_progress($userid) {
     return $foobar->count;
 }
 
-function start_vote($config,$logged_in_user,$user,$category,$reason) {
+function start_vote($logged_in_user, $user, $category, $reason) {
     $now=time();
     $fin=$now+21600;
-
 
     if ( vote_is_in_progress($user->id) !=0 ) {
         echo "A banishment vote is already underway for this user.<p>";
@@ -83,7 +82,7 @@ function start_vote($config,$logged_in_user,$user,$category,$reason) {
     return send_banish_vote_email($user, 86400*14, $reason, $now+21600);
 }
 
-function vote_yes($config,$logged_in_user,$user) {
+function vote_yes($logged_in_user, $user) {
     $now=time();
     // Check that a vote is underway.
     if (vote_is_in_progress($user->id)<1) {
@@ -124,7 +123,7 @@ function vote_yes($config,$logged_in_user,$user) {
     return 1;
 }
 
-function vote_no($config,$logged_in_user,$user) {
+function vote_no($logged_in_user, $user) {
     // Check that a vote is underway.
     $now=time();
     if (vote_is_in_progress($user->id)<1) {

--- a/html/user/forum_banishment_vote.php
+++ b/html/user/forum_banishment_vote.php
@@ -24,8 +24,6 @@ if (DISABLE_FORUMS) error_page("Forums are disabled");
 
 check_get_args(array("action", "userid"));
 
-$config = get_config();
-
 $logged_in_user = get_logged_in_user();
 BoincForumPrefs::lookup($logged_in_user);
 
@@ -34,7 +32,7 @@ if (!get_str('action')) {
 }
 if (!$logged_in_user->prefs->privilege(S_MODERATOR)) {
     // Can't moderate without being moderator
-    error_page(tra("You are not authorized to banish users."));
+    error_page("You are not authorized to banish users.");
 }
 
 $userid = get_int('userid');
@@ -79,9 +77,9 @@ row2(
     "<input class=\"btn btn-default\" type=\"submit\" name=\"submit\" value=\"".tra("Proceed with vote")."\">"
 );
 } elseif (get_str('action')=="yes") {
-    vote_yes($config,$logged_in_user,$user);
+    vote_yes($logged_in_user, $user);
 } elseif (get_str('action')=="no") {
-    vote_no($config,$logged_in_user,$user);
+    vote_no($logged_in_user, $user);
 } else {
     error_page("Unknown action");
 }

--- a/html/user/forum_banishment_vote.php
+++ b/html/user/forum_banishment_vote.php
@@ -32,7 +32,7 @@ if (!get_str('action')) {
 }
 if (!$logged_in_user->prefs->privilege(S_MODERATOR)) {
     // Can't moderate without being moderator
-    error_page("You are not authorized to banish users.");
+    error_page(tra("You are not authorized to banish users."));
 }
 
 $userid = get_int('userid');
@@ -58,7 +58,7 @@ if (get_str('action')=="start") {
     //display input that selects reason
     echo "<input type=hidden name=action value=start>";
     echo "<input type=\"hidden\" name=\"userid\" value=\"".$userid."\">\n";
-    row1(tra("Are you sure you want to banish %1 ?<br/>This will prevent %1 from posting for chosen time period.<br/>It should be done only if %1 has consistently exhibited trollish behavior.", $user->name));
+    row1(tra("Are you sure you want to banish %1 ?<br/>This will prevent %1 from posting for chosen time period.<br/>It should be done only if %1 has repeatedly violated forum rules.", $user->name));
     row2("",
     tra("Select the reason category, optionally write a longer description of why the user should be banished."));
     row2(tra("Category"),

--- a/html/user/forum_banishment_vote_action.php
+++ b/html/user/forum_banishment_vote_action.php
@@ -25,20 +25,19 @@ if (DISABLE_FORUMS) error_page("Forums are disabled");
 
 check_get_args(array("action", "userid", "tnow", "ttok"));
 
-$config = get_config();
-
 $logged_in_user = get_logged_in_user();
 BoincForumPrefs::lookup($logged_in_user);
 check_tokens($logged_in_user->authenticator);
 
 if (!$logged_in_user->prefs->privilege(S_MODERATOR)) {
-    error_page(tra("You are not authorized to banish users."));
+    error_page("You are not authorized to banish users.");
 }
 
 // See if "action" is provided - either through post or get
+//
 if (!post_str('action', true)) {
     if (!get_str('action', true)){
-	    error_page(tra("You must specify an action..."));
+	    error_page("You must specify an action...");
     } else {
         $action = get_str('action');
     }
@@ -47,7 +46,7 @@ if (!post_str('action', true)) {
 }
 
 $userid = post_int('userid');
-$user=BoincUser::lookup_id($userid);
+$user = BoincUser::lookup_id($userid);
 if (!$user) error_page('No such user');
 
 if ($action!="start"){
@@ -66,10 +65,10 @@ switch (post_int("category", true)) {
         $mod_category = tra("Other");
 }
 
-if (post_str('reason', true)){
-    start_vote($config,$logged_in_user,$user, $mod_category,post_str("reason"));
+if (post_str('reason', true)) {
+    start_vote($logged_in_user, $user, $mod_category, post_str("reason"));
 } else {
-    start_vote($config,$logged_in_user,$user, $mod_category,"None given");
+    start_vote($logged_in_user, $user, $mod_category, "None given");
 }
 
 ?>

--- a/html/user/forum_banishment_vote_action.php
+++ b/html/user/forum_banishment_vote_action.php
@@ -30,14 +30,14 @@ BoincForumPrefs::lookup($logged_in_user);
 check_tokens($logged_in_user->authenticator);
 
 if (!$logged_in_user->prefs->privilege(S_MODERATOR)) {
-    error_page("You are not authorized to banish users.");
+    error_page(tra("You are not authorized to banish users."));
 }
 
 // See if "action" is provided - either through post or get
 //
 if (!post_str('action', true)) {
     if (!get_str('action', true)){
-	    error_page("You must specify an action...");
+	    error_page(tra("You must specify an action"));
     } else {
         $action = get_str('action');
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes moderator banishment voting by aligning function signatures and call sites to prevent errors when starting or casting votes. Restores translation wrappers for moderator messages and updates wording for clarity.

- **Bug Fixes**
  - Removed unused `$config` parameter from `start_vote`, `vote_yes`, and `vote_no`; updated callers in `forum_banishment_vote.php` and `forum_banishment_vote_action.php`.
  - Restored `tra()` around moderator-facing messages and refined text (e.g., “repeatedly violated forum rules”, “You must specify an action”).
  - Minor cleanup: consistent user lookup assignment and spacing; no behavior changes.

<sup>Written for commit 92b714543a45a919d3acdc37e8894a73bf04a820. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

