### PR TITLE
Fix dynamic library building

### DIFF
--- a/api/Makefile.am
+++ b/api/Makefile.am
@@ -59,7 +59,12 @@ endif
 lib_LTLIBRARIES = libboinc_api.la
 pkgconfig_DATA = libboinc_api.pc
 libboinc_api_la_SOURCES = $(api_files)
-libboinc_api_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
+libboinc_api_la_LDFLAGS = -version-number $(LIBBOINC_VERSION) -lpthread
+libboinc_api_la_LIBADD = -L../lib/.libs $(LIBBOINC)
+libboinc_api_la_AR = gcc-ar
+libboinc_api_la_RANLIB = gcc-ranlib
+libboinc_api_a_AR = gcc-ar
+libboinc_api_a_RANLIB = gcc-ranlib
 
 if BUILD_GRAPHICS_API
 lib_LTLIBRARIES += libboinc_graphics2.la
@@ -67,12 +72,18 @@ pkgconfig_DATA += libboinc_graphics2.pc
 libboinc_graphics2_la_SOURCES = $(graphics2_files)
 libboinc_graphics2_la_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/lib -I$(top_srcdir)/samples/image_libs
 libboinc_graphics2_la_LDFLAGS = -version-number $(LIBBOINC_VERSION) -ljpeg
+libboinc_graphics2_la_LIBADD = -L../lib/.libs $(APPLIBS)
+libboinc_graphics2_la_AR = gcc-ar
+libboinc_graphics2_la_RANLIB = gcc-ranlib
+libboinc_graphics2_a_AR = gcc-ar
+libboinc_graphics2_a_RANLIB = gcc-ranlib
 endif #BUILD_GRAPHICS_API
 
 lib_LTLIBRARIES += libboinc_opencl.la
 pkgconfig_DATA += libboinc_opencl.pc
 libboinc_opencl_la_SOURCES = $(opencl_files)
 libboinc_opencl_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
+libboinc_opencl_la_LIBADD = -L../lib/.libs $(APPLIBS)
 
 if INSTALL_HEADERS
 ## install only headers that are meant for exporting the API !!

--- a/apps/Makefile.am
+++ b/apps/Makefile.am
@@ -23,17 +23,17 @@ example_PROGRAMS = uppercase concat 1sec
 
 uppercase_SOURCES = uppercase.cpp
 uppercase_CXXFLAGS = $(PTHREAD_CFLAGS)
-uppercase_LDFLAGS = -static-libtool-libs $(PTHREAD_CFLAGS)
+uppercase_LDFLAGS = $(PTHREAD_CFLAGS)
 uppercase_LDADD = $(APPLIBS)
 
 concat_SOURCES = concat.cpp
 concat_CXXFLAGS = $(PTHREAD_CFLAGS)
-concat_LDFLAGS = -static-libtool-libs $(PTHREAD_CFLAGS)
+concat_LDFLAGS = $(PTHREAD_CFLAGS)
 concat_LDADD = $(APPLIBS)
 
 1sec_SOURCES = 1sec.cpp
 1sec_CXXFLAGS = $(PTHREAD_CFLAGS)
-1sec_LDFLAGS = -static-libtool-libs $(PTHREAD_CFLAGS)
+1sec_LDFLAGS = $(PTHREAD_CFLAGS)
 1sec_LDADD = $(APPLIBS)
 
 clean: clean-am

--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -7,7 +7,6 @@ CXXFLAGS += -std=gnu++1z
 include $(top_srcdir)/Makefile.incl
 
 if ENABLE_CLIENT_RELEASE
-  AM_LDFLAGS += -static-libtool-libs
 ## for an entirely statically linked library, you may want to try
 ## -all-static instead.  There's a good chance it won't work properly,
 ## so we'll use the safer "-static-libtool-libs" by default.

--- a/clientgui/Makefile.am
+++ b/clientgui/Makefile.am
@@ -22,7 +22,6 @@
 include $(top_srcdir)/Makefile.incl
 
 if ENABLE_CLIENT_RELEASE
