### PR TITLE
BUDA fixes, from Greg Childers

### DIFF
--- a/html/user/buda_submit.php
+++ b/html/user/buda_submit.php
@@ -203,11 +203,17 @@ function create_batch($user, $njobs, $app) {
     return BoincBatch::lookup_id($batch_id);
 }
 
+// stage the batch's input files:
+// first shared files, then per-job files
+//
 function stage_input_files($batch_dir, $batch_desc, $batch_id) {
     $n = count($batch_desc->shared_files);
     $batch_desc->shared_files_phys_names = [];
     for ($i=0; $i<$n; $i++) {
-        $path = sprintf('%s/%s', $batch_dir, $batch_desc->shared_files[$i]);
+        $path = sprintf(
+            '%s/shared_input_files/%s',
+            $batch_dir, $batch_desc->shared_files[$i]
+        );
         [$md5, $size] = $batch_desc->shared_file_infos[$i];
         $phys_name = sprintf('batch_%d_%s', $batch_id, $md5);
         stage_file_aux($path, $md5, $size, $phys_name);

--- a/sched/sched_main.cpp
+++ b/sched/sched_main.cpp
@@ -503,8 +503,6 @@ int main(int argc, char** argv) {
     }
     strip_whitespace(code_sign_key);
 
-    buda_init();
-
     g_pid = getpid();
 #ifdef _USING_FCGI_
     //while(FCGI_Accept() >= 0 && counter < MAX_FCGI_COUNT) {
@@ -531,6 +529,9 @@ int main(int argc, char** argv) {
         send_message("Server error: can't attach shared memory", config.maintenance_delay);
         goto done;
     }
+
+    buda_init();    // must follow attaching to shmem
+
     if (config.keyword_sched) {
         keyword_sched_init();
     }

--- a/tools/manage_privileges
+++ b/tools/manage_privileges
@@ -18,7 +18,9 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
-// script for controlling "manage" privileges.
+// script for assigning "manage" privileges for apps.
+// this lets you submit jobs, create new versions,
+// and give other users submit access.
 // See https://github.com/BOINC/boinc/wiki/MultiUser
 // Run this from the project directory.
 
@@ -28,7 +30,7 @@
 // manage_privileges revoke userid {appname|all}
 // manage_privileges list
 //
-// grant/revoke the "manage" privileges for the given app (or all apps),
+// grant/revoke the "manage" privilege for the given app (or all apps),
 // or list all privileges
 
 error_reporting(E_ALL);


### PR DESCRIPTION
- job submission: put shared files in the right place
- scheduler: call buda_init() after mapping shmem

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BUDA job submission paths and scheduler init order. Shared input files are now staged from batch_dir/shared_input_files instead of batch_dir, and `buda_init()` now runs after attaching shared memory to prevent startup issues.

- Old vs new behavior:
  - Job submission: was reading shared files from batch_dir/<name>; now reads from batch_dir/shared_input_files/<name>. Ensure shared files are placed in that subdirectory before staging; per-job files are unchanged.
  - Scheduler: previously called `buda_init()` before shmem attach; now calls it after attach. This avoids reads from uninitialized shmem. No functional change beyond init reliability.
  - `tools/manage_privileges`: comments clarified only; no runtime changes.

**Rollout**
- Move or upload shared batch files into batch_dir/shared_input_files before submission. Required.
- Restart the scheduler after deploy to use the new init sequence.
- No DB or API changes.

<sup>Written for commit 90ad85c092e0c6230a8f0f55fe85af86d815b6a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

