### PR TITLE
Manager: Don't use a pointer to a local stack variable

### DIFF
--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -600,7 +600,7 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
 
             // OnRPCComplete() clears m_bWaitingForRPC and deletes m_RPCWaitDlg if RPC completed
             if (! m_bWaitingForRPC) {
-                return request.retval;
+                return current_rpc_request.retval;
             }
 
 #if wxDEBUG_LEVEL

--- a/clientgui/AsyncRPC.cpp
+++ b/clientgui/AsyncRPC.cpp
@@ -102,6 +102,7 @@ int AsyncRPC::RPC_Wait(RPC_SELECTOR which_rpc, void *arg1, void *arg2,
     ASYNC_RPC_REQUEST request;
     int retval = 0;
 
+    // Note: ASYNC_RPC_REQUEST constructor set request.resultPtr to NULL
     request.which_rpc = which_rpc;
     request.arg1 = arg1;
     request.arg2 = arg2;
@@ -148,8 +149,6 @@ void *RPCThread::Entry() {
     locale_t RPC_Thread_Locale = newlocale(LC_ALL_MASK, "C", (locale_t) 0);
     uselocale(RPC_Thread_Locale);
 #endif
-
-
 
     m_pRPC_Thread_Mutex->Lock();
     m_pDoc->m_bRPCThreadIsReady = true;
@@ -505,10 +504,6 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
         }
     }
 
-    if ((request.rpcType == RPC_TYPE_WAIT_FOR_COMPLETION) && (request.resultPtr == NULL)) {
-        request.resultPtr = &retval;
-    }
-
     if (hasPriority) {
         // We may want to set hasPriority for some user-initiated events.
         // Since the user is waiting, insert this at head of request queue.
@@ -605,7 +600,7 @@ int CMainDocument::RequestRPC(ASYNC_RPC_REQUEST& request, bool hasPriority) {
 
             // OnRPCComplete() clears m_bWaitingForRPC and deletes m_RPCWaitDlg if RPC completed
             if (! m_bWaitingForRPC) {
-                return retval;
+                return request.retval;
             }
 
 #if wxDEBUG_LEVEL


### PR DESCRIPTION
Fixes a compiler warning.

Using a pointer to a local stack variable is dangerous, although it did not cause any problems in this case:
`        request.resultPtr = &retval;`
.But it was unnecessary, as the same information (the return value from the RPC) is also available in `request.retval`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compiler warning by removing the pointer to a local stack variable in `RequestRPC`. The old code assigned `request.resultPtr` to the address of a local `retval`; the new code returns the RPC result from `request.retval`, which already holds the same value, so behavior is unchanged.

<sup>Written for commit e6d7ac6cc7f3f5ff4e99a824b7ba353c7b302817. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

