### PR TITLE
[manager] fix crash on application exit when 'Shutdown client' option is not available

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -1484,7 +1484,7 @@ int CBOINCGUIApp::ConfirmExit() {
     }
 
 #ifdef __WXMSW__
-    if (m_iShutdownCoreClient) {
+    if (m_iShutdownCoreClient && dlg.m_DialogShutdownCoreClient) {
         dlg.m_DialogShutdownCoreClient->SetValue(TRUE);
     }
 #endif
@@ -1500,7 +1500,9 @@ int CBOINCGUIApp::ConfirmExit() {
 #ifdef __WXMAC__
         s_bSkipExitConfirmation = true;     // Don't ask twice (only affects Mac)
 #else
-        m_iShutdownCoreClient = dlg.m_DialogShutdownCoreClient->GetValue();
+        if (dlg.m_DialogShutdownCoreClient) {
+            m_iShutdownCoreClient = dlg.m_DialogShutdownCoreClient->GetValue();
+        }
 #endif
         m_iDisplayExitDialog = !dlg.m_DialogDisplay->GetValue();
         retval = true;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a crash on application exit when the 'Shutdown client' option is not present in the exit confirmation dialog. The code now checks for the option's existence before reading its value, preventing a null pointer dereference.

<sup>Written for commit 5ceacdeb266a45a5ab273838d7868300a4b5900c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

