### PR TITLE
Check if there is enough memory after realloc

### DIFF
--- a/lib/unix_util.cpp
+++ b/lib/unix_util.cpp
@@ -80,7 +80,13 @@ int setenv(const char *name, const char *value, int overwrite) {
             }
             if (i!=envstrings.end()) {
                 // we allocated this string.  Reallocate it.
+                char *b=buf;
                 buf=(char *)realloc(buf,strlen(name)+strlen(value)+2);
+                if (!buf) {
+                   free(b);
+                   errno=ENOMEM;
+                   return -1;
+                }
                 *i=buf;
             } else {
                 // someone else allocated the string.  Allocate new memory.


### PR DESCRIPTION
In case of failures in realloc, better free and exit, instead of ignoring the return value...