### PR TITLE
project.sample/project.inc: derive admin email addresses from a bare domain

### DIFF
--- a/html/project.sample/project.inc
+++ b/html/project.sample/project.inc
@@ -19,6 +19,7 @@ define("COPYRIGHT_HOLDER", "REPLACE WITH COPYRIGHT HOLDER");
 
 $master_url = project_config_val("master_url");
 define("URL_BASE", $master_url);
+$master_domain = parse_url($master_url, PHP_URL_HOST) ?: $master_url;
 define("IMAGE_PATH", "../user_profile/images/");
 define("IMAGE_URL", "user_profile/images/");
 define("PROFILE_PATH", "../user_profile/");
@@ -26,11 +27,13 @@ define("PROFILE_URL", "user_profile/");
 define("LANGUAGE_FILE", "languages.txt");
 
 //-------------- contact info
+// These are just guesses at real mailboxes on your domain -- REPLACE WITH
+// addresses that actually exist and are checked.
 
-define("SYS_ADMIN_EMAIL", "admin@$master_url");
-define("UOTD_ADMIN_EMAIL", "admin@$master_url");
+define("SYS_ADMIN_EMAIL", "admin@$master_domain");
+define("UOTD_ADMIN_EMAIL", "admin@$master_domain");
     // who gets emails about user of the day pool running low?
-define("POST_REPORT_EMAILS", "moderator1@$master_url|moderator2@$master_url");
+define("POST_REPORT_EMAILS", "moderator1@$master_domain|moderator2@$master_domain");
     // Email addresses separated by pipe ( | ) that will receive user reports
     // of offensive forum posts.
 


### PR DESCRIPTION
Addresses one of the two bugs reported in #7298.

`SYS_ADMIN_EMAIL`, `UOTD_ADMIN_EMAIL`, and `POST_REPORT_EMAILS` are built as `"admin@$master_url"`. `master_url` is a full URL (e.g. `https://example.org/myproject/`), not a bare domain, so these produce something like `admin@https://example.org/myproject/` — never a valid, deliverable address. Any project that doesn't know to override these three constants silently loses forum-abuse reports and other admin-notification emails.

Fix: derive a bare domain via `parse_url($master_url, PHP_URL_HOST)` (falling back to `$master_url` itself if that ever returns nothing, e.g. a malformed URL) before building these addresses, and added a comment noting these are still just guessed mailboxes that need to be replaced with real, checked ones — the fix makes the *format* valid, not the addresses themselves meaningful.

Confirmed present on current `master`.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes admin notification email addresses in `project.sample/project.inc` so they're built from a bare domain instead of a full URL, addressing one of the two bugs in #7298.

**Bug Fixes**
- Builds `SYS_ADMIN_EMAIL`, `UOTD_ADMIN_EMAIL`, and `POST_REPORT_EMAILS` from the hostname extracted via `parse_url` instead of the full `master_url`, which previously produced invalid addresses like `admin@https://example.org/myproject/`.
- Falls back to the raw URL if `parse_url` returns nothing.
- Adds a comment noting these mailboxes are still guesses and must be replaced with real, checked addresses.

<sup>Written for commit cf68d0c0dac019330f38f94d85a5f6e2602ba9c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

