### PR TITLE
team.inc, team_delta.php: guard BoincUser::lookup_id() against a deleted user

### DIFF
--- a/html/inc/team.inc
+++ b/html/inc/team.inc
@@ -357,7 +357,7 @@ function new_member_list($teamid) {
     $deltas = BoincTeamDelta::enum("teamid=$teamid and timestamp>$yesterday and joining=1");
     foreach ($deltas as $delta) {
         $u = BoincUser::lookup_id($delta->userid);
-        if ($u->teamid == $teamid) {
+        if ($u && $u->teamid == $teamid) {
             $new_members[] = $u->id;  // they might have later quit
         }
     }

--- a/html/user/team_delta.php
+++ b/html/user/team_delta.php
@@ -31,19 +31,22 @@ function show_delta($delta) {
     $user = BoincUser::lookup_id($delta->userid);
     $when = time_str($delta->timestamp);
     $what = $delta->joining?"joined":"quit";
+    $user_id = $user ? $user->id : $delta->userid;
+    $user_name = $user ? $user->name : "(deleted user)";
     if ($xml) {
         echo "    <action>
-        <id>$user->id</id>
-        <name>$user->name</name>
+        <id>$user_id</id>
+        <name>$user_name</name>
         <action>$what</action>
         <total_credit>$delta->total_credit</total_credit>
         <when>$when</when>
     </action>
 ";
     } else {
+        $user_display = $user ? user_links($user, BADGE_HEIGHT_MEDIUM) : $user_name;
         echo "<tr>
            <td>$when</td>
-           <td>",user_links($user, BADGE_HEIGHT_MEDIUM)," (ID $user->id)</td>
+           <td>$user_display (ID $user_id)</td>
            <td>$what</td>
            <td>$delta->total_credit</td>
            </tr>


### PR DESCRIPTION
Fixes a bug reported in #7280: both `new_member_list()` (`team.inc`) and `show_delta()` (`team_delta.php`) call `BoincUser::lookup_id()` without checking for a null result, crashing with "Attempt to read property on null" if a user who joined/left a team, or appears in its change history, has since been deleted.

- `new_member_list()`: added a null check before dereferencing, same as other unguarded lookups already handle elsewhere in this codebase.
- `show_delta()`: this is an audit/history log, so the entry is kept (falling back to `$delta->userid`/"(deleted user)") rather than silently dropped.

Both confirmed live on a running test deployment.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in team member lists and team change history when a user has been deleted since the event occurred.

`new_member_list()` now skips deleted users instead of crashing, and `show_delta()` keeps the audit entry, falling back to the stored user ID and "(deleted user)" for the name.

<sup>Written for commit ddb54b1b01674b6a6cd5f35f07758a391edf461c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

