### PR TITLE
Increase buffers in case of long oses and machines

### DIFF
--- a/client/hostinfo_linux.cpp
+++ b/client/hostinfo_linux.cpp
@@ -55,10 +55,10 @@ bool HOST_INFO::parse_linux_os_info(
         return false;
     }
 
-    char buf[256];
+    char buf[512];
     std::vector<std::string> lines;
 
-    while (fgets(buf, 256, file)) {
+    while (fgets(buf, 512, file)) {
         lines.push_back(buf);
     }
 
@@ -99,8 +99,8 @@ bool HOST_INFO::parse_linux_os_info(
 
     bool found_something = false;
     unsigned int i;
-    char buf[256], buf2[256];
-    char dist_pretty[256], dist_name[256], dist_version[256], dist_codename[256];
+    char buf[512], buf2[512];
+    char dist_pretty[512], dist_name[512], dist_version[512], dist_codename[512];
     //string os_version_extra("");
     strcpy(dist_pretty, "");
     strcpy(dist_name, "");

--- a/client/hostinfo_unix.cpp
+++ b/client/hostinfo_unix.cpp
@@ -482,7 +482,7 @@ static void parse_cpuinfo_linux(HOST_INFO& host) {
     char implementer[32] = {0}, architecture[32] = {0}, variant[32] = {0}, cpu_part[32] = {0}, revision[32] = {0};
     bool model_info_found=false;
 #endif
-    char buf2[256];
+    char buf2[512];
 
     FILE* f = fopen("/proc/cpuinfo", "r");
     if (!f) {
@@ -1760,7 +1760,7 @@ int HOST_INFO::get_os_info() {
 
 #if LINUX_LIKE_SYSTEM
     bool found_something = false;
-    char dist_name[256], dist_version[256];
+    char dist_name[512], dist_version[512];
     string os_version_extra("");
     safe_strcpy(dist_name, "");
     safe_strcpy(dist_version, "");

--- a/client/hostinfo_unix_test.cpp
+++ b/client/hostinfo_unix_test.cpp
@@ -338,10 +338,10 @@ bool parse_linux_os_info(FILE* file, const LINUX_OS_INFO_PARSER parser,
         return false;
     }
 
-    char buf[256];
+    char buf[512];
     std::vector<std::string> lines;
 
-    while (fgets(buf, 256, file)) {
+    while (fgets(buf, 512, file)) {
         lines.push_back(buf);
     }
 
@@ -372,10 +372,10 @@ int main(void) {
     char implementer[32] = {0}, architecture[32] = {0}, variant[32] = {0}, cpu_part[32] = {0}, revision[32] = {0};
     bool model_info_found=false;
 #endif
-    char  p_vendor[256], p_model[256], product_name[256];
-    char  os_name[256], os_version[256];
+    char  p_vendor[512], p_model[512], product_name[256];
+    char  os_name[512], os_version[512];
     string os_version_extra("");
-    char buf2[256];
+    char buf2[512];
     int m_cache=-1;
 
     // parse /proc/cpuinfo as in parse_cpuinfo_linux() from hostinfo_unix.cpp

--- a/client/hostinfo_wsl.cpp
+++ b/client/hostinfo_wsl.cpp
@@ -252,8 +252,8 @@ int get_wsl_information(WSL_DISTROS &distros) {
             continue;
         }
 
-        char os_name[256];
-        char os_version[256];
+        char os_name[512];
+        char os_version[512];
         strcpy(os_name, "");
         strcpy(os_version, "");
 

--- a/db/boinc_db_types.h
+++ b/db/boinc_db_types.h
@@ -300,15 +300,15 @@ struct HOST {
     double duration_correction_factor;
 
     int p_ncpus;            // Number of CPUs on host
-    char p_vendor[256];     // Vendor name of CPU
-    char p_model[256];      // Model of CPU
+    char p_vendor[512];     // Vendor name of CPU
+    char p_model[512];      // Model of CPU
     double p_fpops;         // measured floating point ops/sec of CPU
     double p_iops;          // measured integer ops/sec of CPU
     double p_membw;         // measured memory bandwidth (bytes/sec) of CPU
                             // The above are per CPU, not total
 
-    char os_name[256];      // Name of operating system
-    char os_version[256];   // Version of operating system
+    char os_name[512];      // Name of operating system
+    char os_version[512];   // Version of operating system
 
     double m_nbytes;        // Size of memory in bytes
     double m_cache;         // Size of CPU cache in bytes (L1 or L2?)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -182,14 +182,14 @@ create table host (
     cpu_efficiency          double          not null default 0,
     duration_correction_factor double       not null default 0,
     p_ncpus                 integer         not null default 0,
-    p_vendor                varchar(254)    not null default '',
-    p_model                 varchar(254)    not null default '',
+    p_vendor                varchar(511)    not null default '',
+    p_model                 varchar(511)    not null default '',
     p_fpops                 double          not null default 0,
     p_iops                  double          not null default 0,
     p_membw                 double          not null default 0,
 
-    os_name                 varchar(254)    not null default '',
-    os_version              varchar(254)    not null default '',
+    os_name                 varchar(511)    not null default '',
+    os_version              varchar(511)    not null default '',
 
     m_nbytes                double          not null default 0,
     m_cache                 double          not null default 0,

--- a/html/ops/db_update.php
+++ b/html/ops/db_update.php
@@ -1332,6 +1332,15 @@ function update_8_23_2026() {
     ");
 }
 
+function update_8_26_2026() {
+    do_query("alter table host
+        modify column p_vendor   varchar(511) not null,
+        modify column p_model    varchar(511) not null,
+        modify column os_name    varchar(511) not null,
+        modify column os_version varchar(511) not null
+    ");
+}
+
 // Updates are done automatically if you use "upgrade".
 //
 // If you need to do updates manually,
@@ -1397,6 +1406,7 @@ $db_updates = array (
     array(27031, "update_5_2_2026a"),
     array(27032, "update_5_2_2026b"),
     array(27033, "update_8_23_2026"),
+    array(27034, "update_8_26_2026"),
 );
 
 ?>

--- a/lib/hostinfo.cpp
+++ b/lib/hostinfo.cpp
@@ -191,7 +191,7 @@ int HOST_INFO::parse(XML_PARSER& xp, bool static_items_only) {
 int HOST_INFO::write(
     MIOFILE& out, bool include_net_info, bool include_coprocs
 ) {
-    char pv[265], pm[256], pf[P_FEATURES_SIZE], osn[256], osv[256], pn[256];
+    char pv[521], pm[512], pf[P_FEATURES_SIZE], osn[512], osv[512], pn[512];
     out.printf(
         "<host_info>\n"
         "    <timezone>%d</timezone>\n",

--- a/lib/hostinfo.h
+++ b/lib/hostinfo.h
@@ -65,8 +65,8 @@ public:
     char host_cpid[64];
 
     int p_ncpus;
-    char p_vendor[256];
-    char p_model[256];
+    char p_vendor[512];
+    char p_model[512];
     char p_features[P_FEATURES_SIZE];
     double p_fpops;
     double p_iops;
@@ -81,8 +81,8 @@ public:
     double d_total;               // Total amount of disk in bytes
     double d_free;                // Total amount of free disk in bytes
 
-    char os_name[256];
-    char os_version[256];
+    char os_name[512];
+    char os_version[512];
 
 #ifdef _WIN32
     // on Windows, Docker info is per WSL_DISTRO, not global

--- a/sched/handle_request.cpp
+++ b/sched/handle_request.cpp
@@ -1067,7 +1067,7 @@ void check_missing_fields() {
 }
 
 bool unacceptable_os() {
-    char buf[1024];
+    char buf[2048];
 
     for (const regex_t& re: *config.ban_os) {
         safe_strcpy(buf, g_request->host.os_name);
@@ -1091,7 +1091,7 @@ bool unacceptable_os() {
 }
 
 bool unacceptable_cpu() {
-    char buf[1024];
+    char buf[2048];
 
     for (const regex_t& re: *config.ban_cpu) {
         safe_strcpy(buf, g_request->host.p_vendor);

--- a/sched/sched_driver.cpp
+++ b/sched/sched_driver.cpp
@@ -53,9 +53,9 @@
 using std::vector;
 
 struct HOST_DESC{
-    char os_name[256];
-    char p_vendor[256];
-    char p_model[256];
+    char os_name[512];
+    char p_vendor[512];
+    char p_model[512];
 };
 
 vector<HOST_DESC> host_descs;
@@ -63,7 +63,7 @@ double min_time = 1;
 double max_time = 1;
 
 void read_hosts() {
-    char buf[256], buf2[256];
+    char buf[512], buf2[512];
     host_descs.clear();
     FILE* f = fopen("host_descs.txt", "r");
     if (!f) {

--- a/tests/unit-tests/client/test_hostinfo_linux.cpp
+++ b/tests/unit-tests/client/test_hostinfo_linux.cpp
@@ -33,7 +33,7 @@ namespace test_hostinfo_linux {
         FILE* lsb_release = fopen(fixture_path.string().c_str(), "r");
         ASSERT_NE(nullptr, lsb_release);
 
-        char os_name[256] = "", os_version[256] = "";
+        char os_name[512] = "", os_version[512] = "";
         EXPECT_TRUE(HOST_INFO::parse_linux_os_info(lsb_release, lsbrelease, os_name, sizeof(os_name), os_version, sizeof(os_version)));
         fclose(lsb_release);
 
@@ -49,7 +49,7 @@ namespace test_hostinfo_linux {
         FILE* os_release = fopen(fixture_path.string().c_str(), "r");
         ASSERT_NE(nullptr, os_release);
 
-        char os_name[256] = "", os_version[256] = "";
+        char os_name[512] = "", os_version[512] = "";
         EXPECT_TRUE(HOST_INFO::parse_linux_os_info(os_release, osrelease, os_name, sizeof(os_name), os_version, sizeof(os_version)));
         fclose(os_release);
 
@@ -65,7 +65,7 @@ namespace test_hostinfo_linux {
         FILE* os_release = fopen(fixture_path.string().c_str(), "r");
         ASSERT_NE(nullptr, os_release);
 
-        char os_name[256] = "", os_version[256] = "";
+        char os_name[512] = "", os_version[512] = "";
         EXPECT_TRUE(HOST_INFO::parse_linux_os_info(os_release, osrelease, os_name, sizeof(os_name), os_version, sizeof(os_version)));
         fclose(os_release);
 


### PR DESCRIPTION
This is an old Debian patch, I guess there were some bugs related to old os versions being more than 256 chars