### PR TITLE
[ci] upgrade Windows 11 ARM images to use VS2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -221,7 +221,7 @@ jobs:
           - platform: x64
             runner: windows-latest
           - platform: arm64
-            runner: windows-11-arm
+            runner: windows-11-vs2026-arm
           - installation_type: normal
             argument_list_alpha: "/quiet /qn /l*v alpha.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"
             argument_list_release: "/quiet /qn /l*v release.log OVERRIDE_LAUNCHWSLIMAGEINSTALLER=0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the Windows ARM64 CI runner from windows-11-arm to windows-11-vs2026-arm to build on the Visual Studio 2026 image. This aligns ARM builds with the VS2026 toolchain and SDKs.

- Uses runner label `windows-11-vs2026-arm`; ensure the runner exists and is online.
- Expect updated MSVC and Windows SDK; watch for new warnings or failures.
- Build caches tied to tool versions may invalidate; allow first run to rebuild.

<sup>Written for commit 0960fca94c427532f179e68adf22c77a179fb5af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

