### PR TITLE
Don't hide moderation-email failures inside a 302 redirect body

### DIFF
--- a/html/user/forum_moderate_post_action.php
+++ b/html/user/forum_moderate_post_action.php
@@ -168,7 +168,7 @@ if ($email_success) {
     header('Location: forum_thread.php?id='.$thread->id);
 } else {
     page_head(tra("Moderation notice"));
-    echo $email_output;
+    echo htmlspecialchars($email_output, ENT_QUOTES, 'UTF-8');
     echo "<p>".tra("The post was successfully %1, but the notification email failed to send.", $action_name)."</p>";
     echo "<a href='forum_thread.php?id=$thread->id'>".tra("Return to thread")."</a>";
     page_tail();

--- a/html/user/forum_moderate_post_action.php
+++ b/html/user/forum_moderate_post_action.php
@@ -160,8 +160,18 @@ if (!$result) {
     error_page("Action failed: possible database problem");
 }
 
-send_moderation_email($forum, $post, $thread, $explanation, $action_name);
+ob_start();
+$email_success = send_moderation_email($forum, $post, $thread, $explanation, $action_name);
+$email_output = ob_get_clean();
 
-header('Location: forum_thread.php?id='.$thread->id);
+if ($email_success) {
+    header('Location: forum_thread.php?id='.$thread->id);
+} else {
+    page_head(tra("Moderation notice"));
+    echo $email_output;
+    echo "<p>".tra("The post was successfully %1, but the notification email failed to send.", $action_name)."</p>";
+    echo "<a href='forum_thread.php?id=$thread->id'>".tra("Return to thread")."</a>";
+    page_tail();
+}
 
 ?>

--- a/html/user/forum_moderate_post_action.php
+++ b/html/user/forum_moderate_post_action.php
@@ -166,10 +166,11 @@ $email_output = ob_get_clean();
 
 if ($email_success) {
     header('Location: forum_thread.php?id='.$thread->id);
+    exit;
 } else {
     page_head(tra("Moderation notice"));
-    echo htmlspecialchars($email_output, ENT_QUOTES, 'UTF-8');
-    echo "<p>".tra("The post was successfully %1, but the notification email failed to send.", $action_name)."</p>";
+    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    echo "<p>".tra("The post was successfully %1, but the notification email failed to send.", htmlspecialchars($action_name, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'))."</p>";
     echo "<a href='forum_thread.php?id=$thread->id'>".tra("Return to thread")."</a>";
     page_tail();
 }

--- a/html/user/forum_moderate_thread_action.php
+++ b/html/user/forum_moderate_thread_action.php
@@ -117,10 +117,23 @@ if (!$result) {
 }
 
 $reason = post_str('reason', true);
-if (!$reason) $reason = "None given";
-send_thread_moderation_email(
-    $forum, $thread, $reason, $action_name, $explanation
-);
-header('Location: forum_thread.php?id='.$thread->id);
+$email_success = true;
+$email_output = '';
+if ($reason) {
+    ob_start();
+    $email_success = send_thread_moderation_email(
+        $forum, $thread, $reason, $action_name, $explanation
+    );
+    $email_output = ob_get_clean();
+}
+if ($email_success) {
+    header('Location: forum_thread.php?id='.$thread->id);
+} else {
+    page_head(tra("Moderation notice"));
+    echo $email_output;
+    echo "<p>".tra("The thread was successfully %1, but the notification email to the thread owner and/or forum moderators failed to send.", $action_name)."</p>";
+    echo "<a href='forum_thread.php?id=$thread->id'>".tra("Return to thread")."</a>";
+    page_tail();
+}
 
 ?>

--- a/html/user/forum_moderate_thread_action.php
+++ b/html/user/forum_moderate_thread_action.php
@@ -117,15 +117,12 @@ if (!$result) {
 }
 
 $reason = post_str('reason', true);
-$email_success = true;
-$email_output = '';
-if (is_string($reason) && trim($reason) !== '') {
-    ob_start();
-    $email_success = send_thread_moderation_email(
-        $forum, $thread, $reason, $action_name, $explanation
-    );
-    $email_output = ob_get_clean();
-}
+if (!$reason) $reason = "None given";
+ob_start();
+$email_success = send_thread_moderation_email(
+    $forum, $thread, $reason, $action_name, $explanation
+);
+$email_output = ob_get_clean();
 if ($email_success) {
     header('Location: forum_thread.php?id='.$thread->id);
 } else {

--- a/html/user/forum_moderate_thread_action.php
+++ b/html/user/forum_moderate_thread_action.php
@@ -119,7 +119,7 @@ if (!$result) {
 $reason = post_str('reason', true);
 $email_success = true;
 $email_output = '';
-if ($reason) {
+if ($reason !== null && trim($reason) !== '') {
     ob_start();
     $email_success = send_thread_moderation_email(
         $forum, $thread, $reason, $action_name, $explanation
@@ -130,8 +130,8 @@ if ($email_success) {
     header('Location: forum_thread.php?id='.$thread->id);
 } else {
     page_head(tra("Moderation notice"));
-    echo $email_output;
-    echo "<p>".tra("The thread was successfully %1, but the notification email to the thread owner and/or forum moderators failed to send.", $action_name)."</p>";
+    echo htmlspecialchars($email_output, ENT_QUOTES, 'UTF-8');
+    echo "<p>".tra("The thread was successfully %1, but the notification email to the thread owner and/or forum moderators failed to send.", htmlspecialchars($action_name, ENT_QUOTES, 'UTF-8'))."</p>";
     echo "<a href='forum_thread.php?id=$thread->id'>".tra("Return to thread")."</a>";
     page_tail();
 }

--- a/html/user/forum_moderate_thread_action.php
+++ b/html/user/forum_moderate_thread_action.php
@@ -125,10 +125,11 @@ $email_success = send_thread_moderation_email(
 $email_output = ob_get_clean();
 if ($email_success) {
     header('Location: forum_thread.php?id='.$thread->id);
+    exit;
 } else {
     page_head(tra("Moderation notice"));
-    echo htmlspecialchars($email_output, ENT_QUOTES, 'UTF-8');
-    echo "<p>".tra("The thread was successfully %1, but the notification email to the thread owner and/or forum moderators failed to send.", htmlspecialchars($action_name, ENT_QUOTES, 'UTF-8'))."</p>";
+    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    echo "<p>".tra("The thread was successfully %1, but the notification email to the thread owner and/or forum moderators failed to send.", htmlspecialchars($action_name, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'))."</p>";
     echo "<a href='forum_thread.php?id=$thread->id'>".tra("Return to thread")."</a>";
     page_tail();
 }

--- a/html/user/forum_moderate_thread_action.php
+++ b/html/user/forum_moderate_thread_action.php
@@ -119,7 +119,7 @@ if (!$result) {
 $reason = post_str('reason', true);
 $email_success = true;
 $email_output = '';
-if ($reason !== null && trim($reason) !== '') {
+if (is_string($reason) && trim($reason) !== '') {
     ob_start();
     $email_success = send_thread_moderation_email(
         $forum, $thread, $reason, $action_name, $explanation


### PR DESCRIPTION
Closes #7279.

Both files called their respective notification-email function and then immediately `header('Location: ...')`, with nothing printed first:

```php
send_thread_moderation_email($forum, $thread, $reason, $action_name, $explanation);
header('Location: forum_thread.php?id='.$thread->id);
```

Since nothing is output before the redirect, `header()` always succeeds — but if the send failed, `send_email()`'s own `echo $mail->ErrorInfo` still produced output, which ends up as the body of the 302 response. Browsers never render a redirect's body, they just follow `Location:`, so the moderator sees a completely normal-looking redirect with zero indication the notification email failed. Confirmed by capturing the actual POST request and replaying it with `curl -i` (no `-L`): the raw SMTP error text is genuinely present in the 302 response body, just never shown by any browser.

Fix: buffer the send with `ob_start()`/`ob_get_clean()`, then redirect cleanly on success or render a real page with the captured output on failure. The moderation action itself already succeeded before this point either way and is never rolled back. Any dynamic text rendered on the failure page (`$email_output`, `$action_name`) is HTML-escaped.

**Edit:** this PR originally also changed `forum_moderate_thread_action.php` to only send the notification when a reason was given, based on a misreading of the "Reason (Mailed if nonempty)" label as gating the whole send. It doesn't — that label describes `$explanation` (built separately, from the same field) conditionally including the reason *text*; the notification itself should always go out. That change has been reverted (see the commit history and review thread below) — the notification is unconditional again, matching original behavior.

Tested against a live deployment with SMTP deliberately broken: before, a failed send's error was invisible inside the redirect; after, a real "Moderation notice" page shows the failure and the raw error text, CSS intact.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commits' `Assisted-by:` trailers.*