### PR TITLE
Adapt code to fix a build failure with openssl-4.0

### DIFF
--- a/lib/crypt.cpp
+++ b/lib/crypt.cpp
@@ -954,7 +954,7 @@ int cert_verify_file(CERT_SIGS* signatures, const string &origFile,
                 continue;
             }
             fflush(stdout);
-            X509_NAME *subj = X509_get_subject_name(cert.get());
+            const X509_NAME *subj = X509_get_subject_name(cert.get());
 
             char buf[256];
             X509_NAME_oneline(subj, buf, 256);


### PR DESCRIPTION
Fixing the latest openssl-4.0 build failure

crypt.cpp: In function 'int cert_verify_file(CERT_SIGS*, const std::string&, const std::string&)':
crypt.cpp:957:52: error: invalid conversion from 'const X509_NAME*' {aka 'const X509_name_st*'} to 'X509_NAME*' {aka 'X509_name_st*'} [-fpermissive]
  957 |             X509_NAME *subj = X509_get_subject_name(cert.get());
      |                               ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
      |                                                    |
      |                                                    const X509_NAME* {aka const X509_name_st*}
make[5]: *** [Makefile:1800: libboinc_crypt_la-crypt.lo] Error 1