### PR TITLE
db_purge: batch a workunit's result deletions into one "where id in (...)" query

### DIFF
--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -570,13 +570,18 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
     return 0;
 }
 
-// Delete the records with the given IDs using batched
-// "delete from <table> where id in (id1,id2,...)" queries
-// instead of one query per ID.
-// The IN() list is split into chunks: 1000 20-digit IDs plus separators
-// is ~21 KB, well within delete_from_db_multi()'s MAX_QUERY_LEN buffer.
+// Delete the given result IDs using batched
+// "delete from result where id in (id1,id2,...)" queries
+// instead of one query per result, and log each result as it's purged.
+// The IN() list is split into chunks (1000 20-digit IDs plus separators
+// is ~21 KB, well within delete_from_db_multi()'s MAX_QUERY_LEN buffer);
+// the per-result log is emitted after each chunk commits, so a failure
+// on a later chunk doesn't hide the results that were already deleted.
 //
-int delete_ids_from_db(DB_BASE& table, const vector<DB_ID_TYPE>& ids) {
+int delete_results_batched(
+    DB_WORKUNIT& wu, const vector<DB_ID_TYPE>& ids, const vector<int>& batches
+) {
+    DB_RESULT result;
     const size_t max_ids_per_query = 1000;
     char idbuf[32];
     for (size_t i=0; i<ids.size(); i+=max_ids_per_query) {
@@ -589,8 +594,19 @@ int delete_ids_from_db(DB_BASE& table, const vector<DB_ID_TYPE>& ids) {
             clause += idbuf;
         }
         clause += ")";
-        int retval = table.delete_from_db_multi(clause.c_str());
-        if (retval) return retval;
+        int retval = result.delete_from_db_multi(clause.c_str());
+        if (retval) {
+            log_messages.printf(MSG_CRITICAL,
+                "Couldn't delete results for workunit [%lu] from database: %d\n",
+                wu.id, retval
+            );
+            return retval;
+        }
+        for (size_t j=i; j<end; j++) {
+            log_messages.printf(MSG_NORMAL,
+                "Purged result [%lu] batch %d\n", ids[j], batches[j]
+            );
+        }
     }
     return 0;
 }
@@ -632,19 +648,8 @@ int purge_and_archive_results(DB_WORKUNIT& wu, int& number_results) {
     // rather than one query per result
     //
     if (!result_ids.empty()) {
-        retval = delete_ids_from_db(result, result_ids);
-        if (retval) {
-            log_messages.printf(MSG_CRITICAL,
-                "Couldn't delete results for workunit [%lu] from database: %d\n",
-                wu.id, retval
-            );
-            return retval;
-        }
-        for (size_t i=0; i<result_ids.size(); i++) {
-            log_messages.printf(MSG_NORMAL,
-                "Purged result [%lu] batch %d\n", result_ids[i], result_batches[i]
-            );
-        }
+        retval = delete_results_batched(wu, result_ids, result_batches);
+        if (retval) return retval;
     }
     return 0;
 }

--- a/sched/db_purge.cpp
+++ b/sched/db_purge.cpp
@@ -44,12 +44,14 @@
 #include <cstdlib>
 #include <ctime>
 #include <string>
+#include <vector>
 #include <time.h>
 #include <errno.h>
 #include <string.h>
 #include "zlib.h"
 
 using std::string;
+using std::vector;
 
 #include "boinc_db.h"
 #include "filesys.h"
@@ -568,10 +570,37 @@ int archive_wu_gz (DB_WORKUNIT& wu) {
     return 0;
 }
 
+// Delete the records with the given IDs using batched
+// "delete from <table> where id in (id1,id2,...)" queries
+// instead of one query per ID.
+// The IN() list is split into chunks: 1000 20-digit IDs plus separators
+// is ~21 KB, well within delete_from_db_multi()'s MAX_QUERY_LEN buffer.
+//
+int delete_ids_from_db(DB_BASE& table, const vector<DB_ID_TYPE>& ids) {
+    const size_t max_ids_per_query = 1000;
+    char idbuf[32];
+    for (size_t i=0; i<ids.size(); i+=max_ids_per_query) {
+        size_t end = i + max_ids_per_query;
+        if (end > ids.size()) end = ids.size();
+        string clause = "id in (";
+        for (size_t j=i; j<end; j++) {
+            if (j > i) clause += ",";
+            snprintf(idbuf, sizeof(idbuf), "%lu", (unsigned long)ids[j]);
+            clause += idbuf;
+        }
+        clause += ")";
+        int retval = table.delete_from_db_multi(clause.c_str());
+        if (retval) return retval;
+    }
+    return 0;
+}
+
 int purge_and_archive_results(DB_WORKUNIT& wu, int& number_results) {
     int retval= 0;
     DB_RESULT result;
     char buf[256];
+    vector<DB_ID_TYPE> result_ids;
+    vector<int> result_batches;
 
     number_results=0;
 
@@ -593,18 +622,29 @@ int purge_and_archive_results(DB_WORKUNIT& wu, int& number_results) {
                 "Didn't purge result [%lu] from database (-dont_delete)\n", result.id
             );
         } else {
-            retval = result.delete_from_db();
-            if (retval) {
-                log_messages.printf(MSG_CRITICAL,
-                    "Couldn't delete result [%lu] from database\n", result.id
-                );
-                return retval;
-            }
-            log_messages.printf(MSG_NORMAL,
-                "Purged result [%lu] batch %d\n", result.id, result.batch
-            );
+            result_ids.push_back(result.id);
+            result_batches.push_back(result.batch);
         }
         number_results++;
+    }
+
+    // delete this workunit's results with one (or a few) batched queries
+    // rather than one query per result
+    //
+    if (!result_ids.empty()) {
+        retval = delete_ids_from_db(result, result_ids);
+        if (retval) {
+            log_messages.printf(MSG_CRITICAL,
+                "Couldn't delete results for workunit [%lu] from database: %d\n",
+                wu.id, retval
+            );
+            return retval;
+        }
+        for (size_t i=0; i<result_ids.size(); i++) {
+            log_messages.printf(MSG_NORMAL,
+                "Purged result [%lu] batch %d\n", result_ids[i], result_batches[i]
+            );
+        }
     }
     return 0;
 }


