### PR TITLE
Remove boinc2docker submodule

### DIFF
--- a/tests/server-test/manage/roles/clone-boinc-server-docker/tasks/clone_boinc_server_docker.yml
+++ b/tests/server-test/manage/roles/clone-boinc-server-docker/tasks/clone_boinc_server_docker.yml
@@ -5,8 +5,8 @@
   command: git clone https://github.com/BOINC/boinc-server-docker.git chdir="{{base_dir}}"
 
 - name: Init some submodules
-  command: git submodule init images/makeproject/boinc2docker images/makeproject/html/inc/phpmailer chdir="{{base_dir}}/boinc-server-docker"
+  command: git submodule init images/makeproject/html/inc/phpmailer chdir="{{base_dir}}/boinc-server-docker"
 
 - name: "Fetch some submodules for boinc-server-docker in {{base_dir}}"
-  command: git submodule update images/makeproject/boinc2docker images/makeproject/html/inc/phpmailer chdir="{{base_dir}}/boinc-server-docker"
+  command: git submodule update images/makeproject/html/inc/phpmailer chdir="{{base_dir}}/boinc-server-docker"
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes the `boinc2docker` submodule from the integration test role’s `boinc-server-docker` clone to reduce flakiness. Previously we initialized and updated `images/makeproject/boinc2docker` and `images/makeproject/html/inc/phpmailer`; now only `phpmailer` is managed.

- **Review**
  - Verify integration tests and the `boinc-server-docker` build do not assume `images/makeproject/boinc2docker` exists.

- **Migration**
  - Remove any CI or local references to `images/makeproject/boinc2docker`; no other actions required.

<sup>Written for commit 417cc5f84dc13bb4de58d45151c5754f1177e9a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

