### PR TITLE
web: fix host display on Science United

### DIFF
--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -286,7 +286,7 @@ function docker_desc($misc) {
     );
     if (isset($d->wsl_distro)) {
         // Science United at point had a bug; work around it
-        $d2 = is_object($d->wsl_distro) ? $d->wsl_distro->wsl_distro : $d;
+        $d2 = is_object($d->wsl_distro) ? $d->wsl_distro : $d;
         if (empty($d2->boinc_buda_runner_version)) {
             $x .= sprintf(
                 '<br>WSL distro: %s',

--- a/html/inc/host.inc
+++ b/html/inc/host.inc
@@ -285,16 +285,18 @@ function docker_desc($misc) {
         htmlspecialchars($d->version)
     );
     if (isset($d->wsl_distro)) {
-        if (empty($d->boinc_buda_runner_version)) {
+        // Science United at point had a bug; work around it
+        $d2 = is_object($d->wsl_distro) ? $d->wsl_distro->wsl_distro : $d;
+        if (empty($d2->boinc_buda_runner_version)) {
             $x .= sprintf(
                 '<br>WSL distro: %s',
-                htmlspecialchars($d->wsl_distro)
+                htmlspecialchars($d2->wsl_distro)
             );
         } else {
             $x .= sprintf(
                 '<br>WSL distro: %s ver %d',
-                htmlspecialchars($d->wsl_distro),
-                $d->boinc_buda_runner_version
+                htmlspecialchars($d2->wsl_distro),
+                $d2->boinc_buda_runner_version
             );
         }
     }


### PR DESCRIPTION
A bug in SU code produced some bad JSON in the host database. This is a workaround to display the data correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Science United host display when SU stored WSL distro info as a nested object. Previously the page assumed flat fields and could show the wrong distro or omit the version; now it handles nested data and renders the correct values.

- Change is isolated to `docker_desc()` in `html/inc/host.inc`; no schema, API, or migration changes.
- Review by testing hosts with both flat and nested `wsl_distro` shapes to confirm correct “WSL distro” and version output.

<sup>Written for commit ad653bd84dcfea3a49b4386512f4e7d09700c487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

