### PR TITLE
web: fix broken links

### DIFF
--- a/html/inc/bootstrap.inc
+++ b/html/inc/bootstrap.inc
@@ -157,7 +157,7 @@ function sample_navbar(
     $x = array();
     if ($user) {
         $x[] = array(tra("Account"), $url_prefix.HOME_PAGE);
-        $x[] = array(tra("Join"), $url_prefix."join.php");
+        $x[] = array(tra("Join"), $url_prefix."signup.php");
         $x[] = array(tra("Preferences"), $url_prefix."prefs.php?subset=project");
     }
     $x[] = array(tra("About %1", PROJECT), $url_prefix."about.php");

--- a/html/user/create_account_form.php
+++ b/html/user/create_account_form.php
@@ -44,7 +44,7 @@ if (!NO_COMPUTING) {
         .tra(
             "If you already have an account and want to run %1 on this computer, %2 go here %3.",
             PROJECT,
-            '<a href=join.php>',
+            '<a href=download_software.php>',
             '</a>'
         )
         ."</p>


### PR DESCRIPTION
There were 2 references to the non-existent 'join.php'. One should have been signup.php; the other, download_software.php

Fixes #7271

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two broken links that pointed to the non-existent `join.php`. The navbar link now points to `signup.php`, and the account creation form link now points to `download_software.php`. Fixes #7271.

<sup>Written for commit 6bd498047ee4790cbcfb19b37de4694be21ae761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

