### PR TITLE
project.sample/project_specific_prefs.inc: fix false-positive parse check

### DIFF
--- a/html/project.sample/project_specific_prefs.inc
+++ b/html/project.sample/project_specific_prefs.inc
@@ -268,7 +268,7 @@ function project_specific_prefs_show($prefs, $columns=false) {
 function project_specific_prefs_parse($prefs_xml) {
     $prefs_xml = "<foo>$prefs_xml</foo>";
     $p = simplexml_load_string($prefs_xml);
-    if (!$p) {
+    if ($p === false) {
         error_page("Can't parse prefs:\n$prefs_xml\n");
     }
     $prefs = new StdClass;


### PR DESCRIPTION
Addresses one of the two bugs reported in #7298.

`project_specific_prefs_parse()` checks `if (!$p)` after `simplexml_load_string()` to detect a parse failure. A `SimpleXMLElement` with no child elements is falsy in PHP even when parsing succeeded — `simplexml_load_string()` only returns `false` on an actual parse failure. Since `COLOR_PREFS`/`GFX_CPU_PREFS` are both `false` in this same sample file, every user's project-specific prefs XML is legitimately just `<foo></foo>` — empty by design, not malformed. Any project starting from this sample unmodified hits "Can't parse prefs:" for every single visitor to their project-prefs page.

Fix: check `=== false` instead of the falsy `!$p`, the correct way to detect an actual `simplexml_load_string()` failure without also catching a validly-empty result.

Confirmed present on current `master`, reproduced against a real deployment before writing this up.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false-positive parse error in project-specific preferences by changing the failure check from a falsy `!$p` to a strict `=== false`, so valid empty XML no longer triggers "Can't parse prefs". This addresses one of the two bugs in #7298.

<sup>Written for commit 30cdb9c32384234d9749c50eaffa85b9e8bd4a3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

