### PR TITLE
[ci] fix wxwidgets build

### DIFF
--- a/3rdParty/vcpkg_ports/.gitattributes
+++ b/3rdParty/vcpkg_ports/.gitattributes
@@ -1,0 +1,7 @@
+* -text
+ports/** -linguist-detectable
+
+# Stored patch files may legitimately contain whitespace that represents the
+# patched content rather than the patch file itself.
+*.diff -whitespace
+*.patch -whitespace

--- a/3rdParty/vcpkg_ports/ports/libsm/msvc.patch
+++ b/3rdParty/vcpkg_ports/ports/libsm/msvc.patch
@@ -1,0 +1,15 @@
+diff --git a/src/sm_genid.c b/src/sm_genid.c
+index 9a52e1d..3a7d1e4 100644
+--- a/src/sm_genid.c
++++ b/src/sm_genid.c
+@@ -64,7 +64,9 @@ in this Software without prior written authorization from The Open Group.
+ # include <X11/Xthreads.h>
+ #endif
+ #include <stdio.h>
+-#include <unistd.h>
++#ifdef HAVE_UNISTD_H
++ #include <unistd.h>
++#endif
+ 
+ #include <time.h>
+ #define Time_t time_t

--- a/3rdParty/vcpkg_ports/ports/libsm/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libsm/portfile.cmake
@@ -1,0 +1,33 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    return()
+endif()
+
+vcpkg_download_distfile(
+    LIBSM_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libSM-${VERSION}.tar.xz"
+    FILENAME "libSM-${VERSION}.tar.xz"
+    SHA512 e544a1dc49a03390f76af35837bfd01f749b806d88d3ee806f20311c47ff53d0aeea4744feb875958031b17d50b57a89dcc41d81241c09333c88b268c44653a7
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBSM_ARCHIVE}"
+    PATCHES
+        msvc.patch
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+)
+
+vcpkg_make_install()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/libsm/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libsm/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libsm",
+  "version": "1.2.6",
+  "port-version": 1,
+  "description": "X Session Management Library",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libsm",
+  "license": null,
+  "dependencies": [
+    "libice",
+    "libxtrans",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    "xorg-macros"
+  ]
+}

--- a/3rdParty/vcpkg_ports/ports/libxtrans/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libxtrans/portfile.cmake
@@ -1,0 +1,22 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in the triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+else()
+
+vcpkg_from_gitlab(
+    GITLAB_URL "https://gitlab.freedesktop.org/xorg"
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO "lib/libxtrans"
+    REF "xtrans-${VERSION}"
+    SHA512 c7037cb6d2fb641486a43c9203949edec2038735ba758f8556add63598dbb3205166a2ec272700639884b1952642c171806e3dab566722cadd4c71ca98c0a1bf
+    HEAD_REF master
+)
+
+# we need both *.h and *.c files to be in the destination include folder
+# this is by the library design that is actually not a library but a shared code
+file(REMOVE_RECURSE ${SOURCE_PATH}/doc)
+file(INSTALL ${SOURCE_PATH}/ DESTINATION ${CURRENT_PACKAGES_DIR}/include/X11/Xtrans FILES_MATCHING PATTERN "*.h" PATTERN "*.c")
+
+# Handle copyright
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")
+endif()

--- a/3rdParty/vcpkg_ports/ports/libxtrans/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libxtrans/vcpkg.json
@@ -1,0 +1,10 @@
+{
+    "name": "libxtrans",
+    "version": "1.6.0",
+    "description": "X Network Transport layer shared code",
+    "homepage": "https://gitlab.freedesktop.org/xorg/lib/libxtrans",
+    "license": null,
+    "dependencies": [
+        "xproto"
+    ]
+}

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/example/CMakeLists.txt
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/example/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.7)
+
+project(wxwidgets-example)
+
+add_executable(main WIN32 popup.cpp)
+
+find_package(wxWidgets REQUIRED)
+target_compile_features(main PRIVATE cxx_std_11)
+target_compile_definitions(main PRIVATE ${wxWidgets_DEFINITIONS} "$<$<CONFIG:DEBUG>:${wxWidgets_DEFINITIONS_DEBUG}>")
+target_include_directories(main PRIVATE ${wxWidgets_INCLUDE_DIRS})
+target_link_libraries(main PRIVATE ${wxWidgets_LIBRARIES})
+
+add_executable(main2 WIN32 popup.cpp)
+
+find_package(wxWidgets CONFIG REQUIRED)
+target_link_libraries(main2 PRIVATE wx::core wx::base)
+target_compile_features(main2 PRIVATE cxx_std_11)
+
+option(USE_WXRC "Use the wxrc resource compiler" ON)
+if(USE_WXRC)
+    execute_process(
+        COMMAND "${wxWidgets_wxrc_EXECUTABLE}" --help
+        RESULTS_VARIABLE error_result
+    )
+    if(error_result)
+        message(FATAL_ERROR "Failed to run wxWidgets_wxrc_EXECUTABLE (${wxWidgets_wxrc_EXECUTABLE})")
+    endif()
+endif()
+
+set(PRINT_VARS "" CACHE STRING "Variables to print at the end of configuration")
+foreach(var IN LISTS PRINT_VARS)
+    message(STATUS "${var}:=${${var}}")
+endforeach()

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/fix-libs-export.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/fix-libs-export.patch
@@ -1,0 +1,21 @@
+diff --git a/build/cmake/config.cmake b/build/cmake/config.cmake
+index b359560..7504458 100644
+--- a/build/cmake/config.cmake
++++ b/build/cmake/config.cmake
+@@ -39,8 +39,14 @@ macro(wx_get_dependencies var lib)
+             else()
+                 # For the value like $<$<CONFIG:DEBUG>:LIB_PATH>
+                 # Or $<$<NOT:$<CONFIG:DEBUG>>:LIB_PATH>
+-                string(REGEX REPLACE "^.+>:(.+)>$" "\\1" dep_name ${dep})
+-                if (NOT dep_name)
++                if(dep MATCHES "^(.+>):(.+)>$")
++                    if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND CMAKE_MATCH_1 STREQUAL [[$<$<NOT:$<CONFIG:DEBUG>>]])
++                        continue()
++                    elseif(CMAKE_BUILD_TYPE STREQUAL "Release" AND CMAKE_MATCH_1 STREQUAL [[$<$<CONFIG:DEBUG>]])
++                        continue()
++                    endif()
++                    set(dep_name "${CMAKE_MATCH_2}")
++                else()
+                     set(dep_name ${dep})
+                 endif()
+             endif()

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/fix-pcre2.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/fix-pcre2.patch
@@ -1,0 +1,23 @@
+diff --git a/build/cmake/modules/FindPCRE2.cmake b/build/cmake/modules/FindPCRE2.cmake
+index a27693a..455675a 100644
+--- a/build/cmake/modules/FindPCRE2.cmake
++++ b/build/cmake/modules/FindPCRE2.cmake
+@@ -24,7 +24,10 @@ set(PCRE2_CODE_UNIT_WIDTH_USED "${PCRE2_CODE_UNIT_WIDTH}" CACHE INTERNAL "")
+ 
+ find_package(PkgConfig QUIET)
+ pkg_check_modules(PC_PCRE2 QUIET libpcre2-${PCRE2_CODE_UNIT_WIDTH})
++set(PCRE2_LIBRARIES ${PC_PCRE2_LINK_LIBRARIES})
++set(PCRE2_INCLUDE_DIRS ${PC_PCRE2_INCLUDE_DIRS})
+ 
++if (0)
+ find_path(PCRE2_INCLUDE_DIRS
+     NAMES pcre2.h
+     HINTS ${PC_PCRE2_INCLUDEDIR}
+@@ -36,6 +39,7 @@ find_library(PCRE2_LIBRARIES
+     HINTS ${PC_PCRE2_LIBDIR}
+           ${PC_PCRE2_LIBRARY_DIRS}
+ )
++endif()
+ 
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(PCRE2 REQUIRED_VARS PCRE2_LIBRARIES PCRE2_INCLUDE_DIRS VERSION_VAR PC_PCRE2_VERSION)

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/fix-wayland-build.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/fix-wayland-build.patch
@@ -1,0 +1,29 @@
+diff --git a/build/cmake/setup.h.in b/build/cmake/setup.h.in
+index d72d20d5cbc6..08169ee065e6 100644
+--- a/build/cmake/setup.h.in
++++ b/build/cmake/setup.h.in
+@@ -626,9 +626,9 @@
+ 
+     This is needed by any Wayland-specific code in wxGTK implementation.
+ 
+-    Recommended setting: 1, only set to 0 if wayland-client is not available.
++    Define if wayland-client is available.
+  */
+-#cmakedefine01 wxHAVE_WAYLAND_CLIENT
++#cmakedefine wxHAVE_WAYLAND_CLIENT 1
+ 
+ /*
+    Use XTest extension to implement wxUIActionSimulator?
+diff --git a/setup.h.in b/setup.h.in
+index 2de3139090d1..4bec4eb6e4e1 100644
+--- a/setup.h.in
++++ b/setup.h.in
+@@ -625,7 +625,7 @@
+ 
+     This is needed by any Wayland-specific code in wxGTK implementation.
+ 
+-    Recommended setting: 1, only set to 0 if wayland-client is not available.
++    Define if wayland-client is available.
+  */
+ #undef wxHAVE_WAYLAND_CLIENT
+ 

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/gtk3-link-libraries.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/gtk3-link-libraries.patch
@@ -1,0 +1,17 @@
+diff --git a/build/cmake/modules/FindGTK3.cmake b/build/cmake/modules/FindGTK3.cmake
+index d2939a1..daf33fe 100644
+--- a/build/cmake/modules/FindGTK3.cmake
++++ b/build/cmake/modules/FindGTK3.cmake
+@@ -47,6 +47,12 @@ include(CheckSymbolExists)
+ set(CMAKE_REQUIRED_INCLUDES ${GTK3_INCLUDE_DIRS})
+ check_symbol_exists(GDK_WINDOWING_WAYLAND "gdk/gdk.h" wxHAVE_GDK_WAYLAND)
+ check_symbol_exists(GDK_WINDOWING_X11 "gdk/gdk.h" wxHAVE_GDK_X11)
++# With Lerc support in TIFF, Gtk3 may carry C++ compiler libs which break FindWxWidgets.cmake.
++# WxWidgets is C++, so we can remove them here using the inverse pattern.
++set(cxx_libs "${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}")
++list(REMOVE_ITEM cxx_libs ${CMAKE_C_IMPLICIT_LINK_LIBRARIES})
++list(REMOVE_ITEM GTK3_LINK_LIBRARIES ${cxx_libs})
++set(GTK3_LIBRARIES "${GTK3_LINK_LIBRARIES}" CACHE INTERNAL "")
+ include(FindPackageHandleStandardArgs)
+ FIND_PACKAGE_HANDLE_STANDARD_ARGS(GTK3 DEFAULT_MSG GTK3_INCLUDE_DIRS GTK3_LIBRARIES VERSION_OK)
+ 

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/install-layout.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/install-layout.patch
@@ -1,0 +1,18 @@
+diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
+--- a/build/cmake/init.cmake
++++ b/build/cmake/init.cmake
+@@ -201,11 +201,11 @@ endif()
+ wx_get_install_dir(include)
+ if(WIN32_MSVC_NAMING)
+     if(wxBUILD_SHARED)
+-        set(lib_suffix "_dll")
++        # set(lib_suffix "_dll")
+     else()
+-        set(lib_suffix "_lib")
++        # set(lib_suffix "_lib")
+     endif()
+-    set(wxPLATFORM_LIB_DIR "${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
++    # set(wxPLATFORM_LIB_DIR "${wxCOMPILER_PREFIX}${wxARCH_SUFFIX}${lib_suffix}")
+     set(wxINSTALL_INCLUDE_DIR "${include_dir}")
+ else()
+     wx_get_flavour(lib_flavour "-")

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/libsecret-link-dirs.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/libsecret-link-dirs.patch
@@ -1,0 +1,15 @@
+diff --git a/build/cmake/lib/base/CMakeLists.txt b/build/cmake/lib/base/CMakeLists.txt
+index 6eed902..ffd095a 100644
+--- a/build/cmake/lib/base/CMakeLists.txt
++++ b/build/cmake/lib/base/CMakeLists.txt
+@@ -46,6 +46,10 @@ if(UNIX AND wxUSE_SECRETSTORE)
+     # requiring it being installed on the target system.
+     list(REMOVE_ITEM LIBSECRET_LIBRARIES secret-1)
+     wx_lib_link_libraries(wxbase PRIVATE ${LIBSECRET_LIBRARIES})
++    # LIBSECRET_LIBRARIES may include transitive deps (gcrypt, gpg-error) that
++    # aren't in the default linker search path; propagate the -L dirs
++    # pkg-config reported so downstream links (wxrc etc.) can find them.
++    wx_lib_link_directories(wxbase PUBLIC ${LIBSECRET_LIBRARY_DIRS})
+ endif()
+ if(wxUSE_LIBICONV)
+     wx_lib_include_directories(wxbase ${ICONV_INCLUDE_DIR})

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/nanosvg-ext-depend.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/nanosvg-ext-depend.patch
@@ -1,0 +1,13 @@
+diff --git a/build/cmake/wxWidgetsConfig.cmake.in b/build/cmake/wxWidgetsConfig.cmake.in
+index b251109..60cf762 100644
+--- a/build/cmake/wxWidgetsConfig.cmake.in
++++ b/build/cmake/wxWidgetsConfig.cmake.in
+@@ -1,5 +1,8 @@
+ @PACKAGE_INIT@
+ 
++include(CMakeFindDependencyMacro)
++find_dependency(NanoSVG CONFIG)
++
+ cmake_policy(PUSH)
+ # Set policies to prevent warnings
+ if(POLICY CMP0057)

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/portfile.cmake
@@ -1,0 +1,272 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO wxWidgets/wxWidgets
+    REF "v${VERSION}"
+    SHA512 c497d6642d6f9fb7f190ab725e3c5ee0e67e96c883eebbe2d7fa7e0b3dec9847871010e53e23c5d46b9158b8a045f162592d0c25f524daedeaca8c1caa555a5a
+    HEAD_REF master
+    PATCHES
+        install-layout.patch
+        relocatable-wx-config.patch
+        nanosvg-ext-depend.patch
+        fix-libs-export.patch
+        fix-pcre2.patch
+        gtk3-link-libraries.patch
+        sdl2.patch
+        libsecret-link-dirs.patch
+        fix-wayland-build.patch
+)
+
+# Submodule dependencies
+vcpkg_from_github(
+    OUT_SOURCE_PATH lexilla_SOURCE_PATH
+    REPO wxWidgets/lexilla
+    REF "bf6ad20062b98808ffa21419263942a427c150a9"
+    SHA512 08360fcd29e6c021857928375509ea48b9c8a02407bcb3c01865f57734c449fc6ff24afbe011f218b7145116e1805f8c9b4a2e3ec26f4a6298dca9453f610887
+    HEAD_REF wx
+)
+file(COPY "${lexilla_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/src/stc/lexilla")
+vcpkg_from_github(
+    OUT_SOURCE_PATH scintilla_SOURCE_PATH
+    REPO wxWidgets/scintilla
+    REF "0b90f31ced23241054e8088abb50babe9a44ae67"
+    SHA512 db1f3007f4bd8860fad0817b6cf87980a4b713777025128cf5caea8d6d17b6fafe23fd22ff6886d7d5a420f241d85b7502b85d7e52b4ddb0774edc4b0a0203e7
+    HEAD_REF wx
+)
+file(COPY "${scintilla_SOURCE_PATH}/" DESTINATION "${SOURCE_PATH}/src/stc/scintilla")
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        fonts   wxUSE_PRIVATE_FONTS
+        media   wxUSE_MEDIACTRL
+        secretstore wxUSE_SECRETSTORE
+        sound   wxUSE_SOUND
+        webview wxUSE_WEBVIEW
+)
+
+# Only use wxUSE_WEBVIEW_EDGE on Windows (webview2)
+if(VCPKG_TARGET_IS_WINDOWS AND "webview" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS "-DwxUSE_WEBVIEW_EDGE=ON")
+endif()
+
+set(OPTIONS_RELEASE "")
+if(NOT "debug-support" IN_LIST FEATURES)
+    list(APPEND OPTIONS_RELEASE "-DwxBUILD_DEBUG_LEVEL=0")
+endif()
+
+set(OPTIONS "")
+if(VCPKG_TARGET_IS_WINDOWS AND (VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64" OR VCPKG_TARGET_ARCHITECTURE STREQUAL "arm"))
+    list(APPEND OPTIONS
+        -DwxUSE_STACKWALKER=OFF
+    )
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS OR VCPKG_TARGET_IS_OSX)
+    list(APPEND OPTIONS -DwxUSE_WEBREQUEST_CURL=OFF)
+else()
+    list(APPEND OPTIONS -DwxUSE_WEBREQUEST_CURL=ON)
+endif()
+
+# Prefer copies over symlinks for the wx-config / wxrc install artifacts.
+# On Windows symlinks require admin; on any platform vcpkg expects real files
+# in its install tree so downstream relocation works.
+list(APPEND OPTIONS -DwxBUILD_INSTALL_USE_SYMLINK=OFF)
+
+if(VCPKG_TARGET_IS_WINDOWS)
+    if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+        list(APPEND OPTIONS -DwxBUILD_USE_STATIC_RUNTIME=OFF)
+    else()
+        list(APPEND OPTIONS -DwxBUILD_USE_STATIC_RUNTIME=ON)
+    endif()
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND "webview" IN_LIST FEATURES AND VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+    list(APPEND OPTIONS -DwxUSE_WEBVIEW_EDGE_STATIC=ON)
+endif()
+
+vcpkg_find_acquire_program(PKGCONFIG)
+
+# This may be set to ON by users in a custom triplet.
+# The use of 'WXWIDGETS_USE_STD_CONTAINERS' (ON or OFF) is not API compatible
+# which is why it must be set in a custom triplet rather than a port feature.
+# For backwards compatibility, we also replace 'wxUSE_STL' (which no longer
+# exists) with 'wxUSE_STD_STRING_CONV_IN_WXSTRING' which still exists and was
+# set by `wxUSE_STL` previously.
+if(NOT DEFINED WXWIDGETS_USE_STL)
+    set(WXWIDGETS_USE_STL OFF)
+endif()
+
+if(NOT DEFINED WXWIDGETS_USE_STD_CONTAINERS)
+    set(WXWIDGETS_USE_STD_CONTAINERS OFF)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DwxUSE_REGEX=sys
+        -DwxUSE_ZLIB=sys
+        -DwxUSE_EXPAT=sys
+        -DwxUSE_LIBJPEG=sys
+        -DwxUSE_LIBPNG=sys
+        -DwxUSE_LIBTIFF=sys
+        -DwxUSE_NANOSVG=sys
+        -DwxUSE_LIBWEBP=sys
+        -DwxUSE_GLCANVAS=ON
+        -DwxUSE_LIBGNOMEVFS=OFF
+        -DwxUSE_LIBNOTIFY=OFF
+        -DwxUSE_STD_STRING_CONV_IN_WXSTRING=${WXWIDGETS_USE_STL}
+        -DwxUSE_STD_CONTAINERS=${WXWIDGETS_USE_STD_CONTAINERS}
+        -DwxUSE_UIACTIONSIMULATOR=OFF
+        -DCMAKE_DISABLE_FIND_PACKAGE_GSPELL=ON
+        -DCMAKE_DISABLE_FIND_PACKAGE_MSPACK=ON
+        -DwxBUILD_INSTALL_RUNTIME_DIR:PATH=bin
+        ${OPTIONS}
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+        # The minimum cmake version requirement for Cotire is 2.8.12.
+        # however, we need to declare that the minimum cmake version requirement is at least 3.1 to use CMAKE_PREFIX_PATH as the path to find .pc.
+        -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON
+    OPTIONS_RELEASE
+        ${OPTIONS_RELEASE}
+    MAYBE_UNUSED_VARIABLES
+        CMAKE_DISABLE_FIND_PACKAGE_GSPELL
+        CMAKE_DISABLE_FIND_PACKAGE_MSPACK
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/wxWidgets-3.3)
+
+# The CMake export is not ready for use: It lacks a config file.
+file(REMOVE_RECURSE
+    ${CURRENT_PACKAGES_DIR}/lib/cmake
+    ${CURRENT_PACKAGES_DIR}/debug/lib/cmake
+)
+
+set(tools wxrc)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND tools wxrc-3.3)
+    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/wx-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wx-config")
+    if(NOT VCPKG_BUILD_TYPE)
+        file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug")
+        file(RENAME "${CURRENT_PACKAGES_DIR}/debug/bin/wx-config" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/wx-config")
+    endif()
+endif()
+vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
+
+# do the copy pdbs now after the dlls got moved to the expected /bin folder above
+vcpkg_copy_pdbs()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/msvc")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/lib/mswu")
+if(VCPKG_BUILD_TYPE STREQUAL "release")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/lib/mswud")
+endif()
+
+file(GLOB_RECURSE INCLUDES "${CURRENT_PACKAGES_DIR}/include/*.h")
+if(EXISTS "${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h")
+    list(APPEND INCLUDES "${CURRENT_PACKAGES_DIR}/lib/mswu/wx/setup.h")
+endif()
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h")
+    list(APPEND INCLUDES "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h")
+endif()
+foreach(INC IN LISTS INCLUDES)
+    file(READ "${INC}" _contents)
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        string(REPLACE "defined(WXUSINGDLL)" "0" _contents "${_contents}")
+    else()
+        string(REPLACE "defined(WXUSINGDLL)" "1" _contents "${_contents}")
+    endif()
+    # Remove install prefix from setup.h to ensure package is relocatable
+    string(REGEX REPLACE "\n#define wxINSTALL_PREFIX [^\n]*" "\n#define wxINSTALL_PREFIX \"\"" _contents "${_contents}")
+    file(WRITE "${INC}" "${_contents}")
+endforeach()
+
+if(NOT EXISTS "${CURRENT_PACKAGES_DIR}/include/wx/setup.h")
+    file(GLOB_RECURSE WX_SETUP_H_FILES_DBG "${CURRENT_PACKAGES_DIR}/debug/lib/*.h")
+    file(GLOB_RECURSE WX_SETUP_H_FILES_REL "${CURRENT_PACKAGES_DIR}/lib/*.h")
+
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+        vcpkg_replace_string("${WX_SETUP_H_FILES_REL}" "${CURRENT_PACKAGES_DIR}" "" IGNORE_UNCHANGED)
+
+        string(REPLACE "${CURRENT_PACKAGES_DIR}/lib/" "" WX_SETUP_H_FILES_REL "${WX_SETUP_H_FILES_REL}")
+        string(REPLACE "/setup.h" "" WX_SETUP_H_REL_RELATIVE "${WX_SETUP_H_FILES_REL}")
+    endif()
+    if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+        vcpkg_replace_string("${WX_SETUP_H_FILES_DBG}" "${CURRENT_PACKAGES_DIR}" "" IGNORE_UNCHANGED)
+
+        string(REPLACE "${CURRENT_PACKAGES_DIR}/debug/lib/" "" WX_SETUP_H_FILES_DBG "${WX_SETUP_H_FILES_DBG}")
+        string(REPLACE "/setup.h" "" WX_SETUP_H_DBG_RELATIVE "${WX_SETUP_H_FILES_DBG}")
+    endif()
+
+    configure_file("${CMAKE_CURRENT_LIST_DIR}/setup.h.in" "${CURRENT_PACKAGES_DIR}/include/wx/setup.h" @ONLY)
+endif()
+
+file(GLOB configs LIST_DIRECTORIES false "${CURRENT_PACKAGES_DIR}/lib/wx/config/*" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wx-config")
+foreach(config IN LISTS configs)
+    vcpkg_replace_string("${config}" "${CURRENT_INSTALLED_DIR}" [[${prefix}]])
+endforeach()
+file(GLOB configs LIST_DIRECTORIES false "${CURRENT_PACKAGES_DIR}/debug/lib/wx/config/*" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/wx-config")
+foreach(config IN LISTS configs)
+    vcpkg_replace_string("${config}" "${CURRENT_INSTALLED_DIR}/debug" [[${prefix}]])
+endforeach()
+
+# wxWidgets 3.3.3's wx_get_dependencies (build/cmake/config.cmake) leaks raw
+# CMake target names into wx-config's LIBS for imported deps that lack an
+# IMPORTED_LOCATION (i.e. vcpkg's header-only NanoSVG), producing entries like
+# "-lNanoSVG::nanosvg" that later trip target_link_libraries in downstream
+# projects. Strip those; vcpkg-cmake-wrapper.cmake re-adds the real
+# NanoSVG::nanosvg{,rast} targets for static builds. Fix targeted for wx 3.3.4
+# (see wxwidgets/wxWidgets#23373).
+file(GLOB all_configs LIST_DIRECTORIES false
+    "${CURRENT_PACKAGES_DIR}/lib/wx/config/*"
+    "${CURRENT_PACKAGES_DIR}/debug/lib/wx/config/*"
+    "${CURRENT_PACKAGES_DIR}/tools/${PORT}/wx-config"
+    "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug/wx-config")
+foreach(config IN LISTS all_configs)
+    file(READ "${config}" _cfg)
+    string(REGEX REPLACE "-l[A-Za-z0-9_+.-]+::[A-Za-z0-9_+.-]+ *" "" _cfg "${_cfg}")
+    file(WRITE "${config}" "${_cfg}")
+endforeach()
+
+# For CMake multi-config in connection with wrapper
+if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h")
+    file(INSTALL "${CURRENT_PACKAGES_DIR}/debug/lib/mswud/wx/setup.h"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/lib/mswud/wx"
+    )
+endif()
+
+if(NOT "debug-support" IN_LIST FEATURES)
+    if(VCPKG_TARGET_IS_WINDOWS)
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wx/debug.h" "#define wxDEBUG_LEVEL 1" "#define wxDEBUG_LEVEL 0")
+    else()
+        vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/wx-3.3/wx/debug.h" "#define wxDEBUG_LEVEL 1" "#define wxDEBUG_LEVEL 0")
+    endif()
+endif()
+
+if("example" IN_LIST FEATURES)
+    file(INSTALL
+        "${CMAKE_CURRENT_LIST_DIR}/example/CMakeLists.txt"
+        "${SOURCE_PATH}/samples/popup/popup.cpp"
+        "${SOURCE_PATH}/samples/sample.xpm"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}/example"
+    )
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/${PORT}/example/popup.cpp" "../sample.xpm" "sample.xpm")
+endif()
+
+configure_file("${CMAKE_CURRENT_LIST_DIR}/vcpkg-cmake-wrapper.cmake" "${CURRENT_PACKAGES_DIR}/share/${PORT}/vcpkg-cmake-wrapper.cmake" @ONLY)
+
+file(REMOVE "${CURRENT_PACKAGES_DIR}/wxwidgets.props")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/wxwidgets.props")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/build")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/build")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(
+    FILE_LIST
+        "${SOURCE_PATH}/docs/licence.txt"
+        "${lexilla_SOURCE_PATH}/License.txt"
+        "${scintilla_SOURCE_PATH}/License.txt"
+)

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/relocatable-wx-config.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/relocatable-wx-config.patch
@@ -1,0 +1,40 @@
+diff --git a/wx-config.in b/wx-config.in
+index 4df8571..a90db3d 100644
+--- a/wx-config.in
++++ b/wx-config.in
+@@ -398,8 +398,23 @@ is_cross()  { [ "x@cross_compiling@" = "xyes" ]; }
+ 
+ 
+ # Determine the base directories we require.
+-prefix=${input_option_prefix-${this_prefix:-@prefix@}}
+-exec_prefix=${input_option_exec_prefix-${input_option_prefix-${this_exec_prefix:-@exec_prefix@}}}
++vcpkg_prefix=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
++case "$vcpkg_prefix" in
++    */lib/wx/config)
++        vcpkg_prefix=${vcpkg_prefix%/*/*/*}
++        ;;
++    */tools/wxwidgets/debug)
++        vcpkg_prefix=${vcpkg_prefix%/*/*/*}/debug
++        ;;
++    */tools/wxwidgets)
++        vcpkg_prefix=${vcpkg_prefix%/*/*}
++        ;;
++esac
++if [ -n "@MINGW@" -a -n "@CMAKE_HOST_WIN32@" ]; then
++    vcpkg_prefix=$(cygpath -m "$vcpkg_prefix")
++fi
++prefix=${input_option_prefix-${this_prefix:-$vcpkg_prefix}}
++exec_prefix=${input_option_exec_prefix-${input_option_prefix-${this_exec_prefix:-$prefix}}}
+ wxconfdir="@libdir@/wx/config"
+ 
+ installed_configs=`cd "$wxconfdir" 2> /dev/null && ls | grep -v "^inplace-"`
+@@ -936,6 +951,9 @@ prefix=${this_prefix-$prefix}
+ exec_prefix=${this_exec_prefix-$exec_prefix}
+ 
+ includedir="@includedir@"
++if [ "@CMAKE_BUILD_TYPE@" = "Debug" ] ; then
++    includedir="${includedir%/debug/include}/include"
++fi
+ libdir="@libdir@"
+ bindir="@bindir@"
+ 

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/sdl2.patch
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/sdl2.patch
@@ -1,0 +1,27 @@
+diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
+--- a/build/cmake/init.cmake
++++ b/build/cmake/init.cmake
+@@ -691,7 +691,9 @@ if(wxUSE_GUI)
+     endif()
+
+     if(wxUSE_SOUND AND wxUSE_LIBSDL AND UNIX AND NOT APPLE)
+-        find_package(SDL2)
++        find_package(SDL2 CONFIG REQUIRED)
++        set(SDL2_INCLUDE_DIR "" CACHE INTERNAL "")
++        set(SDL2_LIBRARY SDL2::SDL2 CACHE INTERNAL "")
+         if(NOT SDL2_FOUND)
+             find_package(SDL)
+             mark_as_advanced(SDL_INCLUDE_DIR SDLMAIN_LIBRARY)
+diff --git a/build/cmake/wxWidgetsConfig.cmake.in b/build/cmake/wxWidgetsConfig.cmake.in
+--- a/build/cmake/wxWidgetsConfig.cmake.in
++++ b/build/cmake/wxWidgetsConfig.cmake.in
+@@ -2,6 +2,9 @@
+
+ include(CMakeFindDependencyMacro)
+ find_dependency(NanoSVG CONFIG)
++if("@wxUSE_LIBSDL@")
++    find_dependency(SDL2 CONFIG)
++endif()
+
+ cmake_policy(PUSH)
+ # Set policies to prevent warnings

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/setup.h.in
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/setup.h.in
@@ -1,0 +1,5 @@
+#ifdef _DEBUG
+#include "../../debug/lib/@WX_SETUP_H_DBG_RELATIVE@/setup.h"
+#else
+#include "../../lib/@WX_SETUP_H_REL_RELATIVE@/setup.h"
+#endif

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/usage
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/usage
@@ -1,0 +1,4 @@
+The package wxwidgets provides CMake targets:
+
+    find_package(wxWidgets CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE wx::core wx::base)

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/vcpkg-cmake-wrapper.cmake
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/vcpkg-cmake-wrapper.cmake
@@ -1,0 +1,87 @@
+cmake_policy(PUSH)
+cmake_policy(SET CMP0012 NEW)
+cmake_policy(SET CMP0054 NEW)
+cmake_policy(SET CMP0057 NEW)
+
+get_filename_component(_vcpkg_wx_root "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
+set(wxWidgets_ROOT_DIR "${_vcpkg_wx_root}" CACHE INTERNAL "")
+set(WX_ROOT_DIR "${_vcpkg_wx_root}" CACHE INTERNAL "")
+unset(_vcpkg_wx_root)
+
+if(WIN32)
+    # Find all libs with "33" infix which is unknown to FindwxWidgets.cmake
+    function(z_vcpkg_wxwidgets_find_base_library BASENAME)
+        find_library(WX_${BASENAME}d wx${BASENAME}33ud NAMES wx${BASENAME}d PATHS "${wxWidgets_ROOT_DIR}/debug/lib" NO_DEFAULT_PATH)
+        find_library(WX_${BASENAME}  wx${BASENAME}33u  NAMES wx${BASENAME}  PATHS "${wxWidgets_ROOT_DIR}/lib" NO_DEFAULT_PATH REQUIRED)
+    endfunction()
+    function(z_vcpkg_wxwidgets_find_suffix_library BASENAME)
+        foreach(lib IN LISTS ARGN)
+            find_library(WX_${lib}d NAMES wx${BASENAME}33ud_${lib} PATHS "${wxWidgets_ROOT_DIR}/debug/lib" NO_DEFAULT_PATH)
+            find_library(WX_${lib}  NAMES wx${BASENAME}33u_${lib}  PATHS "${wxWidgets_ROOT_DIR}/lib" NO_DEFAULT_PATH)
+        endforeach()
+    endfunction()
+    z_vcpkg_wxwidgets_find_base_library(base)
+    z_vcpkg_wxwidgets_find_suffix_library(base net odbc xml)
+    z_vcpkg_wxwidgets_find_suffix_library(msw core adv aui html media xrc dbgrid gl qa richtext stc ribbon propgrid webview)
+    if(WX_stc AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static")
+        z_vcpkg_wxwidgets_find_base_library(scintilla)
+    endif()
+    # Force FindwxWidgets.cmake win32 mode for all windows targets built on windows
+    set(_vcpkg_wxwidgets_backup_crosscompiling "${CMAKE_CROSSCOMPILING}")
+    set(CMAKE_CROSSCOMPILING 0)
+    set(wxWidgets_LIB_DIR "${wxWidgets_ROOT_DIR}/lib" CACHE INTERNAL "")
+else()
+    # FindwxWidgets.cmake unix mode, single-config
+    set(_vcpkg_wxconfig "")
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR "Debug" IN_LIST MAP_IMPORTED_CONFIG_${CMAKE_BUILD_TYPE})
+        # Debug
+        set(wxWidgets_LIB_DIR "${wxWidgets_ROOT_DIR}/debug/lib" CACHE INTERNAL "")
+        file(GLOB _vcpkg_wxconfig LIST_DIRECTORIES false "${wxWidgets_LIB_DIR}/wx/config/*")
+    endif()
+    if(NOT _vcpkg_wxconfig)
+        # Release or fallback
+        set(wxWidgets_LIB_DIR "${wxWidgets_ROOT_DIR}/lib" CACHE INTERNAL "")
+        file(GLOB _vcpkg_wxconfig LIST_DIRECTORIES false "${wxWidgets_LIB_DIR}/wx/config/*")
+    endif()
+    set(wxWidgets_CONFIG_EXECUTABLE "${_vcpkg_wxconfig}" CACHE INTERNAL "")
+    unset(_vcpkg_wxconfig)
+endif()
+set(WX_LIB_DIR "${wxWidgets_LIB_DIR}" CACHE INTERNAL "")
+
+# https://gitlab.kitware.com/cmake/cmake/-/issues/26718
+# Instead of special-casing the `atomic` library, we skip the checks entirely.
+set(_wx_lib_found TRUE)
+
+_find_package(${ARGS})
+
+unset(_wx_lib_found)
+
+if(DEFINED _vcpkg_wxwidgets_backup_crosscompiling)
+    set(CMAKE_CROSSCOMPILING "${_vcpkg_wxwidgets_backup_crosscompiling}")
+    unset(_vcpkg_wxwidgets_backup_crosscompiling)
+endif()
+
+if("@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND NOT "wx::core" IN_LIST wxWidgets_LIBRARIES)
+    find_package(NanoSVG CONFIG QUIET)
+    list(APPEND wxWidgets_LIBRARIES
+        NanoSVG::nanosvg NanoSVG::nanosvgrast
+        )
+endif()
+
+
+if(WIN32 AND "@VCPKG_LIBRARY_LINKAGE@" STREQUAL "static" AND NOT "wx::core" IN_LIST wxWidgets_LIBRARIES)
+    find_package(EXPAT QUIET)
+    find_package(JPEG QUIET)
+    find_package(PNG QUIET)
+    find_package(TIFF QUIET)
+    find_package(ZLIB QUIET)
+    list(APPEND wxWidgets_LIBRARIES
+        ${EXPAT_LIBRARIES}
+        ${JPEG_LIBRARIES}
+        ${PNG_LIBRARIES}
+        ${TIFF_LIBRARIES}
+        ${ZLIB_LIBRARIES}
+    )
+endif()
+
+cmake_policy(POP)

--- a/3rdParty/vcpkg_ports/ports/wxwidgets/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/wxwidgets/vcpkg.json
@@ -1,0 +1,122 @@
+{
+  "name": "wxwidgets",
+  "version": "3.3.3",
+  "description": [
+    "Widget toolkit and tools library for creating graphical user interfaces (GUIs) for cross-platform applications. ",
+    "Set WXWIDGETS_USE_STL in a custom triplet to build with the wxUSE_STL build option.",
+    "Set WXWIDGETS_USE_STD_CONTAINERS in a custom triplet to build with the wxUSE_STD_CONTAINERS build option."
+  ],
+  "homepage": "https://github.com/wxWidgets/wxWidgets",
+  "license": "LGPL-2.0-or-later WITH WxWindows-exception-3.1 AND HPND",
+  "supports": "!uwp & !xbox",
+  "dependencies": [
+    {
+      "name": "cairo",
+      "default-features": false,
+      "platform": "!windows & !osx & !ios"
+    },
+    {
+      "name": "curl",
+      "default-features": false,
+      "platform": "!windows & !osx"
+    },
+    "expat",
+    {
+      "name": "gtk3",
+      "platform": "!windows & !osx & !ios"
+    },
+    {
+      "name": "libiconv",
+      "platform": "!windows"
+    },
+    "libjpeg-turbo",
+    "libpng",
+    {
+      "name": "libsm",
+      "platform": "!windows & !osx & !ios"
+    },
+    "libwebp",
+    "nanosvg",
+    "opengl",
+    {
+      "name": "pcre2",
+      "default-features": false
+    },
+    {
+      "name": "tiff",
+      "default-features": false
+    },
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "zlib"
+  ],
+  "default-features": [
+    "debug-support",
+    "sound"
+  ],
+  "features": {
+    "debug-support": {
+      "description": "Enable wxWidgets debugging support hooks even for release builds (wxDEBUG_LEVEL 1)"
+    },
+    "example": {
+      "description": "Example source code and CMake project"
+    },
+    "fonts": {
+      "description": "Enable to use the font functionality of wxWidgets",
+      "dependencies": [
+        {
+          "name": "fontconfig",
+          "platform": "!windows & !osx"
+        },
+        {
+          "name": "pango",
+          "platform": "!windows & !osx"
+        }
+      ]
+    },
+    "media": {
+      "description": "Build wxMediaCtrl support",
+      "dependencies": [
+        {
+          "name": "gstreamer",
+          "default-features": false,
+          "platform": "!windows & !osx & !ios"
+        }
+      ]
+    },
+    "secretstore": {
+      "description": "Use wxSecretStore class",
+      "dependencies": [
+        {
+          "name": "libsecret",
+          "platform": "!windows & !osx & !ios"
+        }
+      ]
+    },
+    "sound": {
+      "description": "Build wxSound support",
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "platform": "!windows & !osx & !ios"
+        }
+      ]
+    },
+    "webview": {
+      "description": "The Edge backend uses Microsoft's Edge WebView2",
+      "dependencies": [
+        {
+          "name": "webview2",
+          "platform": "windows"
+        }
+      ]
+    }
+  }
+}

--- a/linux/arm64/ci_configure_manager.sh
+++ b/linux/arm64/ci_configure_manager.sh
@@ -59,4 +59,4 @@ export CPPFLAGS="-I$VCPKG_DIR/include"
 export LDFLAGS="-march=armv8-a -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 
-./configure --host=aarch64-linux-gnu --with-boinc-platform="aarch64-unknown-linux-gnu" --with-boinc-alt-platform="arm-unknown-linux-gnueabihf" --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg)" $exec_prefix
+./configure --host=aarch64-linux-gnu --with-boinc-platform="aarch64-unknown-linux-gnu" --with-boinc-alt-platform="arm-unknown-linux-gnueabihf" --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg) -lnanosvg -lnanosvgrast" $exec_prefix

--- a/linux/armhf/ci_configure_manager.sh
+++ b/linux/armhf/ci_configure_manager.sh
@@ -59,4 +59,4 @@ export CPPFLAGS="-I$VCPKG_DIR/include"
 export LDFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard -O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 
-./configure --host=arm-linux-gnueabihf --with-boinc-platform="arm-unknown-linux-gnueabihf" --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg)" $exec_prefix
+./configure --host=arm-linux-gnueabihf --with-boinc-platform="arm-unknown-linux-gnueabihf" --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg) -lnanosvg -lnanosvgrast" $exec_prefix

--- a/linux/ci_configure_manager.sh
+++ b/linux/ci_configure_manager.sh
@@ -53,4 +53,4 @@ export LDFLAGS="-O3 -flto -static-libstdc++ -s"
 export _libcurl_pc="$VCPKG_DIR/lib/pkgconfig/libcurl.pc"
 export PKG_CONFIG_PATH=$VCPKG_DIR/lib/pkgconfig/
 
-./configure --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg)" $exec_prefix
+./configure --disable-server --disable-client --with-wx-config=$VCPKG_DIR/tools/wxwidgets/wx-config CPPFLAGS="-DwxDEBUG_LEVEL=0 -DBUILD_WITH_VCPKG=1" GTK_LIBS="$(pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg) -lnanosvg -lnanosvgrast" $exec_prefix

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -126,7 +126,7 @@ parts:
     - --enable-client
     - --enable-manager
     - --disable-server
-    - GTK_LIBS="`pkg-config --libs gtk+-3.0`"
+    - GTK_LIBS="`pkg-config --libs gtk+-3.0 librsvg-2.0 pixbufloader-svg` -lnanosvg -lnanosvgrast"
     override-build: |
       echo ARCH=$CRAFT_ARCH_BUILD_FOR
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Builds `wxwidgets` 3.3.3 in CI from a custom `vcpkg` port and uses a relocatable `wx-config`, fixing failures from non‑relocatable tooling and misdetected dependencies. Builds now link consistently across Linux, Windows, and Snap.

- Adds a custom `wxwidgets` port with patches to fix dependency discovery and export: PCRE2 via pkg-config, SDL2 in CONFIG mode, GTK3 link cleanup, Wayland define, generator‑expression handling, propagate `libsecret` link dirs, simplify install layout, and make `wx-config` relocatable; installs `wxrc`/`wx-config` under tools.
- Provides a `vcpkg` CMake wrapper so `FindwxWidgets` picks “33”-suffix libs on Windows, selects Debug/Release correctly, and auto‑adds static deps (`NanoSVG` and core image libs) when required.
- Adds `3rdParty/vcpkg_ports/libxtrans` and `3rdParty/vcpkg_ports/libsm` to supply X11 transport headers and session management via `vcpkg` when needed.
- Linux CI and Snap builds append “-lnanosvg -lnanosvgrast” to GTK_LIBS for the Autotools manager build.

**Migration**
- CMake: find_package(wxWidgets CONFIG REQUIRED) and target_link_libraries(<tgt> PRIVATE wx::core wx::base).
- Remove custom FindwxWidgets.cmake overrides; the wrapper resolves “33”-suffix libraries and config-specific paths.

<sup>Written for commit 3d9fae0e0d4ecef1f5adf909e8376a77e7019713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

