### PR TITLE
Update sg_BoincSimpleFrame.cpp

### DIFF
--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -586,7 +586,10 @@ void CSimpleFrame::OnSelectDefaultSkin( wxCommandEvent& WXUNUSED(event) ) {
     pSkinManager->ReloadSkin(pSkinManager->GetDefaultSkinName());
 
     wxGetApp().SaveState();
-    wxConfigBase::Get(FALSE)->Flush();
+    wxConfigBase* pConfig = wxConfigBase::Get(FALSE);
+    if (pConfig) {
+        pConfig->Flush();
+    }
 }
 
 

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -584,6 +584,9 @@ void CSimpleFrame::OnSelectDefaultSkin( wxCommandEvent& WXUNUSED(event) ) {
     // The "Default" skin menu item is localized, but
     // the name of the default skin is not localized
     pSkinManager->ReloadSkin(pSkinManager->GetDefaultSkinName());
+
+    wxGetApp().SaveState();
+    wxConfigBase::Get(FALSE)->Flush();
 }
 
 

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -581,8 +581,8 @@ void CSimpleFrame::OnSelectDefaultSkin( wxCommandEvent& WXUNUSED(event) ) {
     wxASSERT(pSkinManager);
     wxASSERT(wxDynamicCast(pSkinManager, CSkinManager));
 
-    // The "Default" skin menu item is localized, but
-    // the name of the default skin is not localized
+    pSkinManager->SetSelectedSkin(pSkinManager->GetDefaultSkinName());
+
     pSkinManager->ReloadSkin(pSkinManager->GetDefaultSkinName());
 
     wxGetApp().SaveState();

--- a/clientgui/sg_BoincSimpleFrame.cpp
+++ b/clientgui/sg_BoincSimpleFrame.cpp
@@ -627,7 +627,10 @@ void CSimpleFrame::OnSelectSkin( wxCommandEvent& event ){
     pSkinManager->ReloadSkin(newSkinName);
 
     wxGetApp().SaveState();
-    wxConfigBase::Get(FALSE)->Flush();
+    wxConfigBase* pConfig = wxConfigBase::Get(FALSE);
+    if (pConfig) {
+        pConfig->Flush();
+    }
 }
 
 


### PR DESCRIPTION
Fixes #6103

**Description of the Change**
When a user selects the "Default" skin via the View → Skin menu, the GUI reloads the default appearance, but the selection is never saved to the configuration file. On next startup, `RestoreState()` reads the previously saved (non‑default) skin name and re‑applies that skin, effectively discarding the user's choice.

The fix adds the same persistence logic already present in `OnSelectSkin()` for non‑default skins to `OnSelectDefaultSkin()`:
- `wxGetApp().SaveState()` – saves the current skin name via `CSkinManager`
- `wxConfigBase::Get(FALSE)->Flush()` – ensures the config is written to disk immediately

This makes the behaviour consistent across all skin selections and ensures the default skin is remembered across sessions.

Assisted-by: (not using an agent): DeepSeek-V4

**Alternate Designs**
- A more extensive refactoring could unify the persistence logic into a helper method (e.g., `SaveSelectedSkin()`), but that would touch more files and add unnecessary churn for a two‑line fix.

The chosen approach is minimal, safe, and mirrors the existing working implementation for non‑default skins, reducing the risk of regression.

**Release Notes**
Fixed an issue where selecting the default skin did not persist after restarting BOINC Manager.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists selecting the “Default” skin so BOINC Manager restores it after restart; previously it reapplied the last saved non‑default skin. Also guards config flushing to avoid a null dereference. Fixes #6103.

**Changes**
- In `OnSelectDefaultSkin()`: explicitly call `SetSelectedSkin()` with the default name, reload the skin, then call `wxGetApp().SaveState()` and `wxConfigBase::Get(FALSE)->Flush()` only if a config exists.
- In `OnSelectSkin()`: guard the `Flush()` call behind a null check on `wxConfigBase::Get(FALSE)`.

<sup>Written for commit 74514e784d5e22854e005beddb565579bdf8e778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



