### PR TITLE
[ci] update custom gdk-pixbuf vcpkg port

### DIFF
--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/portfile.cmake
@@ -4,7 +4,7 @@ vcpkg_download_distfile(ARCHIVE
         "https://download.gnome.org/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
         "https://www.mirrorservice.org/sites/ftp.gnome.org/pub/GNOME/sources/${PORT}/${VERSION_MAJOR_MINOR}/${PORT}-${VERSION}.tar.xz"
     FILENAME "GNOME-${PORT}-${VERSION}.tar.xz"
-    SHA512 45ad815dda5d7b86fafe4a14300a676130f1c404299989616e41fa84e872516304bc6c3ebee9e1153bce01245333b1f8dfedee4bcde27a323e27d7e70fcb597f
+    SHA512 5fa8066abbfc29d7d9f07d95af2cfa2668e90381ecf1055ea449d35661b997d55e84e64ae1dedc14cf13d66912d05b1398075c560ce1aeeea7ae60a7d73c873a
 )
 
 vcpkg_extract_source_archive(

--- a/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/gdk-pixbuf/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "gdk-pixbuf",
-  "version": "2.44.6",
-  "port-version": 1,
+  "version": "2.44.8",
   "description": "Image loading library.",
   "homepage": "https://gitlab.gnome.org/GNOME/gdk-pixbuf",
   "license": "LGPL-2.1-or-later",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the custom `gdk-pixbuf` vcpkg port from 2.44.6 to 2.44.8 and refreshes the archive checksum.

<sup>Written for commit 70e21d0b3d2e2c09a23ae52f3d06ad9139173d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

