### PR TITLE
manage_user.php: initialize $admin before use in handle_suspend()

### DIFF
--- a/html/ops/manage_user.php
+++ b/html/ops/manage_user.php
@@ -26,6 +26,7 @@
 
 require_once("../inc/util.inc");
 require_once("../inc/user.inc");
+require_once("../inc/user_util.inc");
 require_once("../inc/team.inc");
 require_once("../inc/forum.inc");
 require_once("../inc/util_ops.inc");
@@ -123,7 +124,9 @@ have been restored by ".$g_logged_in_user->name."\n";
 
             $emails = explode(",", POST_REPORT_EMAILS);
             foreach ($emails as $email) {
+                $admin = new stdClass();
                 $admin->email_addr = $email;
+                $admin->name = '';
                 send_email($admin, $subject, $body);
             }
         }


### PR DESCRIPTION
Addresses one of two bugs reported in #7296.

`handle_suspend()` assigns `$admin->email_addr` without ever initializing `$admin`. PHP <8 silently auto-vivified that into a `stdClass`; PHP 8 throws "Attempt to assign property \"email_addr\" on null" instead — fatally, on every single suspend/unsuspend action, after the `forum_preferences` UPDATE has already committed but before either notification email goes out.

Also sets `$admin->name` (not left null), so `send_email()`'s `PHPMailer::addAddress()` call doesn't hand a null into a string parameter further down.

Confirmed present on current `master`, reproduced live against a running test deployment.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a fatal error on PHP 8 when suspending or unsuspending a user. `handle_suspend()` was assigning properties to an uninitialized `$admin` variable, which PHP 8 rejects. Now initializes `$admin` as a `stdClass` and sets `name` to an empty string so email sending works correctly. This addresses one of two bugs reported in #7296.

<sup>Written for commit 45fd8795b9725f48218c436490361cd67612ee32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

