### PR TITLE
[lib] fix build warnings on linux

### DIFF
--- a/lib/opencl_boinc.cpp
+++ b/lib/opencl_boinc.cpp
@@ -303,7 +303,11 @@ void OPENCL_CPU_PROP::clear() {
     opencl_prop.clear();
 }
 
-void OPENCL_CPU_PROP::write_xml(MIOFILE& f) {
+void OPENCL_CPU_PROP::write_xml(MIOFILE&
+#ifndef _USING_FCGI_
+    f
+#endif
+) {
 #ifndef _USING_FCGI_
     f.printf(
         "<opencl_cpu_prop>\n"

--- a/lib/util.cpp
+++ b/lib/util.cpp
@@ -288,7 +288,11 @@ int run_program(
 // Unix: if you want stderr too, add 2>&1 to command
 // Return error if command failed
 //
-int run_command(const char *cmd, vector<string> &out) {
+int run_command(const char*
+#if defined(_WIN32) || !defined (_USING_FCGI_)
+cmd
+#endif
+, vector<string> &out) {
     out.clear();
 #ifdef _WIN32
     HANDLE pipe_read, pipe_write;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Linux build warnings by conditionally omitting unused parameter names in `lib/opencl_boinc.cpp` and `lib/util.cpp` when FastCGI is disabled.

<sup>Written for commit aef48d901f0bbd8d7b5cdf70b5027d910511b5f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

