### PR TITLE
[manager] fix layout of the wizard pages

### DIFF
--- a/clientgui/AccountInfoPage.cpp
+++ b/clientgui/AccountInfoPage.cpp
@@ -17,17 +17,9 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
-#include "wx/valgen.h"
-#include "wx/valtext.h"
 #include "ValidateEmailAddress.h"
 #include "BOINCBaseWizard.h"
 #include "WizardAttach.h"
@@ -408,7 +400,7 @@ void CAccountInfoPage::OnPageChanged( wxWizardEvent& /* event */ ) {
         m_pAccountEmailAddressCtrl->SetFocus();
     }
 
-    Fit();
+    Layout();
 }
 
 void CAccountInfoPage::OnPageChanging(wxWizardEvent& event) {
@@ -515,7 +507,7 @@ void CAccountInfoPage::OnAccountUseExistingCtrlSelected(wxCommandEvent& WXUNUSED
         m_pAccountEmailAddressCtrl->SetFocus();
     }
 
-    Fit();
+    Layout();
 }
 
 void CAccountInfoPage::OnAccountCreateCtrlSelected(wxCommandEvent& WXUNUSED(event)) {
@@ -534,7 +526,7 @@ void CAccountInfoPage::OnAccountCreateCtrlSelected(wxCommandEvent& WXUNUSED(even
         m_pAccountEmailAddressCtrl->SetFocus();
     }
 
-    Fit();
+    Layout();
 }
 
 bool CAccountInfoPage::Validate() {

--- a/clientgui/AccountManagerInfoPage.cpp
+++ b/clientgui/AccountManagerInfoPage.cpp
@@ -18,13 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "str_util.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"

--- a/clientgui/AccountManagerProcessingPage.cpp
+++ b/clientgui/AccountManagerProcessingPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -160,7 +154,7 @@ void CAccountManagerProcessingPage::OnPageChanged(wxWizardEvent& event) {
     CAccountManagerProcessingPageEvent TransitionEvent(wxEVT_ACCOUNTMANAGERPROCESSING_STATECHANGE, this);
     AddPendingEvent(TransitionEvent);
 
-    Fit();
+    Layout();
 }
 
 void CAccountManagerProcessingPage::OnCancel(wxWizardEvent& event) {

--- a/clientgui/AccountManagerPropertiesPage.cpp
+++ b/clientgui/AccountManagerPropertiesPage.cpp
@@ -17,14 +17,6 @@
 //
 
 #include "stdwx.h"
-#include "network.h"
-#include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -173,7 +165,7 @@ void CAccountManagerPropertiesPage::OnPageChanged(wxWizardEvent&) {
     CAccountManagerPropertiesPageEvent TransitionEvent(wxEVT_ACCOUNTMANAGERPROPERTIES_STATECHANGE, this);
     AddPendingEvent(TransitionEvent);
 
-    Fit();
+    Layout();
 }
 
 void CAccountManagerPropertiesPage::OnCancel(wxWizardEvent& event) {

--- a/clientgui/AlreadyExistsPage.cpp
+++ b/clientgui/AlreadyExistsPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -123,7 +117,7 @@ void CErrAlreadyExistsPage::OnPageChanged(wxWizardEvent& event) {
         );
     }
 
-    Fit();
+    Layout();
 }
 
 void CErrAlreadyExistsPage::OnCancel(wxWizardEvent& event) {

--- a/clientgui/CompletionErrorPage.cpp
+++ b/clientgui/CompletionErrorPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -164,7 +158,7 @@ void CCompletionErrorPage::OnPageChanged(wxWizardEvent& event) {
         m_pServerMessagesCtrl->Show();
     }
 
-    Fit();
+    Layout();
 
     m_pParent->DisableBackButton();
 }

--- a/clientgui/CompletionPage.cpp
+++ b/clientgui/CompletionPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -195,13 +189,13 @@ void CCompletionPage::OnPageChanged(wxWizardEvent& event) {
         }
     }
 
-    Fit();
+    Layout();
     int x, y, x1, y1, w, h;
     GetPosition(&x, &y);
     m_pCompletionBrandedMessage->GetPosition(&x1, &y1);
     m_pParent->GetSize(&w, &h);
     m_pCompletionBrandedMessage->Wrap(w - x - x1 - 5);
-    Fit();
+    Layout();
 
     m_pParent->DisableBackButton();
 

--- a/clientgui/NotDetectedPage.cpp
+++ b/clientgui/NotDetectedPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -123,7 +117,7 @@ void CErrNotDetectedPage::OnPageChanged(wxWizardEvent& event) {
         wxASSERT(FALSE);
     }
 
