### PR TITLE
Update ProjectProcessingPage.cpp

### DIFF
--- a/clientgui/ProjectProcessingPage.cpp
+++ b/clientgui/ProjectProcessingPage.cpp
@@ -67,8 +67,6 @@ IMPLEMENT_DYNAMIC_CLASS( CProjectProcessingPage, wxWizardPageEx )
 
 /*!
  * CProjectProcessingPage event table definition
- * NOTE: The EVT_PROJECTPROCESSING_STATECHANGE entry has been removed
- * and replaced with a Bind() call in Create() to avoid unsafe pointer casts.
  */
 BEGIN_EVENT_TABLE( CProjectProcessingPage, wxWizardPageEx )
 
@@ -119,8 +117,6 @@ bool CProjectProcessingPage::Create( CBOINCBaseWizard* parent )
 ////@end CProjectProcessingPage creation
 
     // Bind the custom state-change event to its handler.
-    // This is type-safe and avoids the compiler warning about cast between
-    // incompatible member function pointer types.
     Bind(wxEVT_PROJECTPROCESSING_STATECHANGE,
          &CProjectProcessingPage::OnStateChange, this);
 

--- a/clientgui/ProjectProcessingPage.cpp
+++ b/clientgui/ProjectProcessingPage.cpp
@@ -67,16 +67,14 @@ IMPLEMENT_DYNAMIC_CLASS( CProjectProcessingPage, wxWizardPageEx )
 
 /*!
  * CProjectProcessingPage event table definition
+ * NOTE: The EVT_PROJECTPROCESSING_STATECHANGE entry has been removed
+ * and replaced with a Bind() call in Create() to avoid unsafe pointer casts.
  */
-
 BEGIN_EVENT_TABLE( CProjectProcessingPage, wxWizardPageEx )
-
-    EVT_PROJECTPROCESSING_STATECHANGE( CProjectProcessingPage::OnStateChange )
 
 ////@begin CProjectProcessingPage event table entries
     EVT_WIZARDEX_PAGE_CHANGED( -1, CProjectProcessingPage::OnPageChanged )
     EVT_WIZARDEX_CANCEL( -1, CProjectProcessingPage::OnCancel )
-
 ////@end CProjectProcessingPage event table entries
 
 END_EVENT_TABLE()
@@ -119,6 +117,12 @@ bool CProjectProcessingPage::Create( CBOINCBaseWizard* parent )
     CreateControls();
     GetSizer()->Fit(this);
 ////@end CProjectProcessingPage creation
+
+    // Bind the custom state-change event to its handler.
+    // This is type-safe and avoids the compiler warning about cast between
+    // incompatible member function pointer types.
+    Bind(wxEVT_PROJECTPROCESSING_STATECHANGE,
+         &CProjectProcessingPage::OnStateChange, this);
 
     return TRUE;
 }
@@ -625,4 +629,3 @@ void CProjectProcessingPage::OnStateChange( CProjectProcessingPageEvent& WXUNUSE
         AddPendingEvent(TransitionEvent);
     }
 }
-


### PR DESCRIPTION
Fixes #6104 

**Description of the Change**
The root cause of was an unsafe cast of a member function pointer in the static event table:
```cpp
EVT_PROJECTPROCESSING_STATECHANGE( CProjectProcessingPage::OnStateChange )
```
This macro forced a cast from `void (CProjectProcessingPage::*)(CProjectProcessingPageEvent&)` to `wxEventFunction` (i.e., `void (wxEvtHandler::*)(wxEvent&)`), which is a cast between incompatible pointer types. Under GCC with `-Wcast-function-type`, this results in undefined behavior – the `this` pointer is misadjusted when the event handler is called, causing the state machine (`m_iCurrentState`, flags, and button enable/disable logic) to read/write garbage memory. Consequently, the wizard’s internal page history becomes corrupted, leading to the looping back behaviour and the back button never being greyed out.
To fix this, the static event table entry for `wxEVT_PROJECTPROCESSING_STATECHANGE` has been removed and replaced with a type‑safe dynamic binding using `Bind()` in the `Create()` method. `Bind()` uses templates to correctly adjust the `this` pointer, eliminating the UB and the compiler warning. The other static entries (`EVT_WIZARDEX_PAGE_CHANGED` and `EVT_WIZARDEX_CANCEL`) are unchanged because they use compatible function signatures.
After this change, the wizard’s state transitions work correctly, the back button follows the expected page history, and it becomes disabled when appropriate.

Assisted-by: (not using an agent): DeepSeek-V4

**Alternate Designs**
Keeping the static event table but modify the macro to use `wxDECLARE_EVENT_TABLE_ENTRY` with a proper functor that performs a safe cast. This would require changes in the header file and deeper understanding of wxWidgets’ internal event mechanism, making it more error‑prone and less maintainable.

**Release Notes**
Fixed erratic "Back" button behaviour in the project attach wizard (Linux builds from master).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #6104 by replacing an unsafe static event handler with a type-safe `Bind()` for the state-change event. The project attach wizard now advances correctly and disables the Back button when expected.

- **Bug Fixes**
  - Replaced static `EVT_PROJECTPROCESSING_STATECHANGE` entry with `Bind(wxEVT_PROJECTPROCESSING_STATECHANGE, &CProjectProcessingPage::OnStateChange, this)` in `Create()`.
  - Left `EVT_WIZARDEX_PAGE_CHANGED` and `EVT_WIZARDEX_CANCEL` unchanged.

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

