### PR TITLE
Update main.cpp

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -281,8 +281,8 @@ static void do_gpu_detection(int argc, char** argv) {
     vector<string> warnings;
 
     boinc_install_signal_handlers();
-    gstate.parse_cmdline(argc, argv);
     read_config_file(true);
+    gstate.parse_cmdline(argc, argv);
     gstate.now = dtime();
 
     int flags =

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -203,7 +203,7 @@ static void init_core_client(int argc, char** argv) {
     cc_config.defaults();
     nvc_config.defaults();
 
-    // First pass: parse command line (without --dir)
+    // Parse command line without --dir command
     gstate.parse_cmdline(argc, argv);
     gstate.now = dtime();
 
@@ -217,7 +217,7 @@ static void init_core_client(int argc, char** argv) {
     // Read config file from current working directory
     read_config_file(true);
 
-    // Second pass: parse command line again to override config file settings
+    // Parse command line again to override config file settings
     gstate.parse_cmdline(argc, argv);
 
 #ifndef _WIN32

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -179,27 +179,46 @@ static void signal_handler(int signum, siginfo_t*, void*) {
 static void init_core_client(int argc, char** argv) {
     setbuf(stdout, 0);
     setbuf(stderr, 0);
-    
+
+    // Manually extract --dir argument and change directory before config read
+    bool dir_specified = false;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-dir") || !strcmp(argv[i], "--dir")) {
+            if (i + 1 < argc) {
+                char* dir_path = argv[i+1];
+                // Remove the two arguments
+                for (int j = i; j < argc - 2; j++) {
+                    argv[j] = argv[j+2];
+                }
+                argc -= 2;
+                if (boinc_chdir(dir_path)) {
+                    log_message_error("Failed to chdir to specified directory");
+                }
+                dir_specified = true;
+                break;
+            }
+        }
+    }
+
     cc_config.defaults();
     nvc_config.defaults();
 
-#ifdef _WIN32
+    // First pass: parse command line (without --dir)
     gstate.parse_cmdline(argc, argv);
     gstate.now = dtime();
-    
-    if (!cc_config.allow_multiple_clients && !gstate.cmdline_dir) {
+
+#ifdef _WIN32
+    // On Windows, switch to default data directory if no --dir and not allowing multiple clients
+    if (!dir_specified && !cc_config.allow_multiple_clients && !gstate.cmdline_dir) {
         chdir_to_data_dir();
     }
-
-    read_config_file(true);
-
-    gstate.parse_cmdline(argc, argv);
-    
-#else
-    gstate.now = dtime();
-    read_config_file(true);
-    gstate.parse_cmdline(argc, argv);
 #endif
+
+    // Read config file from current working directory
+    read_config_file(true);
+
+    // Second pass: parse command line again to override config file settings
+    gstate.parse_cmdline(argc, argv);
 
 #ifndef _WIN32
     if (g_use_sandbox) {
@@ -246,7 +265,6 @@ static void init_core_client(int argc, char** argv) {
     //_CrtSetBreakAlloc(653);
     //_CrtSetBreakAlloc(654);
 #endif
-
 
     // NOTE: this must be called BEFORE newer_version_startup_check()
     // Only branded builds of BOINC should have an nvc_config.xml file
@@ -361,7 +379,6 @@ static int initialize() {
             return ERR_EXEC;
         }
     }
-
 
     // Initialize WinSock
 #if defined(_WIN32) && defined(USE_WINSOCK)

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -196,6 +196,7 @@ static void init_core_client(int argc, char** argv) {
     gstate.parse_cmdline(argc, argv);
     
 #else
+    gstate.now = dtime();
     read_config_file(true);
     gstate.parse_cmdline(argc, argv);
 #endif

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -182,6 +182,7 @@ static void init_core_client(int argc, char** argv) {
 
     cc_config.defaults();
     nvc_config.defaults();
+    read_config_file(true);
     gstate.parse_cmdline(argc, argv);
     gstate.now = dtime();
 
@@ -237,7 +238,6 @@ static void init_core_client(int argc, char** argv) {
     //_CrtSetBreakAlloc(654);
 #endif
 
-    read_config_file(true);
 
     // NOTE: this must be called BEFORE newer_version_startup_check()
     // Only branded builds of BOINC should have an nvc_config.xml file
@@ -273,6 +273,7 @@ static void do_gpu_detection(int argc, char** argv) {
     vector<string> warnings;
 
     boinc_install_signal_handlers();
+    read_config_file(true);
     gstate.parse_cmdline(argc, argv);
     gstate.now = dtime();
 
@@ -284,8 +285,6 @@ static void do_gpu_detection(int argc, char** argv) {
         BOINC_DIAG_REDIRECTSTDOUT;
 
     diagnostics_init(flags, "stdoutgpudetect", "stderrgpudetect");
-
-    read_config_file(true);
 
     coprocs.detect_gpus(warnings);
     coprocs.write_coproc_info_file(warnings);

--- a/client/main.cpp
+++ b/client/main.cpp
@@ -179,17 +179,25 @@ static void signal_handler(int signum, siginfo_t*, void*) {
 static void init_core_client(int argc, char** argv) {
     setbuf(stdout, 0);
     setbuf(stderr, 0);
-
+    
     cc_config.defaults();
     nvc_config.defaults();
-    read_config_file(true);
-    gstate.parse_cmdline(argc, argv);
-    gstate.now = dtime();
 
 #ifdef _WIN32
+    gstate.parse_cmdline(argc, argv);
+    gstate.now = dtime();
+    
     if (!cc_config.allow_multiple_clients && !gstate.cmdline_dir) {
         chdir_to_data_dir();
     }
+
+    read_config_file(true);
+
+    gstate.parse_cmdline(argc, argv);
+    
+#else
+    read_config_file(true);
+    gstate.parse_cmdline(argc, argv);
 #endif
 
 #ifndef _WIN32
@@ -273,8 +281,8 @@ static void do_gpu_detection(int argc, char** argv) {
     vector<string> warnings;
 
     boinc_install_signal_handlers();
-    read_config_file(true);
     gstate.parse_cmdline(argc, argv);
+    read_config_file(true);
     gstate.now = dtime();
 
     int flags =


### PR DESCRIPTION
Fixes #1544

**Description of the Change**

Reorder the initialization sequence in init_core_client() to ensure that command-line arguments correctly override settings from cc_config.xml.

Before: command-line parsing happened before reading the config file, so XML values unconditionally overwrote the earlier command-line settings.
After:
1. The --dir/-dir argument is extracted and handled early to change the working directory before any config file is read.
2. cc_config.defaults() and nvc_config.defaults() are called.
3. A first pass of gstate.parse_cmdline() parses all remaining arguments.
4. read_config_file(true) loads cc_config.xml from the now-correct working directory.
5. A second pass of gstate.parse_cmdline() re-applies all command-line options, which now take precedence over the XML-loaded values.

This change also updates do_gpu_detection() to follow the same pattern (read config first, then parse command line), keeping behaviour consistent.
Assisted-by: (not using an agent): DeepSeek-V4

**Alternate Designs**
Two other approaches were considered:

1. Add source-tracking flags – extend CC_CONFIG with per-option set_by_cmdline booleans and skip XML assignment when that flag is true. This is more invasive, touches many configuration members, and increases maintenance overhead.
2. Swap only the order without handling --dir specially – but this would break if cc_config.xml is not in the current directory when the client starts, because the directory change would happen after reading the file.

The chosen design is the simplest and least intrusive: it uses the existing parsing mechanism twice, requiring no changes to parse_options_client() or CC_CONFIG structure, and correctly handles directory changes.

**Release Notes**
Fix command-line options being overridden by `cc_config.xml`; command‑line arguments now take precedence over the configuration file.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Command-line arguments now correctly override cc_config.xml across platforms. init_core_client(): extract and apply `--dir` before first parse, switch to the data dir (or default on Windows), read config, then re-parse CLI to override; do_gpu_detection(): read config before CLI parse and remove the late read so diagnostics honor flags.

<sup>Written for commit 5d583a4fd651a00e3afe0a0fc2d30e699213a7e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



