### PR TITLE
news.inc: skip threads with no posts in show_news()

### DIFF
--- a/html/inc/news.inc
+++ b/html/inc/news.inc
@@ -107,6 +107,7 @@ function show_news($start, $count) {
 
     foreach ($threads as $thread) {
         $posts = BoincPost::enum("thread=$thread->id order by id limit 1");
+        if (!$posts) continue;
         $post = $posts[0];
         if (strstr($post->content, $thread->title) == $post->content) {
             $title = null;


### PR DESCRIPTION
Fixes a bug reported in #7280: `show_news()` assumed every non-hidden thread in the News forum has at least one post, which isn't guaranteed once a thread's only post can be moved elsewhere or deleted via post-level moderation (`forum_moderate_post_action.php`'s "move"/"delete" actions), leaving the thread itself intact but empty. `BoincPost::enum()` then returns an empty array, and dereferencing `$posts[0]` crashes with "Attempt to read property on null" here and in `news_item()`.

Skips the thread instead of crashing. Confirmed live on a running test deployment (a real side effect of testing post moderation).

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7280: `show_news()` crashed when a News forum thread had no posts, which can happen when post-level moderation moves or deletes the only post, leaving the thread empty. It now skips empty threads instead of trying to read the first post.

<sup>Written for commit 7965f762ba6bfb0f4215c65d97654bb6425acb88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

