### PR TITLE
client: on Linux, compare only first 15 chars of exclusive app names

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -319,8 +319,13 @@ bool app_running(PROC_MAP& pm, const char* p) {
     PROC_MAP::iterator i;
     for (i=pm.begin(); i!=pm.end(); ++i) {
         PROCINFO& pi = i->second;
-        //msg_printf(0, MSG_INFO, "running: [%s]", pi.command);
+#ifdef __linux__
+        // on linux we get command from /proc/PID/stat,
+        // which stores only 15 chars
+        if (!strncmp(pi.command, p, 15)) {
+#else
         if (!strcasecmp(pi.command, p)) {
+#endif
             return true;
         }
     }


### PR DESCRIPTION
... because that's all that /proc/PID/stat gives us :-(

Fixes #7231

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns exclusive app detection on Linux with /proc/PID/stat by comparing only the first 15 characters of the process command. Previously we did a case-insensitive full-name match, which failed for commands longer than 15 characters; now Linux checks succeed, while other platforms are unchanged.

- Old behavior: case-insensitive exact match.
- New behavior (Linux only): case-sensitive match on the first 15 characters; other OS keep the old behavior.
- Side effects (Linux): commands that share the same first 15 characters will collide; case differences no longer match.

**Rollout notes**
- Ensure configured exclusive app names on Linux are uniquely identifiable within the first 15 characters and do not rely on case differences.

<sup>Written for commit 91f325a50b7bb4d8425fdb86f9ac8a285ab11f3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

