### PR TITLE
forum_email.inc: fix undefined $action in send_thread_moderation_email()

### DIFF
--- a/html/inc/forum_email.inc
+++ b/html/inc/forum_email.inc
@@ -116,7 +116,7 @@ $explanation
 
 For assistance with ".PROJECT." go to ".$master_url;
 
-    $subject = "THREAD $action REPORT: $thread->title";
+    $subject = "THREAD $action_name REPORT: $thread->title";
     $success = mail_report_list($forum, $subject, $body);
     $success &= send_email($user, $subject, $body);
     pm_send_msg($user, $user, $subject, $body, false);


### PR DESCRIPTION
Fixes a bug reported in #7280: `send_thread_moderation_email()` referenced `$action`, an undefined variable — the function's actual parameter is `$action_name`. This produces a garbled email subject line and a PHP warning. Harmless in effect (PHP substitutes an empty string), but the subject line should actually say what happened.

Confirmed live on a running test deployment.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an undefined variable in `send_thread_moderation_email()` that caused a PHP warning and a garbled email subject line.

- Replaces `$action` with the function's actual parameter, `$action_name`, so moderation email subjects now correctly state what happened.

<sup>Written for commit a38977307c283b48489a2edf7fbdf3dcc8f1fdb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

