### PR TITLE
util.inc: prefix dark-mode/SHORTCUT_ICON hrefs with $url_base

### DIFF
--- a/html/inc/util.inc
+++ b/html/inc/util.inc
@@ -335,14 +335,14 @@ function page_head(
     document.documentElement.style.display = 'none';
     document.head.insertAdjacentHTML(
         'beforeend',
-        '<link rel="stylesheet" href="sample_bootstrap.min.css" onload="document.documentElement.style.display = \'\'"><link rel="stylesheet" href="custom.css">'
+        '<link rel="stylesheet" href="{$url_base}sample_bootstrap.min.css" onload="document.documentElement.style.display = \'\'"><link rel="stylesheet" href="{$url_base}custom.css">'
     );
   }
 </script>
-<link rel="stylesheet" href="bootstrap_darkly.min.css" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="custom_dark.css" media="(prefers-color-scheme: dark)">
-<link rel="stylesheet" href="sample_bootstrap.min.css" media="(prefers-color-scheme: no-preference), (prefers-color-scheme: light)">
-<link rel="stylesheet" href="custom.css" media="(prefers-color-scheme: no-preference), (prefers-color-scheme: light)">
+<link rel="stylesheet" href="{$url_base}bootstrap_darkly.min.css" media="(prefers-color-scheme: dark)">
+<link rel="stylesheet" href="{$url_base}custom_dark.css" media="(prefers-color-scheme: dark)">
+<link rel="stylesheet" href="{$url_base}sample_bootstrap.min.css" media="(prefers-color-scheme: no-preference), (prefers-color-scheme: light)">
+<link rel="stylesheet" href="{$url_base}custom.css" media="(prefers-color-scheme: no-preference), (prefers-color-scheme: light)">
 EOT;
     } else {
         echo '
@@ -363,7 +363,7 @@ EOT;
     }
 
     if (defined("SHORTCUT_ICON")) {
-        echo '<link rel="icon" type="image/x-icon" href="'.SHORTCUT_ICON.'"/>
+        echo '<link rel="icon" href="'.$url_base.SHORTCUT_ICON.'"/>
 ';
     }
 


### PR DESCRIPTION
Addresses one of the bugs reported in #7296.

`page_head()`'s `DARK_MODE` branch hardcodes 5 stylesheet hrefs (`sample_bootstrap.min.css`, `bootstrap_darkly.min.css`, `custom_dark.css`, `custom.css` ×2) as bare relative paths — fine for pages generated at the site's top level, but broken for anything generated one level down, like `update_profile_pages.php`'s static gallery/alphabetical/country pages under `user_profile/`. Every other CSS/JS reference in this same function (`STYLESHEET`/`STYLESHEET2`, the non-dark-mode fallback) already avoids this by prefixing with `$url_base`.

Separately, the `SHORTCUT_ICON` tag has two bugs: it hardcodes `type="image/x-icon"` regardless of the actual file type (wrong for any project not shipping a literal `.ico`), and echoes the path unprefixed by `$url_base` (again unlike `STYLESHEET`/`STYLESHEET2` right above it) — 404s outside the top-level directory.

Fix: prefix all 6 hrefs with `$url_base` (already computed earlier in the function), and drop the hardcoded `type` attribute rather than replace it with a different hardcoded value — browsers correctly sniff a favicon's real type without it, and hardcoding any specific type would just be correct for some projects' icon format and wrong for others.

Confirmed present on current `master`.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `page_head()` so dark-mode stylesheets and the shortcut icon load correctly on pages below the site root, like `user_profile/`. Previously, six hrefs were bare relative paths that 404'd on those pages.

**Bug Fixes**
- Prefixes all dark-mode and `SHORTCUT_ICON` hrefs with `$url_base`.
- Drops the hardcoded `type="image/x-icon"` on the shortcut icon so browsers sniff the real type.

<sup>Written for commit c3b4bbe16371f8cf380e78ecb63e574971312a76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

