### PR TITLE
[ci] fix failing linux ci due to the missing 'azure-cli.sources' file

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,7 +113,9 @@ jobs:
           arch=arm64
           sudo dpkg --add-architecture arm64
           sudo sed -i '/^Types: deb$/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
-          sudo sed -i '/^Types: deb$/a Architectures: amd64' /etc/apt/sources.list.d/azure-cli.sources
+          if [ -f /etc/apt/sources.list.d/azure-cli.sources ]; then
+            sudo sed -i '/^Types: deb$/a Architectures: amd64' /etc/apt/sources.list.d/azure-cli.sources
+          fi
           codename=$(lsb_release -cs)
           cat <<EOT >> arm-cross-compile-sources.list
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $codename main restricted universe multiverse
@@ -130,7 +132,9 @@ jobs:
           arch=armhf
           sudo dpkg --add-architecture armhf
           sudo sed -i '/^Types: deb$/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
-          sudo sed -i '/^Types: deb$/a Architectures: amd64' /etc/apt/sources.list.d/azure-cli.sources
+          if [ -f /etc/apt/sources.list.d/azure-cli.sources ]; then
+            sudo sed -i '/^Types: deb$/a Architectures: amd64' /etc/apt/sources.list.d/azure-cli.sources
+          fi
           codename=$(lsb_release -cs)
           cat <<EOT >> armhf-cross-compile-sources.list
           deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports $codename main restricted universe multiverse


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Linux CI failing when the `azure-cli.sources` file is missing by only modifying it if it exists.

<sup>Written for commit 6ec79eb54ce3deb5408618a7ff0b58a1cfbf6f5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

