### PR TITLE
prefs.inc, prefs_project.inc: guard xml_parse() against null prefs

### DIFF
--- a/html/inc/prefs.inc
+++ b/html/inc/prefs.inc
@@ -442,7 +442,7 @@ function prefs_parse_global($prefs_xml) {
     xml_parser_set_option($xml_parser, XML_OPTION_CASE_FOLDING, 0);
     xml_set_element_handler($xml_parser, "element_start_global", "element_end_global");
     xml_set_character_data_handler($xml_parser, "char_handler");
-    xml_parse($xml_parser, $prefs_xml, 1);
+    xml_parse($xml_parser, $prefs_xml ?? "", 1);
     set_niu_prefs($parse_result);
     return $parse_result;
 }

--- a/html/inc/prefs_project.inc
+++ b/html/inc/prefs_project.inc
@@ -251,7 +251,7 @@ function prefs_parse_project($prefs_xml) {
     xml_parser_set_option($xml_parser, XML_OPTION_CASE_FOLDING, 0);
     xml_set_element_handler($xml_parser, "element_start_project", "element_end_project");
     xml_set_character_data_handler($xml_parser, "char_handler");
-    xml_parse($xml_parser, $prefs_xml, 1);
+    xml_parse($xml_parser, $prefs_xml ?? "", 1);
     return $parse_result;
 }
 


### PR DESCRIPTION
Addresses one of the bugs reported in #7296.

`$user->global_prefs`/`$user->project_prefs` are nullable DB columns (null for anyone who's never saved custom preferences), and both `prefs_parse_global()` and `prefs_parse_project()` passed that straight into `xml_parse()` unguarded — a PHP 8.1 deprecation notice.

Fixed at the source in both parsing functions themselves (not at each of the 4 call sites across `prefs.php`/`add_venue.php`/`prefs_edit.php`/`prefs_remove.php`), since every caller goes through these two functions — default to `""` so `xml_parse()` just parses nothing and the result stays at its defaults, identical behavior to before, just without the deprecation notice.

Confirmed present on current `master`.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PHP 8.1 deprecation notice when parsing preferences for users who have never saved custom preferences. Both parsing functions now pass an empty string to `xml_parse()` instead of null, keeping behavior identical.

**Bug Fixes**
- The fix is at the source in both functions, so all call sites are covered.
- Resolves one of the bugs in #7296.

<sup>Written for commit f3404a694d001f1c0538d02ca8fd7bd5804b4d43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

