### PR TITLE
guard unserialize(get_cached_data()) against a cold cache in 4 files

### DIFF
--- a/html/user/download_network.php
+++ b/html/user/download_network.php
@@ -39,7 +39,8 @@ If this is not enough you should contact the author.").
     </ul>
 ";
 
-$httpFile = unserialize(get_cached_data(3600));
+$cached = get_cached_data(3600);
+$httpFile = $cached ? unserialize($cached) : false;
 if (!$httpFile) {
     $httpFile = @file_get_contents("https://boinc.berkeley.edu/addons.php?strip_header=true");
     if ($httpFile) {

--- a/html/user/get_project_config.php
+++ b/html/user/get_project_config.php
@@ -30,7 +30,8 @@ xml_header();
 // and update it every hour if possible.
 //
 function show_platforms() {
-    $xmlFragment = unserialize(get_cached_data(3600, "project_config_platform_xml"));
+    $cached = get_cached_data(3600, "project_config_platform_xml");
+    $xmlFragment = $cached ? unserialize($cached) : false;
     if ($xmlFragment==false){
         $platforms = BoincDB::get()->enum_fields("platform, DBNAME.app_version, DBNAME.app", "BoincPlatform", "platform.name, platform.user_friendly_name, plan_class", "app_version.platformid = platform.id and app_version.appid = app.id and app_version.deprecated=0 and app.deprecated=0 group by platform.name, plan_class", "");
         $xmlFragment = "    <platforms>";

--- a/html/user/server_status.php
+++ b/html/user/server_status.php
@@ -417,7 +417,8 @@ function get_buda_status() {
 }
 
 function get_job_status() {
-    $s = unserialize(get_cached_data(STATUS_PAGE_TTL, "job_status"));
+    $cached = get_cached_data(STATUS_PAGE_TTL, "job_status");
+    $s = $cached ? unserialize($cached) : false;
     if ($s) {
         return $s;
     }

--- a/html/user/team_members.php
+++ b/html/user/team_members.php
@@ -45,7 +45,8 @@ if ($offset > 1000) {
 $teamid = get_int("teamid");
 
 $cache_args = "teamid=$teamid";
-$team = unserialize(get_cached_data(TEAM_PAGE_TTL, $cache_args));
+$cached = get_cached_data(TEAM_PAGE_TTL, $cache_args);
+$team = $cached ? unserialize($cached) : false;
 if (!$team) {
     $team = BoincTeam::lookup_id($teamid);
     if (!$team) error_page("no such team");


### PR DESCRIPTION
Addresses one of the bugs reported in #7296.

`get_cached_data()` returns `null` on a cold/expired cache, and 4 files pass that straight into `unserialize()` unguarded — a PHP 8.1 deprecation notice ('Passing null to parameter #1 ($data) of type string is deprecated').

Affected: `html/user/server_status.php`, `html/user/download_network.php`, `html/user/get_project_config.php`, `html/user/team_members.php`. `get_project_config.php` is the more consequential of the four — it's the scheduler's own `get_project_config` RPC response, so an unguarded notice there injects straight into the raw XML every BOINC client parses on attach, not just onto a web page.

Same fix in all four: check `get_cached_data()`'s result before passing it to `unserialize()`, rather than passing a possibly-null value straight through.

Confirmed present on current `master`.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Addresses a bug from #7296: `get_cached_data()` returns `null` on a cold or expired cache, and 4 pages pass that straight into `unserialize()`, triggering a PHP 8.1 deprecation. The `html/user/get_project_config.php` case is the most consequential — that page serves the scheduler's `get_project_config` RPC response, so an unguarded notice lands in the raw XML that every BOINC client parses on attach.

- Applies the same guard in `html/user/server_status.php`, `html/user/download_network.php`, `html/user/get_project_config.php`, and `html/user/team_members.php`.
- Caches the `get_cached_data()` result and only calls `unserialize()` when it's truthy; a falsy result keeps the existing fallback behavior unchanged.

<sup>Written for commit f2908b82e3066baee458385ddd1444b3e8afc334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

