### PR TITLE
lib: add FreeBSD-native process enumeration and total CPU time

### DIFF
--- a/client/app.cpp
+++ b/client/app.cpp
@@ -560,7 +560,7 @@ void ACTIVE_TASK_SET::get_memory_usage() {
     // compute non_boinc_cpu_usage
     non_boinc_cpu_usage = 0;
 
-#if defined(__linux__) || defined(_WIN32) || defined(__APPLE__)
+#if defined(__linux__) || defined(_WIN32) || defined(__APPLE__) || defined(__FreeBSD__)
 #ifndef ANDROID
     // Improved version for systems where we can get total CPU
     // (Win, Linux, Mac)

--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -30,6 +30,16 @@
 #endif
 #endif
 
+#ifdef __FreeBSD__
+#include <errno.h>
+#include <sys/sysctl.h>
+#include <sys/time.h>       // struct clockinfo
+#include <sys/resource.h>   // CPUSTATES, CP_USER, CP_NICE, CP_SYS, CP_INTR, CP_IDLE
+#include <sys/user.h>       // struct kinfo_proc
+#include "util.h"
+#include <vector>
+#endif
+
 #include <cstdio>
 #include <string.h>
 #include <sys/param.h>
@@ -148,6 +158,64 @@ void PROCINFO::get_mem_info() {
 // or its command contains 'boinc'
 //
 int procinfo_setup(PROC_MAP& pm) {
+#ifdef __FreeBSD__
+// FreeBSD-native process enumeration, replacing the /proc-based approach
+// used on Linux/Solaris. This requires no /proc mount of any kind (native
+// procfs or linprocfs) and works correctly and identically whether running
+// on bare metal or inside a jail.
+//
+    int mib[3] = { CTL_KERN, KERN_PROC, KERN_PROC_PROC };
+    size_t len;
+    std::vector<struct kinfo_proc> kprocs;
+
+    for (;;) {
+        len = 0;
+        if (sysctl(mib, 3, NULL, &len, NULL, 0) != 0) {
+            fprintf(stderr,
+                "procinfo_setup(): sysctl(KERN_PROC_PROC) size query failed\n");
+            return ERR_IO;
+        }
+        kprocs.resize((len + sizeof(struct kinfo_proc) - 1) / sizeof(struct kinfo_proc));
+        size_t buflen = kprocs.size() * sizeof(struct kinfo_proc);
+        if (sysctl(mib, 3, kprocs.data(), &buflen, NULL, 0) == 0) {
+            len = buflen;
+            break;
+        }
+        if (errno != ENOMEM) {
+            fprintf(stderr,
+                "procinfo_setup(): sysctl(KERN_PROC_PROC) failed\n");
+            return ERR_IO;
+        }
+    }
+
+    int nprocs = len / sizeof(struct kinfo_proc);
+    struct kinfo_proc* kp = kprocs.data();
+    int mypid = getpid();
+    long page_size = sysconf(_SC_PAGESIZE);
+
+    for (int i = 0; i < nprocs; i++) {
+        // Guard against a userland/kernel struct-layout mismatch
+        if (kp[i].ki_structsize != sizeof(struct kinfo_proc)) continue;
+
+        PROCINFO p;
+        p.clear();
+        p.id = kp[i].ki_pid;
+        p.parentid = kp[i].ki_ppid;
+        safe_strcpy(p.command, kp[i].ki_comm);
+        p.user_time = kp[i].ki_rusage.ru_utime.tv_sec
+            + kp[i].ki_rusage.ru_utime.tv_usec / 1e6;
+        p.kernel_time = kp[i].ki_rusage.ru_stime.tv_sec
+            + kp[i].ki_rusage.ru_stime.tv_usec / 1e6;
+        // ki_rssize is in pages; PROCINFO::rss wants bytes.
+        p.rss = (double)kp[i].ki_rssize * page_size;
+        // No direct per-process swap-usage accounting on FreeBSD
+        p.swap_usage = 0;
+        p.is_boinc_app = (p.id == mypid || strcasestr(p.command, "boinc"));
+        p.is_low_priority = (kp[i].ki_nice >= PROCESS_IDLE_PRIORITY);
+        pm.insert(std::pair<int, PROCINFO>(p.id, p));
+    }
+#else // !__FreeBSD__
+
     DIR *dir;
     dirent *piddir;
     FILE* f;
@@ -230,6 +298,7 @@ int procinfo_setup(PROC_MAP& pm) {
 #endif
     }
     closedir(dir);
+#endif
     find_children(pm);
     return 0;
 }
@@ -238,6 +307,44 @@ int procinfo_setup(PROC_MAP& pm) {
 // see https://www.baeldung.com/linux/get-cpu-usage
 //
 double total_cpu_time() {
+#ifdef __FreeBSD__
+// Host-wide (jail-transparent) CPU busy time via kern.cp_time.
+// Unlike a /proc-based per-process walk, this is a single set of
+// kernel-global tick counters covering every process on the host --
+// including sibling jails and the host's own processes. This is the
+// same source top(1) uses for its aggregate CPU line, and jails do not
+// restrict or virtualize this sysctl the way they do the process table.
+//
+    long cp_time[CPUSTATES];
+    size_t len = sizeof(cp_time);
+    static double tick_scale = 0;
+
+    if (!tick_scale) {
+        struct clockinfo ci;
+        size_t cilen = sizeof(ci);
+        if (sysctlbyname("kern.clockrate", &ci, &cilen, NULL, 0) == 0
+            && ci.stathz > 0
+        ) {
+            tick_scale = 1.0 / ci.stathz;
+        } else {
+            fprintf(stderr,
+                "total_cpu_time(): kern.clockrate/stathz unavailable, assuming 100Hz\n"
+            );
+            tick_scale = 1.0 / 100.0;
+        }
+    }
+
+    if (sysctlbyname("kern.cp_time", cp_time, &len, NULL, 0) != 0) {
+        fprintf(stderr, "total_cpu_time(): sysctl kern.cp_time failed\n");
+        return 0;
+    }
+
+    double busy_ticks = (double)(
+        cp_time[CP_USER] + cp_time[CP_NICE] + cp_time[CP_SYS] + cp_time[CP_INTR]
+    );
+    return busy_ticks * tick_scale;
+
+#else // !__FreeBSD__
     char buf[1024];
     static FILE *f=NULL;
     static double scale;
@@ -264,4 +371,5 @@ double total_cpu_time() {
         return 0;
     }
     return (user+nice+kernel)*scale;
+#endif
 }


### PR DESCRIPTION
- Add a `__FreeBSD__` branch to `procinfo_setup()` that uses `sysctl(CTL_KERN, KERN_PROC, KERN_PROC_PROC)` to populate `PROCINFO` from `struct kinfo_proc (ki_pid, ki_ppid, ki_comm, ki_rusage, ki_rssize, ki_nice)`, instead of walking `/proc`.
- Add a `__FreeBSD__` branch to `total_cpu_time()` that reads the `kern.cp_time` sysctl, scaled by` kern.clockrate`'s `stathz`, instead of parsing `/proc/stat`.
- Include `lib/util.h` for `PROCESS_IDLE_PRIORITY`.

Assisted-by: Claude:claude-sonnet-5 [web_search] [web_fetch]
Assisted-by: ChatGPT:GPT-5.6 Luna

Fixes # — no existing issue. On FreeBSD, `procinfo_setup()` and `total_cpu_time()` fall through to the Linux-format `/proc` parsing path unconditionally, since it's currently written to run for "any non-Solaris Unix." FreeBSD has no `/proc` by default inside jails, so in these cases, `procinfo_setup()` fails outright (`procinfo_setup(): can't open /proc`, visible in client logs) and CPU-load-based task suspension does not function. Separately, even where a Linux-compatible `/proc` is made available (via `linprocfs`), a per-process approach run inside a FreeBSD jail can only ever observe that jail's own process table by design — never sibling jails' or the host's CPU load — so it cannot deliver correct suspend/resume behavior for the common deployment pattern of running `boinc-client` in an isolated jail alongside other jailed or host-level workloads.

**Description of the Change**
Adds a native FreeBSD branch to `procinfo_setup()` using `sysctl(CTL_KERN, KERN_PROC, KERN_PROC_PROC)`, reading `struct kinfo_proc` directly instead of walking `/proc/PID/stat`; this is naturally scoped by the kernel to whatever the calling jail can see, matching the existing behavior of `ps`/`top` inside a jail, and is exactly the correct process set for "BOINC-related processes" since BOINC only ever runs inside its own jail. Adds a native FreeBSD branch to `total_cpu_time()` using the `kern.cp_time` sysctl, scaled by `kern.clockrate`'s `stathz`; unlike a per-process walk, this is a host-wide kernel counter unaffected by jail process-visibility restrictions, giving an accurate "how busy is the whole machine" signal from inside a jail with no special configuration required. Together these give correct CPU-load-based suspension covering sibling jails and the host, not just the calling jail. Tested on FreeBSD 14.3/amd64: confirmed BOINC-driven computation correctly suspends when non-jailed CPU load is introduced from outside the BOINC jail, and resumes when that load is removed. This method also functions properly when BOINC is run on bare metal.

**Alternate Designs**

- Mount `linprocfs` at `/proc` inside the BOINC jail and rely on the existing Linux-format-parsing code path unmodified. Rejected: per-process enumeration inside a jail can only ever see that jail's own processes by design — a hard security boundary, not a configuration gap — so this can never observe sibling-jail or host-level CPU load regardless of `/proc` availability, and does not solve the underlying problem.
- Use `libkvm` instead of `sysctl(KERN_PROC_PROC`) for process enumeration. Not pursued: `libkvm` typically requires additional privileges (e.g. `kmem` group membership) that a raw `sysctl` call does not, with no capability advantage for the fields needed here (pid, ppid, command, rusage, rss, nice), all available directly via `struct kinfo_proc`.

**Release Notes**
Added native FreeBSD support for CPU-load-based task suspension, so `boinc-client` running inside a FreeBSD jail correctly responds to CPU demand from sibling jails and the host, not just from within its own jail.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces `/proc`-based process and CPU time reading on FreeBSD with native sysctl calls so CPU-load suspension works inside jails and without a procfs mount. Previously the code fell through to the Linux `/proc` parsing path, which fails outright in FreeBSD jails (no `/proc` by default) and, even with `linprocfs`, only sees the jail's own processes, so host and sibling-jail CPU load never triggered suspension.

**Bug Fixes**
- Process enumeration now uses `sysctl(CTL_KERN, KERN_PROC, KERN_PROC_PROC)` instead of walking `/proc`.
- Total CPU time reads `kern.cp_time`, a host-wide counter unaffected by jail process-visibility restrictions.
- Enables the improved `non_boinc_cpu_usage` calculation on FreeBSD by adding it to the conditional compile guard.

<sup>Written for commit 0169e330b5a41c63ab13be7d6aca4ad2d8db284e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

