### PR TITLE
[ci] update libwebp vcpkg custom port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libwebp/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libwebp/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "libwebp",
   "version": "1.6.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "WebP codec: library to encode and decode images in WebP format",
   "homepage": "https://github.com/webmproject/libwebp",
   "license": "BSD-3-Clause",
@@ -208,7 +208,7 @@
             "vwebp"
           ]
         },
-        "sdl1"
+        "sdl2"
       ]
     }
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the `libwebp` vcpkg custom port from port-version 2 to 3 and switches the satools dependency from `sdl1` to `sdl2` so the port builds against the current SDL version. The port-version bump will cause vcpkg to rebuild dependent packages.

<sup>Written for commit d9ebde3e440eda3c33866ab845ba9e4265185925. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

