### PR TITLE
Add patch to make hurd build sanely

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -887,8 +887,8 @@ void CBOINCGUIApp::DetectExecutableName() {
     // Store the root directory for later use.
     m_strBOINCMGRExecutableName = pszProg;
 #elif defined(__WXGTK__)
-    char path[PATH_MAX];
-    if (!get_real_executable_path(path, PATH_MAX)) {
+    char path[MAXPATHLEN];
+    if (!get_real_executable_path(path, MAXPATHLEN)) {
         // find filename component
         char* name = strrchr(path, '/');
         if (name) {
@@ -918,8 +918,8 @@ void CBOINCGUIApp::DetectRootDirectory() {
     // Store the root directory for later use.
     m_strBOINCMGRRootDirectory = szPath;
 #elif defined(__WXGTK__)
-    char path[PATH_MAX];
-    if (!get_real_executable_path(path, PATH_MAX)) {
+    char path[MAXPATHLEN];
+    if (!get_real_executable_path(path, MAXPATHLEN)) {
         // find path component
         char* name = strrchr(path, '/');
         if (name) {

--- a/clientscr/Mac_Saver_Module.h
+++ b/clientscr/Mac_Saver_Module.h
@@ -104,8 +104,8 @@ protected:
     pid_t           getClientPID(void);
     void            updateSSMessageText(char *msg);
     void            strip_cr(char *buf);
-    char            m_gfx_Switcher_Path[PATH_MAX];
-    char            m_gfx_Cleanup_Path[PATH_MAX];
+    char            m_gfx_Switcher_Path[MAXPATHLEN];
+    char            m_gfx_Cleanup_Path[MAXPATHLEN];
     FILE*           m_gfx_Cleanup_IPC;
     void            SetDiscreteGPU(bool setDiscrete);
     void            CheckDualGPUPowerSource();

--- a/lib/mac/QMachOImageList.c
+++ b/lib/mac/QMachOImageList.c
@@ -234,7 +234,7 @@ static int ImageListForTaskNew(
                 if (infoIndex < imageArraySize) {
                     QTMAddr     machHeader;
                     QTMAddr     filePathAddr;
-                    char        filePath[PATH_MAX];
+                    char        filePath[MAXPATHLEN];
 
                     if (is64Bit) {
                         machHeader   = QMOImageToLocalUInt64(dyldImage, ((uint64_t *) infoArrayLocal)[infoIndex * 3] );
@@ -390,7 +390,7 @@ static int ImageListForTaskOldWithNames(
 						if ( (imageArray != NULL) && (*imageCountPtr < imageArraySize) ) {
                             QTMAddr     machHeader;
                             QTMAddr     filePathAddr;
-                            char        filePath[PATH_MAX];
+                            char        filePath[MAXPATHLEN];
 
 							machHeader   = QMOImageToLocalUInt32(dyldImage, *(uint32_t *) (listChunk + elemIndex * elemSize + kMHOffset          ));
                             filePathAddr = QMOImageToLocalUInt32(dyldImage, *(uint32_t *) (listChunk + elemIndex * elemSize + kPhysicalNameOffset));

--- a/samples/cygwin_fstab/fstab.c
+++ b/samples/cygwin_fstab/fstab.c
@@ -43,11 +43,7 @@
 #include <sys/stat.h>
 #endif
 
-#ifndef PATH_MAX
-#define PATH_MAX 4096
-#endif
-
-char path[PATH_MAX];
+char path[MAXPATHLEN];
 
 int main(int argc, char*argv[]) {
   char* c = argv[1];


### PR DESCRIPTION
Hurd is missing PATH_MAX

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `PATH_MAX` with `MAXPATHLEN` so the build works on GNU Hurd, which doesn't define `PATH_MAX`.

- Applies the change to the GUI app, Mac screen saver module, Mach-O image list, and `cygwin_fstab` sample.
- Drops the local `PATH_MAX` fallback definition in `cygwin_fstab` in favor of `MAXPATHLEN`.

<sup>Written for commit 35d828848c42997f53a42991c02496df523f35c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

