### PR TITLE
Mac minor fixes

### DIFF
--- a/clientgui/BOINCGUIApp.cpp
+++ b/clientgui/BOINCGUIApp.cpp
@@ -301,7 +301,7 @@ bool CBOINCGUIApp::OnInit() {
     }
 
 #ifdef SANDBOX
-    if (!success) iErrorCode = -1016;
+    if (!success) iErrorCode = -1021;
 #endif
 
     // Initialize the BOINC Diagnostics Framework

--- a/mac_build/boinc.xcodeproj/project.pbxproj
+++ b/mac_build/boinc.xcodeproj/project.pbxproj
@@ -326,7 +326,6 @@
 		DD81C81D144D900B000BE61A /* rdcolmap.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7DB144D900B000BE61A /* rdcolmap.c */; };
 		DD81C81E144D900B000BE61A /* rdgif.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7DC144D900B000BE61A /* rdgif.c */; };
 		DD81C81F144D900B000BE61A /* rdppm.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7DD144D900B000BE61A /* rdppm.c */; };
-		DD81C820144D900B000BE61A /* rdrle.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7DE144D900B000BE61A /* rdrle.c */; };
 		DD81C821144D900B000BE61A /* rdswitch.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7DF144D900B000BE61A /* rdswitch.c */; };
 		DD81C822144D900B000BE61A /* rdtarga.c in Sources */ = {isa = PBXBuildFile; fileRef = DD81C7E0144D900B000BE61A /* rdtarga.c */; };
 		DD82D83C1F831E0500EEC6AD /* keyword.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DD82D83A1F831E0500EEC6AD /* keyword.cpp */; };
@@ -4032,7 +4031,6 @@
 				DD81C81D144D900B000BE61A /* rdcolmap.c in Sources */,
 				DD81C81E144D900B000BE61A /* rdgif.c in Sources */,
 				DD81C81F144D900B000BE61A /* rdppm.c in Sources */,
-				DD81C820144D900B000BE61A /* rdrle.c in Sources */,
 				DD81C821144D900B000BE61A /* rdswitch.c in Sources */,
 				DD81C822144D900B000BE61A /* rdtarga.c in Sources */,
 			);


### PR DESCRIPTION
Fix error code when data directory inaccessible
Fix compiler warning: jpeg source file object has no symbols


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two minor Mac issues: the manager now exits with -1021 instead of -1016 when the data directory is inaccessible, and removes the unused `rdrle.c` from the Xcode project to fix a compiler warning about the jpeg source file object having no symbols. The error code change may affect scripts that checked for the old value.

<sup>Written for commit bf39e1e507b7dd2c5aab5dc8f1042ac5574f1005. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/BOINC/boinc/pull/7325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

