### PR TITLE
create_forums.php: catch the duplicate-key exception so the fallback runs

### DIFF
--- a/html/ops/create_forums.php
+++ b/html/ops/create_forums.php
@@ -35,6 +35,7 @@ function create_category($orderID, $name, $is_helpdesk) {
     try {
         $result = $db->insert("category", $q);
     } catch (\mysqli_sql_exception $e) {
+        if ($e->getCode() != 1062) throw $e;
         $insert_error = $e->getMessage();
     }
     if (!$result) {
@@ -55,6 +56,7 @@ function create_forum($category, $orderID, $title, $description, $is_dev_blog=0)
     try {
         $result = $db->insert("forum", $q);
     } catch (\mysqli_sql_exception $e) {
+        if ($e->getCode() != 1062) throw $e;
         $insert_error = $e->getMessage();
     }
     if (!$result) {

--- a/html/ops/create_forums.php
+++ b/html/ops/create_forums.php
@@ -30,12 +30,18 @@ require_once("../inc/util_ops.inc");
 function create_category($orderID, $name, $is_helpdesk) {
     $q = "(orderID, lang, name, is_helpdesk) values ($orderID, 1, '$name', $is_helpdesk)";
     $db = BoincDB::get();
-    $result = $db->insert("category", $q);
+    $result = false;
+    $insert_error = "";
+    try {
+        $result = $db->insert("category", $q);
+    } catch (\mysqli_sql_exception $e) {
+        $insert_error = $e->getMessage();
+    }
     if (!$result) {
         $cat = BoincCategory::lookup("name='$name' and is_helpdesk=$is_helpdesk");
         if ($cat) return $cat->id;
         echo "can't create category\n";
-        echo $db->base_error();
+        echo $insert_error ?: $db->base_error();
         exit();
     }
     return $db->insert_id();
@@ -44,12 +50,18 @@ function create_category($orderID, $name, $is_helpdesk) {
 function create_forum($category, $orderID, $title, $description, $is_dev_blog=0) {
     $q = "(category, orderID, title, description, is_dev_blog) values ($category, $orderID, '$title', '$description', $is_dev_blog)";
     $db = BoincDB::get();
-    $result = $db->insert("forum",$q);
+    $result = false;
+    $insert_error = "";
+    try {
+        $result = $db->insert("forum", $q);
+    } catch (\mysqli_sql_exception $e) {
+        $insert_error = $e->getMessage();
+    }
     if (!$result) {
         $forum = BoincForum::lookup("category=$category and title='$title'");
         if ($forum) return $forum->id;
         echo "can't create forum\n";
-        echo $db->base_error();
+        echo $insert_error ?: $db->base_error();
         exit();
     }
     return $db->insert_id();


### PR DESCRIPTION
Addresses one of the bugs reported in #7296.

`create_category()`/`create_forum()` both have a "look up the existing row on insert failure" fallback meant to make this script safely re-runnable, but it's dead code: modern PHP/mysqli throws `mysqli_sql_exception` on a failed query by default instead of returning `false`, so a duplicate-key insert (what a second run produces, since both tables have unique keys) crashes with an uncaught exception before ever reaching the fallback.

Fix: catch the exception around each insert so the existing lookup-and-reuse path is actually reachable again — same pattern already used for the same underlying bug class in #7295 (`team_forum.php`/`team_admins.php`).

Confirmed present on current `master`.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `create_forums.php` so re-running the script no longer crashes on duplicate-key inserts and the existing lookup-and-reuse fallback actually executes.

Previously, modern PHP/mysqli throws `mysqli_sql_exception` on a failed insert instead of returning `false`, so the duplicate-key fallback in `create_category()` and `create_forum()` was unreachable. The insert is now wrapped in a try/catch, and only duplicate-key (error 1062) exceptions fall through to the lookup path; other exceptions are re-thrown. This addresses the bug reported in #7296 and matches the pattern already used in #7295.

<sup>Written for commit 58dca65d3021cda57b14afa6abe13a67c33fc9ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

