### PR TITLE
forum_banishment_vote_action.php: add page_head()/page_tail(), fix switch fallthrough

### DIFF
--- a/html/user/forum_banishment_vote_action.php
+++ b/html/user/forum_banishment_vote_action.php
@@ -53,16 +53,22 @@ if ($action!="start"){
     error_page("Unknown action");
 }
 
+page_head(tra("Banishment Vote"));
+
 // TODO: create a function for this in forum_banishment_vote.inc to make it more flexible
 switch (post_int("category", true)) {
     case 1:
         $mod_category = tra("Obscene");
+        break;
     case 2:
         $mod_category = tra("Flame/Hate mail");
+        break;
     case 3:
         $mod_category = tra("User Request");
+        break;
     default:
         $mod_category = tra("Other");
+        break;
 }
 
 if (post_str('reason', true)) {
@@ -70,5 +76,7 @@ if (post_str('reason', true)) {
 } else {
     start_vote($logged_in_user, $user, $mod_category, "None given");
 }
+
+page_tail();
 
 ?>


### PR DESCRIPTION
Fixes two independent bugs reported in #7280:

- The script never called `page_head()`/`page_tail()` at all, so its response was permanently a bare, unstyled page with no HTML structure whatsoever — not conditional on failure, just always like this.
- The reason-category `switch` had no `break;` statements, so every case fell through to `"Other"` regardless of what was actually selected. Note this currently has no visible effect: `start_vote()` (`html/inc/forum_banishment_vote.inc`) accepts the category as a parameter but never references it, the `banishment_vote` table has no column to store it in, and the actual notification email only ever includes the reason text, never the category. Fixing it anyway for correctness, so a future change that wires the category into the vote record or notification starts from correct data.

Both confirmed live on a running test deployment.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two bugs from #7280 in the banishment vote action page: it always rendered without HTML structure, and the reason-category switch fell through to "Other" regardless of selection.

- Adds `page_head()`/`page_tail()` so the page now renders with proper structure and styling.
- Adds missing `break` statements to the category switch.
- The category fix has no visible effect yet because the category is never stored or used, but it ensures correct data for future wiring.

<sup>Written for commit 30d24c8e66c98cbcc4922148f1fe30f4997570bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

