### PR TITLE
forum_email.inc: fix undefined $thread in send_forum_notification_email()

### DIFF
--- a/html/inc/forum_email.inc
+++ b/html/inc/forum_email.inc
@@ -148,7 +148,7 @@ function send_forum_notification_email($forum, $user){
     $title = PROJECT . ": there is a new thread in '". $forum->title ."'";
     $link = secure_url_base() . "forum_forum.php?id=" . $forum->id;
     $body = "A " . PROJECT . " user has added a thread to the forum
-\"" . $thread->title . "\".\n"
+\"" . $forum->title . "\".\n"
            ."To view the updated forum, visit:\n$link
 
 --------------------------


### PR DESCRIPTION
Closes #7311.

`send_forum_notification_email($forum, $user)` referenced `$thread->title`, but `$thread` isn't in scope in this function at all — only `$forum`/`$user` are parameters (the `$title` line two lines above correctly uses `$forum->title`). Under PHP 8+, `$thread->title` on an undefined (and therefore null) variable is a fatal error, not just a deprecation notice — this function crashed every time it was actually called.

Genuinely reachable through ordinary user action, not dead code: `forum.inc`'s own `create_thread()` (called on every new thread, e.g. `forum_post.php`) calls `notify_forum_subscribers()` → `notify_forum_subscriber()` → this function, for every subscriber with `pm_notification=1`.

Fix: `$thread->title` → `$forum->title`. Live-tested end to end against a running deployment: subscribed to a forum, had another account post a new thread there, confirmed the notification email now sends successfully instead of crashing.

---

*Assisted by AI (Claude Sonnet 5) per the BOINC AI Assistants Usage Policy — see the commit's `Assisted-by:` trailer.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the forum notification email crashing on PHP 8+ when a new thread is posted. The old code referenced `$thread->title` even though `$thread` isn't in scope; it now uses `$forum->title`.  

Closes #7311.

<sup>Written for commit 1db136ad2147c70028bcad17598f35f80e903229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