-  AM_LDFLAGS += -static-libtool-libs
 ## for an entirely statically linked library, you may want to try
 ## -all-static instead.  There's a good chance it won't work properly,
 ## so we'll use the safer "-static-libtool-libs" by default.

--- a/clientscr/Makefile.am
+++ b/clientscr/Makefile.am
@@ -20,7 +20,6 @@ include $(top_srcdir)/Makefile.incl
 
 AM_LDFLAGS += -lpthread
 if ENABLE_CLIENT_RELEASE
-  AM_LDFLAGS += -static-libtool-libs
 ## for an entirely statically linked library, you may want to try
 ## -all-static instead.  There's a good chance it won't work properly,
 ## so we'll use the safer "-static-libtool-libs" by default.

--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,12 @@ AM_PROG_CC_C_O
 PKG_PROG_PKG_CONFIG
 PKG_INSTALLDIR
 
+dnl ------
+dnl  essential for LTO and static applications in apps and samples
+AC_PROG_RANLIB
+AM_PROG_AR
+dnl ------
+
 m4_divert_once([HELP_ENABLE],
   AS_HELP_STRING([BOINC Default enable values], [--enable-server --enable-client --enable-libraries --enable-manager: builds server, client, and libraries]))
 

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -187,7 +187,11 @@ pkgconfig_DATA = libboinc.pc
 libboinc_la_SOURCES = $(generic_sources) $(mac_sources) $(win_sources)
 libboinc_la_CFLAGS = $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
 libboinc_la_CXXFLAGS = $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
-libboinc_la_LDFLAGS = -static -version-number $(LIBBOINC_VERSION)
+libboinc_la_AR = gcc-ar
+libboinc_la_RANLIB = gcc-ranlib
+libboinc_a_AR = gcc-ar
+libboinc_a_RANLIB = gcc-ranlib
+libboinc_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 if OS_FREEBSD
 libboinc_la_LDFLAGS += -lexecinfo
 endif
@@ -199,8 +203,12 @@ pkgconfig_DATA += libboinc_crypt.pc
 libboinc_crypt_la_SOURCES = crypt.cpp
 libboinc_crypt_la_CFLAGS = $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(SSL_CFLAGS)
 libboinc_crypt_la_CXXFLAGS = $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(SSL_CXXFLAGS)
-libboinc_crypt_la_LDFLAGS = -static -version-number $(LIBBOINC_VERSION)
-libboinc_crypt_la_LIBADD =
+libboinc_crypt_la_AR = gcc-ar
+libboinc_crypt_la_RANLIB = gcc-ranlib
+libboinc_crypt_a_AR = gcc-ar
+libboinc_crypt_a_RANLIB = gcc-ranlib
+libboinc_crypt_la_LDFLAGS = -version-number $(LIBBOINC_VERSION) $(SSL_LIBS) $(RSA_LIBS)
+libboinc_crypt_la_LIBADD = $(LIBBOINC)
 endif
 
 if ENABLE_FCGI
@@ -209,6 +217,10 @@ pkgconfig_DATA += libboinc_fcgi.pc
 libboinc_fcgi_la_SOURCES = $(libfcgi_sources) $(mac_sources) $(win_sources)
 libboinc_fcgi_la_CFLAGS = -D_USING_FCGI_ $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
 libboinc_fcgi_la_CXXFLAGS = -D_USING_FCGI_ $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS)
+libboinc_fcgi_la_AR = gcc-ar
+libboinc_fcgi_la_RANLIB = gcc-ranlib
+libboinc_fcgi_a_AR = gcc-ar
+libboinc_fcgi_a_RANLIB = gcc-ranlib
 libboinc_fcgi_la_LDFLAGS = -version-number $(LIBBOINC_VERSION)
 libboinc_fcgi_la_LIBADD =
 endif
@@ -272,7 +284,7 @@ msg_test_CXXFLAGS = $(PTHREAD_CFLAGS)
 msg_test_LDADD = $(LIBBOINC)
 crypt_prog_SOURCES = crypt_prog.cpp
 crypt_prog_CXXFLAGS = $(PTHREAD_CFLAGS) $(SSL_CXXFLAGS)
