### PR TITLE
Fix MacOS build warnings

### DIFF
--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -35,7 +35,6 @@
 
 using std::make_pair;
 using std::make_tuple;
-using std::move;
 using std::string;
 using std::pair;
 using std::tie;
@@ -355,7 +354,7 @@ pair<int, unique_EVP_PKEY> private_to_openssl(
     }
 
     unique_EVP_PKEY pkey(pkey_raw);
-    return make_pair(0, move(pkey));
+    return make_pair(0, std::move(pkey));
 }
 
 pair<int, unique_EVP_PKEY> public_to_openssl(const R_RSA_PUBLIC_KEY& pub) {
@@ -397,7 +396,7 @@ pair<int, unique_EVP_PKEY> public_to_openssl(const R_RSA_PUBLIC_KEY& pub) {
     }
     unique_EVP_PKEY pkey(pkey_raw);
 
-    return make_pair(0, move(pkey));
+    return make_pair(0, std::move(pkey));
 }
 
 // encrypt some data.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes macOS build warnings by removing the `using std::move` import and qualifying calls as `std::move` in lib/crypt.cpp. Behavior is unchanged: returns still move `pkey`.

- Change is limited to two return statements in lib/crypt.cpp; other platforms are unaffected.
- Expect macOS/Clang warnings to disappear; no API/ABI or runtime changes.
- No migration required.

<sup>Written for commit d642d2db16363e45512b01dd9f5812959e27da0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

