### PR TITLE
profile.inc: cast scale_image() dimensions to int

### DIFF
--- a/html/inc/profile.inc
+++ b/html/inc/profile.inc
@@ -127,8 +127,8 @@ function scale_image(
     ($origWidth > $origHeight)? $scalar = ($origWidth / $targetWidth) : $scalar = ($origHeight / $targetHeight);
 
     if ($scalar != 0) {
-        $destWidth = $origWidth / $scalar;
-        $destHeight = $origHeight / $scalar;
+        $destWidth = (int)($origWidth / $scalar);
+        $destHeight = (int)($origHeight / $scalar);
     } else {
         $destWidth = $origWidth;
         $destHeight = $origHeight;


### PR DESCRIPTION
Addresses one of the bugs reported in #7296.

`scale_image()`'s `$destWidth`/`$destHeight` are computed via float division but passed straight into `ImageCreateTrueColor()`/`ImageCopyResampled()`/`ImageCreate()`/`ImageCopyResized()`, all of which take `int` width/height parameters. Under PHP 8.1+ this throws a real 'Implicit conversion from float to int loses precision' deprecation notice — shown directly to whoever's uploading a profile picture on a project with `display_errors` on.

Fix: cast both to `(int)` right after they're computed, before any GD call uses them.

Confirmed present on current `master`, reproduced live uploading a real profile picture.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `scale_image()` passing float dimensions to GD functions, which triggers PHP 8.1+ implicit float-to-int deprecation notices when uploading profile pictures on setups with `display_errors` on. Casts `$destWidth` and `$destHeight` to int right after they're computed. Addresses issue #7296.

<sup>Written for commit 1038ae945847831d0ea5d23ee4a1f26aed323ca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