-crypt_prog_LDADD = $(LIBBOINC_CRYPT_STATIC) $(LIBBOINC) $(SSL_LIBS)
+crypt_prog_LDADD = $(LIBBOINC_CRYPT) $(LIBBOINC) $(SSL_LIBS)
 parse_test_SOURCES = parse_test.cpp
 parse_test_CXXFLAGS = $(PTHREAD_CFLAGS)
 parse_test_LDADD = $(LIBBOINC)

--- a/samples/condor/Makefile
+++ b/samples/condor/Makefile
@@ -68,6 +68,8 @@ ifdef BUILD_WITH_MINGW
   CURL_EXTRA_LDFLAGS += -liphlpapi
 endif
 
+LDFLAGS := -static $(LDFLAGS)
+
 PROGS = boinc_gahp
 
 all: $(PROGS)

--- a/samples/example_app/Makefile
+++ b/samples/example_app/Makefile
@@ -63,6 +63,8 @@ CXXFLAGS += \
     -L/usr/X11R6/lib \
     -L.
 
+LDFLAGS := -static $(LDFLAGS)
+
 # to get the graphics app to compile you may need to install some packages
 # e.g. ftgl-devel.x86_64
 #
@@ -146,7 +148,7 @@ uc2_graphics: uc2_graphics.o ttfont.o $(MAKEFILE_STDLIB) $(BOINC_LIB_DIR)/libboi
     $(LIBFTGL) $(LIBGL) $(LIBUI) -lm
 
 slide_show: slide_show.o $(MAKEFILE_STDLIB) $(BOINC_LIB_DIR)/libboinc.a $(BOINC_API_DIR)/libboinc_graphics2.a
-	$(CXX) $(CXXFLAGS) -o slide_show slide_show.o $(MAKEFILE_LDFLAGS) \
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -o slide_show slide_show.o $(MAKEFILE_LDFLAGS) \
 	$(BOINC_API_DIR)/libboinc_graphics2.a \
 	$(BOINC_API_DIR)/libboinc_api.a \
 	$(BOINC_LIB_DIR)/libboinc.a \

--- a/samples/multi_thread/Makefile
+++ b/samples/multi_thread/Makefile
@@ -64,6 +64,8 @@ CXXFLAGS += \
     -L$(BOINC_LIB_DIR) \
     -L.
 
+LDFLAGS := -static $(LDFLAGS)
+
 PROG = multi_thread$(MULTITHREAD_RELEASE_SUFFIX)
 
 all: $(PROG)

--- a/samples/openclapp/Makefile
+++ b/samples/openclapp/Makefile
@@ -72,11 +72,11 @@ distclean:
 install: all
 
 openclapp: openclapp.o boinc_opencl.o libstdc++.a
-	$(CXX) $(CXXFLAGS) -o openclapp openclapp.o boinc_opencl.o \
-        libstdc++.a -lOpenCL -lboinc_api -lboinc -lpthread
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -o openclapp openclapp.o boinc_opencl.o \
+        libstdc++.a -lOpenCL $(BOINC_API_DIR)/libboinc_api.a $(BOINC_LIB_DIR)/libboinc.a -lpthread
 
 openclapp.o: openclapp.cpp openclapp.hpp
-	$(CXX) $(CXXFLAGS) -c openclapp.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c openclapp.cpp
 
 boinc_opencl.o: $(BOINC_API_DIR)/boinc_opencl.cpp $(BOINC_API_DIR)/boinc_opencl.h
-	$(CXX) $(CXXFLAGS) -c $(BOINC_API_DIR)/boinc_opencl.cpp
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $(BOINC_API_DIR)/boinc_opencl.cpp

--- a/samples/sleeper/Makefile
+++ b/samples/sleeper/Makefile
@@ -55,6 +55,8 @@ CXXFLAGS += \
     -L$(BOINC_LIB_DIR) \
     -L.
 
+LDFLAGS := -static $(LDFLAGS)
+
 PROGS = sleeper
 
 all: $(PROGS)

