### PR TITLE
team_import.php: don't let one team's failure kill the whole run

### DIFF
--- a/html/ops/team_import.php
+++ b/html/ops/team_import.php
@@ -101,8 +101,7 @@ function update_team($t, $team) {
     }
     $retval = $team->update($query);
     if (!$retval) {
-        echo "   update failed: $query\n";
-        exit;
+        throw new Exception("update failed: $query");
     }
 }
 
@@ -141,10 +140,7 @@ function insert_case($t, $user) {
         $t->description, $t->country
     );
     if (!$team) {
-        echo "   Can't make team $t->id\n";
-        echo BoincDb::error();
-        echo "\n";
-        exit;
+        throw new Exception("Can't make team $t->id: ".BoincDb::error());
     }
     $team->update("seti_id=$t->id");
     if ($user) {

--- a/html/ops/team_import.php
+++ b/html/ops/team_import.php
@@ -256,14 +256,20 @@ function main() {
         echo "Can't get teams file\n";
         exit;
     }
+    $failures = 0;
     foreach($x->team as $team) {
         try {
             handle_team($team);
         } catch (Throwable $e) {
             echo "   ERROR processing this team, skipping: ".$e->getMessage()."\n";
+            $failures++;
         }
     }
     echo "------------ Finished at ".time_str(time())."-------\n";
+    if ($failures) {
+        echo "$failures team(s) failed to import; see ERROR lines above.\n";
+        exit(1);
+    }
 }
 
 db_init();

--- a/html/ops/team_import.php
+++ b/html/ops/team_import.php
@@ -257,7 +257,11 @@ function main() {
         exit;
     }
     foreach($x->team as $team) {
-        handle_team($team);
+        try {
+            handle_team($team);
+        } catch (Throwable $e) {
+            echo "   ERROR processing this team, skipping: ".$e->getMessage()."\n";
+        }
     }
     echo "------------ Finished at ".time_str(time())."-------\n";
 }


### PR DESCRIPTION
Addresses #4779's team_import.php crash.

`handle_team()`'s per-team loop had no try/catch around it at all, so any uncaught exception during processing — a duplicate-key collision, an encoding issue like the one in #4779, or anything else a single team's data can trigger — kills the entire run mid-list. Every team after the failing one silently never gets processed, and since most collisions/data issues recur identically on every subsequent run, the import can get stuck at the exact same point forever.

Confirmed independently via a different trigger: two real official teams whose placeholder founder both had the display name "Coordinador" hit `user.name`'s unique constraint, throwing the same uncaught `mysqli_sql_exception` shown in #4779's own stack trace.

Fix wraps each team's `handle_team()` call in try/catch so one team's failure becomes an isolated, logged skip instead of a total outage — every other team still gets processed. Tested against a deliberately crafted collision fixture: the unpatched script reproduces the exact crash-and-stop behavior; the patched version logs the failure and continues to the next team.

Note this only covers the try/catch — `delete_spammers.php`'s separate `strftime()` deprecation reported in the same issue is untouched, happy to look at that too if useful.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `team_import.php` so one team's import failure no longer kills the whole run — each team is processed in a try/catch, failures are logged and skipped, and the script exits non-zero if any team failed.

- Converts the hard `exit()` calls in `update_team()` and `insert_case()` into thrown exceptions so the per-team try/catch catches them instead of terminating the script.
- Covers the duplicate-`user.name` crash from #4779.
- `delete_spammers.php`'s `strftime()` deprecation is not addressed here.

<sup>Written for commit 544398ac161809df5eddeb9f50b36d3a38c12a59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

