### PR TITLE
forum.inc: floor posts count in move_thread(), use time_str() in check_banished()

### DIFF
--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -826,7 +826,7 @@ function is_banished($user) {
 function check_banished($user) {
     if (is_banished($user)) {
         error_page(
-            tra("You may not post or rate messages until %1", gmdate('M j, Y', $user->prefs->banished_until))
+            tra("You may not post or rate messages until %1", time_str($user->prefs->banished_until))
         );
     }
 }
@@ -1116,7 +1116,7 @@ function unhide_thread($thread, $forum) {
 
 function move_thread($thread, $old_forum, $new_forum) {
     $now = time();
-    $old_forum->update("threads=if(threads>0, threads-1, 0), posts=posts-$thread->replies-1");
+    $old_forum->update("threads=if(threads>0, threads-1, 0), posts=if(posts>=$thread->replies+1, posts-$thread->replies-1, 0)");
     $new_forum->update("threads=threads+1, posts=posts+$thread->replies+1, timestamp=$now");
     return $thread->update("forum=$new_forum->id");
 }


### PR DESCRIPTION
Fixes two independent bugs reported in #7280:

- `move_thread()`: `posts` was decremented with no floor, unlike `threads` right next to it in the same query, so it can go negative. Clamped the same way `threads` already is.
- `check_banished()`: showed only a bare date (`gmdate('M j, Y', ...)`) for a posting suspension, with no time and no timezone label. For any suspension under 48 hours (most of `manage_user.php`'s own duration options), this is close to meaningless. Switched to `time_str()`, the project's own standard helper used elsewhere for exactly this, which includes the time and an explicit UTC label.

Both confirmed live on a running test deployment.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two forum bugs reported in #7280: moving a thread could drive the source forum's `posts` count negative, and ban notices showed only a bare date with no time or timezone.

- Floors the `posts` decrement at 0, matching the existing `threads` handling in the same query.
- Replaces the `gmdate()` call in `check_banished()` with `time_str()`, adding the time and an explicit UTC label so short suspensions under 48 hours are meaningful.

Both fixes were confirmed on a live test deployment.

<sup>Written for commit 6edf2d9653c58c35176d0c03653ad729cdd7d97b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