--- a/samples/vboxmonitor/Makefile
+++ b/samples/vboxmonitor/Makefile
@@ -56,6 +56,8 @@ CXXFLAGS += \
     -L$(BOINC_LIB_DIR) \
     -L.
 
+LDFLAGS := -static $(LDFLAGS)
+
 PROGS = vboxmonitor
 
 all: $(PROGS)

--- a/samples/vboxwrapper/Makefile
+++ b/samples/vboxwrapper/Makefile
@@ -66,6 +66,8 @@ CXXFLAGS += \
     -L$(BOINC_LIB_DIR) \
     -L.
 
+LDFLAGS := -static $(LDFLAGS)
+
 PROGS = vboxwrapper$(VBOXWRAPPER_RELEASE_SUFFIX)
 
 HEADERS = vbox_common.h vboxjob.h vbox_vboxmanage.h vboxwrapper.h

--- a/samples/worker/Makefile
+++ b/samples/worker/Makefile
@@ -31,7 +31,7 @@ distclean:
 	rm -f $(PROGS) $(addsuffix .exe, $(PROGS)) *.o
 
 worker$(WORKER_RELEASE_SUFFIX): worker.cpp
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -o worker$(WORKER_RELEASE_SUFFIX) worker.cpp
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(LDFLAGS) -static -o worker$(WORKER_RELEASE_SUFFIX) worker.cpp
 
 install: all
 

--- a/samples/wrapper/Makefile
+++ b/samples/wrapper/Makefile
@@ -55,8 +55,8 @@ else
   BOINC_LIB_DIR = $(BOINC_SOURCE_LIB_DIR)
   BOINC_ZIP_DIR = $(BOINC_SOURCE_ZIP_DIR)
 
-  MAKEFILE_LDFLAGS = libstdc++.a -lpthread
-  MAKEFILE_STDLIB  = libstdc++.a
+  MAKEFILE_LDFLAGS = -pthread
+  MAKEFILE_STDLIB  =
 endif
 
 CXXFLAGS += \
@@ -77,6 +77,8 @@ ifdef BUILD_APPS_WITH_VCPKG
     -I$(VCPKG_DIR)/include \
     -L$(VCPKG_DIR)/lib
 endif
+
+LDFLAGS := -static $(LDFLAGS)
 
 PROGS = wrapper$(WRAPPER_RELEASE_SUFFIX)
 

--- a/samples/wrappture/Makefile
+++ b/samples/wrappture/Makefile
@@ -60,6 +60,8 @@ CXXFLAGS += \
     -L$(VCPKG_DIR)/lib \
     -L.
 
+LDFLAGS := -static $(LDFLAGS)
+
 PROGS = wrappture_example fermi
 
 all: $(PROGS)

--- a/sched/Makefile.am
+++ b/sched/Makefile.am
@@ -4,7 +4,6 @@
 include $(top_srcdir)/Makefile.incl
 
 AM_CPPFLAGS += $(MYSQL_CFLAGS) $(PTHREAD_CFLAGS)
-AM_LDFLAGS += -static
 
 if ENABLE_LIBRARIES
 
@@ -25,8 +24,8 @@ lib_LTLIBRARIES = libsched.la
 libsched_la_SOURCES = $(libsched_sources)
 libsched_la_CFLAGS = $(AM_CPPFLAGS)
 libsched_la_CXXFLAGS = $(AM_CPPFLAGS)
-libsched_la_LDFLAGS= -version-number $(LIBBOINC_VERSION)
-libsched_la_LIBADD= $(SSL_LIBS)
+libsched_la_LDFLAGS= -version-number $(LIBBOINC_VERSION) $(SSL_LIBS)
+libsched_la_LIBADD= $(LIBBOINC) $(LIBBOINC_CRYPT)
 
 ## install only headers that are meant for exporting the API !!
 if INSTALL_HEADERS
@@ -48,7 +47,7 @@ libsched_fcgi_la_SOURCES = $(libsched_sources)
 libsched_fcgi_la_CFLAGS = -D_USING_FCGI_ $(AM_CPPFLAGS)
 libsched_fcgi_la_CXXFLAGS = -D_USING_FCGI_ $(AM_CPPFLAGS)
 libsched_fcgi_la_LDFLAGS= -version-number $(LIBBOINC_VERSION)
