### PR TITLE
scheduler: add plan class spec for min BOINC WSL distro version

### DIFF
--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -598,16 +598,24 @@ bool PLAN_CLASS_SPEC::check(
                 add_no_work_message("Client config does not allow using WSL");
                 return false;
             }
-            bool found = false;
-            for (WSL_DISTRO &wd: sreq.host.wsl_distros.distros) {
-                if (wd.disallowed) continue;
-                if (wd.docker_version.empty()) continue;
-                found = true;
-                break;
-            }
-            if (!found) {
-                add_no_work_message("No usable WSL distros found");
-                return false;
+            if (min_boinc_wsl_distro_version) {
+                int v = sreq.host.wsl_distros.boinc_distro_version();
+                if (v < min_boinc_wsl_distro_version) {
+                    add_no_work_message("Current BOINC WSL distro needed");
+                    return false;
+                }
+            } else {
+                bool found = false;
+                for (WSL_DISTRO &wd: sreq.host.wsl_distros.distros) {
+                    if (wd.disallowed) continue;
+                    if (wd.docker_version.empty()) continue;
+                    found = true;
+                    break;
+                }
+                if (!found) {
+                    add_no_work_message("No usable WSL distros found");
+                    return false;
+                }
             }
         } else {
             if (strlen(sreq.host.docker_version) == 0) {
@@ -1391,6 +1399,7 @@ PLAN_CLASS_SPEC::PLAN_CLASS_SPEC() {
     virtualbox = false;
     wsl = false;
     docker = false;
+    min_boinc_wsl_distro_version = 0;
     is64bit = false;
     min_ncpus = 0;
     max_threads = 1;

--- a/sched/plan_class_spec.cpp
+++ b/sched/plan_class_spec.cpp
@@ -1245,6 +1245,7 @@ int PLAN_CLASS_SPEC::parse(XML_PARSER& xp) {
         if (xp.parse_bool("virtualbox", virtualbox)) continue;
         if (xp.parse_bool("wsl", wsl)) continue;
         if (xp.parse_bool("docker", docker)) continue;
+        if (xp.parse_int("min_boinc_wsl_distro_version", min_boinc_wsl_distro_version)) continue;
         if (xp.parse_bool("is64bit", is64bit)) continue;
         if (xp.parse_str("cpu_feature", buf, sizeof(buf))) {
             cpu_features.push_back(" " + (string)buf + " ");

--- a/sched/plan_class_spec.h
+++ b/sched/plan_class_spec.h
@@ -34,6 +34,8 @@ struct PLAN_CLASS_SPEC {
     bool virtualbox;
     bool wsl;
     bool docker;
+    int min_boinc_wsl_distro_version;
+        // if client is Win, min version of the BOINC WSL distro
     bool is64bit;
     std::vector<std::string> cpu_features;
     double min_ncpus;

--- a/sched/plan_class_spec.xml.sample
+++ b/sched/plan_class_spec.xml.sample
@@ -128,4 +128,9 @@
         <name>                  docker      </name>
         <docker/>
     </plan_class>
+    <plan_class>
+        <name>                  docker_nvidia_cuda      </name>
+        <docker/>
+        <min_boinc_wsl_distro_version>  6   </min_boinc_wsl_distro_version>
+    </plan_class>
 </plan_classes>


### PR DESCRIPTION
This is needed to support Docker GPU apps

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a min_boinc_wsl_distro_version plan class option to require a minimum BOINC WSL distro on Windows hosts. This lets us schedule Docker GPU apps only on hosts with a sufficient BOINC WSL distro; existing plan classes behave as before unless they set this field.

- Adds min_boinc_wsl_distro_version (default 0 = disabled) to PLAN_CLASS_SPEC and parses <min_boinc_wsl_distro_version> from plan class XML.
- Scheduler change: when set, check() compares host.wsl_distros.boinc_distro_version() and denies work with "Current BOINC WSL distro needed" if below the minimum; when not set, it keeps the previous "usable WSL distro" check and may deny with "No usable WSL distros found".
- Updates sample config with a docker_nvidia_cuda plan class requiring <min_boinc_wsl_distro_version>6</min_boinc_wsl_distro_version>.

<sup>Written for commit e7ddfd72f3b1dcbe05b9cfbe52579322fb549444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

