### PR TITLE
[manager][windows] Fix dark mode issues. Remove custom 'bold' menu item that makes the appearance in dark mode not nice, also this unifies the look and feel of the menu on all platforms.

### DIFF
--- a/clientgui/BOINCTaskBar.cpp
+++ b/clientgui/BOINCTaskBar.cpp
@@ -619,28 +619,6 @@ void CTaskBarIcon::AdjustMenuItems(wxMenu* pMenu) {
         }
     }
 
-#ifdef __WXMSW__
-    // Weird things happen with menus and wxWidgets on Windows when you try
-    //   to change the font and use the system default as the baseline, so
-    //   instead of fighting the system get the original font and tweak it
-    //   a bit. It shouldn't hurt other platforms.
-    for (loc = 0; loc < pMenu->GetMenuItemCount(); loc++) {
-        pMenuItem = pMenu->FindItemByPosition(loc);
-        pMenu->Remove(pMenuItem);
-
-        font = pMenuItem->GetFont();
-        font.SetPointSize(8);
-        if (pMenuItem->GetId() != ID_OPENBOINCMANAGER) {
-            font.SetWeight(wxFONTWEIGHT_NORMAL);
-        } else {
-            font.SetWeight(wxFONTWEIGHT_BOLD);
-        }
-        pMenuItem->SetFont(font);
-
-        pMenu->Insert(loc, pMenuItem);
-    }
-#endif
-
     // Prevent recursive entry of CMainDocument::RequestRPC()
     if (pDoc->WaitingForRPC()) return;
 

--- a/clientgui/BOINCTaskCtrl.cpp
+++ b/clientgui/BOINCTaskCtrl.cpp
@@ -176,6 +176,9 @@ wxInt32 CBOINCTaskCtrl::UpdateControls() {
         pGroup = m_pParent->m_TaskGroups[i];
         if (!pGroup->m_pStaticBoxSizer) {
             pGroup->m_pStaticBox = new wxStaticBox(this, wxID_ANY, pGroup->m_strName);
+#ifdef __WXMSW__
+            pGroup->m_pStaticBox->SetForegroundColour(m_pParent->GetForegroundColour());
+#endif
             pGroup->m_pStaticBoxSizer = new wxStaticBoxSizer(pGroup->m_pStaticBox, wxVERTICAL);
             m_pSizer->Add(pGroup->m_pStaticBoxSizer, 0, wxEXPAND|wxALL, 5);
             layoutChanged = 1;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Windows dark mode rendering by removing custom menu font tweaks and inheriting system colors. Previously the tray menu forced an 8pt font and bolded “Open BOINC Manager”; now the menu uses system defaults, and Windows static box labels use the parent foreground color for proper contrast. This unifies the menu look across platforms and eliminates dark‑mode artifacts.

**Review notes**
- Removed Windows-only font manipulation; menu items and order are unchanged.
- On Windows, `wxStaticBox` labels now use the parent foreground color in dark mode.
- Validate on Windows (light and dark): tray menu uses system font, “Open BOINC Manager” is not bold, group headers remain readable.
- No configuration or API changes.

<sup>Written for commit ed2e34a7d87b7d703787047457ab542915d551a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

