### PR TITLE
Check send_email()'s return value in 4 account-flow pages

### DIFF
--- a/html/user/delete_account_request.php
+++ b/html/user/delete_account_request.php
@@ -57,10 +57,14 @@ function delete_account_request_form($user) {
 function delete_account_request_action($user) {
     $passwd = post_str("passwd");
     check_passwd_ui($user, $passwd);
-    send_confirm_delete_email($user);
+    page_head(tra("Delete account request"));
+    $success = send_confirm_delete_email($user);
 
-    page_head(tra("Confirmation Email Sent"));
-    echo "<p>".tra("The email to confirm your request to delete your account has been sent.")."</p>";
+    if ($success) {
+        echo "<p>".tra("The email to confirm your request to delete your account has been sent.")."</p>";
+    } else {
+        echo "<p>".tra("Can't send confirmation email to %1. Please try again later.", $user->email_addr)."</p>";
+    }
     page_tail();
 }
 

--- a/html/user/edit_email_action.php
+++ b/html/user/edit_email_action.php
@@ -77,7 +77,10 @@ if (!is_valid_email_syntax($email_addr)) {
                 if (defined("SHOW_NONVALIDATED_EMAIL_ADDR")) {
                     echo "<p>".tra("Please %1 validate this email address %2.", "<a href=validate_email_addr.php>", "</a>")."\n";
                 }
-                send_changed_email($user);
+                $email_success = send_changed_email($user);
+                if (!$email_success) {
+                    echo "<p>".tra("Your email address was changed, but we were unable to send the confirmation email to %1 or %2. Please note this change yourself.", $user->email_addr, $user->previous_email_addr)."</p>";
+                }
             } else {
                 echo tra("We can't update your email address due to a database problem.  Please try again later.");
             }

--- a/html/user/team_founder_transfer_action.php
+++ b/html/user/team_founder_transfer_action.php
@@ -105,9 +105,15 @@ case "initiate_transfer":
         // whose founder email is invalid
         //
         $team->update("ping_user=$user->id, ping_time=$now");
-        echo "<p>".tra("The current founder has been notified of your request by email and private message.<br /><br />
-                       If the founder does not respond within 60 days you will be allowed to become the founder.")
-        ."</p>\n";
+        if ($success) {
+            echo "<p>".tra("The current founder has been notified of your request by email and private message.<br /><br />
+                           If the founder does not respond within 60 days you will be allowed to become the founder.")
+            ."</p>\n";
+        } else {
+            echo "<p>".tra("The current founder has been notified of your request by private message (the notification email failed to send).<br /><br />
+                           If the founder does not respond within 60 days you will be allowed to become the founder.")
+            ."</p>\n";
+        }
     } else {
         error_page(tra("Foundership request not allowed now"));
     }
@@ -137,9 +143,14 @@ case "decline":
         $ping_user = BoincUser::lookup_id($team->ping_user);
 
         $team->update("ping_user=0");
-        send_founder_transfer_decline_email($team, $ping_user);
-        echo "<p>".tra("The foundership request from %1 has been declined.", user_links($ping_user))
-        ."</p>";
+        $email_success = send_founder_transfer_decline_email($team, $ping_user);
+        if ($email_success) {
+            echo "<p>".tra("The foundership request from %1 has been declined.", user_links($ping_user))
+            ."</p>";
+        } else {
+            echo "<p>".tra("The foundership request from %1 has been declined, but the notification email to them failed to send.", user_links($ping_user))
+            ."</p>";
+        }
     } else {
         echo "<p>".tra("There were no foundership requests.")."</p>";
     }

--- a/html/user/validate_email_addr.php
+++ b/html/user/validate_email_addr.php
@@ -25,16 +25,20 @@ function send_validate_email() {
     $master_url = master_url();
     $user = get_logged_in_user();
     $x2 = make_login_token($user);
-    send_email(
+    page_head(tra("Validate email address"));
+    $success = send_email(
         $user,
         tra("Validate BOINC email address"),
         tra("Please visit the following link to validate the email address of your %1 account:", PROJECT)
         ."\n".$master_url."validate_email_addr.php?validate=1&u=$user->id&x=$x2"
     );
-    page_head(tra("Validate email sent"));
-    echo tra("An email has been sent to %1. Visit the link it contains to validate your email address.", $user->email_addr);
-    echo "<p>";
-    echo tra("If you don't receive this email, check your spam folder.");
+    if ($success) {
+        echo tra("An email has been sent to %1. Visit the link it contains to validate your email address.", $user->email_addr);
+        echo "<p>";
+        echo tra("If you don't receive this email, check your spam folder.");
+    } else {
+        echo tra("Can't send email to %1.", $user->email_addr);
+    }
     page_tail();
 }
 


### PR DESCRIPTION
Closes #7278.

`send_email()` returns `false` on failure, but these pages ignore that return value and unconditionally show a success message:

- `validate_email_addr.php`'s `send_validate_email()` — always shows "An email has been sent to you."
- `delete_account_request.php`'s `delete_account_request_action()` — always shows "Confirmation Email Sent." This one's the most consequential: the confirmation link is the only way to delete an account, so a silent failure blocked the feature with zero indication anything went wrong.
- `edit_email_action.php` — the address change itself succeeds (correctly, unchanged here), but the page never said whether the two notice emails (old + new address) failed.
- `team_founder_transfer_action.php` — both the `initiate_transfer` and `decline` branches claimed the other party was notified "by email" regardless of whether the send actually worked.

Each fix checks the return value and shows an honest message on failure; the underlying action (DB update, PM, etc.) stays non-blocking either way — only the message changes.

`validate_email_addr.php`/`delete_account_request.php` also had `page_head()` called only after the send, so a failure's raw `echo $mail->ErrorInfo` (from inside `send_email()`) landed before any `<head>`/stylesheet output and broke the page's CSS. Moved `page_head()` before the send in both.

Tested against a live deployment with SMTP deliberately broken: each page now shows the correct failure message instead of a false success, with CSS intact.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four account-flow pages that claimed an email was sent even when `send_email()` failed.

- `delete_account_request.php` is the most consequential: the confirmation email is the only way to delete an account, so a silent failure blocked the feature with no indication.
- `validate_email_addr.php` and `delete_account_request.php` now call `page_head()` before sending, so a failed send no longer prints raw error output before the stylesheet and breaks page CSS.
- `edit_email_action.php` and `team_founder_transfer_action.php` now report when the notice emails failed to send; the underlying action (email address change, transfer request/decline) stays non-blocking.

<sup>Written for commit 434204e6b38186c1a3cc7a6f11178960714fec65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

