### PR TITLE
Fix missing safe_strlcpy reference

### DIFF
--- a/client/file_names.cpp
+++ b/client/file_names.cpp
@@ -76,7 +76,7 @@ void get_pathname(FILE_INFO* fip, char* path, int len) {
         if (fip->is_auto_update_file) {
             boinc_version_dir(*p, gstate.auto_update.version, buf);
         } else {
-            strcpy(buf, p->project_dir());
+            safe_strcpy(buf, p->project_dir());
         }
 #else
         safe_strcpy(buf, p->project_dir());


### PR DESCRIPTION
From previous PR #7256

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a missing `safe_strcpy` reference so the auto-update file path branch uses the safe string copy like the fallback branch does, preventing a potential buffer overflow.

<sup>Written for commit 1cccad8bb67c6c165c87025cf272e1e8f570a315. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

