### PR TITLE
[ci] improve python tests formatting

### DIFF
--- a/tests/testset.py
+++ b/tests/testset.py
@@ -1,6 +1,6 @@
 # This file is part of BOINC.
 # https://boinc.berkeley.edu
-# Copyright (C) 2024 University of California
+# Copyright (C) 2026 University of California
 #
 # BOINC is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License
@@ -15,25 +15,33 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
+
 class TestSet:
     def __init__(self, name):
         self.name = name
         self.passed = 0
         self.failed = 0
-        print(("Running test set [{name}]...").format(name=self.name))
+        print(f"Running test set [{self.name}]...")
+        self.testset_start = datetime.datetime.now()
 
     def __del__(self):
-        print(("Test set [{name}]: \033[92mpassed [{passed}]\033[0m, \033[91mfailed [{failed}]\033[0m.").format(name=self.name, passed=self.passed, failed=self.failed))
+        testset_end = datetime.datetime.now()
+        str = f"Test set [{self.name}]: passed [{self.passed}], failed [{self.failed}]. ({testset_end - self.testset_start})"
+        if self.failed == 0:
+            self._print_success(str)
+        else:
+            self._print_failure(str)
 
     def _print_success_report(self, test_name):
         self.passed += 1
-        self._print_success(("Passed [{test_name}]").format(test_name=test_name))
+        self._print_success(f"Passed [{test_name}]")
 
     def _print_success(self, message):
-        print(("\033[92m{message}\033[0m").format(message=message))
+        print(f"\033[92m{message}\033[0m")
 
     def _print_failure(self, message):
-        print(("\033[91m{message}\033[0m").format(message=message))
+        print(f"\033[91m{message}\033[0m")
 
     def result(self):
         return self.failed == 0
@@ -41,7 +49,7 @@ class TestSet:
     def expect_true(self, condition, test_name):
         if not condition:
             self.failed += 1
-            self._print_failure(("Failed [{test_name}]: expected True, got False").format(test_name=test_name))
+            self._print_failure(f"Failed [{test_name}]: expected True, got False")
             return False
         self._print_success_report(test_name)
         return True
@@ -49,7 +57,7 @@ class TestSet:
     def expect_false(self, condition, test_name):
         if condition:
             self.failed += 1
-            self._print_failure(("Failed [{test_name}]: expected False, got True").format(test_name=test_name))
+            self._print_failure(f"Failed [{test_name}]: expected False, got True")
             return False
         self._print_success_report(test_name)
         return True
@@ -57,7 +65,7 @@ class TestSet:
     def expect_equal(self, expected, actual, test_name):
         if expected != actual:
             self.failed += 1
-            self._print_failure(("Failed [{test_name}]: expected [{expected}], got [{actual}]").format(test_name=test_name, expected=expected, actual=actual))
+            self._print_failure(f"Failed [{test_name}]: expected [{expected}], got [{actual}]")
             return False
         self._print_success_report(test_name)
         return True
@@ -65,6 +73,6 @@ class TestSet:
     def expect_not_equal(self, a, b, test_name):
         if a == b:
             self.failed += 1
-            self._print_failure(("Failed [{test_name}]: expected {a} != {b}").format(test_name=test_name, a=a, b=b))
+            self._print_failure(f"Failed [{test_name}]: expected {a} != {b}")
             return False
         self._print_success_report(test_name)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors test output formatting in `tests/testset.py` to use f-strings and adds per-test-set duration reporting. This clarifies CI logs and changes the final summary to green on success and red on failure.

- Adds `datetime` start/end tracking and appends elapsed time to the summary line.
- Replaces `.format()` with f-strings; no changes to test assertions or pass/fail accounting.
- Summary output changes: previously mixed green/red counts; now the entire line is green if no failures, red otherwise. Migration: update any log parsers/greps to tolerate ANSI color and the trailing duration.

<sup>Written for commit 8b971ae1c81edf6204b55396833cf00a1e3c66af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