### PR DESCRIPTION
### What

`db_purge` deleted each of a workunit's results with its own `delete from result where id = X` query in `purge_and_archive_results()`. For a project with `target_nresults = N` that's `N` round-trips per workunit on top of the one for the workunit itself.

This collects the result IDs while archiving and issues a single `delete from result where id in (id1, id2, ...)` per workunit instead. The `IN ()` list is chunked at 1000 IDs so the generated query stays well within `MAX_QUERY_LEN` (262144) — 1000 twenty-digit IDs plus separators is ~21 KB.

Partly addresses #6735 — workunit and assignment deletes are still one-per-row; batching those defers deletes across a whole `do_pass()` and widens the archived-but-not-deleted window much further, so I left it for a separate change.

### Unchanged

- **Archiving** — still per-result, same order, same `archive_result()` / `archive_result_gz()` paths.
- **`--dont_delete`** — still logs `Didn't purge result [...]` per result and deletes nothing (the ID list stays empty).
- **Per-result logging** — `Purged result [id] batch N` is still emitted for every purged result (now grouped after the batched delete rather than interleaved with individual deletes).
- **PR #5694's invariant** — a workunit is still never deleted unless its results all deleted first: a failed batch delete returns the error, `do_pass()` does `continue`, and the workunit + results are retried next pass.
- **`--max`, `--max_wu_per_file`, `enable_assignment`, the workunit delete itself, `number_results`** — untouched.

### Behaviour change

Result deletes are issued once per workunit, after the workunit has been fully archived, instead of one immediately after each result is archived. If `db_purge` is killed (OOM / power loss) between archiving a workunit's results and the batched delete committing, the restart re-enumerates the workunit and re-archives its entire result set — previously this window was at most one result. No DB inconsistency (the workunit is still never deleted while any of its results survive) and archive entries are keyed by ID for de-duplication, but it's a real change to crash-recovery behaviour in the area #5694 touched.

Also: the two `DB_RESULT` deletes previously happened while a `mysql_store_result`-buffered enumeration over `result` was open; they now happen after that enumeration finishes, which is strictly safer.

### Testing

- `g++ -fsyntax-only` against the real headers is clean, no new `-Wall -Wextra` warnings.
- The chunking of `delete_ids_from_db()` was unit-tested in isolation: 0 IDs -> 0 queries, 3 -> 1, exactly 1000 -> 1, 1001 -> 2, 2500 -> 3; no leading/trailing commas; full-width IDs format correctly.
- I couldn't run a full server build in my environment; relying on CI for the complete compile/link.

---

*Assisted by Claude (Sonnet 5) per the [BOINC AI Assistants Usage Policy](https://github.com/BOINC/boinc/wiki/Contributing-to-BOINC-with-AI-assistants); the commit carries the `Assisted-by:` trailer. I've read the full diff and verified the behaviour described above.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches result deletions in `db_purge` from one query per result to a single `WHERE id IN (...)` query per workunit, reducing database round-trips. The query is chunked at 1000 IDs to stay within `MAX_QUERY_LEN`.

**Behavior change**
- Result deletes now happen after the whole workunit is archived, so a crash in that window re-archives the entire result set on restart (previously at most one result). Archiving order, `--dont_delete` handling, and the per-result log format are unchanged.
- Per-result purge logs are emitted after each chunk's delete commits, so a failure on a later chunk doesn't hide results already deleted.

<sup>Written for commit 41a4f11b49d7635dc9b1c8b8385fbe561db579d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

