### PR TITLE
client: include sched.h to fix build error with uClibc-ng

### DIFF
--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -51,7 +51,7 @@
 #include "sysmon_win.h"
 #else
 #include "config.h"
-#if HAVE_SCHED_SETSCHEDULER && defined (__linux__)
+#if defined(HAVE_SCHED_SETSCHEDULER) && HAVE_SCHED_SETSCHEDULER && defined (__linux__)
 #include <sched.h>
 #endif
 #include <string>

--- a/client/cpu_sched.cpp
+++ b/client/cpu_sched.cpp
@@ -51,6 +51,9 @@
 #include "sysmon_win.h"
 #else
 #include "config.h"
+#if HAVE_SCHED_SETSCHEDULER && defined (__linux__)
+#include <sched.h>
+#endif
 #include <string>
 #include <cstring>
 #include <list>


### PR DESCRIPTION
**Description of the Change**

Fixes build error with uClibc-ng as detected by the buildroot autobuilders:
https://autobuild.buildroot.net/results/f10/f1015559e37d73403c396ee883d9a73fd167b9dd/build-end.log
```
In file included from /home/autobuild/autobuild/instance-6/output-1/host/i686-buildroot-linux-uclibc/sysroot/usr/include/pthread.h:20,
                 from thread.h:23,
                 from client_state.h:37,
                 from cpu_sched.cpp:76:
cpu_sched.cpp: In member function 'void PROC_RESOURCES::schedule(RESULT*, ACTIVE_TASK*, bool)': cpu_sched.cpp:247:30: error: 'struct PROJECT' has no member named '__sched_priority'; did you mean 'sched_priority'?
  247 |                 rp->project->sched_priority
      |                              ^~~~~~~~~~~~~~
cpu_sched.cpp: In member function 'RESULT* CLIENT_STATE::highest_prio_project_best_result()':
cpu_sched.cpp:438:25: error: 'struct PROJECT' has no member named '__sched_priority'; did you mean 'sched_priority'?
  438 |         if (first || p->sched_priority > best_prio) {
      |                         ^~~~~~~~~~~~~~
cpu_sched.cpp:441:28: error: 'struct PROJECT' has no member named '__sched_priority'; did you mean 'sched_priority'?
  441 |             best_prio = p->sched_priority;
      |                            ^~~~~~~~~~~~~~
cpu_sched.cpp: In function 'RESULT* first_coproc_result(int)':
cpu_sched.cpp:474:29: error: 'struct PROJECT' has no member named '__sched_priority'; did you mean 'sched_priority'?
  474 |         prio = rp->project->sched_priority;
      |                             ^~~~~~~~~~~~~~
cpu_sched.cpp: In function 'void project_priority_init(bool)':
cpu_sched.cpp:684:16: error: 'struct PROJECT' has no member named '__sched_priority'; did you mean 'sched_priority'?
  684 |             p->sched_priority = 0;
      |                ^~~~~~~~~~~~~~
cpu_sched.cpp:690:24: error: 'struct PROJECT' has no member named '__sched_priority'; did you mean 'sched_priority'?
  690 |                     p->sched_priority, p->resource_share_frac,
      |                        ^~~~~~~~~~~~~~
cpu_sched.cpp: In member function 'void PROJECT::compute_sched_priority()':
cpu_sched.cpp:705:9: error: '__sched_priority' was not declared in this scope; did you mean 'sched_priority'?
  705 |         sched_priority = -1e3 - rec_frac;
      |         ^~~~~~~~~~~~~~
cpu_sched.cpp:708:13: error: '__sched_priority' was not declared in this scope; did you mean 'sched_priority'?
  708 |             sched_priority = - rec_frac/resource_share_frac;
      |             ^~~~~~~~~~~~~~
cpu_sched.cpp:710:13: error: '__sched_priority' was not declared in this scope; did you mean 'sched_priority'?
  710 |             sched_priority = - rec_frac;
      |             ^~~~~~~~~~~~~~
```


**Release Notes**
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the build error with uClibc-ng by conditionally including `<sched.h>` in `client/cpu_sched.cpp` on Linux when `HAVE_SCHED_SETSCHEDULER` is defined. The missing header caused `sched_priority` to be undeclared in several scheduling functions.

<sup>Written for commit 4d805e5562a728fee4ce06103fbb562f7e674f8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

