### PR TITLE
forum_report_post.php: fix CSS breaking on a failed email send

### DIFF
--- a/html/user/forum_report_post.php
+++ b/html/user/forum_report_post.php
@@ -66,7 +66,7 @@ if (get_str("submit",true)){
     if ($sent){
         $success_page=1;
     } else {
-        $email_output .= "send email failed";
+        $email_output .= " send email failed";
         $success_page=-1;
     }
 }

--- a/html/user/forum_report_post.php
+++ b/html/user/forum_report_post.php
@@ -56,13 +56,17 @@ if ($user->total_credit<$forum->rate_min_total_credit || $user->expavg_credit<$f
 // Action part
 //
 $success_page=0;
+$email_output = '';
 if (get_str("submit",true)){
     check_tokens($user->authenticator);
     $reason = get_str("reason");
-    if (send_report_post_email($user, $forum, $thread, $post, $reason)){
+    ob_start();
+    $sent = send_report_post_email($user, $forum, $thread, $post, $reason);
+    $email_output = ob_get_clean();
+    if ($sent){
         $success_page=1;
     } else {
-        echo "send email failed";
+        $email_output .= "send email failed";
         $success_page=-1;
     }
 }
@@ -73,6 +77,7 @@ $no_forum_rating = project_config_bool("no_forum_rating");
 //
 if ($success_page==1) {
     page_head(tra("Report Registered"));
+    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     echo tra("Your report has been recorded. Thanks for your input.")."<p>"
         .tra("A moderator will now look at your report and decide what will happen - this may take a little while, so please be patient");
 
@@ -107,6 +112,7 @@ if ($success_page==1) {
     echo "</form>";
 } elseif ($success_page==-1) {
     page_head(tra("Report not registered"));
+    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     echo "<p>".tra("Your report could not be recorded. Please wait a while and try again.")."</p>
         <p>".tra("If this is not a temporary error, please report it to the project developers.")."</p>
     ";

--- a/html/user/forum_report_post.php
+++ b/html/user/forum_report_post.php
@@ -56,12 +56,17 @@ if ($user->total_credit<$forum->rate_min_total_credit || $user->expavg_credit<$f
 // Action part
 //
 $success_page=0;
+$email_output = '';
 if (get_str("submit",true)){
     check_tokens($user->authenticator);
     $reason = get_str("reason");
-    if (send_report_post_email($user, $forum, $thread, $post, $reason)){
+    ob_start();
+    $sent = send_report_post_email($user, $forum, $thread, $post, $reason);
+    $email_output = ob_get_clean();
+    if ($sent){
         $success_page=1;
     } else {
+        $email_output .= " send email failed";
         $success_page=-1;
     }
 }
@@ -72,6 +77,7 @@ $no_forum_rating = project_config_bool("no_forum_rating");
 //
 if ($success_page==1) {
     page_head(tra("Report Registered"));
+    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     echo tra("Your report has been recorded. Thanks for your input.")."<p>"
         .tra("A moderator will now look at your report and decide what will happen - this may take a little while, so please be patient");
 
@@ -106,6 +112,7 @@ if ($success_page==1) {
     echo "</form>";
 } elseif ($success_page==-1) {
     page_head(tra("Report not registered"));
+    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     echo "<p>".tra("Your report could not be recorded. Please wait a while and try again.")."</p>
         <p>".tra("If this is not a temporary error, please report it to the project developers.")."</p>
     ";

--- a/html/user/forum_report_post.php
+++ b/html/user/forum_report_post.php
@@ -77,7 +77,7 @@ $no_forum_rating = project_config_bool("no_forum_rating");
 //
 if ($success_page==1) {
     page_head(tra("Report Registered"));
-    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    echo nl2br(htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
     echo tra("Your report has been recorded. Thanks for your input.")."<p>"
         .tra("A moderator will now look at your report and decide what will happen - this may take a little while, so please be patient");
 
@@ -112,7 +112,7 @@ if ($success_page==1) {
     echo "</form>";
 } elseif ($success_page==-1) {
     page_head(tra("Report not registered"));
-    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    echo nl2br(htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
     echo "<p>".tra("Your report could not be recorded. Please wait a while and try again.")."</p>
         <p>".tra("If this is not a temporary error, please report it to the project developers.")."</p>
     ";

--- a/html/user/forum_report_post.php
+++ b/html/user/forum_report_post.php
@@ -56,17 +56,12 @@ if ($user->total_credit<$forum->rate_min_total_credit || $user->expavg_credit<$f
 // Action part
 //
 $success_page=0;
-$email_output = '';
 if (get_str("submit",true)){
     check_tokens($user->authenticator);
     $reason = get_str("reason");
-    ob_start();
-    $sent = send_report_post_email($user, $forum, $thread, $post, $reason);
-    $email_output = ob_get_clean();
-    if ($sent){
+    if (send_report_post_email($user, $forum, $thread, $post, $reason)){
         $success_page=1;
     } else {
-        $email_output .= " send email failed";
         $success_page=-1;
     }
 }
@@ -77,7 +72,6 @@ $no_forum_rating = project_config_bool("no_forum_rating");
 //
 if ($success_page==1) {
     page_head(tra("Report Registered"));
-    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     echo tra("Your report has been recorded. Thanks for your input.")."<p>"
         .tra("A moderator will now look at your report and decide what will happen - this may take a little while, so please be patient");
 
@@ -112,7 +106,6 @@ if ($success_page==1) {
     echo "</form>";
 } elseif ($success_page==-1) {
     page_head(tra("Report not registered"));
-    echo htmlspecialchars($email_output, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     echo "<p>".tra("Your report could not be recorded. Please wait a while and try again.")."</p>
         <p>".tra("If this is not a temporary error, please report it to the project developers.")."</p>
     ";


### PR DESCRIPTION
Closes #3392.

`send_report_post_email()`'s failure output (`echo "send email failed"`, plus whatever `send_email()` itself echoes on an SMTP failure) ran before any of the three `page_head()` calls this file can take depending on the outcome — the raw text landed before any `<head>`/stylesheet output, breaking the page's CSS. The return-value handling itself was already correct here; this is purely the output-ordering fix.

Since the page's title depends on the outcome (three different `page_head()` calls), a simple reorder isn't enough — buffers the output and replays it inside whichever branch actually renders, escaped with `htmlspecialchars(..., ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')` (same treatment as the rest of the moderation-notice email-visibility series, #7287).

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes #3392. Fixes the forum report page styling when the report email fails to send. Output from `send_report_post_email()`, including the failure message, is now buffered and replayed escaped with line breaks preserved after `page_head()`, so the head markup stays first on every path.

<sup>Written for commit 4b79196d76537d6708ee320cab85494375c79c2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

