### PR TITLE
snap: migrate builds to core26

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -16,7 +16,7 @@
 # along with BOINC.  If not, see <http://www.gnu.org/licenses/>.
 
 name: boinc
-base: core24
+base: core26
 version: "8.3.0"
 type: app
 title: BOINC Manager
@@ -103,6 +103,8 @@ parts:
     - software-properties-common
     - cmake
     - dbus
+    - python3
+    - python3-pip
     - python3-venv
     - flex
     source: .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -140,8 +140,9 @@ parts:
       aws --version
 
       export PATH=$HOME/.local/bin:$PATH
-      pip install -U --user pip
-      pip install --user jinja2
+      python3 -m venv "$CRAFT_PART_BUILD/.venv"
+      export PATH="$CRAFT_PART_BUILD/.venv/bin:$PATH"
+      python -m pip install -U pip jinja2
 
       # first parameter is the target triplet
       # second parameter is the host triplet


### PR DESCRIPTION
Fixes #7199

## Description of the change

Migrates the Snap base from `core24` to `core26`. The existing Python build dependencies now run in a project-local virtual environment so the build does not invoke externally managed system pip under PEP 668.

This replacement removes the unnecessary test file from #7238. Each AI-assisted commit includes the BOINC-required `Assisted-by: Hermes Agent:gpt-5.6-sol` trailer.

## Verification completed

- Reproduced system `pip install --user` failing with `externally-managed-environment` in Ubuntu 26.04
- Reproduced the project-local venv path succeeding for pip and Jinja2
- BOINC source-code check passed
- BOINC trailing-whitespace check passed
- YAML parsing and semantic configuration checks passed
- `git diff --check upstream/master...HEAD` passed
- Independent policy and scope review passed

## Draft status

A complete Snap package build has not yet been verified at this exact head. This PR remains draft until that build path is green.

## AI assistance

Hermes Agent using gpt-5.6-sol assisted with investigation, implementation, validation, and review. I reviewed the final one-file diff and the commands listed above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Snap base from `core24` to `core26` and isolates Python build dependencies in a project-local virtual environment. Previously the build used `pip --user` and `$HOME/.local/bin`; now it creates `.venv` under `$CRAFT_PART_BUILD` and installs `pip` and `jinja2` there to avoid PEP 668 externally-managed-environment failures on Ubuntu 26.04.

- Adds `python3` and `python3-pip` to `build-packages`; keeps `python3-venv`; updates PATH to use `.venv/bin`.
- Replaces `pip --user` installs with `python3 -m venv` and `python -m pip install -U pip jinja2`.
- Builders must support `base: core26` in Snapcraft; verify a full snapcraft build before promotion.

<sup>Written for commit 1964c1afab1d5930fddd77c2092a07bc5afad6b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

