### PR TITLE
client: don't use swap usage from state file

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -1016,7 +1016,12 @@ int ACTIVE_TASK::parse(XML_PARSER& xp) {
         else if (xp.parse_double("fraction_done", fraction_done)) continue;
             // deprecated - for backwards compat
         else if (xp.parse_int("app_version_num", n)) continue;
-        else if (xp.parse_double("swap_size",  procinfo.swap_usage)) continue;
+
+        // older clients measured swap usage incorrectly,
+        // so ignore value on state file.
+        // We'll learn the right value when we run it.
+        //
+        //else if (xp.parse_double("swap_size",  procinfo.swap_usage)) continue;
         else if (xp.parse_double("working_set_size", procinfo.rss)) continue;
         else if (xp.parse_double("working_set_size_smoothed", procinfo.rss_smoothed)) continue;
         else if (xp.parse_double("current_cpu_time", x)) continue;


### PR DESCRIPTION
8.2.15 and earlier clients used VM size as swap usage. In some cases this value was greater than swap space size. The client would then never schedule the job.

Instead, ignore the value in the state file.
The client will measure the swap usage (correctly) when it runs the job.

Fixes #7146

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore swap usage from the client state file to prevent false scheduling blocks. Previously the client used the saved swap value (often VM size), which could exceed actual swap space and keep tasks from ever running; now the state value is ignored and swap usage is measured when the task runs.

- Removes parsing of the swap_size field in the state file; other state fields are unchanged.
- No migration or config changes. Existing state files remain valid; their swap values are simply ignored.
- Tasks previously blocked by inflated swap usage should now be scheduled and run.

<sup>Written for commit 450b2ac89f0504a68aac58e64e73cdb387a4a9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

