### PR TITLE
lib: Guard get_mem_info() definition for Linux

### DIFF
--- a/lib/procinfo_unix.cpp
+++ b/lib/procinfo_unix.cpp
@@ -117,6 +117,7 @@ int PROC_STAT::parse_stat(char* buf) {
     return 0;
 }
 
+#ifdef __linux__
 // parse /proc/pid/status fields like
 // VmRSS:    279424 kB
 //
@@ -142,6 +143,7 @@ void PROCINFO::get_mem_info() {
     swap_usage = get_field(buf, "VmSwap:")*1024.;
     fclose(f);
 }
+#endif
 
 // build a map pid=>descriptor of all processes in system.
 // set descriptor.is_boinc_app if the proc is the calling proc


### PR DESCRIPTION
Wrap the `get_mem_info()` definition in procinfo_unix.cpp with an `ifdef __linux__` preprocessor guard to match its declaration in `procinfo.h`.

Assisted-by: ChatGPT: GPT-5.6 Luna

Fixes an unreported non-Linux build error in procinfo_unix.cpp.

**Description of the Change**
The `PROCINFO::get_mem_info()` declaration in `procinfo.h` is guarded by `#ifdef __linux__`, but the corresponding definition in `procinfo_unix.cpp` is not. On FreeBSD, this causes the compiler to encounter an out-of-line definition for a member function that is not declared in `PROCINFO`:

`error: out-of-line definition of 'get_mem_info' does not match any declaration in 'PROCINFO'`

Guard the definition with the same `#ifdef __linux__` condition used by the declaration. This keeps the existing Linux behavior unchanged while allowing the source to compile on FreeBSD.

The Linux-only declaration was added in commit 2743c05.

**Alternate Designs**
One alternative is to remove the `#ifdef __linux__` from the declaration in `procinfo.h` and provide implementations for other Unix platforms. That would unnecessarily broaden the scope of this change, since `get_mem_info()` currently reads Linux `/proc/<pid>/status` data and the reported problem is that the function is being defined on platforms where it is not declared.

Another alternative is to change the FreeBSD implementation to provide an equivalent `get_mem_info()` function. That is also outside the scope of this change.

The proposed change keeps the existing platform-specific design and makes the definition match its existing declaration.

**Release Notes**
N/A

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wraps the `get_mem_info()` and `get_field()` definitions in `procinfo_unix.cpp` with an `#ifdef __linux__` guard to match their declarations in `procinfo.h`. This fixes a FreeBSD build error where the out-of-line definitions didn't match any declaration; Linux behavior is unchanged.

<sup>Written for commit d988b1892bf8e775fce455303159c43585456172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7300?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

