### PR TITLE
Remove old time64_t hack, breaking build on Debian with armhf actuall…

### DIFF
--- a/lib/mem_usage.cpp
+++ b/lib/mem_usage.cpp
@@ -21,7 +21,7 @@
 #include "config.h"
 #if HAVE_PROCFS_H
 // Can't use large file calls with solaris procfs.
-#if defined(_FILE_OFFSET_BITS) && ( _FILE_OFFSET_BITS == 64 )
+#if defined(_FILE_OFFSET_BITS) && ( _FILE_OFFSET_BITS == 64 ) && defined(__sun)
 #undef _FILE_OFFSET_BITS
 #undef _LARGE_FILES
 #undef _LARGEFILE_SOURCE

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -22,7 +22,7 @@
 
 #if HAVE_PROCFS_H
 // Can't use large file calls with solaris procfs.
-#if defined(_FILE_OFFSET_BITS) && ( _FILE_OFFSET_BITS == 64 )
+#if defined(_FILE_OFFSET_BITS) && ( _FILE_OFFSET_BITS == 64 ) && defined(__sun)
 #undef _FILE_OFFSET_BITS
 #undef _LARGE_FILES
 #undef _LARGEFILE_SOURCE

--- a/samples/gfx_html/mongoose.cpp
+++ b/samples/gfx_html/mongoose.cpp
@@ -49,10 +49,12 @@
 #define _XOPEN_SOURCE 600       // For flockfile() on Linux
 #define __STDC_FORMAT_MACROS    // <inttypes.h> wants this for C++
 #define __STDC_LIMIT_MACROS     // C++ wants that for INT64_MAX
-#ifndef _LARGEFILE_SOURCE
+#ifndef _LARGEFILE_SOURCE && defined(__sun)
 #define _LARGEFILE_SOURCE       // Enable fseeko() and ftello() functions
 #endif
+#ifndef _FILE_OFFSET_BITS && defined(__sun)
 #define _FILE_OFFSET_BITS 64    // Enable 64-bit file offsets
+#endif
 
 #ifdef _MSC_VER
 #pragma warning (disable : 4127)  // FD_SET() emits warning, disable it


### PR DESCRIPTION
I think this hack can be dropped, even if I can't test solaris...