-    Fit();
+    Layout();
 }
 
 void CErrNotDetectedPage::OnCancel( wxWizardEvent& event ) {

--- a/clientgui/NotFoundPage.cpp
+++ b/clientgui/NotFoundPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -123,7 +117,7 @@ void CErrNotFoundPage::OnPageChanged(wxWizardEvent& event) {
     m_pParent->DisableNextButton();
     m_pParent->GetBackButton()->SetDefault();
 
-    Fit();
+    Layout();
 }
 
 void CErrNotFoundPage::OnCancel(wxWizardEvent& event) {

--- a/clientgui/ProjectInfoPage.cpp
+++ b/clientgui/ProjectInfoPage.cpp
@@ -18,14 +18,7 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
 #include "url.h"
-#include "error_numbers.h"
-
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -35,7 +28,6 @@
 #include "CompletionErrorPage.h"
 #include "ProjectPropertiesPage.h"
 #include "ProjectInfoPage.h"
-
 
 #include "res/windowsicon.xpm"
 #include "res/macosicon.xpm"

--- a/clientgui/ProjectProcessingPage.cpp
+++ b/clientgui/ProjectProcessingPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -261,7 +255,7 @@ void CProjectProcessingPage::OnPageChanged(wxWizardEvent& event) {
     CProjectProcessingPageEvent TransitionEvent(wxEVT_PROJECTPROCESSING_STATECHANGE, this);
     AddPendingEvent(TransitionEvent);
 
-    Fit();
+    Layout();
 }
 
 void CProjectProcessingPage::OnCancel(wxWizardEvent& event) {

--- a/clientgui/ProjectPropertiesPage.cpp
+++ b/clientgui/ProjectPropertiesPage.cpp
@@ -17,14 +17,7 @@
 //
 
 #include "stdwx.h"
-#include "network.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -280,7 +273,7 @@ void CProjectPropertiesPage::OnPageChanged(wxWizardEvent& event) {
     CProjectPropertiesPageEvent TransitionEvent(wxEVT_PROJECTPROPERTIES_STATECHANGE, this);
     AddPendingEvent(TransitionEvent);
 
-    Fit();
+    Layout();
 }
 
 void CProjectPropertiesPage::OnCancel(wxWizardEvent& event) {

--- a/clientgui/ProjectWelcomePage.cpp
+++ b/clientgui/ProjectWelcomePage.cpp
@@ -23,12 +23,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"

--- a/clientgui/ProxyInfoPage.cpp
+++ b/clientgui/ProxyInfoPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -132,7 +126,7 @@ void CErrProxyInfoPage::OnPageChanged( wxWizardEvent& event ) {
     );
 #endif
 
-    Fit();
+    Layout();
 }
 
 void CErrProxyInfoPage::OnCancel(wxWizardEvent& event) {

--- a/clientgui/ProxyPage.cpp
+++ b/clientgui/ProxyPage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -305,7 +299,7 @@ void CErrProxyPage::OnPageChanged(wxWizardEvent& WXUNUSED(event)) {
     strBuffer.Printf(wxT("%d"), pDoc->proxy_info.socks_server_port);
     m_pProxySOCKSPortCtrl->SetValue(strBuffer);
 
-    Fit();
+    Layout();
     m_pProxyHTTPServerCtrl->SetFocus();
 }
 

--- a/clientgui/TermsOfUsePage.cpp
+++ b/clientgui/TermsOfUsePage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -181,7 +175,7 @@ void CTermsOfUsePage::OnPageChanged(wxWizardEvent& event) {
     SetUserAgrees(false);
     m_pParent->DisableNextButton();
 
-    Fit();
+    Layout();
 }
 
 void CTermsOfUsePage::OnPageChanging(wxWizardEvent& event) {

--- a/clientgui/UnavailablePage.cpp
+++ b/clientgui/UnavailablePage.cpp
@@ -18,12 +18,6 @@
 
 #include "stdwx.h"
 #include "diagnostics.h"
-#include "util.h"
-#include "mfile.h"
-#include "miofile.h"
-#include "parse.h"
-#include "error_numbers.h"
-#include "error_numbers.h"
 #include "BOINCGUIApp.h"
 #include "SkinManager.h"
 #include "MainDocument.h"
@@ -123,7 +117,7 @@ void CErrUnavailablePage::OnPageChanged(wxWizardEvent& event) {
         wxASSERT(FALSE);
     }
 
-    Fit();
+    Layout();
 }
 
 void CErrUnavailablePage::OnCancel( wxWizardEvent& event ) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes wizard page layout so pages no longer resize the wizard window when they change.

- Replaces `Fit()` with `Layout()` on all wizard pages so the dialog size stays stable while content updates.
- Removes unused includes from the affected page files.

<sup>Written for commit d9585e7e4325f7bb91487ab0874b19d590b34f4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

