### PR TITLE
team_forum.php, team_admins.php: supply missing NOT NULL column values on INSERT

### DIFF
--- a/html/user/team_admins.php
+++ b/html/user/team_admins.php
@@ -110,7 +110,7 @@ function add_admin($team) {
         error_page(tra("%1 is already an admin of %2", $email_addr, $team->name));
     }
     $now = time();
-    $ret = BoincTeamAdmin::insert("(teamid, userid, create_time) values ($team->id, $user->id, $now)");
+    $ret = BoincTeamAdmin::insert("(teamid, userid, create_time, rights) values ($team->id, $user->id, $now, 0)");
     if (!$ret) error_page(tra("Couldn't add admin"));
 }
 

--- a/html/user/team_forum.php
+++ b/html/user/team_forum.php
@@ -49,7 +49,7 @@ function create_forum($user, $team) {
     if ($f) {
         error_page(tra("Team already has a message board"));
     }
-    $id = BoincForum::insert("(category, parent_type) values ($team->id, 1)");
+    $id = BoincForum::insert("(category, orderID, title, description, parent_type) values ($team->id, 0, '', '', 1)");
     $forum = BoincForum::lookup_id($id);
     if (!$forum) {
         error_page("couldn't create message board");


### PR DESCRIPTION
Closes #7294.

- **`team_forum.php`, `create_forum()`** — the INSERT only set `category`/`parent_type`, but `forum.orderID`/`title`/`description` are all `NOT NULL` with no default. Throws an uncaught `mysqli_sql_exception` under `STRICT_TRANS_TABLES` when creating a team's message board. Empty string for `title`/`description` is intentional: `edit_form()`, called right after this INSERT, already falls back to `$team->name`/a generated description for display when either is blank, and the row is only meant to become a real placeholder until the founder submits that form. `orderID=0` matches what a lenient SQL mode would have inserted anyway.
- **`team_admins.php`, `add_admin()`** — same class: the INSERT never set `rights`, and `team_admin.rights` is `NOT NULL` with no default. `rights` isn't read anywhere in this codebase or upstream's own `team_admins.php`/`team.inc`, so `0` has no behavioral effect beyond avoiding the crash.

Both confirmed live on a running test deployment (STOCK crashes on creating a team message board / adding a team admin under strict SQL mode; PATCHED succeeds in both cases).

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes uncaught `mysqli_sql_exception` when creating a team message board or adding a team admin under strict SQL mode, resolving #7294.

The INSERTs in `team_forum.php` and `team_admins.php` now supply values for NOT NULL columns. Empty strings and zeros preserve the previous lenient-mode behavior; display fallbacks already exist for blank title/description.

<sup>Written for commit b4e9d31475e6ef9df7b816cb7fa0e82b84f0ee4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

