### PR TITLE
[ci] update custom libsm vcpkg ports

### DIFF
--- a/3rdParty/vcpkg_ports/ports/libsm/msvc.patch
+++ b/3rdParty/vcpkg_ports/ports/libsm/msvc.patch
@@ -1,0 +1,15 @@
+diff --git a/src/sm_genid.c b/src/sm_genid.c
+index 9a52e1d..3a7d1e4 100644
+--- a/src/sm_genid.c
++++ b/src/sm_genid.c
+@@ -64,7 +64,9 @@ in this Software without prior written authorization from The Open Group.
+ # include <X11/Xthreads.h>
+ #endif
+ #include <stdio.h>
+-#include <unistd.h>
++#ifdef HAVE_UNISTD_H
++ #include <unistd.h>
++#endif
+ 
+ #include <time.h>
+ #define Time_t time_t

--- a/3rdParty/vcpkg_ports/ports/libsm/portfile.cmake
+++ b/3rdParty/vcpkg_ports/ports/libsm/portfile.cmake
@@ -1,0 +1,34 @@
+if(NOT X_VCPKG_FORCE_VCPKG_X_LIBRARIES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(STATUS "Utils and libraries provided by '${PORT}' should be provided by your system! Install the required packages or force vcpkg libraries by setting X_VCPKG_FORCE_VCPKG_X_LIBRARIES in your triplet!")
+    set(VCPKG_POLICY_EMPTY_PACKAGE enabled)
+    return()
+endif()
+
+vcpkg_download_distfile(
+    LIBSM_ARCHIVE
+    URLS "https://www.x.org/releases/individual/lib/libSM-${VERSION}.tar.xz"
+    FILENAME "libSM-${VERSION}.tar.xz"
+    SHA512 e544a1dc49a03390f76af35837bfd01f749b806d88d3ee806f20311c47ff53d0aeea4744feb875958031b17d50b57a89dcc41d81241c09333c88b268c44653a7
+)
+
+vcpkg_extract_source_archive(
+    SOURCE_PATH
+    ARCHIVE "${LIBSM_ARCHIVE}"
+    PATCHES
+        msvc.patch
+        xtrans.patch # https://gitlab.freedesktop.org/xorg/lib/libsm/-/commit/d65819505c31f74ffc731003029702576eb9811d
+)
+
+set(ENV{ACLOCAL} "aclocal -I \"${CURRENT_INSTALLED_DIR}/share/xorg/aclocal/\"")
+
+vcpkg_make_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    AUTORECONF
+)
+
+vcpkg_make_install()
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/COPYING")

--- a/3rdParty/vcpkg_ports/ports/libsm/vcpkg.json
+++ b/3rdParty/vcpkg_ports/ports/libsm/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name": "libsm",
+  "version": "1.2.6",
+  "port-version": 3,
+  "description": "X Session Management Library",
+  "homepage": "https://gitlab.freedesktop.org/xorg/lib/libsm",
+  "license": null,
+  "dependencies": [
+    "libice",
+    {
+      "name": "vcpkg-make",
+      "host": true
+    },
+    "xorg-macros"
+  ]
+}

--- a/3rdParty/vcpkg_ports/ports/libsm/xtrans.patch
+++ b/3rdParty/vcpkg_ports/ports/libsm/xtrans.patch
@@ -1,0 +1,32 @@
+diff --git a/configure.ac b/configure.ac
+index 7d274a5f71f2626b9dbce243c7ad4fdb8057321f..e65dad7e7adb66207383773eebdc45fc3ef9cca0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -53,13 +53,13 @@ AM_CONDITIONAL(WITH_LIBUUID, test x"$HAVE_LIBUUID" = xyes)
+ # If UUID support is not found, fall back to using network addresses
+ # to generate client ids
+ AS_IF([test x"$HAVE_LIBUUID" != xyes && test x"$ac_cv_func_uuid_create" != xyes],
+-      [genid_module="xtrans"
++      [
+ # Needed to check for TCP & IPv6 support and set flags appropriately
+ XTRANS_CONNECTION_FLAGS
+ AC_CHECK_FUNCS([getaddrinfo]) ])
+ 
+ # Obtain compiler/linker options for dependencies
+-PKG_CHECK_MODULES(SM, [ice >= 1.1.0 xproto $genid_module])
++PKG_CHECK_MODULES(SM, [ice >= 1.1.0 xproto])
+ 
+ 
+ AC_CONFIG_FILES([Makefile
+diff --git a/src/sm_manager.c b/src/sm_manager.c
+index e792021d8b905cd39ef7ca27c81cbddc968568db..5986de8666d66ca65df3a0306749434f0fef8ee9 100644
+--- a/src/sm_manager.c
++++ b/src/sm_manager.c
+@@ -33,7 +33,6 @@ in this Software without prior written authorization from The Open Group.
+ #endif
+ #include <X11/SM/SMlib.h>
+ #include "SMlibint.h"
+-#include <X11/Xtrans/Xtrans.h>
+ 
+ static Status
+ _SmsProtocolSetupProc (IceConn    iceConn,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a custom vcpkg port for `libSM` 1.2.6 so it can be built on Windows, where no system package is available. Patches make the source compile under MSVC and remove the xtrans dependency.

**Details**
- The portfile downloads `libSM-1.2.6` and applies both patches.
- `msvc.patch` guards the `unistd.h` include in `sm_genid.c`.
- `xtrans.patch` drops the xtrans module from `configure.ac` and the `Xtrans.h` include from `sm_manager.c`.
- On non-Windows targets the port is empty unless `X_VCPKG_FORCE_VCPKG_X_LIBRARIES` is set.

<sup>Written for commit c4d198a5cb865059a64c9e947f648863c5ffd3c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

