### PR TITLE
client: fix CPU feature-name typos in Windows get_processor_features()

### DIFF
--- a/client/hostinfo_win.cpp
+++ b/client/hostinfo_win.cpp
@@ -1325,11 +1325,11 @@ int get_processor_features(char* vendor, char* features, int features_size) {
 	FEATURE_TEST(std_supported, (std_ecx & (1 << 13)), "cx16 ");
     FEATURE_TEST(std_supported, (std_ecx & (1 << 19)), "sse4_1 ");
     FEATURE_TEST(std_supported, (std_ecx & (1 << 20)), "sse4_2 ");
-    FEATURE_TEST(std_supported, (std_ecx & (1 << 22)), "movebe ");
+    FEATURE_TEST(std_supported, (std_ecx & (1 << 22)), "movbe ");
     FEATURE_TEST(std_supported, (std_ecx & (1 << 23)), "popcnt ");
     FEATURE_TEST(std_supported, (std_ecx & (1 << 25)), "aes ");
 	FEATURE_TEST(std_supported, (std_ecx & (1 << 29)), "f16c ");
-	FEATURE_TEST(std_supported, (std_ecx & (1 << 30)), "rdrand");
+	FEATURE_TEST(std_supported, (std_ecx & (1 << 30)), "rdrand ");
 
     FEATURE_TEST(ext_supported, (ext_edx & (1 << 11)), "syscall ");
     FEATURE_TEST(ext_supported, (ext_edx & (1 << 20)), "nx ");
@@ -1385,9 +1385,9 @@ int get_processor_features(char* vendor, char* features, int features_size) {
 		FEATURE_TEST(ext_supported, (ext_ecx & (1 << 17)), "tce ");
 		FEATURE_TEST(ext_supported, (ext_ecx & (1 << 18)), "cvt16 ");
 		FEATURE_TEST(ext_supported, (ext_ecx & (1 << 21)), "tbm ");
-		FEATURE_TEST(ext_supported, (ext_ecx & (1 << 22)), "topx ");
+		FEATURE_TEST(ext_supported, (ext_ecx & (1 << 22)), "topoext ");
 
-        FEATURE_TEST(ext_supported, (ext_edx & (1 << 26)), "page1gb ");
+        FEATURE_TEST(ext_supported, (ext_edx & (1 << 26)), "pdpe1gb ");
         FEATURE_TEST(ext_supported, (ext_edx & (1 << 27)), "rdtscp ");
         FEATURE_TEST(ext_supported, (ext_edx & (1 << 30)), "3dnowext ");
         FEATURE_TEST(ext_supported, (ext_edx & (1 << 31)), "3dnow ");


### PR DESCRIPTION
Correct three feature-name string literals:

  - "movebe"  -> "movbe"
  - "page1gb" -> "pdpe1gb"
  - "topx"    -> "topoext"

Also add a trailing space after "rdrand" for consistency with the rest of the function. No change to which CPUID bits are tested.

Assisted-by: Claude:claude-sonnet-5 [web_search] [web_fetch]
Assisted-by: ChatGPT:GPT-5.6 Luna

Fixes unreported issue. Three feature-name strings written by `get_processor_features()` on Windows don't match the canonical names BOINC uses elsewhere (`movebe` vs. `movbe`, `page1gb` vs. `pdpe1gb`, `topx` vs. `topoext`). Since `plan_class` project logic matches `p_features` with substring checks, these typos cause silent, unreported mismatches on Windows hosts specifically — a rule written against `movbe`, `pdpe1gb`, or `topoext` never matches on Windows even when the underlying CPUID bit is set, with no error surfaced anywhere.

**Description of the Change**
The canonical spelling for CPU feature tokens comes from Linux's `/proc/cpuinfo` `flags` line, which BOINC's `parse_cpuinfo_linux()` passes through verbatim from the kernel, and which is what existing project `plan_class` rules are written against. This PR brings the three mismatched Windows strings in line with that spelling, and adds a trailing space after `rdrand` for consistency with every other entry in the function. This is a pure string-literal correction — no change to which CPUID bits are tested or to control flow.

**Alternate Designs**

- Teach project-side `plan_class` parsers to recognize the Windows-specific spellings as aliases. Rejected: this pushes a client-side bug onto every project maintainer indefinitely, and the incorrect spellings aren't documented anywhere as an intentional convention worth aliasing against.
- Rename all platforms' tokens to Intel SDM instruction-set naming instead of Linux kernel naming. Rejected: Linux's spelling is already what most existing `plan_class` rules are written against, since it's what the largest share of BOINC hosts report; introducing a third naming convention would create a new mismatch rather than resolving the existing one.

**Release Notes**
Fixed three CPU feature-name typos on Windows (`movebe`, `page1gb`, `topx`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three CPU feature-name typos in Windows `get_processor_features()` so feature strings match the canonical names used in Linux and in `plan_class` rules.

- Corrects `"movebe"` to `"movbe"`, `"page1gb"` to `"pdpe1gb"`, and `"topx"` to `"topoext"` on Windows hosts.
- Adds a trailing space after `"rdrand"` for consistency with the other feature strings. No CPUID bits tested are changed.

<sup>Written for commit f6efff98dcbab28a29323b491816e7ebd8d07316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

