### PR TITLE
web: small fixes

### DIFF
--- a/html/inc/forum.inc
+++ b/html/inc/forum.inc
@@ -591,7 +591,7 @@ function show_post(
     $is_posted_by_special = false;
     for ($i=0; $i<sizeof($special_user_bitfield);$i++) {
         if ($user->prefs && $user->prefs->privilege($keys[$i])) {
-            $fstatus .= "<nobr>".$special_user_bitfield[$keys[$i]]."<nobr><br>";
+            $fstatus .= "<nobr>".$special_user_bitfield[$keys[$i]]."</nobr><br>";
             $is_posted_by_special = true;
         }
     }

--- a/html/user/gpu_list.php
+++ b/html/user/gpu_list.php
@@ -27,6 +27,7 @@
 // TODO: this is fantastically inefficient
 
 require_once("../inc/util.inc");
+require_once("../inc/common_defs.inc");
 
 // strip leading AMD, NVIDIA, etc.
 // This avoids showing the same model twice


### PR DESCRIPTION
From Greg Childers

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an unclosed `<nobr>` tag in forum posts so special user badges render without breaking layout, and adds the missing `common_defs.inc` include to the GPU list page so it loads without errors.

<sup>Written for commit 9225c81a6cac9162fa88bd9d7d875f306e7d33ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