-libsched_fcgi_la_LIBADD=
+libsched_fcgi_la_LIBADD= $(LIBBOINC_CRYPT)
 
 endif
 # end of "if ENABLE_FCGI"
@@ -286,7 +285,7 @@ update_stats_SOURCES = update_stats.cpp
 update_stats_LDADD = $(SERVERLIBS)
 
 file_upload_handler_SOURCES = file_upload_handler.cpp sched_config.cpp sched_util_basic.cpp sched_limit.cpp
-file_upload_handler_LDADD = $(FUHLIBS)
+file_upload_handler_LDADD = $(FUHLIBS) $(LIBBOINC)
 
 make_work_SOURCES = make_work.cpp
 make_work_LDADD = $(SERVERLIBS)
@@ -325,7 +324,7 @@ fcgi_LDADD = $(SERVERLIBS_FCGI)
 
 fcgi_file_upload_handler_SOURCES = file_upload_handler.cpp sched_config.cpp sched_util_basic.cpp sched_limit.cpp
 fcgi_file_upload_handler_CPPFLAGS = -D_USING_FCGI_ $(AM_CPPFLAGS)
-fcgi_file_upload_handler_LDADD = $(FUHLIBS_FCGI)
+fcgi_file_upload_handler_LDADD = $(FUHLIBS_FCGI) $(LIBBOINC)
 
 endif
 # end of "if ENABLE_FCGI"

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -63,7 +63,6 @@ dist_tools_DATA = \
     gui_urls.xml
 
 AM_CXXFLAGS += $(MYSQL_CFLAGS)
-AM_LDFLAGS += -static
 
 cancel_jobs_SOURCES = cancel_jobs.cpp
 cancel_jobs_LDADD = $(SERVERLIBS)

--- a/vda/Makefile.am
+++ b/vda/Makefile.am
@@ -22,7 +22,6 @@ vdadir=$(libexecdir)/boinc-server-maker/vda
 vda_PROGRAMS = vda vdad ssim
 
 AM_CXXFLAGS += $(MYSQL_CFLAGS)
-AM_LDFLAGS += -static
 
 vda_SOURCES = vda.cpp vda_lib.cpp vda_lib2.cpp vda_policy.cpp stats.cpp
 vda_LDADD = $(SERVERLIBS)

--- a/zip/Makefile.am
+++ b/zip/Makefile.am
@@ -30,7 +30,11 @@ libboinc_zip_la_SOURCES = boinc_zip.cpp
 libboinc_zip_la_CFLAGS = $(AM_CFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(LIBZIP_CFLAGS)
 libboinc_zip_la_CXXFLAGS = $(AM_CXXFLAGS) $(PICFLAGS) $(PTHREAD_CFLAGS) $(LIBZIP_CFLAGS)
 libboinc_zip_la_LDFLAGS = -version-number $(LIBBOINC_VERSION) $(LIBZIP_LIBS)
-libboinc_zip_la_LIBADD =
+libboinc_zip_la_LIBADD = $(LIBBOINC)
+libboinc_zip_la_AR = gcc-ar
+libboinc_zip_la_RANLIB = gcc-ranlib
+libboinc_zip_a_AR = gcc-ar
+libboinc_zip_a_RANLIB = gcc-ranlib
 
 # Some OSs may not prefix libraries with lib.
 # For example OS2


### PR DESCRIPTION
Don't know how much this makes sense, it fixes some underlinking issues when boinc is built as shared library

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BOINC dynamic library builds by removing forced static linking and adding missing link dependencies so shared libraries work without underlinking.

- Removes `-static` and `-static-libtool-libs` from library and tool Makefiles.
- Adds `-lpthread`, SSL, and BOINC library dependencies to API, scheduler, and zip libraries.
- Sets `gcc-ar` and `gcc-ranlib` for LTO-compatible archives.
- Adds explicit `-static` to sample app Makefiles, preserving static linking for those binaries.

<sup>Written for commit 201d27b6a1995af9545136f59b0975db5f91ecd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

