### PR TITLE
Fix android build

### DIFF
--- a/3rdParty/vcpkg_ports/configs/libs/android/vcpkg.json
+++ b/3rdParty/vcpkg_ports/configs/libs/android/vcpkg.json
@@ -1,0 +1,20 @@
+{
+    "name": "boinc-libs",
+    "dependencies":
+    [
+        {
+          "name": "curl",
+          "features": ["openssl"],
+          "default-features": false
+        },
+        {
+          "name": "openssl",
+          "features": ["ssl3", "weak-ssl-ciphers"],
+          "default-features": false
+        },
+        {
+          "name": "libzip",
+          "default-features": false
+        }
+    ]
+}

--- a/android/buildAndroidBOINC-CI.sh
+++ b/android/buildAndroidBOINC-CI.sh
@@ -3,7 +3,7 @@ set -e
 
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -209,7 +209,7 @@ else
     triplets_setup="default"
 fi
 manifest_dir=$THIRD_PARTY/vcpkg_ports/configs/$component
-if [ $component = "apps" ]; then
+if [ "$component" = "apps" ] || [ "$component" = "libs" ]; then
     manifest_dir=$manifest_dir/android
 fi
 manifests="--x-manifest-root=$manifest_dir --x-install-root=$VCPKG_ROOT/installed/"

--- a/android/ci_build_libs_cmake.sh
+++ b/android/ci_build_libs_cmake.sh
@@ -2,7 +2,7 @@
 
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2025 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -144,7 +144,7 @@ for TRIPLET in $TRIPLETS_LIST ; do
     fi
 
     BUILD_TRIPLET=build-$TRIPLET
-    cmake -E env CC="${CC}" CXX="${CXX}" LD="${LD}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" cmake lib -B $BUILD_TRIPLET -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_MANIFEST_DIR=3rdParty/vcpkg_ports/configs/libs/ -DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed/ -DVCPKG_OVERLAY_PORTS=$VCPKG_PORTS/ports -DVCPKG_OVERLAY_TRIPLETS=$VCPKG_PORTS/triplets/ci -DVCPKG_TARGET_TRIPLET=$TRIPLET -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DHOST=$HOST
+    cmake -E env CC="${CC}" CXX="${CXX}" LD="${LD}" CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}" cmake lib -B $BUILD_TRIPLET -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_MANIFEST_DIR=3rdParty/vcpkg_ports/configs/libs/android/ -DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed/ -DVCPKG_OVERLAY_PORTS=$VCPKG_PORTS/ports -DVCPKG_OVERLAY_TRIPLETS=$VCPKG_PORTS/triplets/ci -DVCPKG_TARGET_TRIPLET=$TRIPLET -DVCPKG_INSTALL_OPTIONS=--clean-after-build -DHOST=$HOST
     cmake --build $BUILD_TRIPLET
 
     echo "\e[1;32m $TRIPLET done \e[0m"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Android CI build by adding an Android-specific vcpkg manifest for BOINC libs and updating build scripts to point to it. Ensures correct dependency resolution for `curl`/`openssl` and `libzip` on Android.

- **Bug Fixes**
  - Added `3rdParty/vcpkg_ports/configs/libs/android/vcpkg.json` with `curl` (with `openssl`), `openssl` (features: `ssl3`, `weak-ssl-ciphers`), and `libzip`.
  - Updated `buildAndroidBOINC-CI.sh` and `ci_build_libs_cmake.sh` to use the Android libs manifest path.

<sup>Written for commit 8057db11378ebc11a9ec828205822805c33b171d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

