### PR TITLE
Add missing Exception.php require in send_email()

### DIFF
--- a/html/inc/email.inc
+++ b/html/inc/email.inc
@@ -64,7 +64,7 @@ function send_email($user, $subject, $body, $body_html=null, $email_addr=null) {
             $mail->Body = $body;
         }
         if (!$mail->Send()) {
-            echo htmlspecialchars($mail->ErrorInfo, ENT_QUOTES, 'UTF-8');
+            error_log("send_email() failed: ".$mail->ErrorInfo);
             return false;
         } else {
             return true;

--- a/html/inc/email.inc
+++ b/html/inc/email.inc
@@ -64,7 +64,7 @@ function send_email($user, $subject, $body, $body_html=null, $email_addr=null) {
             $mail->Body = $body;
         }
         if (!$mail->Send()) {
-            echo $mail->ErrorInfo;
+            echo htmlspecialchars($mail->ErrorInfo, ENT_QUOTES, 'UTF-8');
             return false;
         } else {
             return true;

--- a/html/inc/email.inc
+++ b/html/inc/email.inc
@@ -43,7 +43,8 @@ function send_email($user, $subject, $body, $body_html=null, $email_addr=null) {
         pclose($pipe);
         return true;
     } else if (function_exists("make_php_mailer")) {
-        if (file_exists("../inc/PHPMailer/src/PHPMailer.php") && file_exists("../inc/PHPMailer/src/SMTP.php")) {
+        if (file_exists("../inc/PHPMailer/src/PHPMailer.php") && file_exists("../inc/PHPMailer/src/SMTP.php") && file_exists("../inc/PHPMailer/src/Exception.php")) {
+            require_once("../inc/PHPMailer/src/Exception.php");
             require_once("../inc/PHPMailer/src/PHPMailer.php");
             require_once("../inc/PHPMailer/src/SMTP.php");
         } else if (file_exists("../inc/phpmailer/class.phpmailer.php")) {


### PR DESCRIPTION
Closes #7277.

`send_email()` requires `PHPMailer.php` and `SMTP.php` but never `Exception.php`, even though all three are part of the vendored PHPMailer library. This is invisible on the happy path — `PHPMailer\PHPMailer\Exception` is only touched when `smtpConnect()`/`smtpSend()`/`postSend()` hit a real connection or auth failure and try to throw it. Since the class was never loaded, PHP can't construct it, so instead of a catchable exception (which PHPMailer's own code turns into a clean `Send()` returning `false`), you get an uncaught fatal `Error` that crashes the whole request.

Tested against a live deployment with a deliberately-broken SMTP password: before this change, a failed send crashes with `Class "PHPMailer\PHPMailer\Exception" not found`; after, `send_email()` returns `false` as intended.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`send_email()` no longer crashes with an uncaught `Class "PHPMailer\PHPMailer\Exception" not found` error on real SMTP connection or auth failures; it now requires `Exception.php` alongside `PHPMailer.php` and `SMTP.php` and returns `false` as intended. SMTP error details are now written to the error log via `error_log()` instead of being echoed to end users. Closes #7277.

<sup>Written for commit 6217599ee5b2d16a33b4a7d5a7578952ed1bcf27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

