### PR TITLE
login_form.php: avoid calling strlen() on a possibly-null value

### DIFF
--- a/html/ops/login_form.php
+++ b/html/ops/login_form.php
@@ -8,7 +8,7 @@ admin_page_head("Log in");
 
 $next_url = sanitize_local_url(get_str('next_url', true));
 
-if (strlen($next_url) == 0) $next_url = "index.php";
+if (!$next_url) $next_url = "index.php";
 
 print_login_form_ops($next_url);
 admin_page_tail();

--- a/html/ops/login_form.php
+++ b/html/ops/login_form.php
@@ -8,7 +8,7 @@ admin_page_head("Log in");
 
 $next_url = sanitize_local_url(get_str('next_url', true));
 
-if (!$next_url) $next_url = "index.php";
+if ($next_url === null || $next_url === '') $next_url = "index.php";
 
 print_login_form_ops($next_url);
 admin_page_tail();


### PR DESCRIPTION
Addresses one of the bugs reported in #7296.

`get_str('next_url', true)` returns `null` when the GET param is absent (the common case for most links into the ops area), and `sanitize_local_url()` passes that straight through — `strlen(null)` is deprecated as of PHP 8.1.

Fix: use a truthy check instead of `strlen(...) == 0`, avoiding the call to `strlen()` on a possibly-null value entirely.

Confirmed present on current `master`.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ops login form's `next_url` handling so it no longer calls `strlen()` on a possibly-null value. `get_str('next_url', true)` returns `null` when the GET param is absent, and `strlen(null)` is deprecated as of PHP 8.1; the new check compares against `null` and `''` directly, preserving the original behavior. Addresses one of the bugs reported in #7296.

<sup>Written for commit 0aaccb7c9b14c7a04e5fd4e408d2f1d698eb96a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

